### PR TITLE
CSI support proposal

### DIFF
--- a/design/csi-snapshots.md
+++ b/design/csi-snapshots.md
@@ -142,7 +142,7 @@ var defaultRestorePriorities = []string{
 Volumes found in a `Pod`'s `backup.velero.io/backup-volumes` list will use Velero's current Restic code path.
 This also means Velero will continue to offer Restic as an option for CSI volumes.
 
-To ensure this is the case, server code must be extended so that PVCs are labeled in such a way that the CSI BackupItemAction plugin is not invoked for PVCs known to be covered by Velero.
+To ensure this is the case, server code must be extended so that PVCs are marked in such a way that the CSI BackupItemAction plugin is not invoked for PVCs known to be backed up by restic.
 This can be accomplished by:
     putting a label on the PVC, so that the AppliesTo function will only match PVCs labeled correctly.
     using an annotation so the Execute function can inspect it and decide to exit early
@@ -156,6 +156,9 @@ To ensure that all created resources are deleted when a backup expires or is del
 In order to fully delete these objects, each `VolumeSnapshotContent`s object will need to be edited to ensure the associated provider snapshot is deleted.
 This will be done by editing the object and setting `VolumeSnapshotContent.Spec.DeletionPolicy` to `Delete`, regardless of whether or not the default policy for the class is `Retain`.
 See the Deletion Policies section below.
+The edit will happen before making Kubernetes API deletion calls to ensure that the cascade works as expected.
+
+Deleting a Velero `Backup` or any associated CSI object via `kubectl` is unsupported; data will be lost or orphaned if this is done.
 
 ## Velero client changes
 

--- a/design/csi-snapshots.md
+++ b/design/csi-snapshots.md
@@ -3,7 +3,7 @@
 Status: Draft
 
 The Container Storage Interface (CSI) [introduced an alpha snapshot API in Kubernetes v1.12][1].
-It will reach beta support in Kubernetes v1.17.
+It will reach beta support in Kubernetes v1.17, scheduled for release in December 2019.
 This proposal documents an approach for integrating support for this snapshot API within Velero, augmenting its existing capabilities.
 
 ## Goals
@@ -110,7 +110,6 @@ Only `PersistentVolumeClaim` objects with the `velero.io/volume-snapshot-name` l
 Metadata (excluding labels) will be cleared, and the `velero.io/volume-snapshot-name` label will be used to find the relevant `VolumeSnapshot`.
 A reference to the `VolumeSnapshot` will be added to the `PersistentVolumeClaim.DataSource` field.
 
-
 No special logic is required to restore `VolumeSnapshotClass` objects.
 
 These plugins should be provided with Velero, as there will also be some changes to core Velero code to enable association of a `Backup` to the included `VolumeSnapshot`s.
@@ -185,7 +184,7 @@ To use CSI features, the Velero client must use the `EnableCSI` feature flag.
 
 A new `describeCSIVolumeSnapshots` function should be added to the [output][12] package that knows how to render the included `VolumeSnapshot` names referenced in the `csi-snapshots.json.gz` file.
 
-### Snapshot mechanism selection
+### Snapshot selection mechanism
 
 The most accurate, reliable way to detect if a PersistentVolume is a CSI volume is to check for a non-`nil` [`PersistentVolume.Spec.PersistentVolumeSource.CSI`][16] field.
 Using the [`volume.beta.kubernetes.io/storage-provisioner`][14] is not viable, since the usage is for any PVC that should be dynamically provisioned, and is _not_ limited to CSI implementations.

--- a/design/csi-snapshots.md
+++ b/design/csi-snapshots.md
@@ -3,7 +3,7 @@
 Status: Draft
 
 The Container Storage Interface (CSI) [introduced an alpha snapshot API in Kubernetes v1.12][1].
-Current plans indicate it will reach beta support in Kubernetes v1.16.
+It will reach beta support in Kubernetes v1.17.
 This proposal documents an approach for integrating support for this snapshot API within Velero, augmenting its existing capabilities.
 
 ## Goals

--- a/design/csi-snapshots.md
+++ b/design/csi-snapshots.md
@@ -52,6 +52,7 @@ This plugin will act directly on PVCs, since an implementation of Velero's Volum
 
 The associated PV will be queried and checked for the presence of `PersistentVolume.Spec.PersistentVolumeSource.CSI`. (See the "Snapshot Mechanism Selection" section below).
 If this field is `nil`, then the plugin will return early without taking action.
+If the `Backup.Spec.SnapshotVolumes` value is `false`, the plugin will return early without taking action.
 
 Create a `VolumeSnapshot.snapshot.storage.k8s.io` object from the PVC.
 Label the `VolumeSnapshot` object with the [`velero.io/backup-name`][10] label for ease of lookup later.
@@ -133,6 +134,8 @@ var defaultRestorePriorities = []string{
     "replicaset",
 }
 ```
+
+
 
 ## Velero client changes
 

--- a/design/csi-snapshots.md
+++ b/design/csi-snapshots.md
@@ -153,6 +153,15 @@ Volumes found in a `Pod`'s `backup.velero.io/backup-volumes` list will use Veler
 This also means Velero will continue to offer Restic as an option for CSI volumes.
 
 
+### Garbage collection and deletion
+
+To ensure that all created resources are deleted when a backup expires or is deleted, `VolumeSnapshot`s will have an `ownerRef` defined pointing to the Velero backup that created them.
+
+In order to fully delete these objects, each `VolumeSnapshotContent`s object will need to be edited to ensure the associated provider snapshot is deleted.
+This will be done by editing the object and setting `VolumeSnapshotContent.Spec.DeletionPolicy` to `Delete`, regardless of whether or not the default policy for the class is `Retain`.
+See the Deletion Policies section below.
+
+
 ## Alternatives Considered
 
 * Implementing similar logic in a Velero VolumeSnapshotter plugin was considered.
@@ -172,9 +181,9 @@ This is important, because to display snapshots included in a backup, whether as
 Snapshots are not listed directly on the `Backup` to fit within the etcd size limitations.
 Additionally, there are no client-side Velero plugin mechanisms, which means that the `velero describe backup --details` command would have no way of displaying the objects to the user, even if they were stored.
 
-## Notes on Usage
+## Deletion Policies
 
-In order for underlying, provider-level snapshots to be retained similarly to Velero's current functionality, the `VolumeSnapshotContent.DeletionPolicy` field must be set to `Retain`.
+In order for underlying, provider-level snapshots to be retained similarly to Velero's current functionality, the `VolumeSnapshotContent.Spec.DeletionPolicy` field must be set to `Retain`.
 
 This is most easily accomplished by setting the `VolumeSnapshotClass.DeletionPolicy` field to `Retain`, which will be inherited by all `VolumeSnapshotContent` objects associated with the `VolumeSnapshotClass`.
 

--- a/design/csi-snapshots.md
+++ b/design/csi-snapshots.md
@@ -1,0 +1,157 @@
+# CSI Snapshot Support
+
+Status: Draft
+
+One to two sentences that describes the goal of this proposal.
+The reader should be able to tell by the title, and the opening paragraph, if this document is relevant to them.
+
+The Container Storage Interface (CSI) has [introduced an alpha snapshot API in Kubernetes v1.12][1].
+This document suggests an approach for integrating support for this snapshot API within Velero, augmenting its existing capabilities.
+
+## Goals
+
+- Enable Velero to create CSI snapshot objects
+
+## Non Goals
+
+- Replacing Velero's existing [VolumeSnapshotter][7] API
+- Replacing Velero's Restic support
+
+## Background
+
+Velero has had support for performing persistent volume snapshots since it's inception.
+However, support has been limited to a handful of providers.
+The plugin API introduced in Velero v0.7 enabled the community to expand the number of supported providers.
+In the meantime, the Kubernetes sig-storage advanced the CSI spec to allow for a generic storage interface, opening up the possibility of moving storage code out of the core Kubernetes code base.
+The CSI working group has also developed a generic snapshotting API that any CSI driver developer may implement, giving users the ability to snapshot volumes from a standard interface.
+
+By supporting the CSI snapshot API, Velero can extend it's support to any CSI driver, without requiring a Velero-specific plugin be written, easing the development burden on providers while also reaching more end users.
+
+## High-Level Design
+
+One to two paragraphs that describe the high level changes that will be made to implement this proposal.
+
+In order to support CSI's snapshot API, Velero must interact with the [`VolumeSnapshot`][2] and [`VolumeSnapshotContent`][3] CRDs.
+These act as requests to the CSI driver to perform a snapshot on the underlying provider's volume.
+This can largely be accomplished with Velero `BackupItemAction` and `RestoreItemAction` plugins that operate on these CRDs.
+
+Additionally, changes to the Velero server and client code are necessary to track `VolumeSnapshots` that are associated with a given backup, similarly to how Velero tracks its own [`volume.Snapshot`][4] type.
+Tracking these is important for allowing users to see what is in their backup, and provides parity for the existing `volume.Snapshot` and [`PodVolumeBackup`][5] types.
+This is also done to retain the object store as Velero's source of truth, without having to query the Kubernetes API server for associated `VolumeSnapshot`s.
+
+`velero backup describe --details` will use the stored VolumeSnapshots to list CSI snapshots included in the backup to the user.
+
+## Detailed Design
+
+### Resource plugins
+
+A set of [prototype][6] plugins was developed that informed this design.
+
+The plugins will be as follows:
+
+* A `BackupItemAction` for `PersistentVolumeClaim`s, named `velero.io/csi-pvc` that will create a `VolumeSnapshot.snapshot.storage.k8s.io` object from the PVC.
+The CSI controllers will create a `VolumeSnapshotContent.snapshot.storage.k8s.io` object associated with the `VolumeSnapshot`.
+This plugin should label both the created `VolumeSnapshot` and `VolumeSnapshotContent` objects with [`v1.BackupNameLabel`][10] for ease of lookup later.
+`velero.io/volume-snapshot-name` will be applied as a label to the PVC so that the `VolumeSnapshot` can be found easily for restore.
+`VolumeSnapshot`, `VolumeSnapshotContent`, and `VolumeSnapshotClass` objects would be returned as additional items to be backed up.
+The `VolumeSnapshotContent.Spec.VolumeSnapshotSource.SnapshotHandle` field is the link to the underlying platform's snapshot, and must be preserved for restoration.
+
+* A `RestoreItemAction` for `VolumeSnapshotContent` objects, named `velero.io/csi-vsc`.
+The metadata (excluding labels), `PersistentVolumeClaim.UUID`, and `VolumeSnapshotRef.UUID` fields will be cleared.
+The reference fields are cleared because the associated objects will get new UUIDs in the cluster.
+This also maps to the "import" case of [the snapshot API][1].
+
+* A `RestoreItemAction` for `VolumeSnapshot` objects, named `velero.io/csi-vs`.
+Metadata (excluding labels) and `Source` fields on the object will be cleared.
+The `VolumeSnapshot.Spec.SnapshotContentName` is the link back to the `VolumeSnapshotContent` object, and thus the actual snapshot.
+The `Source` field indicates that a new CSI snapshot operation should be performed, which isn't relevant on restore.
+This follows the "import" case of [the snapshot API][1].
+
+* A `RestoreItemAction` for `PersistentVolumeClaim`s named `velero.io/csi-pvc`.
+Metadata (excluding labels) will be cleared, and the `velero.io/volume-snapshot-name` label will be used to find the relevant `VolumeSnapshot`.
+A reference to the `VolumeSnapshot` will be added to the `PersistentVolumeClaim.DataSource` field.
+
+No special logic is required to restore `VolumeSnapshotClass` objects.
+
+These plugins should be provided with Velero, as there will also be some changes to core Velero code to enable association of a `Backup` to the included `VolumeSnapshot`s.
+
+### Velero server changes
+
+[`persistBackup`][8] will be extended to query for all `VolumeSnapshot`s associated with the backup, and persist the list to JSON.
+
+[`BackupStore.PutBackup`][9] will receive an additional argument, `volumeSnapshots io.Reader`, that contains the JSON representation of `VolumeSnapshots`.
+This will be written to a file named `csi-snapshots.json.gz`.
+
+[`defaultRestorePriorities`][11] should be rewritten to the following to accomodate proper association between the CSI objects and PVCs. `CustomResourceDefinition`s are moved up because they're necessary for creating the CSI CRDs. The CSI CRDs are created before `PersistentVolume`s and `PersistentVolumeClaim`s so that they may be used as data sources.
+
+```go
+var defaultRestorePriorities = []string{
+    "namespaces",
+    "storageclasses",
+    "customresourcedefinitions",
+    "volumesnapshotclass.snapshot.storage.k8s.io",
+    "volumesnapshots.snapshot.storage.k8s.io",
+    "volumesnapshotcontents.snapshot.storage.k8s.io",
+    "persistentvolumes",
+    "persistentvolumeclaims",
+    "secrets",
+    "configmaps",
+    "serviceaccounts",
+    "limitranges",
+    "pods",
+    "replicaset",
+}
+```
+
+## Velero client changes
+
+[`DescribeBackupStatus`][13] will be extended to download the `csi-snapshots.json.gz` file for processing.
+
+A new `describeCSIVolumeSnapshots` function should be added to the [output][12] package that knows how to render the included `VolumeSnapshot` names referenced in the `csi-snapshots.json.gz` file.
+
+### CSI snapshot enablement
+
+Some mechanism for enabling CSI snapshots, either at a global or individual volume level, is necessary.
+
+Some options are:
+
+    * providing a command line switch for the server that will enable CSI snapshotting for all volumes.
+    * using annotations on pods to indicate which volumes to use CSI snapshotting on, akin to current restic support
+    * a ConfigMap defining which StorageClasses are CSI-enabled, allowing plugins to query based on StorageClass and use CSI if applicable
+
+
+## Notes on usage
+
+In order for underlying, provider-level snapshots to be retained similarly to Velero's current functionality, the `VolumeSnapshotContent.DeletionPolicy` field must be set to `Retain`.
+
+This is most easily accomplished by setting the `VolumeSnapshotClass.DeletionPolicy` field to `Retain`, which will be inherited by all `VolumeSnapshotContent` objects associated with the `VolumeSnapshotClass`.
+
+It is not currently possible to define a deletion policy on a `VolumeSnapshot` that gets passed to a `VolumeSnapshotContent` object on an individual basis.
+
+## Alternatives Considered
+
+* Implementing similar logic in a Velero VolumeSnapshotter plugin was considered.
+However, this is inappropriate given CSI's data model, which requires a PVC/PV's StorageClass.
+Given the arguments to the VolumeSnapshotter interface, the plugin would have to instantiate its own client and do queries against the Kubernetes API server to get the necessary information.
+This is unnecessary given the fact that the `BackupItemAction` and `RestoreItemAction` APIs can act directly on the appropriate objects.
+
+* Implement CSI logic directly in Velero core code.
+The plugins could be packaged separately, but that doesn't necessarily make sense with server and client changes being made to accomodate CSI snapshot lookup.
+
+## Security Considerations
+
+If this proposal has an impact to the security of the product, its users, or data stored or transmitted via the product, they must be addressed here.
+
+[1]: https://kubernetes.io/blog/2018/10/09/introducing-volume-snapshot-alpha-for-kubernetes/
+[2]: https://github.com/kubernetes-csi/external-snapshotter/blob/master/pkg/apis/volumesnapshot/v1alpha1/types.go#L41
+[3]: https://github.com/kubernetes-csi/external-snapshotter/blob/master/pkg/apis/volumesnapshot/v1alpha1/types.go#L161
+[4]: https://github.com/heptio/velero/blob/master/pkg/volume/snapshot.go#L21
+[5]: https://github.com/heptio/velero/blob/master/pkg/apis/velero/v1/pod_volume_backup.go#L88
+[6]: https://github.com/heptio/velero-csi-plugin/
+[7]: https://github.com/heptio/velero/blob/master/pkg/plugin/velero/volume_snapshotter.go#L26
+[8]: https://github.com/heptio/velero/blob/master/pkg/controller/backup_controller.go#L560
+[9]: https://github.com/heptio/velero/blob/master/pkg/persistence/object_store.go#L46
+[10]: https://github.com/heptio/velero/blob/master/pkg/apis/velero/v1/labels_annotations.go#L21
+[11]: https://github.com/heptio/velero/blob/master/pkg/cmd/server/server.go#L471
+[12]: https://github.com/heptio/velero/blob/master/pkg/cmd/util/output/backup_describer.go
+[13]: https://github.com/heptio/velero/blob/master/pkg/cmd/util/output/backup_describer.go#L214

--- a/design/csi-snapshots.md
+++ b/design/csi-snapshots.md
@@ -2,16 +2,13 @@
 
 Status: Draft
 
-One to two sentences that describes the goal of this proposal.
-The reader should be able to tell by the title, and the opening paragraph, if this document is relevant to them.
-
 The Container Storage Interface (CSI) has [introduced an alpha snapshot API in Kubernetes v1.12][1].
 Current plans indicate it will reach beta support in Kubernetes v1.16.
 This document suggests an approach for integrating support for this snapshot API within Velero, augmenting its existing capabilities.
 
 ## Goals
 
-- Enable Velero to create CSI snapshot objects
+- Enable Velero to backup and restore CSI-backed volumes using the Kubernetes CSI CustomResourceDefinition API
 
 ## Non Goals
 
@@ -29,8 +26,6 @@ The CSI working group has also developed a generic snapshotting API that any CSI
 By supporting the CSI snapshot API, Velero can extend it's support to any CSI driver, without requiring a Velero-specific plugin be written, easing the development burden on providers while also reaching more end users.
 
 ## High-Level Design
-
-One to two paragraphs that describe the high level changes that will be made to implement this proposal.
 
 In order to support CSI's snapshot API, Velero must interact with the [`VolumeSnapshot`][2] and [`VolumeSnapshotContent`][3] CRDs.
 These act as requests to the CSI driver to perform a snapshot on the underlying provider's volume.
@@ -117,7 +112,7 @@ var defaultRestorePriorities = []string{
 
 ## Velero client changes
 
-[`DescribeBackupStatus`][13] will be extended to download the `csi-snapshots.json.gz` file for processing.
+[`DescribeBackupStatus`][13] will be extended to download the `csi-snapshots.json.gz` file for processing. GitHub Issue [1568][19] captures this work.
 
 A new `describeCSIVolumeSnapshots` function should be added to the [output][12] package that knows how to render the included `VolumeSnapshot` names referenced in the `csi-snapshots.json.gz` file.
 
@@ -194,3 +189,4 @@ Without these objects, the provider-level snapshots cannot be located in order t
 [16]: https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/types.go#L237
 [17]: https://github.com/heptio/velero/issues/1565
 [18]: https://github.com/heptio/velero/issues/1566
+[19]: https://github.com/heptio/velero/issues/1568

--- a/design/csi-snapshots.md
+++ b/design/csi-snapshots.md
@@ -1,7 +1,5 @@
 # CSI Snapshot Support
 
-Status: Draft
-
 The Container Storage Interface (CSI) [introduced an alpha snapshot API in Kubernetes v1.12][1].
 It will reach beta support in Kubernetes v1.17, scheduled for release in December 2019.
 This proposal documents an approach for integrating support for this snapshot API within Velero, augmenting its existing capabilities.

--- a/design/csi-snapshots.md
+++ b/design/csi-snapshots.md
@@ -45,7 +45,9 @@ A set of [prototype][6] plugins was developed that informed this design.
 
 The plugins will be as follows:
 
-* A `BackupItemAction` for `PersistentVolumeClaim`s, named `velero.io/csi-pvc` 
+
+#### A `BackupItemAction` for `PersistentVolumeClaim`s, named `velero.io/csi-pvc` 
+
 The associated PV will be queried and checked for the presence of `PersistentVolume.Spec.PersistentVolumeSource.CSI`. (See the "Snapshot Mechanism Selection" section below)
 If this field is `nil`, then the plugin will return early without taking action.
 Create a `VolumeSnapshot.snapshot.storage.k8s.io` object from the PVC.
@@ -59,20 +61,23 @@ The `VolumeSnapshotContent.Spec.VolumeSnapshotSource.SnapshotHandle` field is th
 The plugin will _not_ wait for the `VolumeSnapshot.Status.IsReady` field to be `true` before returning.
 This maintains current Velero behavior, though may not be desirable for all storage providers.
 
-* A `RestoreItemAction` for `VolumeSnapshotContent` objects, named `velero.io/csi-vsc`.
+#### A `RestoreItemAction` for `VolumeSnapshotContent` objects, named `velero.io/csi-vsc`
+
 Only `VolumeSnapshotContent` objects with the `velero.io/backup-name` label will be processed; if the label is missing, the plugin will return the unmodified object.
 The metadata (excluding labels), `PersistentVolumeClaim.UUID`, and `VolumeSnapshotRef.UUID` fields will be cleared.
 The reference fields are cleared because the associated objects will get new UUIDs in the cluster.
 This also maps to the "import" case of [the snapshot API][1].
 
-* A `RestoreItemAction` for `VolumeSnapshot` objects, named `velero.io/csi-vs`.
+#### A `RestoreItemAction` for `VolumeSnapshot` objects, named `velero.io/csi-vs`
+
 Only `VolumeSnapshot` objects with the `velero.io/backup-name` label will be processed; if the label is missing, the plugin will return the unmodified object.
 Metadata (excluding labels) and `Source` fields on the object will be cleared.
 The `VolumeSnapshot.Spec.SnapshotContentName` is the link back to the `VolumeSnapshotContent` object, and thus the actual snapshot.
 The `Source` field indicates that a new CSI snapshot operation should be performed, which isn't relevant on restore.
 This follows the "import" case of [the snapshot API][1].
 
-* A `RestoreItemAction` for `PersistentVolumeClaim`s named `velero.io/csi-pvc`.
+#### A `RestoreItemAction` for `PersistentVolumeClaim`s named `velero.io/csi-pvc`
+
 Only `PersistentVolumeClaim` objects with the `velero.io/volume-snapshot-name` label will be processed; if the label is missing, the plugin will return the unmodified object.
 Metadata (excluding labels) will be cleared, and the `velero.io/volume-snapshot-name` label will be used to find the relevant `VolumeSnapshot`.
 A reference to the `VolumeSnapshot` will be added to the `PersistentVolumeClaim.DataSource` field.

--- a/design/csi-snapshots.md
+++ b/design/csi-snapshots.md
@@ -74,7 +74,7 @@ This maintains current Velero behavior, though may not be desirable for all stor
 
 On restore, `VolumeSnapshotContent` objects are cleaned so that they may be properly associated with IDs assigned by the target cluster.
 
-Only `VolumeSnapshotContent` objects with the `velero.io/backup-name` label will be processed; if the label is missing, the plugin will return the unmodified object.
+Only `VolumeSnapshotContent` objects with the `velero.io/backup-name` label will be processed, using the plugin's `AppliesTo` function.
 
 The metadata (excluding labels), `PersistentVolumeClaim.UUID`, and `VolumeSnapshotRef.UUID` fields will be cleared.
 The reference fields are cleared because the associated objects will get new UUIDs in the cluster.
@@ -84,7 +84,7 @@ This also maps to the "import" case of [the snapshot API][1].
 
 `VolumeSnapshot` objects must be prepared for importing into the target cluster by removing IDs and metadata associated with their origin cluster.
 
-Only `VolumeSnapshot` objects with the `velero.io/backup-name` label will be processed; if the label is missing, the plugin will return the unmodified object.
+Only `VolumeSnapshot` objects with the `velero.io/backup-name` label will be processed, using the plugin's `AppliesTo` function.
 
 Metadata (excluding labels) and `Source` fields on the object will be cleared.
 The `VolumeSnapshot.Spec.SnapshotContentName` is the link back to the `VolumeSnapshotContent` object, and thus the actual snapshot.
@@ -97,7 +97,7 @@ The `Backup` associated with the `VolumeSnapshot` will be queried, and set as an
 
 On restore, `PersistentVolumeClaims` will need to be created from the snapshot, and thus will require editing before submission.
 
-Only `PersistentVolumeClaim` objects with the `velero.io/volume-snapshot-name` label will be processed; if the label is missing, the plugin will return the unmodified object.
+Only `PersistentVolumeClaim` objects with the `velero.io/volume-snapshot-name` label will be processed, using the plugin's `AppliesTo` function.
 Metadata (excluding labels) will be cleared, and the `velero.io/volume-snapshot-name` label will be used to find the relevant `VolumeSnapshot`.
 A reference to the `VolumeSnapshot` will be added to the `PersistentVolumeClaim.DataSource` field.
 

--- a/design/csi-snapshots.md
+++ b/design/csi-snapshots.md
@@ -4,7 +4,7 @@ Status: Draft
 
 The Container Storage Interface (CSI) has [introduced an alpha snapshot API in Kubernetes v1.12][1].
 Current plans indicate it will reach beta support in Kubernetes v1.16.
-This document suggests an approach for integrating support for this snapshot API within Velero, augmenting its existing capabilities.
+This proposal documents an approach for integrating support for this snapshot API within Velero, augmenting its existing capabilities.
 
 ## Goals
 
@@ -17,13 +17,13 @@ This document suggests an approach for integrating support for this snapshot API
 
 ## Background
 
-Velero has had support for performing persistent volume snapshots since it's inception.
+Velero has had support for performing persistent volume snapshots since its inception.
 However, support has been limited to a handful of providers.
 The plugin API introduced in Velero v0.7 enabled the community to expand the number of supported providers.
 In the meantime, the Kubernetes sig-storage advanced the CSI spec to allow for a generic storage interface, opening up the possibility of moving storage code out of the core Kubernetes code base.
 The CSI working group has also developed a generic snapshotting API that any CSI driver developer may implement, giving users the ability to snapshot volumes from a standard interface.
 
-By supporting the CSI snapshot API, Velero can extend it's support to any CSI driver, without requiring a Velero-specific plugin be written, easing the development burden on providers while also reaching more end users.
+By supporting the CSI snapshot API, Velero can extend its support to any CSI driver, without requiring a Velero-specific plugin be written, easing the development burden on providers while also reaching more end users.
 
 ## High-Level Design
 
@@ -31,7 +31,7 @@ In order to support CSI's snapshot API, Velero must interact with the [`VolumeSn
 These act as requests to the CSI driver to perform a snapshot on the underlying provider's volume.
 This can largely be accomplished with Velero `BackupItemAction` and `RestoreItemAction` plugins that operate on these CRDs.
 
-Additionally, changes to the Velero server and client code are necessary to track `VolumeSnapshots` that are associated with a given backup, similarly to how Velero tracks its own [`volume.Snapshot`][4] type.
+Additionally, changes to the Velero server and client code are necessary to track `VolumeSnapshot`s that are associated with a given backup, similarly to how Velero tracks its own [`volume.Snapshot`][4] type.
 Tracking these is important for allowing users to see what is in their backup, and provides parity for the existing `volume.Snapshot` and [`PodVolumeBackup`][5] types.
 This is also done to retain the object store as Velero's source of truth, without having to query the Kubernetes API server for associated `VolumeSnapshot`s.
 

--- a/design/csi-snapshots.md
+++ b/design/csi-snapshots.md
@@ -194,6 +194,17 @@ It was [introduced with dynamic provisioning support][15] in 2016, predating CSI
 In the `BackupItemAction` for PVCs, the associated PV will be queried and checked for the presence of `PersistentVolume.Spec.PersistentVolumeSource.CSI`.
 Volumes with any other `PersistentVolumeSource` set will use Velero's current VolumeSnapshotter plugin code path.
 
+### VolumeSnapshotLocations and VolumeSnapshotClasses
+
+Velero uses its own `VolumeSnapshotLocation` CRDs to specify configuration options for a given storage system.
+In Velero, this often includes topology information such as regions or availibility zones, as well as credential information.
+
+CSI volume snapshotting has a `VolumeSnapshotClass` CRD which also contains configuration options for a given storage system, but these options are not the same as those that Velero would use.
+Since CSI volume snapshotting is operating within the same storage system that manages the volumes already, it does not need the same topology or credential information that Velero does.
+
+As such, when used with CSI volumes, Velero's `VolumeSnapshotLocation` CRDs are not relevant, and could be omitted.
+
+This will create a separate path in our documentation for the time being, and should be called out explicitly.
 
 ## Alternatives Considered
 

--- a/design/csi-snapshots.md
+++ b/design/csi-snapshots.md
@@ -58,7 +58,7 @@ Label the `VolumeSnapshot` object with the [`velero.io/backup-name`][10] label f
 The CSI controllers will create a `VolumeSnapshotContent.snapshot.storage.k8s.io` object associated with the `VolumeSnapshot`.
 Associated `VolumeSnapshotContent` objects will be retrieved and updated with the [`velero.io/backup-name`][10] label for ease of lookup later.
 `velero.io/volume-snapshot-name` will be applied as a label to the PVC so that the `VolumeSnapshot` can be found easily for restore.
-`VolumeSnapshot`, `VolumeSnapshotContent`, and `VolumeSnapshotClass` objects would be returned as additional items to be backed up.
+`VolumeSnapshot`, `VolumeSnapshotContent`, and `VolumeSnapshotClass` objects would be returned as additional items to be backed up. GitHub issue [1566][18] represents this work.
 The `VolumeSnapshotContent.Spec.VolumeSnapshotSource.SnapshotHandle` field is the link to the underlying platform's snapshot, and must be preserved for restoration.
 
 The plugin will _not_ wait for the `VolumeSnapshot.Status.IsReady` field to be `true` before returning.
@@ -94,6 +94,7 @@ These plugins should be provided with Velero, as there will also be some changes
 This will be written to a file named `csi-snapshots.json.gz`.
 
 [`defaultRestorePriorities`][11] should be rewritten to the following to accomodate proper association between the CSI objects and PVCs. `CustomResourceDefinition`s are moved up because they're necessary for creating the CSI CRDs. The CSI CRDs are created before `PersistentVolume`s and `PersistentVolumeClaim`s so that they may be used as data sources.
+GitHub issue [1565][17] represents this work.
 
 ```go
 var defaultRestorePriorities = []string{
@@ -191,3 +192,5 @@ Without these objects, the provider-level snapshots cannot be located in order t
 [14]: https://github.com/kubernetes/kubernetes/blob/8ea9edbb0290e9de1e6d274e816a4002892cca6f/pkg/controller/volume/persistentvolume/util/util.go#L69
 [15]: https://github.com/kubernetes/kubernetes/pull/30285
 [16]: https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/types.go#L237
+[17]: https://github.com/heptio/velero/issues/1565
+[18]: https://github.com/heptio/velero/issues/1566


### PR DESCRIPTION
Remaining:

* [x] disabling CSI snapshotting, similar to disabling Velero-native snapshots
* [x] skipping CSI snapshotting in the plugins if the volume is covered by restic
* [x] mention feature flags/gates
* [x] use ownerRefs
* [x] deleting the underlying snapshot when the backup expires (using a `Retain` deletion policy means it will not be cleaned up by default)

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>