### PR TITLE
Account for possible missing schemas on v1 CRDs

### DIFF
--- a/changelogs/unreleased/2264-nrb
+++ b/changelogs/unreleased/2264-nrb
@@ -1,0 +1,1 @@
+Back up schema-less CustomResourceDefinitions as v1beta1, even if they are retrieved via the v1 endpoint.

--- a/pkg/backup/remap_crd_version_action.go
+++ b/pkg/backup/remap_crd_version_action.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2017 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backup
+
+import (
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+)
+
+// RemapCRDVersionAction inspects a PersistentVolumeClaim for the PersistentVolume
+// that it references and backs it up
+type RemapCRDVersionAction struct {
+	logger logrus.FieldLogger
+}
+
+func NewRemapCRDVersionAction(logger logrus.FieldLogger) *RemapCRDVersionAction {
+	return &RemapCRDVersionAction{logger: logger}
+}
+
+func (a *RemapCRDVersionAction) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+		IncludedResources: []string{"customresourcedefinition.apiextensions.k8s.io"},
+	}, nil
+}
+
+// TODO, if this works
+func (a *RemapCRDVersionAction) Execute(item runtime.Unstructured, backup *v1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, error) {
+	a.logger.Info("Executing RemapCRDVersionAction")
+
+	var crd apiextv1.CustomResourceDefinition
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(item.UnstructuredContent(), &crd); err != nil {
+		return nil, nil, errors.Wrap(err, "unable to convert unstructured item to CRD")
+	}
+
+	log := a.logger.WithField("plugin", "RemapCRDVersionAction").WithField("CRD", crd.Name)
+
+	// TODO: Is it possible or likely that a CRD had multiple versions without a Schema?
+	if len(crd.Spec.Versions) == 1 && crd.Spec.Versions[0].Schema == nil {
+		log.Debug("CRD is a candidate for v1beta1 backup")
+
+		// Two solutions are presented here, and they both appear to work. I've uncommented them both for readability; they won't necessarily compile this way.
+
+		// Solution 1: create empty structs where they're required, so that the definition is technically conformant.
+		// Pros:
+		//   - Compatible with the existing restore plugin for x-preserve-unknown-fields, which is necessary on v1 without a schema
+		//   - "upgrading" the CRD to v1 keeps the backup valid for longer, across more versions of Kubernetes
+		// Cons:
+		//   - Even though the structs are empty, they're not taking the data as it was.
+		crd.Spec.Versions[0].Schema = new(apiextv1.CustomResourceValidation)
+		crd.Spec.Versions[0].Schema.OpenAPIV3Schema = new(apiextv1.JSONSchemaProps)
+
+		newItem, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&crd)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "unable to convert crd to unstructured item")
+		}
+
+		return &unstructured.Unstructured{Object: newItem}, nil, nil
+	}
+
+	// Solution 2: Change the API version that's retained in the backup so that on restore, it will be restored as v1beta1.
+	// Pros:
+	//   - Relatively simple; just changing a string
+	//   - Data is the same as what's in the source Kubernetes cluster - the only reason we got it as a v1 instance was due to our usage of the preferred version endpoint.
+	// Cons:
+	//   - Data in the backup won't be valid for as long - v1beta1 CRDs will have to be upgraded sooner rather than later - but is that Velero's problem?
+
+	// Since we can't manipulate an Unstructured's Object map directly, get a copy to manipulate before setting it back
+	tempMap := item.UnstructuredContent()
+
+	if err := unstructured.SetNestedField(tempMap, "apiextensions.k8s.io/v1beta1", "apiVersion"); err != nil {
+		return nil, nil, errors.Wrap(err, "unable to set apiversion to v1beta1")
+	}
+	item.SetUnstructuredContent(tempMap)
+	}
+
+	return item, nil, nil
+}

--- a/pkg/backup/remap_crd_version_action.go
+++ b/pkg/backup/remap_crd_version_action.go
@@ -60,8 +60,6 @@ func (a *RemapCRDVersionAction) Execute(item runtime.Unstructured, backup *v1.Ba
 		return item, nil, nil
 	}
 
