### PR TITLE
Do not backup volumes of pending pods

### DIFF
--- a/changelogs/unreleased/2270-ctrox
+++ b/changelogs/unreleased/2270-ctrox
@@ -1,0 +1,1 @@
+Do not backup volumes of pending pods

--- a/pkg/backup/pod_action.go
+++ b/pkg/backup/pod_action.go
@@ -61,6 +61,11 @@ func (a *PodAction) Execute(item runtime.Unstructured, backup *v1.Backup) (runti
 		return item, nil, nil
 	}
 
+	if pod.Status.Phase == corev1api.PodPending {
+		a.log.Info("pod is pending")
+		return item, nil, nil
+	}
+
 	var additionalItems []velero.ResourceIdentifier
 	for _, volume := range pod.Spec.Volumes {
 		if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName != "" {

--- a/pkg/backup/pod_action_test.go
+++ b/pkg/backup/pod_action_test.go
@@ -80,6 +80,29 @@ func TestPodActionExecute(t *testing.T) {
 			`),
 		},
 		{
+			name: "pod is pending",
+			pod: velerotest.UnstructuredOrDie(`
+			{
+				"apiVersion": "v1",
+				"kind": "Pod",
+				"metadata": {
+					"namespace": "foo",
+					"name": "bar"
+				},
+				"status": {
+					"phase": "Pending"
+				},
+				"spec": {
+					"volumes": [
+						{
+							"persistentVolumeClaim": {"claimName": "claim1"}
+						}
+					]
+				}
+			}
+			`),
+		},
+		{
 			name: "full test, mix of volume types",
 			pod: velerotest.UnstructuredOrDie(`
 			{


### PR DESCRIPTION
Fixes #2269

My preferred solution to this would be to actually check if a PVC exists and not just completely ignore PVCs of `Pending` pods. But as far as I can see that is not easy to achieve since we don't have a kubernetes client in `PodAction`.