### PR TITLE
add replicasets.apps to prioritized restore resources

### DIFF
--- a/changelogs/unreleased/2120-skriss
+++ b/changelogs/unreleased/2120-skriss
@@ -1,0 +1,1 @@
+bug fix: restore both `replicasets.apps` *and* `replicasets.extensions` before `deployments`

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -450,6 +450,9 @@ func (s *server) validateBackupStorageLocations() error {
 // - Limit ranges go before pods or controllers so pods can use them.
 // - Pods go before controllers so they can be explicitly restored and potentially
 //	 have restic restores run before controllers adopt the pods.
+// - Replica sets go before deployments/other controllers so they can be explicitly
+//	 restored and be adopted. Restore from both the 'apps' and 'extensions' API group,
+//   in that order, since they existed in both prior to v1.16.
 // - Custom Resource Definitions come before Custom Resource so that they can be
 //   restored with their corresponding CRD.
 var defaultRestorePriorities = []string{
@@ -462,7 +465,10 @@ var defaultRestorePriorities = []string{
 	"serviceaccounts",
 	"limitranges",
 	"pods",
-	"replicaset",
+	"replicasets.apps",
+	// TODO(sk): delete the following line once we no longer support Kubernetes
+	// versions prior to v1.16.
+	"replicasets.extensions",
 	"customresourcedefinitions",
 }
 


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

I noticed while testing #2118 that replica sets were not being restored prior to deployments like they were supposed to be.  It turns out that only `replicasets.extensions` was being prioritized, but not `replicasets.apps`. I updated the restore priorities list to include both, with a comment to drop `replicasets.extensions` once we no longer support Kube versions that serve it from that API group.  