-	a.logger.Infof("Unstructured looked like: %#v", item.UnstructuredContent())
-
 	// We've got a v1 CRD, so proceed.
 	var crd apiextv1.CustomResourceDefinition
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(item.UnstructuredContent(), &crd); err != nil {

--- a/pkg/backup/remap_crd_version_action.go
+++ b/pkg/backup/remap_crd_version_action.go
@@ -55,10 +55,12 @@ func (a *RemapCRDVersionAction) Execute(item runtime.Unstructured, backup *v1.Ba
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "unable to read apiVersion from CRD")
 	}
-	if ok && apiVersion != "v1" {
+	if ok && apiVersion != "apiextensions.k8s.io/v1" {
 		a.logger.Info("Exiting RemapCRDVersionAction, CRD is not v1")
 		return item, nil, nil
 	}
+
+	a.logger.Infof("Unstructured looked like: %#v", item.UnstructuredContent())
 
 	// We've got a v1 CRD, so proceed.
 	var crd apiextv1.CustomResourceDefinition

--- a/pkg/backup/remap_crd_version_action_test.go
+++ b/pkg/backup/remap_crd_version_action_test.go
@@ -35,9 +35,9 @@ func TestRemapCRDVersionAction(t *testing.T) {
 	a := NewRemapCRDVersionAction(velerotest.NewLogger())
 
 	t.Run("Test a v1 CRD without any Schema information", func(t *testing.T) {
-		b := builder.ForCustomResourceDefinition("test.velero.io")
+		b := builder.ForV1CustomResourceDefinition("test.velero.io")
 		// Set a version that does not include and schema information.
-		b.Version(builder.ForCustomResourceDefinitionVersion("v1").Served(true).Storage(true).Result())
+		b.Version(builder.ForV1CustomResourceDefinitionVersion("v1").Served(true).Storage(true).Result())
 		c := b.Result()
 		obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&c)
 		require.NoError(t, err)
@@ -48,8 +48,8 @@ func TestRemapCRDVersionAction(t *testing.T) {
 	})
 
 	t.Run("Test a v1 CRD with a NonStructuralSchema Condition", func(t *testing.T) {
-		b := builder.ForCustomResourceDefinition("test.velero.io")
-		b.Condition(builder.ForCustomResourceDefinitionCondition().Type(apiextv1.NonStructuralSchema).Result())
+		b := builder.ForV1CustomResourceDefinition("test.velero.io")
+		b.Condition(builder.ForV1CustomResourceDefinitionCondition().Type(apiextv1.NonStructuralSchema).Result())
 		c := b.Result()
 		obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&c)
 		require.NoError(t, err)

--- a/pkg/backup/remap_crd_version_action_test.go
+++ b/pkg/backup/remap_crd_version_action_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2020 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/builder"
+	velerotest "github.com/vmware-tanzu/velero/pkg/test"
+)
+
+func TestRemapCRDVersionAction(t *testing.T) {
+	backup := &v1.Backup{}
+	a := NewRemapCRDVersionAction(velerotest.NewLogger())
+
+	t.Run("Test a v1 CRD without any Schema information", func(t *testing.T) {
+		b := builder.ForCustomResourceDefinition("test.velero.io")
+		// Set a version that does not include and schema information.
+		b.Version(builder.ForCustomResourceDefinitionVersion("v1").Served(true).Storage(true).Result())
+		c := b.Result()
+		obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&c)
+		require.NoError(t, err)
+
+		item, _, err := a.Execute(&unstructured.Unstructured{Object: obj}, backup)
+		require.NoError(t, err)
+		assert.Equal(t, "apiextensions.k8s.io/v1beta1", item.UnstructuredContent()["apiVersion"])
+	})
+
+	t.Run("Test a v1 CRD with a NonStructuralSchema Condition", func(t *testing.T) {
+		b := builder.ForCustomResourceDefinition("test.velero.io")
+		b.Condition(builder.ForCustomResourceDefinitionCondition().Type(apiextv1.NonStructuralSchema).Result())
+		c := b.Result()
+		obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&c)
+		require.NoError(t, err)
+
+		item, _, err := a.Execute(&unstructured.Unstructured{Object: obj}, backup)
+		require.NoError(t, err)
+		assert.Equal(t, "apiextensions.k8s.io/v1beta1", item.UnstructuredContent()["apiVersion"])
+	})
+}

