### PR TITLE
Adding extra labels on backup CRD #2342 - for future enhanced migration logic

### DIFF
--- a/pkg/apis/velero/v1/labels_annotations.go
+++ b/pkg/apis/velero/v1/labels_annotations.go
@@ -52,6 +52,14 @@ const (
 	ResticVolumeNamespaceLabel = "velero.io/volume-namespace"
 
 	// SourceClusterK8sVersionLabel is the label key used to identify the k8s
-	// major version of the backup 
+	// git version of the backup , i.e. v1.16.4
 	SourceClusterK8sVersionLabel = "velero.io/source-cluster-k8s-version"
+
+	// SourceClusterK8sMajorVersionLabel is the label key used to identify the k8s
+	// major version of the backup , i.e. 1
+	SourceClusterK8sMajorVersionLabel = "velero.io/source-cluster-k8s-major-version"
+
+	// SourceClusterK8sMajorVersionLabel is the label key used to identify the k8s
+	// minor version of the backup , i.e. 16
+	SourceClusterK8sMinorVersionLabel = "velero.io/source-cluster-k8s-minor-version"
 )

--- a/pkg/apis/velero/v1/labels_annotations.go
+++ b/pkg/apis/velero/v1/labels_annotations.go
@@ -50,4 +50,8 @@ const (
 	// ResticVolumeNamespaceLabel is the label key used to identify which
 	// namespace a restic repository stores pod volume backups for.
 	ResticVolumeNamespaceLabel = "velero.io/volume-namespace"
+
+	// SourceClusterK8sVersionLabel is the label key used to identify the k8s
+	// major version of the backup 
+	SourceClusterK8sVersionLabel = "velero.io/source-cluster-k8s-version"
 )

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -587,6 +587,7 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 		backupController := controller.NewBackupController(
 			s.sharedInformerFactory.Velero().V1().Backups(),
 			s.veleroClient.VeleroV1(),
+			s.discoveryHelper,
 			backupper,
 			s.logger,
 			s.logLevel,

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -51,6 +51,7 @@ import (
 	kubeutil "github.com/vmware-tanzu/velero/pkg/util/kube"
 	"github.com/vmware-tanzu/velero/pkg/util/logging"
 	"github.com/vmware-tanzu/velero/pkg/volume"
+	// "github.com/vmware-tanzu/velero/pkg/discovery"
 )
 
 type backupController struct {
@@ -328,6 +329,7 @@ func (c *backupController) prepareBackupRequest(backup *velerov1api.Backup) *pkg
 		request.Labels = make(map[string]string)
 	}
 	request.Labels[velerov1api.StorageLocationLabel] = label.GetValidName(request.Spec.StorageLocation)
+	request.Labels[velerov1api.SourceClusterK8sVersionLabel] = label.GetValidName("placeholder-for-version")
 
 	// validate the included/excluded resources
 	for _, err := range collections.ValidateIncludesExcludes(request.Spec.IncludedResources, request.Spec.ExcludedResources) {

--- a/pkg/controller/backup_sync_controller.go
+++ b/pkg/controller/backup_sync_controller.go
@@ -211,6 +211,7 @@ func (c *backupSyncController) run() {
 				backup.Labels = make(map[string]string)
 			}
 			backup.Labels[velerov1api.StorageLocationLabel] = label.GetValidName(backup.Spec.StorageLocation)
+			backup.Labels[velerov1api.SourceClusterK8sVersionLabel] = label.GetValidName("placeholder-for-version")
 
 			// attempt to create backup custom resource via API
 			backup, err = c.backupClient.Backups(backup.Namespace).Create(backup)

--- a/pkg/controller/backup_sync_controller.go
+++ b/pkg/controller/backup_sync_controller.go
@@ -211,7 +211,6 @@ func (c *backupSyncController) run() {
 				backup.Labels = make(map[string]string)
 			}
 			backup.Labels[velerov1api.StorageLocationLabel] = label.GetValidName(backup.Spec.StorageLocation)
-			backup.Labels[velerov1api.SourceClusterK8sVersionLabel] = label.GetValidName("placeholder-for-version")
 
 			// attempt to create backup custom resource via API
 			backup, err = c.backupClient.Backups(backup.Namespace).Create(backup)


### PR DESCRIPTION
closes #2342 

This PR is to add labels on backup CRD about the k8s version of the source cluster.
These labels will be parsed and used for future migration/transformation logic on skip-lelevel k8s migration.
The code was tested using "kind cluster create" on multiple versions

```
$ velero backup describe nginx-backup
Name:         nginx-backup
Namespace:    velero
Labels:       velero.io/source-cluster-k8s-major-version=1
              velero.io/source-cluster-k8s-minor-version=14
              velero.io/source-cluster-k8s-version=v1.14.10
              velero.io/storage-location=default
Annotations:  <none>
```