### PR TITLE
Cleanup .velero directory when init-container finishes

### DIFF
--- a/changelogs/unreleased/1754-dymurray
+++ b/changelogs/unreleased/1754-dymurray
@@ -1,0 +1,1 @@
+cleanup .velero directory when restic helper container finishes

--- a/cmd/velero-restic-restore-helper/main.go
+++ b/cmd/velero-restic-restore-helper/main.go
@@ -77,8 +77,9 @@ func done() bool {
 	return true
 }
 
-// cleanupDoneFiles returns an error if it fails to remove all of the `.velero`
-// dirs created by Velero when a restic restore completes
+// cleanupDoneFiles returns if it fails to remove all of the `.velero` dirs
+// created by Velero when a restic restore completes or when all directories
+// are removed. It does not return an error to run a 'soft' cleanup.
 func cleanupDoneFiles() {
 	children, err := ioutil.ReadDir("/restores")
 	if err != nil {

--- a/cmd/velero-restic-restore-helper/main.go
+++ b/cmd/velero-restic-restore-helper/main.go
@@ -93,7 +93,7 @@ func cleanupDoneFiles() {
 			continue
 		}
 		doneFileDir := filepath.Join("/restores", child.Name(), ".velero")
-		if err := os.RemoveAll(filepath.Join(doneFileDir, ".velero")); err != nil {
+		if err := os.RemoveAll(doneFileDir); err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR removing .velero directory: %s\n", err)
 		}
 	}

--- a/cmd/velero-restic-restore-helper/main.go
+++ b/cmd/velero-restic-restore-helper/main.go
@@ -94,8 +94,9 @@ func cleanupDoneFiles() {
 		}
 		doneFileDir := filepath.Join("/restores", child.Name(), ".velero")
 		if err := os.RemoveAll(doneFileDir); err != nil {
-			fmt.Fprintf(os.Stderr, "ERROR removing .velero directory: %s\n", err)
+			fmt.Fprintf(os.Stderr, "ERROR removing .velero directory [%s]: %s\n", doneFileDir, err)
 		}
+		fmt.Printf("Successfully removed .velero directory: %s\n", doneFileDir)
 	}
 	return
 }

--- a/cmd/velero-restic-restore-helper/main.go
+++ b/cmd/velero-restic-restore-helper/main.go
@@ -95,6 +95,7 @@ func cleanupDoneFiles() {
 		doneFileDir := filepath.Join("/restores", child.Name(), ".velero")
 		if err := os.RemoveAll(doneFileDir); err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR removing .velero directory [%s]: %s\n", doneFileDir, err)
+			continue
 		}
 		fmt.Printf("Successfully removed .velero directory: %s\n", doneFileDir)
 	}

--- a/pkg/controller/pod_volume_restore_controller.go
+++ b/pkg/controller/pod_volume_restore_controller.go
@@ -369,7 +369,7 @@ func (c *podVolumeRestoreController) restorePodVolume(req *velerov1api.PodVolume
 	// Write a done file with name=<restore-uid> into the just-created .velero dir
 	// within the volume. The velero restic init container on the pod is waiting
 	// for this file to exist in each restored volume before completing.
-	if err := ioutil.WriteFile(filepath.Join(volumePath, ".velero", string(restoreUID)), nil, 0644); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(volumePath, ".velero", string(restoreUID)), nil, 0755); err != nil {
 		return errors.Wrap(err, "error writing done file")
 	}
 


### PR DESCRIPTION
Signed-off-by: Dylan Murray <dymurray@redhat.com>

Choosing not to error out when cleanup fails since the PVR controller attempts to wipe stale data as well. This is a soft cleanup.