### PR TITLE
Fix restic backup volume snapshot to the second location failed

### DIFF
--- a/changelogs/unreleased/2244-jenting
+++ b/changelogs/unreleased/2244-jenting
@@ -1,0 +1,1 @@
+Bug fix: restic backup volume snapshot to the second location failed

--- a/pkg/controller/pod_volume_backup_controller.go
+++ b/pkg/controller/pod_volume_backup_controller.go
@@ -321,6 +321,10 @@ func getParentSnapshot(log logrus.FieldLogger, pvcUID, backupStorageLocation str
 		}
 
 		if backupStorageLocation != backup.Spec.BackupStorageLocation {
+			// Check the backup storage location is the same as spec in order to support backup to multiple backup-locations.
+			// Otherwise, there exists a case that backup volume snapshot to the second location would failed, since the founded
+			// parent ID is only valid for the first backup location, not the second backup location.
+			// Also, the second backup should not use the first backup parent ID since its for the first backup location only.
 			continue
 		}
 

--- a/pkg/controller/pod_volume_backup_controller.go
+++ b/pkg/controller/pod_volume_backup_controller.go
@@ -320,12 +320,11 @@ func getParentSnapshot(log logrus.FieldLogger, pvcUID, backupStorageLocation str
 			continue
 		}
 
-		if (mostRecentBackup == nil || backup.Status.StartTimestamp.After(mostRecentBackup.Status.StartTimestamp.Time)) &&
-			// Check the backup storage location is the same as spec in order to support backup to multiple backup-locations.
-			// Otherwise, there exist a case that backup volume snapshot to the second location would failed, since the founded
-			// parent ID is valid for the first backup location, not the second backup location.
-			// Also, the second backup should not use first backup parent ID since eachthe parent ID is for the first backup location only.
-			(backupStorageLocation == backup.Spec.BackupStorageLocation) {
+		if backupStorageLocation != backup.Spec.BackupStorageLocation {
+			continue
+		}
+
+		if mostRecentBackup == nil || backup.Status.StartTimestamp.After(mostRecentBackup.Status.StartTimestamp.Time) {
 			mostRecentBackup = backup
 		}
 	}


### PR DESCRIPTION
fix #2192
fix #2241 
related PR #1807

## Description
Backup files _should_ supports HA scenario. Schedule create backups to different object storage location with volume snapshot by resic.

## Root Cause
The current restic pass `--parent` flag to restic to support incremental backup.
When backup to the second storage location, it find the first storage location's parent snapshot ID and this cause restic backup volume failed since restic cannot find this parent snapshot ID.

## Solution
Add the backup location check when finding restic parent snapshot ID in PodVolumeBackup CRD.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>