### PR TITLE
bug fix: don't restore cluster-scoped resources by default when restoring specific namespaces

### DIFF
--- a/changelogs/unreleased/2118-skriss
+++ b/changelogs/unreleased/2118-skriss
@@ -1,0 +1,1 @@
+bug fix: don't restore cluster-scoped resources when restoring specific namespaces and IncludeClusterResources is nil

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -663,6 +663,11 @@ func (ctx *context) restoreResource(resource, targetNamespace, originalNamespace
 		return warnings, errs
 	}
 
+	if targetNamespace == "" && !boolptr.IsSetToTrue(ctx.restore.Spec.IncludeClusterResources) && !ctx.namespaceIncludesExcludes.IncludeEverything() {
+		ctx.log.Infof("Skipping resource %s because it's cluster-scoped and only specific namespaces are included in the restore", resource)
+		return warnings, errs
+	}
+
 	if targetNamespace != "" {
 		ctx.log.Infof("Restoring resource '%s' into namespace '%s'", resource, targetNamespace)
 	} else {

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -1408,7 +1408,7 @@ func TestRestoreActionAdditionalItems(t *testing.T) {
 			},
 		},
 		{
-			name:    "when using a restore namespace filter, additional items that are cluster-scoped are restored",
+			name:    "when using a restore namespace filter, additional items that are cluster-scoped are restored when IncludeClusterResources=nil",
 			restore: defaultRestore().IncludedNamespaces("ns-1").Result(),
 			backup:  defaultBackup().Result(),
 			tarball: newTarWriter(t).
@@ -1434,8 +1434,8 @@ func TestRestoreActionAdditionalItems(t *testing.T) {
 			},
 		},
 		{
-			name:    "when using a restore resource filter, additional items that are non-included resources are not restored",
-			restore: defaultRestore().IncludedResources("pods").Result(),
+			name:    "additional items that are cluster-scoped are not restored when IncludeClusterResources=false",
+			restore: defaultRestore().IncludeClusterResources(false).Result(),
 			backup:  defaultBackup().Result(),
 			tarball: newTarWriter(t).
 				addItems("pods", builder.ForPod("ns-1", "pod-1").Result()).
@@ -1460,8 +1460,8 @@ func TestRestoreActionAdditionalItems(t *testing.T) {
 			},
 		},
 		{
-			name:    "when IncludeClusterResources=false, additional items that are cluster-scoped are not restored",
-			restore: defaultRestore().IncludeClusterResources(false).Result(),
+			name:    "when using a restore resource filter, additional items that are non-included resources are not restored",
+			restore: defaultRestore().IncludedResources("pods").Result(),
 			backup:  defaultBackup().Result(),
 			tarball: newTarWriter(t).
 				addItems("pods", builder.ForPod("ns-1", "pod-1").Result()).

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -311,6 +311,36 @@ func TestRestoreResourceFiltering(t *testing.T) {
 			want: map[*test.APIResource][]string{
 				test.Pods():        {"ns-1/pod-1"},
 				test.Deployments(): {"ns-1/deploy-1"},
+				test.PVs():         {},
+			},
+		},
+		{
+			name:    "should not include cluster-scoped resources if restoring subset of namespaces and IncludeClusterResources=nil",
+			restore: defaultRestore().IncludedNamespaces("ns-1").Result(),
+			backup:  defaultBackup().Result(),
+			tarball: newTarWriter(t).
+				addItems("pods",
+					builder.ForPod("ns-1", "pod-1").Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+				).
+				addItems("deployments.apps",
+					builder.ForDeployment("ns-1", "deploy-1").Result(),
+					builder.ForDeployment("ns-2", "deploy-2").Result(),
+				).
+				addItems("persistentvolumes",
+					builder.ForPersistentVolume("pv-1").Result(),
+					builder.ForPersistentVolume("pv-2").Result(),
+				).
+				done(),
+			apiResources: []*test.APIResource{
+				test.Pods(),
+				test.Deployments(),
+				test.PVs(),
+			},
+			want: map[*test.APIResource][]string{
+				test.Pods():        {"ns-1/pod-1"},
+				test.Deployments(): {"ns-1/deploy-1"},
+				test.PVs():         {},
 			},
 		},
 		{


### PR DESCRIPTION
Closes #1914 

Units are passing but I want to make sure we have adequate coverage around this combo of params before merging.