### PR TITLE
Revert "Revert "allow self signed certs with insecureSkipVerify""

### DIFF
--- a/changelogs/unreleased/1793-s12chung
+++ b/changelogs/unreleased/1793-s12chung
@@ -1,0 +1,1 @@
+adds `insecureSkipTLSVerify` server config for AWS storage and `--insecure-skip-tls-verify` flag on client for self-signed certs

--- a/pkg/cloudprovider/aws/object_store.go
+++ b/pkg/cloudprovider/aws/object_store.go
@@ -17,7 +17,9 @@ limitations under the License.
 package aws
 
 import (
+	"crypto/tls"
 	"io"
+	"net/http"
 	"sort"
 	"strconv"
 	"time"
@@ -36,14 +38,15 @@ import (
 )
 
 const (
-	s3URLKey                = "s3Url"
-	publicURLKey            = "publicUrl"
-	kmsKeyIDKey             = "kmsKeyId"
-	s3ForcePathStyleKey     = "s3ForcePathStyle"
-	bucketKey               = "bucket"
-	signatureVersionKey     = "signatureVersion"
-	credentialProfileKey    = "profile"
-	serverSideEncryptionKey = "serverSideEncryption"
+	s3URLKey                 = "s3Url"
+	publicURLKey             = "publicUrl"
+	kmsKeyIDKey              = "kmsKeyId"
+	s3ForcePathStyleKey      = "s3ForcePathStyle"
+	bucketKey                = "bucket"
+	signatureVersionKey      = "signatureVersion"
+	credentialProfileKey     = "profile"
+	serverSideEncryptionKey  = "serverSideEncryption"
+	insecureSkipTLSVerifyKey = "insecureSkipTLSVerify"
 )
 
 type s3Interface interface {
@@ -86,27 +89,30 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		signatureVersionKey,
 		credentialProfileKey,
 		serverSideEncryptionKey,
+		insecureSkipTLSVerifyKey,
 	); err != nil {
 		return err
 	}
 
 	var (
-		region               = config[regionKey]
-		s3URL                = config[s3URLKey]
-		publicURL            = config[publicURLKey]
-		kmsKeyID             = config[kmsKeyIDKey]
-		s3ForcePathStyleVal  = config[s3ForcePathStyleKey]
-		signatureVersion     = config[signatureVersionKey]
-		credentialProfile    = config[credentialProfileKey]
-		serverSideEncryption = config[serverSideEncryptionKey]
+		region                   = config[regionKey]
+		s3URL                    = config[s3URLKey]
+		publicURL                = config[publicURLKey]
+		kmsKeyID                 = config[kmsKeyIDKey]
+		s3ForcePathStyleVal      = config[s3ForcePathStyleKey]
+		signatureVersion         = config[signatureVersionKey]
+		credentialProfile        = config[credentialProfileKey]
+		serverSideEncryption     = config[serverSideEncryptionKey]
+		insecureSkipTLSVerifyVal = config[insecureSkipTLSVerifyKey]
 
 		// note that bucket is automatically added to the config map
 		// by the server from the ObjectStorageProviderConfig so
 		// doesn't need to be explicitly set by the user within
 		// config.
-		bucket           = config[bucketKey]
-		s3ForcePathStyle bool
-		err              error
+		bucket                = config[bucketKey]
+		s3ForcePathStyle      bool
+		insecureSkipTLSVerify bool
+		err                   error
 	)
 
 	if s3ForcePathStyleVal != "" {
@@ -129,6 +135,20 @@ func (o *ObjectStore) Init(config map[string]string) error {
 	serverConfig, err := newAWSConfig(s3URL, region, s3ForcePathStyle)
 	if err != nil {
 		return err
+	}
+
+	if insecureSkipTLSVerifyVal != "" {
+		if insecureSkipTLSVerify, err = strconv.ParseBool(insecureSkipTLSVerifyVal); err != nil {
+			return errors.Wrapf(err, "could not parse %s (expected bool)", insecureSkipTLSVerifyKey)
+		}
+	}
+
+	if insecureSkipTLSVerify {
+		serverConfig.HTTPClient = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		}
 	}
 
 	serverSession, err := getSession(serverConfig, credentialProfile)

--- a/pkg/cmd/cli/backup/describe.go
+++ b/pkg/cmd/cli/backup/describe.go
@@ -33,8 +33,9 @@ import (
 
 func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 	var (
-		listOptions metav1.ListOptions
-		details     bool
+		listOptions           metav1.ListOptions
+		details               bool
+		insecureSkipTLSVerify bool
 	)
 
 	c := &cobra.Command{
@@ -71,7 +72,7 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 					fmt.Fprintf(os.Stderr, "error getting PodVolumeBackups for backup %s: %v\n", backup.Name, err)
 				}
 
-				s := output.DescribeBackup(&backup, deleteRequestList.Items, podVolumeBackupList.Items, details, veleroClient)
+				s := output.DescribeBackup(&backup, deleteRequestList.Items, podVolumeBackupList.Items, details, veleroClient, insecureSkipTLSVerify)
 				if first {
 					first = false
 					fmt.Print(s)
@@ -85,6 +86,7 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 
 	c.Flags().StringVarP(&listOptions.LabelSelector, "selector", "l", listOptions.LabelSelector, "only show items matching this label selector")
 	c.Flags().BoolVar(&details, "details", details, "display additional detail in the command output")
+	c.Flags().BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", insecureSkipTLSVerify, "If true, the object store's TLS certificate will not be checked for validity. This is insecure and susceptible to man-in-the-middle attacks. Not recommended for production.")
 
 	return c
 }

--- a/pkg/cmd/cli/backup/download.go
+++ b/pkg/cmd/cli/backup/download.go
@@ -52,11 +52,12 @@ func NewDownloadCommand(f client.Factory) *cobra.Command {
 }
 
 type DownloadOptions struct {
-	Name         string
-	Output       string
-	Force        bool
-	Timeout      time.Duration
-	writeOptions int
+	Name                  string
+	Output                string
+	Force                 bool
+	Timeout               time.Duration
+	InsecureSkipTLSVerify bool
+	writeOptions          int
 }
 
 func NewDownloadOptions() *DownloadOptions {
@@ -69,6 +70,7 @@ func (o *DownloadOptions) BindFlags(flags *pflag.FlagSet) {
 	flags.StringVarP(&o.Output, "output", "o", o.Output, "path to output file. Defaults to <NAME>-data.tar.gz in the current directory")
 	flags.BoolVar(&o.Force, "force", o.Force, "forces the download and will overwrite file if it exists already")
 	flags.DurationVar(&o.Timeout, "timeout", o.Timeout, "maximum time to wait to process download request")
+	flags.BoolVar(&o.InsecureSkipTLSVerify, "insecure-skip-tls-verify", o.InsecureSkipTLSVerify, "If true, the object store's TLS certificate will not be checked for validity. This is insecure and susceptible to man-in-the-middle attacks. Not recommended for production.")
 }
 
 func (o *DownloadOptions) Validate(c *cobra.Command, args []string, f client.Factory) error {
@@ -111,7 +113,7 @@ func (o *DownloadOptions) Run(c *cobra.Command, f client.Factory) error {
 	}
 	defer backupDest.Close()
 
-	err = downloadrequest.Stream(veleroClient.VeleroV1(), f.Namespace(), o.Name, v1.DownloadTargetKindBackupContents, backupDest, o.Timeout)
+	err = downloadrequest.Stream(veleroClient.VeleroV1(), f.Namespace(), o.Name, v1.DownloadTargetKindBackupContents, backupDest, o.Timeout, o.InsecureSkipTLSVerify)
 	if err != nil {
 		os.Remove(o.Output)
 		cmd.CheckError(err)

--- a/pkg/cmd/cli/backup/logs.go
+++ b/pkg/cmd/cli/backup/logs.go
@@ -32,6 +32,7 @@ import (
 
 func NewLogsCommand(f client.Factory) *cobra.Command {
 	timeout := time.Minute
+	insecureSkipTLSVerify := false
 
 	c := &cobra.Command{
 		Use:   "logs BACKUP",
@@ -58,12 +59,13 @@ func NewLogsCommand(f client.Factory) *cobra.Command {
 					"until the backup has a phase of Completed or Failed and try again.", backupName)
 			}
 
-			err = downloadrequest.Stream(veleroClient.VeleroV1(), f.Namespace(), backupName, v1.DownloadTargetKindBackupLog, os.Stdout, timeout)
+			err = downloadrequest.Stream(veleroClient.VeleroV1(), f.Namespace(), backupName, v1.DownloadTargetKindBackupLog, os.Stdout, timeout, insecureSkipTLSVerify)
 			cmd.CheckError(err)
 		},
 	}
 
 	c.Flags().DurationVar(&timeout, "timeout", timeout, "how long to wait to receive logs")
+	c.Flags().BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", insecureSkipTLSVerify, "If true, the object store's TLS certificate will not be checked for validity. This is insecure and susceptible to man-in-the-middle attacks. Not recommended for production.")
 
 	return c
 }

--- a/pkg/cmd/cli/restore/describe.go
+++ b/pkg/cmd/cli/restore/describe.go
@@ -32,8 +32,9 @@ import (
 
 func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 	var (
-		listOptions metav1.ListOptions
-		details     bool
+		listOptions           metav1.ListOptions
+		details               bool
+		insecureSkipTLSVerify bool
 	)
 
 	c := &cobra.Command{
@@ -64,7 +65,7 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 					fmt.Fprintf(os.Stderr, "error getting PodVolumeRestores for restore %s: %v\n", restore.Name, err)
 				}
 
-				s := output.DescribeRestore(&restore, podvolumeRestoreList.Items, details, veleroClient)
+				s := output.DescribeRestore(&restore, podvolumeRestoreList.Items, details, veleroClient, insecureSkipTLSVerify)
 				if first {
 					first = false
 					fmt.Print(s)
@@ -78,6 +79,7 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 
 	c.Flags().StringVarP(&listOptions.LabelSelector, "selector", "l", listOptions.LabelSelector, "only show items matching this label selector")
 	c.Flags().BoolVar(&details, "details", details, "display additional detail in the command output")
+	c.Flags().BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", insecureSkipTLSVerify, "If true, the object store's TLS certificate will not be checked for validity. This is insecure and susceptible to man-in-the-middle attacks. Not recommended for production.")
 
 	return c
 }

--- a/pkg/cmd/cli/restore/logs.go
+++ b/pkg/cmd/cli/restore/logs.go
@@ -32,6 +32,7 @@ import (
 
 func NewLogsCommand(f client.Factory) *cobra.Command {
 	timeout := time.Minute
+	insecureSkipTLSVerify := false
 
 	c := &cobra.Command{
 		Use:   "logs RESTORE",
@@ -58,12 +59,13 @@ func NewLogsCommand(f client.Factory) *cobra.Command {
 					"until the restore has a phase of Completed or Failed and try again.", restoreName)
 			}
 
-			err = downloadrequest.Stream(veleroClient.VeleroV1(), f.Namespace(), restoreName, v1.DownloadTargetKindRestoreLog, os.Stdout, timeout)
+			err = downloadrequest.Stream(veleroClient.VeleroV1(), f.Namespace(), restoreName, v1.DownloadTargetKindRestoreLog, os.Stdout, timeout, insecureSkipTLSVerify)
 			cmd.CheckError(err)
 		},
 	}
 
 	c.Flags().DurationVar(&timeout, "timeout", timeout, "how long to wait to receive logs")
+	c.Flags().BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", insecureSkipTLSVerify, "If true, the object store's TLS certificate will not be checked for validity. This is insecure and susceptible to man-in-the-middle attacks. Not recommended for production.")
 
 	return c
 }

--- a/pkg/cmd/util/downloadrequest/downloadrequest_test.go
+++ b/pkg/cmd/util/downloadrequest/downloadrequest_test.go
@@ -151,7 +151,7 @@ func TestStream(t *testing.T) {
 			output := new(bytes.Buffer)
 			errCh := make(chan error)
 			go func() {
-				err := Stream(client.VeleroV1(), "namespace", "name", test.kind, output, timeout)
+				err := Stream(client.VeleroV1(), "namespace", "name", test.kind, output, timeout, false)
 				errCh <- err
 			}()
 

--- a/pkg/cmd/util/output/backup_describer.go
+++ b/pkg/cmd/util/output/backup_describer.go
@@ -38,6 +38,7 @@ func DescribeBackup(
 	podVolumeBackups []velerov1api.PodVolumeBackup,
 	details bool,
 	veleroClient clientset.Interface,
+	insecureSkipTLSVerify bool,
 ) string {
 	return Describe(func(d *Describer) {
 		d.DescribeMetadata(backup.ObjectMeta)
@@ -74,7 +75,7 @@ func DescribeBackup(
 		DescribeBackupSpec(d, backup.Spec)
 
 		d.Println()
-		DescribeBackupStatus(d, backup, details, veleroClient)
+		DescribeBackupStatus(d, backup, details, veleroClient, insecureSkipTLSVerify)
 
 		if len(deleteRequests) > 0 {
 			d.Println()
@@ -211,7 +212,7 @@ func DescribeBackupSpec(d *Describer, spec velerov1api.BackupSpec) {
 }
 
 // DescribeBackupStatus describes a backup status in human-readable format.
-func DescribeBackupStatus(d *Describer, backup *velerov1api.Backup, details bool, veleroClient clientset.Interface) {
+func DescribeBackupStatus(d *Describer, backup *velerov1api.Backup, details bool, veleroClient clientset.Interface, insecureSkipTLSVerify bool) {
 	status := backup.Status
 
 	d.Printf("Backup Format Version:\t%d\n", status.Version)
@@ -234,7 +235,7 @@ func DescribeBackupStatus(d *Describer, backup *velerov1api.Backup, details bool
 	d.Println()
 
 	if details {
-		describeBackupResourceList(d, backup, veleroClient)
+		describeBackupResourceList(d, backup, veleroClient, insecureSkipTLSVerify)
 		d.Println()
 	}
 
@@ -245,7 +246,7 @@ func DescribeBackupStatus(d *Describer, backup *velerov1api.Backup, details bool
 		}
 
 		buf := new(bytes.Buffer)
-		if err := downloadrequest.Stream(veleroClient.VeleroV1(), backup.Namespace, backup.Name, velerov1api.DownloadTargetKindBackupVolumeSnapshots, buf, downloadRequestTimeout); err != nil {
+		if err := downloadrequest.Stream(veleroClient.VeleroV1(), backup.Namespace, backup.Name, velerov1api.DownloadTargetKindBackupVolumeSnapshots, buf, downloadRequestTimeout, insecureSkipTLSVerify); err != nil {
 			d.Printf("Persistent Volumes:\t<error getting volume snapshot info: %v>\n", err)
 			return
 		}
@@ -266,9 +267,9 @@ func DescribeBackupStatus(d *Describer, backup *velerov1api.Backup, details bool
 	d.Printf("Persistent Volumes: <none included>\n")
 }
 
-func describeBackupResourceList(d *Describer, backup *velerov1api.Backup, veleroClient clientset.Interface) {
+func describeBackupResourceList(d *Describer, backup *velerov1api.Backup, veleroClient clientset.Interface, insecureSkipTLSVerify bool) {
 	buf := new(bytes.Buffer)
-	if err := downloadrequest.Stream(veleroClient.VeleroV1(), backup.Namespace, backup.Name, velerov1api.DownloadTargetKindBackupResourceList, buf, downloadRequestTimeout); err != nil {
+	if err := downloadrequest.Stream(veleroClient.VeleroV1(), backup.Namespace, backup.Name, velerov1api.DownloadTargetKindBackupResourceList, buf, downloadRequestTimeout, insecureSkipTLSVerify); err != nil {
 		if err == downloadrequest.ErrNotFound {
 			d.Println("Resource List:\t<backup resource list not found, this could be because this backup was taken prior to Velero 1.1.0>")
 		} else {

--- a/pkg/cmd/util/output/restore_describer.go
+++ b/pkg/cmd/util/output/restore_describer.go
@@ -31,7 +31,7 @@ import (
 	pkgrestore "github.com/vmware-tanzu/velero/pkg/restore"
 )
 
-func DescribeRestore(restore *v1.Restore, podVolumeRestores []v1.PodVolumeRestore, details bool, veleroClient clientset.Interface) string {
+func DescribeRestore(restore *v1.Restore, podVolumeRestores []v1.PodVolumeRestore, details bool, veleroClient clientset.Interface, insecureSkipTLSVerify bool) string {
 	return Describe(func(d *Describer) {
 		d.DescribeMetadata(restore.ObjectMeta)
 
@@ -56,7 +56,7 @@ func DescribeRestore(restore *v1.Restore, podVolumeRestores []v1.PodVolumeRestor
 			}
 		}
 
-		describeRestoreResults(d, restore, veleroClient)
+		describeRestoreResults(d, restore, veleroClient, insecureSkipTLSVerify)
 
 		d.Println()
 		d.Printf("Backup:\t%s\n", restore.Spec.BackupName)
@@ -114,7 +114,7 @@ func DescribeRestore(restore *v1.Restore, podVolumeRestores []v1.PodVolumeRestor
 	})
 }
 
-func describeRestoreResults(d *Describer, restore *v1.Restore, veleroClient clientset.Interface) {
+func describeRestoreResults(d *Describer, restore *v1.Restore, veleroClient clientset.Interface, insecureSkipTLSVerify bool) {
 	if restore.Status.Warnings == 0 && restore.Status.Errors == 0 {
 		return
 	}
@@ -122,7 +122,7 @@ func describeRestoreResults(d *Describer, restore *v1.Restore, veleroClient clie
 	var buf bytes.Buffer
 	var resultMap map[string]pkgrestore.Result
 
-	if err := downloadrequest.Stream(veleroClient.VeleroV1(), restore.Namespace, restore.Name, v1.DownloadTargetKindRestoreResults, &buf, downloadRequestTimeout); err != nil {
+	if err := downloadrequest.Stream(veleroClient.VeleroV1(), restore.Namespace, restore.Name, v1.DownloadTargetKindRestoreResults, &buf, downloadRequestTimeout, insecureSkipTLSVerify); err != nil {
 		d.Printf("Warnings:\t<error getting warnings: %v>\n\nErrors:\t<error getting errors: %v>\n", err, err)
 		return
 	}

--- a/site/docs/master/api-types/backupstoragelocation.md
+++ b/site/docs/master/api-types/backupstoragelocation.md
@@ -55,6 +55,7 @@ The configurable parameters are as follows:
 | `kmsKeyId` | string | Empty | *Example*: "502b409c-4da1-419f-a16e-eif453b3i49f" or "alias/`<KMS-Key-Alias-Name>`"<br><br>Specify an [AWS KMS key][10] id or alias to enable encryption of the backups stored in S3. Only works with AWS S3 and may require explicitly granting key usage rights.|
 | `signatureVersion` | string | `"4"` | Version of the signature algorithm used to create signed URLs that are used by velero cli to download backups or fetch logs. Possible versions are "1" and "4". Usually the default version 4 is correct, but some S3-compatible providers like Quobyte only support version 1.|
 | `profile` | string | "default" | AWS profile within the credential file to use for given store |
+| `insecureSkipTLSVerify` | bool | `false` | Set this to `true` if you do not want to verify the TLS certificate when connecting to the object store--like self-signed certs in Minio. This is susceptible to man-in-the-middle attacks and is not recommended for production. |
 
 #### Azure
 


### PR DESCRIPTION
Reverts heptio/velero#1776, which is a revert of #1769

I'd like to bring this code up, as it'd be great if we could have this feature. I don't think I can put in the time to support support custom CA bundles per https://github.com/heptio/velero/issues/1027#issuecomment-523119113 now. I understand that `insecureSkipVerify` is insecure--hence the warnings. If I can get the code in, awesome. Otherwise, our team will live with our fork until we move away from self-signed certs.

Can we discuss about this topic on this PR?

relates to #1027