### PR TITLE
Fix shortlinks redirect

### DIFF
--- a/site/_data/shortlinks.yml
+++ b/site/_data/shortlinks.yml
@@ -1,9 +1,9 @@
 - title: Troubleshooting
   key: troubleshooting
   destination: troubleshooting
-- title: Support Matrix
-  key: support-matrix
-  destination: support-matrix
+- title: Supported Providers
+  key: supported-providers
+  destination: supported-providers
 - title: ZenHub
   key: zenhub
   destination: zenhub

--- a/site/_layouts/redirect.html
+++ b/site/_layouts/redirect.html
@@ -1,28 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  {% if page.dir != "/docs/" %}
-  <meta http-equiv="refresh" content="0; url={{ page.redirect.to }}" />
-  <script type="text/javascript">
-    window.location.href = "{{ page.redirect.to }}"
-  </script>
-  <title>Redirecting...</title>
-</head>
-<body>
-Redirecting to {{ page.redirect.to }}. If it doesn't load, click <a href="{{ page.redirect.to }}" />here</a>.
-</body>
-</html>
-  {% endif %}
-  {% if page.dir == "/docs/" %}
+  {% if page.dir contains "/docs/" %}
   <meta http-equiv="refresh" content="0; url=/docs/{{ site.latest }}/{{ page.destination }}" />
   <script type="text/javascript">
     window.location.href = "/docs/{{ site.latest }}/{{ page.destination }}"
   </script>
-  <title>Redirecting...</title>
+  <title>Redirecting to docs...</title>
 </head>
 <body>
 Redirecting to {{ page.destination }}. If it doesn't load, click <a href="/docs/{{ site.latest }}/{{ page.destination }}" />here</a>.
 </body>
 </html>
-{% endif %}
-
+  {% endif %}


### PR DESCRIPTION
closes #2005 

This should fix the issues we've been having with #2005, and make the shortlinks work again:
velero.io/docs/troubleshooting
velero.io/docs/install-overview
velero.io/docs/supported-providers
velero.io/docs/zenhub

Signed-off-by: jonasrosland <jrosland@vmware.com>