### PR TITLE
run goreleaser.sh in container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,8 +215,27 @@ ci: all verify test
 changelog:
 	hack/changelog.sh
 
+# release builds a GitHub release using goreleaser within the build container.
+#
+# To dry-run the release, which will build the binaries/artifacts locally but
+# will *not* create a GitHub release:
+#		GITHUB_TOKEN=an-invalid-token-so-you-dont-accidentally-push-release \
+#		RELEASE_NOTES_FILE=changelogs/CHANGELOG-1.2.md \
+#		PUBLISH=false \
+#		make release
+#
+# To run the release, which will publish a *DRAFT* GitHub release in github.com/vmware-tanzu/velero 
+# (you still need to review/publish the GitHub release manually):
+#		GITHUB_TOKEN=your-github-token \ 
+#		RELEASE_NOTES_FILE=changelogs/CHANGELOG-1.2.md \
+#		PUBLISH=true \
+#		make release
 release:
-	hack/goreleaser.sh
+	$(MAKE) shell CMD="-c '\
+		GITHUB_TOKEN=$(GITHUB_TOKEN) \
+		RELEASE_NOTES_FILE=$(RELEASE_NOTES_FILE) \
+		PUBLISH=$(PUBLISH) \
+		./hack/goreleaser.sh'"
 
 serve-docs:
 	docker run \

--- a/hack/build-image/Dockerfile
+++ b/hack/build-image/Dockerfile
@@ -46,3 +46,7 @@ WORKDIR /go/src/github.com/golang
 RUN git clone -b v1.0.0 https://github.com/golang/protobuf
 WORKDIR /go/src/github.com/golang/protobuf
 RUN go install ./protoc-gen-go
+RUN wget --quiet https://github.com/goreleaser/goreleaser/releases/download/v0.120.8/goreleaser_Linux_x86_64.tar.gz && \
+    tar xvf goreleaser_Linux_x86_64.tar.gz && \
+    mv goreleaser /usr/bin/goreleaser && \
+    chmod +x /usr/bin/goreleaser


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

closes #1383 

This PR moves running `goreleaser` into the existing build container image.  `goreleaser` generates GitHub releases, including building all of the `velero` binaries that get published as part of the GitHub release.

Previously, `goreleaser` would run on your (my) laptop, which was not ideal. Now, it runs in the same build container image that we use for building the binaries that go into the server container images.

I tested this out all the way through publishing a draft GH release (I've since deleted it).