### PR TITLE
Restrict file permissions for config file/dir

### DIFF
--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -69,11 +69,11 @@ func SaveConfig(config VeleroConfig) error {
 
 	// Try to make the directory in case it doesn't exist
 	dir := filepath.Dir(fileName)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0700); err != nil {
 		return errors.WithStack(err)
 	}
 
-	configFile, err := os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+	configFile, err := os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 	if err != nil {
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
Velero client config file should have restricted file permissions to be
read/write-able for the user that creates it--similiar to files like
`.ssh/id_rsa`

Ticket: #1758