### PR TITLE
allow ignoring labels when creating backups from a schedule

### DIFF
--- a/changelogs/unreleased/2320-tareqhs
+++ b/changelogs/unreleased/2320-tareqhs
@@ -1,0 +1,1 @@
+allow ignoring label in Schedule when copying to Backup via `--ignore-schedule-labels`

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -2026,7 +2026,7 @@ func TestBackupWithSnapshots(t *testing.T) {
 			},
 			apiResources: []*test.APIResource{
 				test.PVs(
-					builder.ForPersistentVolume("pv-1").ObjectMeta(builder.WithLabelsMap(map[string]string{"failure-domain.beta.kubernetes.io/zone": "zone-1-deprecated", "topology.kubernetes.io/zone": "zone-1-ga"})).Result(),
+					builder.ForPersistentVolume("pv-1").ObjectMeta(builder.WithLabelsMap(map[string]string{"failure-domain.beta.kubernetes.io/zone": "zone-1-deprecated", "topology.kubernetes.io/zone": "zone-1-ga"}, []string{})).Result(),
 				),
 			},
 			snapshotterGetter: map[string]velero.VolumeSnapshotter{

--- a/pkg/builder/backup_builder.go
+++ b/pkg/builder/backup_builder.go
@@ -74,7 +74,7 @@ func (b *BackupBuilder) ObjectMeta(opts ...ObjectMetaOpt) *BackupBuilder {
 }
 
 // FromSchedule sets the Backup's spec and labels from the Schedule template
-func (b *BackupBuilder) FromSchedule(schedule *velerov1api.Schedule) *BackupBuilder {
+func (b *BackupBuilder) FromSchedule(schedule *velerov1api.Schedule, ignoreLabels []string) *BackupBuilder {
 	labels := schedule.Labels
 	if labels == nil {
 		labels = make(map[string]string)
@@ -82,7 +82,7 @@ func (b *BackupBuilder) FromSchedule(schedule *velerov1api.Schedule) *BackupBuil
 	labels[velerov1api.ScheduleNameLabel] = schedule.Name
 
 	b.object.Spec = schedule.Spec.Template
-	b.ObjectMeta(WithLabelsMap(labels))
+	b.ObjectMeta(WithLabelsMap(labels, ignoreLabels))
 	return b
 }
 

--- a/pkg/builder/object_meta.go
+++ b/pkg/builder/object_meta.go
@@ -44,16 +44,24 @@ func WithLabels(vals ...string) func(obj metav1.Object) {
 
 // WithLabelsMap is a functional option that applies the specified labels map to
 // an object.
-func WithLabelsMap(labels map[string]string) func(obj metav1.Object) {
+func WithLabelsMap(labels map[string]string, ignoreLabels []string) func(obj metav1.Object) {
 	return func(obj metav1.Object) {
 		objLabels := obj.GetLabels()
 		if objLabels == nil {
 			objLabels = make(map[string]string)
 		}
 
+		// a map of ignored labels for simpler lookup
+		ignored := make(map[string]bool, len(ignoreLabels))
+		for _, name := range ignoreLabels {
+			ignored[name] = true
+		}
+
 		// If the label already exists in the object, it will be overwritten
 		for k, v := range labels {
-			objLabels[k] = v
+			if !ignored[k] {
+				objLabels[k] = v
+			}
 		}
 
 		obj.SetLabels(objLabels)

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -136,6 +136,7 @@ type serverConfig struct {
 	formatFlag                                                              *logging.FormatFlag
 	defaultResticMaintenanceFrequency                                       time.Duration
 	defaultVolumesToRestic                                                  bool
+	ignoredScheduleLabels                                                   []string
 }
 
 type controllerRunInfo struct {
@@ -225,6 +226,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 	command.Flags().DurationVar(&config.defaultBackupTTL, "default-backup-ttl", config.defaultBackupTTL, "how long to wait by default before backups can be garbage collected")
 	command.Flags().DurationVar(&config.defaultResticMaintenanceFrequency, "default-restic-prune-frequency", config.defaultResticMaintenanceFrequency, "how often 'restic prune' is run for restic repositories by default")
 	command.Flags().BoolVar(&config.defaultVolumesToRestic, "default-volumes-to-restic", config.defaultVolumesToRestic, "backup all volumes with restic by default")
+	command.Flags().StringSliceVar(&config.ignoredScheduleLabels, "ignore-schedule-labels", config.ignoredScheduleLabels, "labels in Schedule resource to not copy to the Backup resources")
 
 	return command
 }
@@ -708,6 +710,7 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 			s.sharedInformerFactory.Velero().V1().Schedules(),
 			s.logger,
 			s.metrics,
+			s.config.ignoredScheduleLabels,
 		)
 
 		return controllerRunInfo{


### PR DESCRIPTION
Currently when a Backup is created from a Schedule all the labels are copied to the backup as-is. In some scenarios it is desired to customize this behavior and ignore some labels.

I suggest adding a multi-values flag like this:
```
velero ... --ignore-schedule-label=mylabel ...
```

Example: In a Continuous Delivery system, a user can maintain a velero Schedule in a chart. The CD controller uses labels to track resources and reconcile them. Since velero copies the labels from Schedule to Backup, the CD controller keeps getting confused about the Backup resources. Also because usually there is a big number of Backup resources, this causes an unwanted overhead.