### PR TITLE
ISSUE-1660 Use meta-data to populate region if no config value is inc…

### DIFF
--- a/changelogs/unreleased/2000-carthewd
+++ b/changelogs/unreleased/2000-carthewd
@@ -1,0 +1,1 @@
+enhancement: use EC2 metadata from the node running Velero to determine the AWS region if none is specified


### PR DESCRIPTION
Use EC2 metadata to lookup the region where velero is running if no region is defined in the config property. 

Fixes #1660  