### PR TITLE
Revert "Remove unused flag" for verifying code gen in CI

### DIFF
--- a/hack/verify-generated-crd-code.sh
+++ b/hack/verify-generated-crd-code.sh
@@ -16,7 +16,7 @@
 
 HACK_DIR=$(dirname "${BASH_SOURCE}")
 
-${HACK_DIR}/update-generated-crd-code.sh
+${HACK_DIR}/update-generated-crd-code.sh --verify-only
 
 # ensure no changes to generated CRDs
 if ! git diff --exit-code pkg/generated/crds/crds.go >/dev/null; then


### PR DESCRIPTION
Reverts vmware-tanzu/velero#1913

The flag is needed to ensure CI fails if code generation differs from checked-in code: https://github.com/vmware-tanzu/velero/pull/1913#issuecomment-538588854