--- a/pkg/builder/customresourcedefinition_builder.go
+++ b/pkg/builder/customresourcedefinition_builder.go
@@ -17,21 +17,21 @@ limitations under the License.
 package builder
 
 import (
-	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // CustomResourceDefinitionBuilder builds CustomResourceDefinition objects.
 type CustomResourceDefinitionBuilder struct {
-	object *apiextv1beta1.CustomResourceDefinition
+	object *apiextv1.CustomResourceDefinition
 }
 
 // ForCustomResourceDefinition is the constructor for a CustomResourceDefinitionBuilder.
 func ForCustomResourceDefinition(name string) *CustomResourceDefinitionBuilder {
 	return &CustomResourceDefinitionBuilder{
-		object: &apiextv1beta1.CustomResourceDefinition{
+		object: &apiextv1.CustomResourceDefinition{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: apiextv1beta1.SchemeGroupVersion.String(),
+				APIVersion: apiextv1.SchemeGroupVersion.String(),
 				Kind:       "CustomResourceDefinition",
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -42,13 +42,25 @@ func ForCustomResourceDefinition(name string) *CustomResourceDefinitionBuilder {
 }
 
 // Condition adds a CustomResourceDefinitionCondition objects to a CustomResourceDefinitionBuilder.
-func (c *CustomResourceDefinitionBuilder) Condition(cond apiextv1beta1.CustomResourceDefinitionCondition) *CustomResourceDefinitionBuilder {
-	c.object.Status.Conditions = append(c.object.Status.Conditions, cond)
-	return c
+func (b *CustomResourceDefinitionBuilder) Condition(cond apiextv1.CustomResourceDefinitionCondition) *CustomResourceDefinitionBuilder {
+	b.object.Status.Conditions = append(b.object.Status.Conditions, cond)
+	return b
+}
+
+// Version adds a CustomResourceDefinitionVersion object to a CustomResourceDefinitionBuilder.
+func (b *CustomResourceDefinitionBuilder) Version(ver apiextv1.CustomResourceDefinitionVersion) *CustomResourceDefinitionBuilder {
+	b.object.Spec.Versions = append(b.object.Spec.Versions, ver)
+	return b
+}
+
+// PreserveUnknownFields sets PreserveUnknownFields on a CustomResourceDefinition.
+func (b *CustomResourceDefinitionBuilder) PreserveUnknownFields(preserve bool) *CustomResourceDefinitionBuilder {
+	b.object.Spec.PreserveUnknownFields = preserve
+	return b
 }
 
 // Result returns the built CustomResourceDefinition.
-func (b *CustomResourceDefinitionBuilder) Result() *apiextv1beta1.CustomResourceDefinition {
+func (b *CustomResourceDefinitionBuilder) Result() *apiextv1.CustomResourceDefinition {
 	return b.object
 }
 
@@ -63,29 +75,58 @@ func (b *CustomResourceDefinitionBuilder) ObjectMeta(opts ...ObjectMetaOpt) *Cus
 
 // CustomResourceDefinitionConditionBuilder builds CustomResourceDefinitionCondition objects.
 type CustomResourceDefinitionConditionBuilder struct {
-	object apiextv1beta1.CustomResourceDefinitionCondition
+	object apiextv1.CustomResourceDefinitionCondition
 }
 
-// ForCustomResourceDefinitionConditionBuilder is the construction for a CustomResourceDefinitionConditionBuilder.
+// ForCustomResourceDefinitionConditionBuilder is the constructor for a CustomResourceDefinitionConditionBuilder.
 func ForCustomResourceDefinitionCondition() *CustomResourceDefinitionConditionBuilder {
 	return &CustomResourceDefinitionConditionBuilder{
-		object: apiextv1beta1.CustomResourceDefinitionCondition{},
+		object: apiextv1.CustomResourceDefinitionCondition{},
 	}
 }
 
 // Type sets the Condition's type.
-func (c *CustomResourceDefinitionConditionBuilder) Type(t apiextv1beta1.CustomResourceDefinitionConditionType) *CustomResourceDefinitionConditionBuilder {
+func (c *CustomResourceDefinitionConditionBuilder) Type(t apiextv1.CustomResourceDefinitionConditionType) *CustomResourceDefinitionConditionBuilder {
 	c.object.Type = t
 	return c
 }
 
 // Status sets the Condition's status.
-func (c *CustomResourceDefinitionConditionBuilder) Status(cs apiextv1beta1.ConditionStatus) *CustomResourceDefinitionConditionBuilder {
+func (c *CustomResourceDefinitionConditionBuilder) Status(cs apiextv1.ConditionStatus) *CustomResourceDefinitionConditionBuilder {
 	c.object.Status = cs
 	return c
 }
 
-// Results returns the built CustomResourceDefinitionCondition.
-func (b *CustomResourceDefinitionConditionBuilder) Result() apiextv1beta1.CustomResourceDefinitionCondition {
+// Result returns the built CustomResourceDefinitionCondition.
+func (b *CustomResourceDefinitionConditionBuilder) Result() apiextv1.CustomResourceDefinitionCondition {
+	return b.object
+}
+
+// CustomResourceDefinitionVersionBuilder builds CustomResourceDefinitionVersion objects.
+type CustomResourceDefinitionVersionBuilder struct {
+	object apiextv1.CustomResourceDefinitionVersion
+}
+
+// ForCustomResourceDefinitionVersion is the constructor for a CustomResourceDefinitionVersionBuilder.
+func ForCustomResourceDefinitionVersion(name string) *CustomResourceDefinitionVersionBuilder {
+	return &CustomResourceDefinitionVersionBuilder{
+		object: apiextv1.CustomResourceDefinitionVersion{Name: name},
+	}
+}
+
+// Served sets the Served field on a CustomResourceDefinitionVersion.
+func (b *CustomResourceDefinitionVersionBuilder) Served(s bool) *CustomResourceDefinitionVersionBuilder {
+	b.object.Served = s
+	return b
+}
+
+// Storage sets the Storage field on a CustomResourceDefinitionVersion.
+func (b *CustomResourceDefinitionVersionBuilder) Storage(s bool) *CustomResourceDefinitionVersionBuilder {
+	b.object.Storage = s
+	return b
+}
+
+// Result returns the built CustomResourceDefinitionVersion.
+func (b *CustomResourceDefinitionVersionBuilder) Result() apiextv1.CustomResourceDefinitionVersion {
 	return b.object
 }

--- a/pkg/builder/customresourcedefinition_builder.go
+++ b/pkg/builder/customresourcedefinition_builder.go
@@ -17,21 +17,21 @@ limitations under the License.
 package builder
 
 import (
-	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // CustomResourceDefinitionBuilder builds CustomResourceDefinition objects.
 type CustomResourceDefinitionBuilder struct {
-	object *apiextv1.CustomResourceDefinition
+	object *apiextv1beta1.CustomResourceDefinition
 }
 
 // ForCustomResourceDefinition is the constructor for a CustomResourceDefinitionBuilder.
 func ForCustomResourceDefinition(name string) *CustomResourceDefinitionBuilder {
 	return &CustomResourceDefinitionBuilder{
-		object: &apiextv1.CustomResourceDefinition{
+		object: &apiextv1beta1.CustomResourceDefinition{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: apiextv1.SchemeGroupVersion.String(),
+				APIVersion: apiextv1beta1.SchemeGroupVersion.String(),
 				Kind:       "CustomResourceDefinition",
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -42,25 +42,13 @@ func ForCustomResourceDefinition(name string) *CustomResourceDefinitionBuilder {
 }
 
 // Condition adds a CustomResourceDefinitionCondition objects to a CustomResourceDefinitionBuilder.
-func (b *CustomResourceDefinitionBuilder) Condition(cond apiextv1.CustomResourceDefinitionCondition) *CustomResourceDefinitionBuilder {
-	b.object.Status.Conditions = append(b.object.Status.Conditions, cond)
-	return b
-}
-
-// Version adds a CustomResourceDefinitionVersion object to a CustomResourceDefinitionBuilder.
-func (b *CustomResourceDefinitionBuilder) Version(ver apiextv1.CustomResourceDefinitionVersion) *CustomResourceDefinitionBuilder {
-	b.object.Spec.Versions = append(b.object.Spec.Versions, ver)
-	return b
-}
-
-// PreserveUnknownFields sets PreserveUnknownFields on a CustomResourceDefinition.
-func (b *CustomResourceDefinitionBuilder) PreserveUnknownFields(preserve bool) *CustomResourceDefinitionBuilder {
-	b.object.Spec.PreserveUnknownFields = preserve
-	return b
+func (c *CustomResourceDefinitionBuilder) Condition(cond apiextv1beta1.CustomResourceDefinitionCondition) *CustomResourceDefinitionBuilder {
+	c.object.Status.Conditions = append(c.object.Status.Conditions, cond)
+	return c
 }
 
 // Result returns the built CustomResourceDefinition.
-func (b *CustomResourceDefinitionBuilder) Result() *apiextv1.CustomResourceDefinition {
+func (b *CustomResourceDefinitionBuilder) Result() *apiextv1beta1.CustomResourceDefinition {
 	return b.object
 }
 
@@ -75,58 +63,29 @@ func (b *CustomResourceDefinitionBuilder) ObjectMeta(opts ...ObjectMetaOpt) *Cus
 
 // CustomResourceDefinitionConditionBuilder builds CustomResourceDefinitionCondition objects.
 type CustomResourceDefinitionConditionBuilder struct {
-	object apiextv1.CustomResourceDefinitionCondition
+	object apiextv1beta1.CustomResourceDefinitionCondition
 }
 
-// ForCustomResourceDefinitionConditionBuilder is the constructor for a CustomResourceDefinitionConditionBuilder.
+// ForCustomResourceDefinitionConditionBuilder is the construction for a CustomResourceDefinitionConditionBuilder.
 func ForCustomResourceDefinitionCondition() *CustomResourceDefinitionConditionBuilder {
 	return &CustomResourceDefinitionConditionBuilder{
-		object: apiextv1.CustomResourceDefinitionCondition{},
+		object: apiextv1beta1.CustomResourceDefinitionCondition{},
 	}
 }
 
 // Type sets the Condition's type.
-func (c *CustomResourceDefinitionConditionBuilder) Type(t apiextv1.CustomResourceDefinitionConditionType) *CustomResourceDefinitionConditionBuilder {
+func (c *CustomResourceDefinitionConditionBuilder) Type(t apiextv1beta1.CustomResourceDefinitionConditionType) *CustomResourceDefinitionConditionBuilder {
 	c.object.Type = t
 	return c
 }
 
 // Status sets the Condition's status.
-func (c *CustomResourceDefinitionConditionBuilder) Status(cs apiextv1.ConditionStatus) *CustomResourceDefinitionConditionBuilder {
+func (c *CustomResourceDefinitionConditionBuilder) Status(cs apiextv1beta1.ConditionStatus) *CustomResourceDefinitionConditionBuilder {
 	c.object.Status = cs
 	return c
 }
 
-// Result returns the built CustomResourceDefinitionCondition.
-func (b *CustomResourceDefinitionConditionBuilder) Result() apiextv1.CustomResourceDefinitionCondition {
-	return b.object
-}
-
-// CustomResourceDefinitionVersionBuilder builds CustomResourceDefinitionVersion objects.
-type CustomResourceDefinitionVersionBuilder struct {
-	object apiextv1.CustomResourceDefinitionVersion
-}
-
-// ForCustomResourceDefinitionVersion is the constructor for a CustomResourceDefinitionVersionBuilder.
-func ForCustomResourceDefinitionVersion(name string) *CustomResourceDefinitionVersionBuilder {
-	return &CustomResourceDefinitionVersionBuilder{
-		object: apiextv1.CustomResourceDefinitionVersion{Name: name},
-	}
-}
-
-// Served sets the Served field on a CustomResourceDefinitionVersion.
-func (b *CustomResourceDefinitionVersionBuilder) Served(s bool) *CustomResourceDefinitionVersionBuilder {
-	b.object.Served = s
-	return b
-}
-
-// Storage sets the Storage field on a CustomResourceDefinitionVersion.
-func (b *CustomResourceDefinitionVersionBuilder) Storage(s bool) *CustomResourceDefinitionVersionBuilder {
-	b.object.Storage = s
-	return b
-}
-
-// Result returns the built CustomResourceDefinitionVersion.
-func (b *CustomResourceDefinitionVersionBuilder) Result() apiextv1.CustomResourceDefinitionVersion {
+// Results returns the built CustomResourceDefinitionCondition.
+func (b *CustomResourceDefinitionConditionBuilder) Result() apiextv1beta1.CustomResourceDefinitionCondition {
 	return b.object
 }

--- a/pkg/builder/v1_customresourcedefinition_builder.go
+++ b/pkg/builder/v1_customresourcedefinition_builder.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 the Velero contributors.
+Copyright 2020 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/builder/v1_customresourcedefinition_builder.go
+++ b/pkg/builder/v1_customresourcedefinition_builder.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2019 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// V1CustomResourceDefinitionBuilder builds CustomResourceDefinition objects.
+type V1CustomResourceDefinitionBuilder struct {
+	object *apiextv1.CustomResourceDefinition
+}
+
+// ForV1CustomResourceDefinition is the constructor for a V1CustomResourceDefinitionBuilder.
+func ForV1CustomResourceDefinition(name string) *V1CustomResourceDefinitionBuilder {
+	return &V1CustomResourceDefinitionBuilder{
+		object: &apiextv1.CustomResourceDefinition{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: apiextv1.SchemeGroupVersion.String(),
+				Kind:       "CustomResourceDefinition",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		},
+	}
+}
+
+// Condition adds a CustomResourceDefinitionCondition objects to a V1CustomResourceDefinitionBuilder.
+func (b *V1CustomResourceDefinitionBuilder) Condition(cond apiextv1.CustomResourceDefinitionCondition) *V1CustomResourceDefinitionBuilder {
+	b.object.Status.Conditions = append(b.object.Status.Conditions, cond)
+	return b
+}
+
+// Version adds a CustomResourceDefinitionVersion object to a V1CustomResourceDefinitionBuilder.
+func (b *V1CustomResourceDefinitionBuilder) Version(ver apiextv1.CustomResourceDefinitionVersion) *V1CustomResourceDefinitionBuilder {
+	b.object.Spec.Versions = append(b.object.Spec.Versions, ver)
+	return b
+}
+
+// PreserveUnknownFields sets PreserveUnknownFields on a CustomResourceDefinition.
+func (b *V1CustomResourceDefinitionBuilder) PreserveUnknownFields(preserve bool) *V1CustomResourceDefinitionBuilder {
+	b.object.Spec.PreserveUnknownFields = preserve
+	return b
+}
+
+// Result returns the built CustomResourceDefinition.
+func (b *V1CustomResourceDefinitionBuilder) Result() *apiextv1.CustomResourceDefinition {
+	return b.object
+}
+
+// ObjectMeta applies functional options to the CustomResourceDefinition's ObjectMeta.
+func (b *V1CustomResourceDefinitionBuilder) ObjectMeta(opts ...ObjectMetaOpt) *V1CustomResourceDefinitionBuilder {
+	for _, opt := range opts {
+		opt(b.object)
+	}
+
+	return b
+}
+
+// V1CustomResourceDefinitionConditionBuilder builds CustomResourceDefinitionCondition objects.
+type V1CustomResourceDefinitionConditionBuilder struct {
+	object apiextv1.CustomResourceDefinitionCondition
+}
+
+// ForV1V1CustomResourceDefinitionConditionBuilder is the constructor for a V1CustomResourceDefinitionConditionBuilder.
+func ForV1CustomResourceDefinitionCondition() *V1CustomResourceDefinitionConditionBuilder {
+	return &V1CustomResourceDefinitionConditionBuilder{
+		object: apiextv1.CustomResourceDefinitionCondition{},
+	}
+}
+
+// Type sets the Condition's type.
+func (c *V1CustomResourceDefinitionConditionBuilder) Type(t apiextv1.CustomResourceDefinitionConditionType) *V1CustomResourceDefinitionConditionBuilder {
+	c.object.Type = t
+	return c
+}
+
+// Status sets the Condition's status.
+func (c *V1CustomResourceDefinitionConditionBuilder) Status(cs apiextv1.ConditionStatus) *V1CustomResourceDefinitionConditionBuilder {
+	c.object.Status = cs
+	return c
+}
+
+// Result returns the built CustomResourceDefinitionCondition.
+func (b *V1CustomResourceDefinitionConditionBuilder) Result() apiextv1.CustomResourceDefinitionCondition {
+	return b.object
+}
+
+// V1CustomResourceDefinitionVersionBuilder builds CustomResourceDefinitionVersion objects.
+type V1CustomResourceDefinitionVersionBuilder struct {
+	object apiextv1.CustomResourceDefinitionVersion
+}
+
+// ForV1CustomResourceDefinitionVersion is the constructor for a V1CustomResourceDefinitionVersionBuilder.
+func ForV1CustomResourceDefinitionVersion(name string) *V1CustomResourceDefinitionVersionBuilder {
+	return &V1CustomResourceDefinitionVersionBuilder{
+		object: apiextv1.CustomResourceDefinitionVersion{Name: name},
+	}
+}
+
+// Served sets the Served field on a CustomResourceDefinitionVersion.
+func (b *V1CustomResourceDefinitionVersionBuilder) Served(s bool) *V1CustomResourceDefinitionVersionBuilder {
+	b.object.Served = s
+	return b
+}
+
+// Storage sets the Storage field on a CustomResourceDefinitionVersion.
+func (b *V1CustomResourceDefinitionVersionBuilder) Storage(s bool) *V1CustomResourceDefinitionVersionBuilder {
+	b.object.Storage = s
+	return b
+}
+
+// Result returns the built CustomResourceDefinitionVersion.
+func (b *V1CustomResourceDefinitionVersionBuilder) Result() apiextv1.CustomResourceDefinitionVersion {
+	return b.object
+}

--- a/pkg/cmd/server/plugin/plugin.go
+++ b/pkg/cmd/server/plugin/plugin.go
@@ -38,6 +38,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 				RegisterBackupItemAction("velero.io/pv", newPVBackupItemAction).
 				RegisterBackupItemAction("velero.io/pod", newPodBackupItemAction).
 				RegisterBackupItemAction("velero.io/service-account", newServiceAccountBackupItemAction(f)).
+				RegisterBackupItemAction("velero.io/crd-remap-version", newRemapCRDVersionAction).
 				RegisterRestoreItemAction("velero.io/job", newJobRestoreItemAction).
 				RegisterRestoreItemAction("velero.io/pod", newPodRestoreItemAction).
 				RegisterRestoreItemAction("velero.io/restic", newResticRestoreItemAction(f)).
@@ -89,6 +90,10 @@ func newServiceAccountBackupItemAction(f client.Factory) veleroplugin.HandlerIni
 
 		return action, nil
 	}
+}
+
+func newRemapCRDVersionAction(logger logrus.FieldLogger) (interface{}, error) {
+	return backup.NewRemapCRDVersionAction(logger), nil
 }
 
 func newJobRestoreItemAction(logger logrus.FieldLogger) (interface{}, error) {

--- a/pkg/restore/crd_v1_preserve_unknown_fields_action.go
+++ b/pkg/restore/crd_v1_preserve_unknown_fields_action.go
@@ -79,12 +79,13 @@ func (c *CRDV1PreserveUnknownFieldsAction) Execute(input *velero.RestoreItemActi
 
 		// Make sure all versions are set to preserve unknown fields
 		for _, v := range crd.Spec.Versions {
-			// If the Schema is nil, there are no nested fields to set, so skip over it for this version.
-			if v.Schema == nil {
+			// If the schema fields are nil, there are no nested fields to set, so skip over it for this version.
+			if v.Schema == nil || v.Schema.OpenAPIV3Schema == nil {
 				continue
 			}
 
-			// Use the address, since the XPreserveUnknownFields value is undefined or true (false is not allowed)
+			// Use the address, since the XPreserveUnknownFields value is nil or
+			// a pointer to true (false is not allowed)
 			preserve := true
 			v.Schema.OpenAPIV3Schema.XPreserveUnknownFields = &preserve
 			log.Debugf("Set x-preserve-unknown-fields in Open API for schema version %s", v.Name)


### PR DESCRIPTION
Fixes #2249 

If a v1beta1 CRD without a Schema was submitted to a Kubernetes v1.16
cluster, then Kubernetes will serve it back as a v1 CRD without a
schema.

However, when Velero tries to restore this document, the request will be
rejected as a v1 CRD must have a schema.

This commit has some defensive coding on the restore side, as well as
potential fixes on the backup side for getting around this.

In draft until we reach some consensus on a solution.

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>