### PR TITLE
refactor restore priorities code to use single loop and lazy discovery

### DIFF
--- a/changelogs/unreleased/2248-skriss
+++ b/changelogs/unreleased/2248-skriss
@@ -1,0 +1,1 @@
+refactor restore code to lazily resolve resources via discovery and eliminate second restore loop for instances of restored CRDs


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

This refactors the restore code to:
- lazily resolve resources via discovery, i.e. not until they're just about to be restored;
- refreshes discovery immediately after restoring CRDs (since new APIs/resources may have been created)
- removes the second restore loop

I've done some manual testing here and things seem to be working as expected across CRDs, CRs, and built-in resources.

Keeping in draft until nolan is back.