### PR TITLE
Fix restore issues for CRD v1 on Kubernetes v1.16 clusters

### DIFF
--- a/changelogs/unreleased/2197-nrb
+++ b/changelogs/unreleased/2197-nrb
@@ -1,0 +1,1 @@
+When restoring a v1 CRD with PreserveUnknownFields = True, make sure that the preservation behavior is maintained by copying the flag into the Open API V3 schema, but update the flag so as to allow the Kubernetes API server to accept the CRD without error.

--- a/pkg/cmd/server/plugin/plugin.go
+++ b/pkg/cmd/server/plugin/plugin.go
@@ -48,6 +48,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 				RegisterRestoreItemAction("velero.io/change-storage-class", newChangeStorageClassRestoreItemAction(f)).
 				RegisterRestoreItemAction("velero.io/role-bindings", newRoleBindingItemAction).
 				RegisterRestoreItemAction("velero.io/cluster-role-bindings", newClusterRoleBindingItemAction).
+				RegisterRestoreItemAction("velero.io/crd-preserve-fields", newCRDV1PreserveUnknownFieldsItemAction).
 				Serve()
 		},
 	}
@@ -128,6 +129,10 @@ func newAddPVCFromPodRestoreItemAction(logger logrus.FieldLogger) (interface{}, 
 
 func newAddPVFromPVCRestoreItemAction(logger logrus.FieldLogger) (interface{}, error) {
 	return restore.NewAddPVFromPVCAction(logger), nil
+}
+
+func newCRDV1PreserveUnknownFieldsItemAction(logger logrus.FieldLogger) (interface{}, error) {
+	return restore.NewCRDV1PreserveUnknownFieldsAction(logger), nil
 }
 
 func newChangeStorageClassRestoreItemAction(f client.Factory) veleroplugin.HandlerInitializer {

--- a/pkg/restore/crd_v1_preserve_unknown_fields_action.go
+++ b/pkg/restore/crd_v1_preserve_unknown_fields_action.go
@@ -69,7 +69,7 @@ func (c *CRDV1PreserveUnknownFieldsAction) Execute(input *velero.RestoreItemActi
 	// The v1 API doesn't allow the PreserveUnknownFields value to be true, so make sure the schema flag is set instead
 	if crd.Spec.PreserveUnknownFields {
 		// First, change the top-level value since the Kubernetes API server on 1.16+ will generate errors otherwise.
-		log.Info("Set PreserveUnknownFields to False")
+		log.Debug("Set PreserveUnknownFields to False")
 		crd.Spec.PreserveUnknownFields = false
 
 		// Make sure all versions are set to preserve unknown fields
@@ -77,7 +77,7 @@ func (c *CRDV1PreserveUnknownFieldsAction) Execute(input *velero.RestoreItemActi
 			// Use the address, since the XPreserveUnknownFields value is undefined or true (false is not allowed)
 			preserve := true
 			v.Schema.OpenAPIV3Schema.XPreserveUnknownFields = &preserve
-			log.Infof("Set x-preserve-unknown-fields in Open API for schema version %s", v.Name)
+			log.Debugf("Set x-preserve-unknown-fields in Open API for schema version %s", v.Name)
 		}
 	}
 

--- a/pkg/restore/crd_v1_preserve_unknown_fields_action.go
+++ b/pkg/restore/crd_v1_preserve_unknown_fields_action.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2020 the Velero contributors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	 http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restore
+
+import (
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+)
+
+// The CRDV1PreserveUnknownFieldsAction will take a CRD and inspect it for the API version and the PreserveUnknownFields value.
+// If the API Version is 1 and the PreserveUnknownFields value is True, then the x-preserve-unknown-fields value in the OpenAPIV3 schema will be set to true in order to allow Kubernetes 1.16+ servers to accept the object.
+type CRDV1PreserveUnknownFieldsAction struct {
+	logger logrus.FieldLogger
+}
+
+func NewCRDV1PreserveUnknownFieldsAction(logger logrus.FieldLogger) *CRDV1PreserveUnknownFieldsAction {
+	return &CRDV1PreserveUnknownFieldsAction{logger: logger}
+}
+
+func (c *CRDV1PreserveUnknownFieldsAction) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+		IncludedResources: []string{"customresourcedefinition.apiextensions.k8s.io"},
+	}, nil
+}
+
+func (c *CRDV1PreserveUnknownFieldsAction) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
+	c.logger.Info("Executing CRDV1PreserveUnknownFieldsAction")
+
+	log := c.logger.WithField("plugin", "CRDV1PreserveUnknownFieldsAction")
+
+	version, _, err := unstructured.NestedString(input.Item.UnstructuredContent(), "apiVersion")
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get CRD version")
+	}
+
+	// We don't want to "fix" anything in beta CRDS at the moment, just v1 versions with preserveunknownfields = true
+	if version == "apiextensions.k8s.io/v1beta1" {
+		return &velero.RestoreItemActionExecuteOutput{
+			UpdatedItem: input.Item,
+		}, nil
+	}
+
+	var crd apiextv1.CustomResourceDefinition
+
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(input.Item.UnstructuredContent(), &crd); err != nil {
+		return nil, errors.Wrap(err, "unable to conver unstructured item to custom resource definition")
+	}
+
+	// The v1 API doesn't allow the PreserveUnknownFields value to be true, so make sure the schema flag is set instead
+	if crd.Spec.PreserveUnknownFields {
+		// First, change the top-level value since the Kubernetes API server on 1.16+ will generate errors otherwise.
+		log.Info("Set PreserveUnknowFields to False")
+		crd.Spec.PreserveUnknownFields = false
+
+		// Make sure all versions are set to preserve unknown fields
+		for _, v := range crd.Spec.Versions {
+			// Use the address, since the XPreserveUnknownFields value is undefined or true (false is not allowed)
+			preserve := true
+			v.Schema.OpenAPIV3Schema.XPreserveUnknownFields = &preserve
+			log.Infof("Set x-preserve-unknown-fields in Open API for schema version %s", v.Name)
+		}
+	}
+
+	res, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&crd)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to convert crd to runtime.Unstructured")
+	}
+
+	return &velero.RestoreItemActionExecuteOutput{
+		UpdatedItem: &unstructured.Unstructured{Object: res},
+	}, nil
+}

