### PR TITLE
bug fix: deep-copy backup's labels for snapshot tags

### DIFF
--- a/changelogs/unreleased/2075-skriss
+++ b/changelogs/unreleased/2075-skriss
@@ -1,0 +1,1 @@
+bug fix: deep-copy backup's labels when constructing snapshot tags, so the PV name isn't added as a label to the backup

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -456,9 +456,10 @@ func (ib *defaultItemBackupper) takePVSnapshot(obj runtime.Unstructured, log log
 
 	log = log.WithField("volumeID", volumeID)
 
-	tags := ib.backupRequest.GetLabels()
-	if tags == nil {
-		tags = map[string]string{}
+	// create tags from the backup's labels
+	tags := map[string]string{}
+	for k, v := range ib.backupRequest.GetLabels() {
+		tags[k] = v
 	}
 	tags["velero.io/backup"] = ib.backupRequest.Name
 	tags["velero.io/pv"] = pv.Name


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

Closes #2074 

Still needs to be tested.