### PR TITLE
Add --no-default-backup-location flag to velero install

### DIFF
--- a/changelogs/unreleased/1931-Frank51
+++ b/changelogs/unreleased/1931-Frank51
@@ -1,0 +1,1 @@
+Add --no-default-backup-location flag to velero install

--- a/pkg/install/resources.go
+++ b/pkg/install/resources.go
@@ -216,6 +216,7 @@ type VeleroOptions struct {
 	VSLConfig                         map[string]string
 	DefaultResticMaintenanceFrequency time.Duration
 	Plugins                           []string
+	NoDefaultBackupLocation           bool
 }
 
 // AllResources returns a list of all resources necessary to install Velero, in the appropriate order, into a Kubernetes cluster.
@@ -244,8 +245,10 @@ func AllResources(o *VeleroOptions) (*unstructured.UnstructuredList, error) {
 		appendUnstructured(resources, sec)
 	}
 
-	bsl := BackupStorageLocation(o.Namespace, o.ProviderName, o.Bucket, o.Prefix, o.BSLConfig)
-	appendUnstructured(resources, bsl)
+	if !o.NoDefaultBackupLocation {
+		bsl := BackupStorageLocation(o.Namespace, o.ProviderName, o.Bucket, o.Prefix, o.BSLConfig)
+		appendUnstructured(resources, bsl)
+	}
 
 	// A snapshot location may not be desirable for users relying on restic
 	if o.UseVolumeSnapshots {

--- a/site/docs/master/install-overview.md
+++ b/site/docs/master/install-overview.md
@@ -38,6 +38,8 @@ platform-agnostic backup solution for volume data.
 
 Whether you run Velero on a cloud provider or on-premises, if you have more than one volume snapshot location for a given volume provider, you can specify its default location for backups by setting a server flag in your Velero deployment YAML.
 
+If you need to install Velero without a default backup storage location (without specifying `--bucket` or `--provider`), the `--no-default-backup-location` flag is required for confirmation.
+
 For details, see the documentation topics for individual cloud providers.
 
 ## Installing with the Helm chart


### PR DESCRIPTION
This adds --no-default-backup-location flag to velero install to enable velero deployment without default BSL, closes #1853.

