### PR TITLE
add a few more shortlinks to docs pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you encounter issues, review the [troubleshooting docs][30], [file an issue][
 
 ## Contributing
 
-If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](https://velero.io/docs/master/start-contributing/) documentation for guidance on how to setup Velero for development.
+If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing][31] documentation for guidance on how to setup Velero for development.
 
 ## Changelog
 
@@ -46,4 +46,5 @@ See [the list of releases][6] to find out about feature changes.
 [25]: https://kubernetes.slack.com/messages/velero
 [29]: https://velero.io/docs/
 [30]: https://velero.io/docs/troubleshooting
+[31]: https://velero.io/docs/start-contributing
 [100]: https://velero.io/docs/master/img/velero.png

--- a/site/_data/shortlinks.yml
+++ b/site/_data/shortlinks.yml
@@ -10,3 +10,12 @@
 - title: Install Overview
   key: install-overview
   destination: basic-install
+- title: Start Contributing
+  key: start-contributing
+  destination: start-contributing
+- title: Customize Installation
+  key: customize-installation
+  destination: customize-installation
+- title: Frequently Asked Questions
+  key: faq
+  destination: faq


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

Some of these are for the plugin repos to use, rather than linking directly to `master` docs (which may be unstable). Will follow up with PRs for those docs separately.