### PR TITLE
Remove ref to exclude label in v1.1.0

### DIFF
--- a/site/_data/v1-1-0-toc.yml
+++ b/site/_data/v1-1-0-toc.yml
@@ -31,6 +31,8 @@ toc:
         url: /disaster-case
       - page: Cluster migration
         url: /migration-case
+      - page: Backup reference
+        url: /backup-reference
       - page: Restore reference
         url: /restore-reference
       - page: Run in any namespace

--- a/site/_data/v1-1-0-toc.yml
+++ b/site/_data/v1-1-0-toc.yml
@@ -31,8 +31,6 @@ toc:
         url: /disaster-case
       - page: Cluster migration
         url: /migration-case
-      - page: Backup reference
-        url: /backup-reference
       - page: Restore reference
         url: /restore-reference
       - page: Run in any namespace

--- a/site/docs/v1.1.0/backup-reference.md
+++ b/site/docs/v1.1.0/backup-reference.md
@@ -1,9 +1,0 @@
-# Backup Reference
-
-## Exclude Specific Items from Backup
-
-It is possible to exclude individual items from being backed up, even if they match the resource/namespace/label selectors defined in the backup spec. To do this, label the item as follows:
-
-```bash
-kubectl label -n <ITEM_NAMESPACE> <RESOURCE>/<NAME> velero.io/exclude-from-backup=true
-```

--- a/site/docs/v1.1.0/backup-reference.md
+++ b/site/docs/v1.1.0/backup-reference.md
@@ -1,0 +1,11 @@
+# Backup Reference
+
+## Exclude Specific Items from Backup
+
+It is possible to exclude individual items from being backed up, even if they match the resource/namespace/label selectors defined in the backup spec. To do this, label the item as follows:
+
+```bash
+kubectl label -n <ITEM_NAMESPACE> <RESOURCE>/<NAME> velero.io/exclude-from-backup=true
+```
+
+Please note, in v1.1.0 the label will not be honoured for "additional items" eg; PVCs/PVs that are in use by a pod that is being backed up. If this scenario is required, consider upgrading to v1.2.0 or later.


### PR DESCRIPTION
In reference to https://github.com/vmware-tanzu/velero/issues/2015 - v1.1.0 does not support the use of the exclude via label for ".additional items"