### PR TITLE
add velero install --crds-only to easily update CRDs

### DIFF
--- a/pkg/cmd/cli/install/install.go
+++ b/pkg/cmd/cli/install/install.go
@@ -24,11 +24,10 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/client"

--- a/pkg/cmd/cli/install/install.go
+++ b/pkg/cmd/cli/install/install.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -66,6 +68,7 @@ type InstallOptions struct {
 	DefaultResticMaintenanceFrequency time.Duration
 	Plugins                           flag.StringArray
 	NoDefaultBackupLocation           bool
+	CRDsOnly                          bool
 }
 
 // BindFlags adds command line values to the options struct.
@@ -96,6 +99,7 @@ func (o *InstallOptions) BindFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&o.Wait, "wait", o.Wait, "wait for Velero deployment to be ready. Optional.")
 	flags.DurationVar(&o.DefaultResticMaintenanceFrequency, "default-restic-prune-frequency", o.DefaultResticMaintenanceFrequency, "how often 'restic prune' is run for restic repositories by default. Optional.")
 	flags.Var(&o.Plugins, "plugins", "Plugin container images to install into the Velero Deployment")
+	flags.BoolVar(&o.CRDsOnly, "crds-only", o.CRDsOnly, "only generate CustomResourceDefinition resources. Useful for updating CRDs for an existing Velero install.")
 }
 
 // NewInstallOptions instantiates a new, default InstallOptions struct.
@@ -118,6 +122,7 @@ func NewInstallOptions() *InstallOptions {
 		// Default to creating a VSL unless we're told otherwise
 		UseVolumeSnapshots:      true,
 		NoDefaultBackupLocation: false,
+		CRDsOnly:                false,
 	}
 }
 
@@ -222,14 +227,19 @@ This is useful as a starting point for more customized installations.
 
 // Run executes a command in the context of the provided arguments.
 func (o *InstallOptions) Run(c *cobra.Command, f client.Factory) error {
-	vo, err := o.AsVeleroOptions()
-	if err != nil {
-		return err
-	}
+	var resources *unstructured.UnstructuredList
+	if o.CRDsOnly {
+		resources = install.AllCRDs()
+	} else {
+		vo, err := o.AsVeleroOptions()
+		if err != nil {
+			return err
+		}
 
-	resources, err := install.AllResources(vo)
-	if err != nil {
-		return err
+		resources, err = install.AllResources(vo)
+		if err != nil {
+			return err
+		}
 	}
 
 	if _, err := output.PrintWithFormat(c, resources); err != nil {
@@ -287,6 +297,11 @@ func (o *InstallOptions) Complete(args []string, f client.Factory) error {
 func (o *InstallOptions) Validate(c *cobra.Command, args []string, f client.Factory) error {
 	if err := output.ValidateFlags(c); err != nil {
 		return err
+	}
+
+	// If we're only installing CRDs, we can skip the rest of the validation.
+	if o.CRDsOnly {
+		return nil
 	}
 
 	// Our main 3 providers don't support bucket names starting with a dash, and a bucket name starting with one

--- a/pkg/install/resources.go
+++ b/pkg/install/resources.go
@@ -219,9 +219,7 @@ type VeleroOptions struct {
 	NoDefaultBackupLocation           bool
 }
 
-// AllResources returns a list of all resources necessary to install Velero, in the appropriate order, into a Kubernetes cluster.
-// Items are unstructured, since there are different data types returned.
-func AllResources(o *VeleroOptions) (*unstructured.UnstructuredList, error) {
+func AllCRDs() *unstructured.UnstructuredList {
 	resources := new(unstructured.UnstructuredList)
 	// Set the GVK so that the serialization framework outputs the list properly
 	resources.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "List"})
@@ -230,6 +228,14 @@ func AllResources(o *VeleroOptions) (*unstructured.UnstructuredList, error) {
 		crd.SetLabels(labels())
 		appendUnstructured(resources, crd)
 	}
+
+	return resources
+}
+
+// AllResources returns a list of all resources necessary to install Velero, in the appropriate order, into a Kubernetes cluster.
+// Items are unstructured, since there are different data types returned.
+func AllResources(o *VeleroOptions) (*unstructured.UnstructuredList, error) {
+	resources := AllCRDs()
 
 	ns := Namespace(o.Namespace)
 	appendUnstructured(resources, ns)


### PR DESCRIPTION
closes #2034 

This PR adds a `--crds-only` flag to `velero install`, that enables users to only output CRDs that they can then `kubectl apply` to update an existing velero install.

```
> ./_output/bin/darwin/amd64/velero install --crds-only --dry-run -o yaml | kubectl apply -f -
Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
customresourcedefinition.apiextensions.k8s.io/backups.velero.io configured
Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
customresourcedefinition.apiextensions.k8s.io/backupstoragelocations.velero.io configured
Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
customresourcedefinition.apiextensions.k8s.io/deletebackuprequests.velero.io configured
Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
customresourcedefinition.apiextensions.k8s.io/downloadrequests.velero.io configured
Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
customresourcedefinition.apiextensions.k8s.io/podvolumebackups.velero.io configured
Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
customresourcedefinition.apiextensions.k8s.io/podvolumerestores.velero.io configured
Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
customresourcedefinition.apiextensions.k8s.io/resticrepositories.velero.io configured
Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
customresourcedefinition.apiextensions.k8s.io/restores.velero.io configured
Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
customresourcedefinition.apiextensions.k8s.io/schedules.velero.io configured
Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
customresourcedefinition.apiextensions.k8s.io/serverstatusrequests.velero.io configured
Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
customresourcedefinition.apiextensions.k8s.io/volumesnapshotlocations.velero.io configured
```

Signed-off-by: Adnan Abdulhussein <aadnan@vmware.com>