### PR TITLE
Make "not restored" message a bit better

### DIFF
--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1062,13 +1062,13 @@ func (ctx *context) restoreItem(obj *unstructured.Unstructured, groupResource sc
 					ctx.log.Infof("ServiceAccount %s successfully updated", kube.NamespaceAndName(obj))
 				}
 			default:
-				e := errors.Errorf("not restored: %s and is different from backed up version.", restoreErr)
+				e := errors.Errorf("restore of %s not possible: it already exists in the cluster but is different from the backed up version.", restoreErr)
 				addToResult(&warnings, namespace, e)
 			}
 			return warnings, errs
 		}
 
-		ctx.log.Infof("Skipping restore of %s: %v because it already exists in the cluster and is unchanged from the backed up version", obj.GroupVersionKind().Kind, name)
+		ctx.log.Infof("Restore of %s, %v skipped: it already exists in the cluster and is the same as the backed up version", obj.GroupVersionKind().Kind, name)
 		return warnings, errs
 	}
 

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1062,7 +1062,7 @@ func (ctx *context) restoreItem(obj *unstructured.Unstructured, groupResource sc
 					ctx.log.Infof("ServiceAccount %s successfully updated", kube.NamespaceAndName(obj))
 				}
 			default:
-				e := errors.Errorf("error restoring %s: not possible since it already exists in the cluster but is different from the backed up version.", restoreErr)
+				e := errors.Errorf("could not restore, %s. Warning: the in-cluster version is different than the backed-up version.", restoreErr)
 				addToResult(&warnings, namespace, e)
 			}
 			return warnings, errs

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1062,7 +1062,7 @@ func (ctx *context) restoreItem(obj *unstructured.Unstructured, groupResource sc
 					ctx.log.Infof("ServiceAccount %s successfully updated", kube.NamespaceAndName(obj))
 				}
 			default:
-				e := errors.Errorf("restore of %s not possible: it already exists in the cluster but is different from the backed up version.", restoreErr)
+				e := errors.Errorf("error restoring %s: not possible since it already exists in the cluster but is different from the backed up version.", restoreErr)
 				addToResult(&warnings, namespace, e)
 			}
 			return warnings, errs


### PR DESCRIPTION
What the new messages try to convey:

In one case, the restore it is legit and possible, but we are choosing to skip it because the resources are the same. In the other case, it is NOT possible and the reason why is the difference between the resources.

Also changed the formatting a bit for consistency.

Signed-off-by: Carlisia <carlisia@vmware.com>