### PR TITLE
Add error return to pvRenamer func

### DIFF
--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -2237,7 +2237,10 @@ func TestRestorePersistentVolumes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			h := newHarness(t)
 			h.restorer.resourcePriorities = []string{"persistentvolumes", "persistentvolumeclaims"}
-			h.restorer.pvRenamer = func(oldName string) string { return "renamed-" + oldName }
+			h.restorer.pvRenamer = func(oldName string) (string, error) {
+				renamed := "renamed-" + oldName
+				return renamed, nil
+			}
 
 			// set up the VolumeSnapshotLocation informer/lister and add test data to it
 			vslInformer := velerov1informers.NewSharedInformerFactory(h.VeleroClient, 0).Velero().V1().VolumeSnapshotLocations()


### PR DESCRIPTION
Migrate logic from NewUUID function into the pvRenamer function.

PR #2133 switched to a new NewUUID function that returns an error, but
the invocation of that function needs to happen within the pvRenamer
closure. Because the new function returns an error, the pvRenamer should
return the error, the signature needs to be changed and the return
checked.

Closes #2137