### PR TITLE
Support AWS_PROFILE for restic backups/restore operations

### DIFF
--- a/changelogs/unreleased/2096-dinesh
+++ b/changelogs/unreleased/2096-dinesh
@@ -1,0 +1,1 @@
+Enableing Velero to switch credentials (`AWS_PROFILE`) if multiple s3-compatible backupLocations are present

--- a/pkg/controller/pod_volume_backup_controller.go
+++ b/pkg/controller/pod_volume_backup_controller.go
@@ -227,7 +227,8 @@ func (c *podVolumeBackupController) processBackup(req *velerov1api.PodVolumeBack
 		req.Spec.Tags,
 	)
 
-	// if this is azure, set resticCmd.Env appropriately
+	// Running restic command might need additional provider specific environment variables. Based on the provider, we
+	// set resticCmd.Env appropriately (currently for Azure and S3 based backuplocations)
 	var env []string
 	if strings.HasPrefix(req.Spec.RepoIdentifier, "azure") {
 		if env, err = restic.AzureCmdEnv(c.backupLocationLister, req.Namespace, req.Spec.BackupStorageLocation); err != nil {

--- a/pkg/controller/pod_volume_backup_controller.go
+++ b/pkg/controller/pod_volume_backup_controller.go
@@ -234,6 +234,11 @@ func (c *podVolumeBackupController) processBackup(req *velerov1api.PodVolumeBack
 			return c.fail(req, errors.Wrap(err, "error setting restic cmd env").Error(), log)
 		}
 		resticCmd.Env = env
+	} else if strings.HasPrefix(req.Spec.RepoIdentifier, "s3") {
+		if env, err = restic.S3CmdEnv(c.backupLocationLister, req.Namespace, req.Spec.BackupStorageLocation); err != nil {
+			return c.fail(req, errors.Wrap(err, "error setting restic cmd env").Error(), log)
+		}
+		resticCmd.Env = env
 	}
 
 	// If this is a PVC, look for the most recent completed pod volume backup for it and get

--- a/pkg/controller/pod_volume_restore_controller.go
+++ b/pkg/controller/pod_volume_restore_controller.go
@@ -328,7 +328,8 @@ func (c *podVolumeRestoreController) restorePodVolume(req *velerov1api.PodVolume
 		volumePath,
 	)
 
-	// if this is azure, set resticCmd.Env appropriately
+	// Running restic command might need additional provider specific environment variables. Based on the provider, we
+	// set resticCmd.Env appropriately (currently for Azure and S3 based backuplocations)
 	if strings.HasPrefix(req.Spec.RepoIdentifier, "azure") {
 		env, err := restic.AzureCmdEnv(c.backupLocationLister, req.Namespace, req.Spec.BackupStorageLocation)
 		if err != nil {

--- a/pkg/controller/pod_volume_restore_controller.go
+++ b/pkg/controller/pod_volume_restore_controller.go
@@ -335,6 +335,12 @@ func (c *podVolumeRestoreController) restorePodVolume(req *velerov1api.PodVolume
 			return c.failRestore(req, errors.Wrap(err, "error setting restic cmd env").Error(), log)
 		}
 		resticCmd.Env = env
+	} else if strings.HasPrefix(req.Spec.RepoIdentifier, "s3") {
+		env, err := restic.S3CmdEnv(c.backupLocationLister, req.Namespace, req.Spec.BackupStorageLocation)
+		if err != nil {
+			return c.failRestore(req, errors.Wrap(err, "error setting restic cmd env").Error(), log)
+		}
+		resticCmd.Env = env
 	}
 
 	var stdout, stderr string

--- a/pkg/restic/aws.go
+++ b/pkg/restic/aws.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017, 2019 the Velero contributors.
+Copyright 2019 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/restic/aws.go
+++ b/pkg/restic/aws.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2017, 2019 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restic
+
+const (
+	// AWS specific environment variable
+	awsProfileEnvVar = "AWS_PROFILE"
+	awsProfileKey    = "profile"
+)
+
+// getS3ResticEnvVars gets the environment variables that restic
+// relies on (AWS_PROFILE) based on info in the provided object
+// storage location config map.
+func getS3ResticEnvVars(config map[string]string) (map[string]string, error) {
+	result := make(map[string]string)
+
+	if profile, ok := config[awsProfileKey]; ok {
+		result[awsProfileEnvVar] = profile
+	}
+
+	return result, nil
+}

--- a/pkg/restic/azure.go
+++ b/pkg/restic/azure.go
@@ -114,10 +114,10 @@ func mapLookup(data map[string]string) func(string) string {
 	}
 }
 
-// getResticEnvVars gets the environment variables that restic
+// getAzureResticEnvVars gets the environment variables that restic
 // relies on (AZURE_ACCOUNT_NAME and AZURE_ACCOUNT_KEY) based
 // on info in the provided object storage location config map.
-func getResticEnvVars(config map[string]string) (map[string]string, error) {
+func getAzureResticEnvVars(config map[string]string) (map[string]string, error) {
 	storageAccountKey, _, err := getStorageAccountKey(config)
 	if err != nil {
 		return nil, err

--- a/pkg/restic/common.go
+++ b/pkg/restic/common.go
@@ -228,13 +228,36 @@ func AzureCmdEnv(backupLocationLister velerov1listers.BackupStorageLocationListe
 		return nil, errors.Wrap(err, "error getting backup storage location")
 	}
 
-	azureVars, err := getResticEnvVars(loc.Spec.Config)
+	azureVars, err := getAzureResticEnvVars(loc.Spec.Config)
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting azure restic env vars")
 	}
 
 	env := os.Environ()
 	for k, v := range azureVars {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return env, nil
+}
+
+// S3CmdEnv returns a list of environment variables (in the format var=val) that
+// should be used when running a restic command for an Azure backend. This list is
+// the current environment, plus the AWS-specific variables restic needs, namely
+// a credential profile.
+func S3CmdEnv(backupLocationLister velerov1listers.BackupStorageLocationLister, namespace, backupLocation string) ([]string, error) {
+	loc, err := backupLocationLister.BackupStorageLocations(namespace).Get(backupLocation)
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting backup storage location")
+	}
+
+	awsVars, err := getS3ResticEnvVars(loc.Spec.Config)
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting aws restic env vars")
+	}
+
+	env := os.Environ()
+	for k, v := range awsVars {
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}
 

--- a/pkg/restic/common.go
+++ b/pkg/restic/common.go
@@ -242,7 +242,7 @@ func AzureCmdEnv(backupLocationLister velerov1listers.BackupStorageLocationListe
 }
 
 // S3CmdEnv returns a list of environment variables (in the format var=val) that
-// should be used when running a restic command for an Azure backend. This list is
+// should be used when running a restic command for an S3 backend. This list is
 // the current environment, plus the AWS-specific variables restic needs, namely
 // a credential profile.
 func S3CmdEnv(backupLocationLister velerov1listers.BackupStorageLocationLister, namespace, backupLocation string) ([]string, error) {

--- a/pkg/restic/repository_manager.go
+++ b/pkg/restic/repository_manager.go
@@ -254,6 +254,16 @@ func (rm *repositoryManager) exec(cmd *Command, backupLocation string) error {
 			return err
 		}
 		cmd.Env = env
+	} else if strings.HasPrefix(cmd.RepoIdentifier, "s3") {
+		if !cache.WaitForCacheSync(rm.ctx.Done(), rm.backupLocationInformerSynced) {
+			return errors.New("timed out waiting for cache to sync")
+		}
+
+		env, err := S3CmdEnv(rm.backupLocationLister, rm.namespace, backupLocation)
+		if err != nil {
+			return err
+		}
+		cmd.Env = env
 	}
 
 	stdout, stderr, err := veleroexec.RunCommand(cmd.Cmd())


### PR DESCRIPTION
Fixes #2033 

It enables Velero to switch credentials if multiple s3-compatible backupLocations are present.
