### PR TITLE
Move validation of plugins

### DIFF
--- a/pkg/cloudprovider/aws/object_store.go
+++ b/pkg/cloudprovider/aws/object_store.go
@@ -24,8 +24,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
@@ -35,6 +33,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
+	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
 )
 
 const (

--- a/pkg/cloudprovider/aws/object_store.go
+++ b/pkg/cloudprovider/aws/object_store.go
@@ -24,6 +24,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
@@ -33,8 +35,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-
-	"github.com/vmware-tanzu/velero/pkg/cloudprovider"
 )
 
 const (
@@ -80,7 +80,7 @@ func isValidSignatureVersion(signatureVersion string) bool {
 }
 
 func (o *ObjectStore) Init(config map[string]string) error {
-	if err := cloudprovider.ValidateObjectStoreConfigKeys(config,
+	if err := framework.ValidateObjectStoreConfigKeys(config,
 		regionKey,
 		s3URLKey,
 		publicURLKey,

--- a/pkg/cloudprovider/aws/volume_snapshotter.go
+++ b/pkg/cloudprovider/aws/volume_snapshotter.go
@@ -22,6 +22,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -32,8 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-
-	"github.com/vmware-tanzu/velero/pkg/cloudprovider"
 )
 
 const regionKey = "region"
@@ -68,7 +68,7 @@ func NewVolumeSnapshotter(logger logrus.FieldLogger) *VolumeSnapshotter {
 }
 
 func (b *VolumeSnapshotter) Init(config map[string]string) error {
-	if err := cloudprovider.ValidateVolumeSnapshotterConfigKeys(config, regionKey, credentialProfileKey); err != nil {
+	if err := framework.ValidateVolumeSnapshotterConfigKeys(config, regionKey, credentialProfileKey); err != nil {
 		return err
 	}
 

--- a/pkg/cloudprovider/aws/volume_snapshotter.go
+++ b/pkg/cloudprovider/aws/volume_snapshotter.go
@@ -22,8 +22,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -34,6 +32,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
 )
 
 const regionKey = "region"

--- a/pkg/cloudprovider/azure/object_store.go
+++ b/pkg/cloudprovider/azure/object_store.go
@@ -23,14 +23,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
-
 	storagemgmt "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2018-02-01/storage"
 	"github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
+	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
 )
 
 const (

--- a/pkg/cloudprovider/azure/object_store.go
+++ b/pkg/cloudprovider/azure/object_store.go
@@ -23,14 +23,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
+
 	storagemgmt "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2018-02-01/storage"
 	"github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-
-	"github.com/vmware-tanzu/velero/pkg/cloudprovider"
 )
 
 const (
@@ -208,7 +208,7 @@ func mapLookup(data map[string]string) func(string) string {
 }
 
 func (o *ObjectStore) Init(config map[string]string) error {
-	if err := cloudprovider.ValidateObjectStoreConfigKeys(config,
+	if err := framework.ValidateObjectStoreConfigKeys(config,
 		resourceGroupConfigKey,
 		storageAccountConfigKey,
 		subscriptionIdConfigKey,

--- a/pkg/cloudprovider/azure/volume_snapshotter.go
+++ b/pkg/cloudprovider/azure/volume_snapshotter.go
@@ -25,8 +25,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
-
 	disk "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/pkg/errors"
@@ -35,6 +33,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
 )
 
 const (

--- a/pkg/cloudprovider/azure/volume_snapshotter.go
+++ b/pkg/cloudprovider/azure/volume_snapshotter.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
+
 	disk "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/pkg/errors"
@@ -33,8 +35,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-
-	"github.com/vmware-tanzu/velero/pkg/cloudprovider"
 )
 
 const (
@@ -72,7 +72,7 @@ func NewVolumeSnapshotter(logger logrus.FieldLogger) *VolumeSnapshotter {
 }
 
 func (b *VolumeSnapshotter) Init(config map[string]string) error {
-	if err := cloudprovider.ValidateVolumeSnapshotterConfigKeys(config, resourceGroupConfigKey, apiTimeoutConfigKey, subscriptionIdConfigKey); err != nil {
+	if err := framework.ValidateVolumeSnapshotterConfigKeys(config, resourceGroupConfigKey, apiTimeoutConfigKey, subscriptionIdConfigKey); err != nil {
 		return err
 	}
 

--- a/pkg/cloudprovider/gcp/object_store.go
+++ b/pkg/cloudprovider/gcp/object_store.go
@@ -22,8 +22,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
-
 	"cloud.google.com/go/storage"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -31,6 +29,8 @@ import (
 	"google.golang.org/api/iamcredentials/v1"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
+
+	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
 )
 
 const (

--- a/pkg/cloudprovider/gcp/object_store.go
+++ b/pkg/cloudprovider/gcp/object_store.go
@@ -22,6 +22,8 @@ import (
 	"io"
 	"time"
 
+	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
+
 	"cloud.google.com/go/storage"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -29,8 +31,6 @@ import (
 	"google.golang.org/api/iamcredentials/v1"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
-
-	"github.com/vmware-tanzu/velero/pkg/cloudprovider"
 )
 
 const (
@@ -76,7 +76,7 @@ func NewObjectStore(logger logrus.FieldLogger) *ObjectStore {
 }
 
 func (o *ObjectStore) Init(config map[string]string) error {
-	if err := cloudprovider.ValidateObjectStoreConfigKeys(config, kmsKeyNameConfigKey, serviceAccountConfig); err != nil {
+	if err := framework.ValidateObjectStoreConfigKeys(config, kmsKeyNameConfigKey, serviceAccountConfig); err != nil {
 		return err
 	}
 	// Find default token source to extract the GoogleAccessID

--- a/pkg/cloudprovider/gcp/volume_snapshotter.go
+++ b/pkg/cloudprovider/gcp/volume_snapshotter.go
@@ -21,6 +21,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
+
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
@@ -31,8 +33,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-
-	"github.com/vmware-tanzu/velero/pkg/cloudprovider"
 )
 
 const (
@@ -54,7 +54,7 @@ func NewVolumeSnapshotter(logger logrus.FieldLogger) *VolumeSnapshotter {
 }
 
 func (b *VolumeSnapshotter) Init(config map[string]string) error {
-	if err := cloudprovider.ValidateVolumeSnapshotterConfigKeys(config, snapshotLocationKey, projectKey); err != nil {
+	if err := framework.ValidateVolumeSnapshotterConfigKeys(config, snapshotLocationKey, projectKey); err != nil {
 		return err
 	}
 

--- a/pkg/cloudprovider/gcp/volume_snapshotter.go
+++ b/pkg/cloudprovider/gcp/volume_snapshotter.go
@@ -21,8 +21,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
-
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
@@ -33,6 +31,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
 )
 
 const (

--- a/pkg/plugin/framework/validation.go
+++ b/pkg/plugin/framework/validation.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloudprovider
+package framework
 
 import (
 	"github.com/pkg/errors"

--- a/pkg/plugin/framework/validation_test.go
+++ b/pkg/plugin/framework/validation_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloudprovider
+package framework
 
 import (
 	"testing"


### PR DESCRIPTION
This validation will need to be used by external plugins, so it needs to be accessible. Example (wip PR): https://github.com/vmware-tanzu/velero/pull/1890/commits/f2b5b7f4a5859ece9efc00f629a68f8f9a956e70#diff-f16fab2b9b32d6ad9fb432403f434e2d

Signed-off-by: Carlisia <carlisia@vmware.com>