--- a/pkg/restore/crd_v1_preserve_unknown_fields_action.go
+++ b/pkg/restore/crd_v1_preserve_unknown_fields_action.go
@@ -53,8 +53,8 @@ func (c *CRDV1PreserveUnknownFieldsAction) Execute(input *velero.RestoreItemActi
 		return nil, errors.Wrap(err, "could not get CRD version")
 	}
 
-	// We don't want to "fix" anything in beta CRDS at the moment, just v1 versions with preserveunknownfields = true
-	if version == "apiextensions.k8s.io/v1beta1" {
+	// We don't want to "fix" anything in beta CRDs at the moment, just v1 versions with preserveunknownfields = true
+	if version != "apiextensions.k8s.io/v1" {
 		return &velero.RestoreItemActionExecuteOutput{
 			UpdatedItem: input.Item,
 		}, nil

--- a/pkg/restore/crd_v1_preserve_unknown_fields_action.go
+++ b/pkg/restore/crd_v1_preserve_unknown_fields_action.go
@@ -26,7 +26,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 )
 
-// The CRDV1PreserveUnknownFieldsAction will take a CRD and inspect it for the API version and the PreserveUnknownFields value.
+// CRDV1PreserveUnknownFieldsAction will take a CRD and inspect it for the API version and the PreserveUnknownFields value.
 // If the API Version is 1 and the PreserveUnknownFields value is True, then the x-preserve-unknown-fields value in the OpenAPIV3 schema will be set to True
 // and PreserveUnknownFields set to False in order to allow Kubernetes 1.16+ servers to accept the object.
 type CRDV1PreserveUnknownFieldsAction struct {

--- a/pkg/restore/crd_v1_preserve_unknown_fields_action.go
+++ b/pkg/restore/crd_v1_preserve_unknown_fields_action.go
@@ -27,7 +27,8 @@ import (
 )
 
 // The CRDV1PreserveUnknownFieldsAction will take a CRD and inspect it for the API version and the PreserveUnknownFields value.
-// If the API Version is 1 and the PreserveUnknownFields value is True, then the x-preserve-unknown-fields value in the OpenAPIV3 schema will be set to true in order to allow Kubernetes 1.16+ servers to accept the object.
+// If the API Version is 1 and the PreserveUnknownFields value is True, then the x-preserve-unknown-fields value in the OpenAPIV3 schema will be set to True
+// and PreserveUnknownFields set to False in order to allow Kubernetes 1.16+ servers to accept the object.
 type CRDV1PreserveUnknownFieldsAction struct {
 	logger logrus.FieldLogger
 }
@@ -62,13 +63,13 @@ func (c *CRDV1PreserveUnknownFieldsAction) Execute(input *velero.RestoreItemActi
 	var crd apiextv1.CustomResourceDefinition
 
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(input.Item.UnstructuredContent(), &crd); err != nil {
-		return nil, errors.Wrap(err, "unable to conver unstructured item to custom resource definition")
+		return nil, errors.Wrap(err, "unable to convert unstructured item to custom resource definition")
 	}
 
 	// The v1 API doesn't allow the PreserveUnknownFields value to be true, so make sure the schema flag is set instead
 	if crd.Spec.PreserveUnknownFields {
 		// First, change the top-level value since the Kubernetes API server on 1.16+ will generate errors otherwise.
-		log.Info("Set PreserveUnknowFields to False")
+		log.Info("Set PreserveUnknownFields to False")
 		crd.Spec.PreserveUnknownFields = false
 
 		// Make sure all versions are set to preserve unknown fields

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -378,8 +378,7 @@ type context struct {
 }
 
 type resourceClientKey struct {
-	resource  schema.GroupResource
-	version   schema.GroupVersion
+	resource  schema.GroupVersionResource
 	namespace string
 }
 
@@ -711,8 +710,7 @@ func (ctx *context) restoreResource(resource, targetNamespace, originalNamespace
 
 func (ctx *context) getResourceClient(groupResource schema.GroupResource, obj *unstructured.Unstructured, namespace string) (client.Dynamic, error) {
 	key := resourceClientKey{
-		resource:  groupResource,
-		version:   obj.GroupVersionKind().GroupVersion(),
+		resource:  groupResource.WithVersion(obj.GroupVersionKind().Version),
 		namespace: namespace,
 	}
 

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -379,6 +379,7 @@ type context struct {
 
 type resourceClientKey struct {
 	resource  schema.GroupResource
+	version   schema.GroupVersion
 	namespace string
 }
 
@@ -711,6 +712,7 @@ func (ctx *context) restoreResource(resource, targetNamespace, originalNamespace
 func (ctx *context) getResourceClient(groupResource schema.GroupResource, obj *unstructured.Unstructured, namespace string) (client.Dynamic, error) {
 	key := resourceClientKey{
 		resource:  groupResource,
+		version:   obj.GroupVersionKind().GroupVersion(),
 		namespace: namespace,
 	}
 


### PR DESCRIPTION
Partial fix for #2159 

Using this patch moves the restore issues beyond version mismatches, however if CRDs in the backup have `Spec.PreserveUnknownFields = True` in the backup, whether they were v1beta1 or v1, they will see these errors if only this change is applied.

```
Errors:
  Velero:     <none>
  Cluster:  error restoring customresourcedefinitions.apiextensions.k8s.io/deletebackuprequests.velero.io: CustomResourceDefinition.apiextensions.k8s.io "deletebackuprequests.velero.io" is invalid: spec.preserveUnknownFields: Invalid value: true: cannot set to true, set x-preserve-unknown-fields to true in spec.versions[*].schema instead
            error restoring customresourcedefinitions.apiextensions.k8s.io/downloadrequests.velero.io: CustomResourceDefinition.apiextensions.k8s.io "downloadrequests.velero.io" is invalid: spec.preserveUnknownFields: Invalid value: true: cannot set to true, set x-preserve-unknown-fields to true in spec.versions[*].schema instead
            error restoring customresourcedefinitions.apiextensions.k8s.io/podvolumebackups.velero.io: CustomResourceDefinition.apiextensions.k8s.io "podvolumebackups.velero.io" is invalid: spec.preserveUnknownFields: Invalid value: true: cannot set to true, set x-preserve-unknown-fields to true in spec.versions[*].schema instead
            error restoring customresourcedefinitions.apiextensions.k8s.io/podvolumerestores.velero.io: CustomResourceDefinition.apiextensions.k8s.io "podvolumerestores.velero.io" is invalid: spec.preserveUnknownFields: Invalid value: true: cannot set to true, set x-preserve-unknown-fields to true in spec.versions[*].schema instead
            error restoring customresourcedefinitions.apiextensions.k8s.io/resticrepositories.velero.io: CustomResourceDefinition.apiextensions.k8s.io "resticrepositories.velero.io" is invalid: spec.preserveUnknownFields: Invalid value: true: cannot set to true, set x-preserve-unknown-fields to true in spec.versions[*].schema instead
            error restoring customresourcedefinitions.apiextensions.k8s.io/restores.velero.io: CustomResourceDefinition.apiextensions.k8s.io "restores.velero.io" is invalid: spec.preserveUnknownFields: Invalid value: true: cannot set to true, set x-preserve-unknown-fields to true in spec.versions[*].schema instead
            error restoring customresourcedefinitions.apiextensions.k8s.io/schedules.velero.io: CustomResourceDefinition.apiextensions.k8s.io "schedules.velero.io" is invalid: spec.preserveUnknownFields: Invalid value: true: cannot set to true, set x-preserve-unknown-fields to true in spec.versions[*].schema instead
            error restoring customresourcedefinitions.apiextensions.k8s.io/serverstatusrequests.velero.io: CustomResourceDefinition.apiextensions.k8s.io "serverstatusrequests.velero.io" is invalid: spec.preserveUnknownFields: Invalid value: true: cannot set to true, set x-preserve-unknown-fields to true in spec.versions[*].schema instead
```

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>