### PR TITLE
🏃allow override of container image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ local-arch:
 endif
 
 MULTIARCH_IMAGE = $(REGISTRY)/$(BIN)
-IMAGE = $(REGISTRY)/$(BIN)-$(GOARCH)
+IMAGE ?= $(REGISTRY)/$(BIN)-$(GOARCH)
 
 # If you want to build all binaries, see the 'all-build' rule.
 # If you want to build all containers, see the 'all-containers' rule.


### PR DESCRIPTION
Signed-off-by: Ashish Amarnath <ashisham@vmware.com>

This should make building containers easy.
E.g.:
```
IMAGE=quay.io/ashish_amarnath/velero VERSION=20200130-00 make container
```