### PR TITLE
Add support for private registry with custom port in restic-helper image

### DIFF
--- a/changelogs/unreleased/1999-cognoz
+++ b/changelogs/unreleased/1999-cognoz
@@ -1,0 +1,1 @@
+add support for a private registry with a custom port in a restic-helper image

--- a/pkg/restore/restic_restore_action.go
+++ b/pkg/restore/restic_restore_action.go
@@ -166,6 +166,10 @@ func getImage(log logrus.FieldLogger, config *corev1.ConfigMap) string {
 		// tagged image name
 		log.Debugf("Plugin config contains image name with tag")
 		return image
+	case len(parts) == 3:
+		// tagged image name with registry port definition
+		log.Debugf("Plugin config contains image name with tag and custom registry port")
+		return image
 	default:
 		// unrecognized
 		log.Warnf("Plugin config contains unparseable image name")

--- a/pkg/restore/restic_restore_action.go
+++ b/pkg/restore/restic_restore_action.go
@@ -158,21 +158,21 @@ func getImage(log logrus.FieldLogger, config *corev1.ConfigMap) string {
 
 	parts := strings.Split(image, "/")
 
-        if len(parts) == 1 {
-                // Image supplied without registry part
-                log.Debugf("Plugin config contains image name without registry name. Return defaultImageBase")
-                return initContainerImage(defaultImageBase)
-        }
+	if len(parts) == 1 {
+		// Image supplied without registry part
+		log.Debugf("Plugin config contains image name without registry name. Return defaultImageBase")
+		return initContainerImage(defaultImageBase)
+	}
 
-        if !(strings.Contains(parts[len(parts)-1], ":")) {
-                // tag-less image name: add tag
+	if !(strings.Contains(parts[len(parts)-1], ":")) {
+		// tag-less image name: add tag
 		log.Debugf("Plugin config contains image name without tag. Adding tag.")
 		return initContainerImage(image)
-        } else {
-                // tagged image name
-                log.Debugf("Plugin config contains image name with tag")
-                return image
-        }
+	} else {
+		// tagged image name
+		log.Debugf("Plugin config contains image name with tag")
+		return image
+	}
 }
 
 // getResourceRequests extracts the CPU and memory requests from a ConfigMap.

--- a/pkg/restore/restic_restore_action.go
+++ b/pkg/restore/restic_restore_action.go
@@ -156,25 +156,23 @@ func getImage(log logrus.FieldLogger, config *corev1.ConfigMap) string {
 
 	log = log.WithField("image", image)
 
-	parts := strings.Split(image, ":")
-	switch {
-	case len(parts) == 1:
-		// tag-less image name: add tag
+	parts := strings.Split(image, "/")
+
+        if len(parts) == 1 {
+                // Image supplied without registry part
+                log.Debugf("Plugin config contains image name without registry name. Return defaultImageBase")
+                return initContainerImage(defaultImageBase)
+        }
+
+        if !(strings.Contains(parts[len(parts)-1], ":")) {
+                // tag-less image name: add tag
 		log.Debugf("Plugin config contains image name without tag. Adding tag.")
 		return initContainerImage(image)
-	case len(parts) == 2:
-		// tagged image name
-		log.Debugf("Plugin config contains image name with tag")
-		return image
-	case len(parts) == 3:
-		// tagged image name with registry port definition
-		log.Debugf("Plugin config contains image name with tag and custom registry port")
-		return image
-	default:
-		// unrecognized
-		log.Warnf("Plugin config contains unparseable image name")
-		return initContainerImage(defaultImageBase)
-	}
+        } else {
+                // tagged image name
+                log.Debugf("Plugin config contains image name with tag")
+                return image
+        }
 }
 
 // getResourceRequests extracts the CPU and memory requests from a ConfigMap.

--- a/pkg/restore/restic_restore_action_test.go
+++ b/pkg/restore/restic_restore_action_test.go
@@ -70,7 +70,7 @@ func TestGetImage(t *testing.T) {
 		},
 		{
 			name:      "config map with invalid data in 'image' key returns default image with buildinfo.Version as tag",
-			configMap: configMapWithData("image", "not:valid:image"),
+			configMap: configMapWithData("image", "not:valid:image:name"),
 			want:      fmt.Sprintf("%s:%s", defaultImageBase, buildinfo.Version),
 		},
 		{

--- a/pkg/restore/restic_restore_action_test.go
+++ b/pkg/restore/restic_restore_action_test.go
@@ -69,8 +69,8 @@ func TestGetImage(t *testing.T) {
 			want:      fmt.Sprintf("%s:%s", defaultImageBase, buildinfo.Version),
 		},
 		{
-			name:      "config map with invalid data in 'image' key returns default image with buildinfo.Version as tag",
-			configMap: configMapWithData("image", "not:valid:image:name"),
+			name:      "config map without '/' in image name returns default image with buildinfo.Version as tag",
+			configMap: configMapWithData("image", "my-image"),
 			want:      fmt.Sprintf("%s:%s", defaultImageBase, buildinfo.Version),
 		},
 		{
@@ -79,9 +79,19 @@ func TestGetImage(t *testing.T) {
 			want:      fmt.Sprintf("%s:%s", "myregistry.io/my-image", buildinfo.Version),
 		},
 		{
+			name:      "config map with untagged image and custom registry port with ':' returns image with buildinfo.Version as tag",
+			configMap: configMapWithData("image", "myregistry.io:34567/my-image"),
+			want:      fmt.Sprintf("%s:%s", "myregistry.io:34567/my-image", buildinfo.Version),
+		},
+		{
 			name:      "config map with tagged image returns tagged image",
 			configMap: configMapWithData("image", "myregistry.io/my-image:my-tag"),
 			want:      "myregistry.io/my-image:my-tag",
+		},
+		{
+			name:      "config map with tagged image and custom registry port with ':' returns tagged image",
+			configMap: configMapWithData("image", "myregistry.io:34567/my-image:my-tag"),
+			want:      "myregistry.io:34567/my-image:my-tag",
 		},
 	}
 


### PR DESCRIPTION
Closes #1972 

example of image definition with custom registry port in CM: 
```yaml
data:
  image: nexus-registry.domain.domain:18116/heptio-images/velero-restic-restore-helper:v1.1.0
```