### PR TITLE
Add initial documentation for CSI support

### DIFF
--- a/site/_data/master-toc.yml
+++ b/site/_data/master-toc.yml
@@ -39,6 +39,8 @@ toc:
         url: /namespace
       - page: Extend with hooks
         url: /hooks
+      - page: CSI Support (beta)
+        url: /csi
   - title: Plugins
     subfolderitems:
       - page: Overview

--- a/site/docs/master/csi.md
+++ b/site/docs/master/csi.md
@@ -1,0 +1,15 @@
+# Container Storage Interface Snapshot Support in Velero
+
+_This feature is under development. Documentation may not be up-to-date and features may not work as expected._
+
+Velero supports taking Container Storage Interface (CSI) snapshots as a beta feature on clusters that meet the following prerequisites.
+
+ 1. The cluster is Kubernetes version 1.17 or greater.
+ 1. The cluster is running a CSI driver capable of support volume snapshots at the [v1beta1 API level](https://kubernetes.io/blog/2019/12/09/kubernetes-1-17-feature-cis-volume-snapshot-beta/).
+ 1. The Velero server is running with the `--features EnableCSI` feature flag to enable CSI logic in Velero's core.
+ 1. The Velero [CSI plugin](https://github.com/vmware-tanzu/velero-plugin-for-csi/) is installed to integrate with the CSI volume snapshot APIs.
+
+# Roadmap
+
+Velero's support level for CSI volume snapshotting will follow upstream Kubernetes support for it, and will reach general availability sometime
+after volume snapshotting is GA in upstream Kubernetes. Beta support is expected to launch in Velero v1.4.


### PR DESCRIPTION
Fixes #2142

I'm open to moving the location of the CSI page in the ToC - however I think for now it's ok to keep it all in 1 spot so our more ambitious users have all the info in one place. Once it's moved to GA, then I think the content should be good to move into relevant portions like Use, Install, Troubleshoot, etc.