### PR TITLE
Fix for issue 2175, changed nobody:nobody to nobody:nogroup

### DIFF
--- a/Dockerfile-velero
+++ b/Dockerfile-velero
@@ -28,6 +28,6 @@ RUN apt-get update && \
 
 ADD /bin/linux/amd64/velero /velero
 
-USER nobody:nobody
+USER nobody:nogroup
 
 ENTRYPOINT ["/velero"]

--- a/Dockerfile-velero-ppc64le
+++ b/Dockerfile-velero-ppc64le
@@ -27,6 +27,6 @@ RUN apt-get update && \
 
 ADD /bin/linux/ppc64le/velero /velero
 
-USER nobody:nobody
+USER nobody:nogroup
 
 ENTRYPOINT ["/velero"]

--- a/Dockerfile-velero-restic-restore-helper
+++ b/Dockerfile-velero-restic-restore-helper
@@ -18,6 +18,6 @@ LABEL maintainer="Steve Kriss <krisss@vmware.com>"
 
 ADD /bin/linux/amd64/velero-restic-restore-helper .
 
-USER nobody:nobody
+USER nobody:nogroup
 
 ENTRYPOINT [ "/velero-restic-restore-helper" ]

--- a/Dockerfile-velero-restic-restore-helper-ppc64le
+++ b/Dockerfile-velero-restic-restore-helper-ppc64le
@@ -18,6 +18,6 @@ LABEL maintainer="Steve Kriss <krisss@vmware.com>"
 
 ADD /bin/linux/ppc64le/velero-restic-restore-helper .
 
-USER nobody:nobody
+USER nobody:nogroup
 
 ENTRYPOINT [ "/velero-restic-restore-helper" ]


### PR DESCRIPTION
Fix for PR 2715, changed container user nobody:nobody to nobody:nogroup to be correct for Debian based image (for some reason, basic Kubernetes is able to run a Debian based container with nobody:nobody but docker run and VMware WCP fail which should be expected behavior)

closes #2175 