### PR TITLE
Apply backup-name label on resources being backed up

### DIFF
--- a/changelogs/unreleased/2295-ashish-amarnath
+++ b/changelogs/unreleased/2295-ashish-amarnath
@@ -1,0 +1,1 @@
+Apply `velero.io/backup-name` label on all backed up resources.

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -1254,7 +1254,7 @@ func TestBackupActionModifications(t *testing.T) {
 				}),
 			},
 			want: map[string]unstructuredObject{
-				"resources/pods/namespaces/ns-1/pod-1.json": toUnstructuredOrFail(t, builder.ForPod("ns-1", "pod-1").ObjectMeta(builder.WithLabels("updated", "true")).Result()),
+				"resources/pods/namespaces/ns-1/pod-1.json": toUnstructuredOrFail(t, builder.ForPod("ns-1", "pod-1").ObjectMeta(builder.WithLabels("updated", "true", "velero.io/backup-name", "backup-1")).Result()),
 			},
 		},
 		{
@@ -1271,7 +1271,7 @@ func TestBackupActionModifications(t *testing.T) {
 				}),
 			},
 			want: map[string]unstructuredObject{
-				"resources/pods/namespaces/ns-1/pod-1.json": toUnstructuredOrFail(t, builder.ForPod("ns-1", "pod-1").Result()),
+				"resources/pods/namespaces/ns-1/pod-1.json": toUnstructuredOrFail(t, builder.ForPod("ns-1", "pod-1").ObjectMeta(builder.WithLabels("velero.io/backup-name", "backup-1")).Result()),
 			},
 		},
 		{
@@ -1288,7 +1288,7 @@ func TestBackupActionModifications(t *testing.T) {
 				}),
 			},
 			want: map[string]unstructuredObject{
-				"resources/pods/namespaces/ns-1/pod-1.json": toUnstructuredOrFail(t, builder.ForPod("ns-1", "pod-1").NodeName("foo").Result()),
+				"resources/pods/namespaces/ns-1/pod-1.json": toUnstructuredOrFail(t, builder.ForPod("ns-1", "pod-1").ObjectMeta(builder.WithLabels("velero.io/backup-name", "backup-1")).NodeName("foo").Result()),
 			},
 		},
 		{
@@ -1307,7 +1307,7 @@ func TestBackupActionModifications(t *testing.T) {
 				}),
 			},
 			want: map[string]unstructuredObject{
-				"resources/pods/namespaces/ns-1-updated/pod-1-updated.json": toUnstructuredOrFail(t, builder.ForPod("ns-1-updated", "pod-1-updated").Result()),
+				"resources/pods/namespaces/ns-1-updated/pod-1-updated.json": toUnstructuredOrFail(t, builder.ForPod("ns-1-updated", "pod-1-updated").ObjectMeta(builder.WithLabels("velero.io/backup-name", "backup-1")).Result()),
 			},
 		},
 	}

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -229,6 +229,14 @@ func (ib *defaultItemBackupper) backupItem(logger logrus.FieldLogger, obj runtim
 	name = metadata.GetName()
 	namespace = metadata.GetNamespace()
 
+	// add BackupNameLabel to the resource being backed up
+	labels := metadata.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[velerov1api.BackupNameLabel] = ib.backupRequest.Backup.Name
+	metadata.SetLabels(labels)
+
 	if groupResource == kuberesource.PersistentVolumes {
 		if err := ib.takePVSnapshot(obj, log); err != nil {
 			backupErrs = append(backupErrs, err)


### PR DESCRIPTION
Default item backupper should label resources when backing up items.
This is important especially for additional items, returned by backupItemActions, to which none of the `ib.backupRequest.ResolvedActions` may apply. This results in these objects to be persisted in the backup without  the `velero.io/backup-name` label being applied to them.


Signed-off-by: Ashish Amarnath <ashisham@vmware.com>