### PR TITLE
Add GOPROXY for go module operations

### DIFF
--- a/hack/build-image/Dockerfile
+++ b/hack/build-image/Dockerfile
@@ -19,6 +19,8 @@ WORKDIR /go/src/k8s.io
 RUN git config --global advice.detachedHead false
 RUN git clone -b kubernetes-1.15.3 https://github.com/kubernetes/code-generator
 RUN git clone -b kubernetes-1.15.3 https://github.com/kubernetes/apimachinery 
+# Use a proxy for go modules to reduce the likelihood of various hosts being down and breaking the build
+ENV GOPROXY=https://proxy.golang.org
 # vendor code-generator go modules to be compatible with pre-1.15
 WORKDIR  /go/src/k8s.io/code-generator
 # Don't use ENV here because we don't want to disable modules for subsequent commands


### PR DESCRIPTION
Without a GOPROXY, go modules are fetched from their respective hosts,
which increases the likelihood that any given host might be unavailable
and break builds.

Fixes #2036

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>