### PR TITLE
remove schedule validation

### DIFF
--- a/changelogs/unreleased/2218-cpanato
+++ b/changelogs/unreleased/2218-cpanato
@@ -1,0 +1,1 @@
+remove the schedule validation and instead of checking the schedule because we might be in another cluster we check if a backup exist with the schedule name.

--- a/pkg/cmd/cli/restore/create.go
+++ b/pkg/cmd/cli/restore/create.go
@@ -171,11 +171,11 @@ func (o *CreateOptions) Validate(c *cobra.Command, args []string, f client.Facto
 			return err
 		}
 	case o.ScheduleName != "":
-		scheduleItems, err := o.client.VeleroV1().Backups(f.Namespace()).List(metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", api.ScheduleNameLabel, o.ScheduleName)})
+		backupItems, err := o.client.VeleroV1().Backups(f.Namespace()).List(metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", api.ScheduleNameLabel, o.ScheduleName)})
 		if err != nil {
 			return err
 		}
-		if len(scheduleItems.Items) == 0 {
+		if len(backupItems.Items) == 0 {
 			return errors.Errorf("No backups found for the schedule %s", o.ScheduleName)
 		}
 	}

--- a/pkg/cmd/cli/restore/create.go
+++ b/pkg/cmd/cli/restore/create.go
@@ -165,13 +165,8 @@ func (o *CreateOptions) Validate(c *cobra.Command, args []string, f client.Facto
 		return errors.New("Velero client is not set; unable to proceed")
 	}
 
-	switch {
-	case o.BackupName != "":
+	if o.BackupName != "" {
 		if _, err := o.client.VeleroV1().Backups(f.Namespace()).Get(o.BackupName, metav1.GetOptions{}); err != nil {
-			return err
-		}
-	case o.ScheduleName != "":
-		if _, err := o.client.VeleroV1().Schedules(f.Namespace()).Get(o.ScheduleName, metav1.GetOptions{}); err != nil {
 			return err
 		}
 	}

--- a/pkg/cmd/cli/restore/create.go
+++ b/pkg/cmd/cli/restore/create.go
@@ -165,9 +165,18 @@ func (o *CreateOptions) Validate(c *cobra.Command, args []string, f client.Facto
 		return errors.New("Velero client is not set; unable to proceed")
 	}
 
-	if o.BackupName != "" {
+	switch {
+	case o.BackupName != "":
 		if _, err := o.client.VeleroV1().Backups(f.Namespace()).Get(o.BackupName, metav1.GetOptions{}); err != nil {
 			return err
+		}
+	case o.ScheduleName != "":
+		scheduleItems, err := o.client.VeleroV1().Backups(f.Namespace()).List(metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", api.ScheduleNameLabel, o.ScheduleName)})
+		if err != nil {
+			return err
+		}
+		if len(scheduleItems.Items) == 0 {
+			return errors.Errorf("No backups found for the schedule %s", o.ScheduleName)
 		}
 	}
 


### PR DESCRIPTION
the backup can be created from a schedule in another cluster and when trying to restore that in a new cluster this schedule might not exist, so removing this validation

More context see:
 - fixes: https://github.com/vmware-tanzu/velero/issues/1168