### PR TITLE
Adding extra labels on backup CRD #2342 #2343

### DIFF
--- a/changelogs/unreleased/2343-brito-rafa
+++ b/changelogs/unreleased/2343-brito-rafa
@@ -1,0 +1,1 @@
+adding labels on backup CRD for k8s major, minor and git versions

--- a/pkg/apis/velero/v1/labels_annotations.go
+++ b/pkg/apis/velero/v1/labels_annotations.go
@@ -52,6 +52,14 @@ const (
 	ResticVolumeNamespaceLabel = "velero.io/volume-namespace"
 
 	// SourceClusterK8sVersionLabel is the label key used to identify the k8s
-	// major version of the backup 
+	// git version of the backup , i.e. v1.16.4
 	SourceClusterK8sVersionLabel = "velero.io/source-cluster-k8s-version"
+
+	// SourceClusterK8sMajorVersionLabel is the label key used to identify the k8s
+	// major version of the backup , i.e. 1
+	SourceClusterK8sMajorVersionLabel = "velero.io/source-cluster-k8s-major-version"
+
+	// SourceClusterK8sMajorVersionLabel is the label key used to identify the k8s
+	// minor version of the backup , i.e. 16
+	SourceClusterK8sMinorVersionLabel = "velero.io/source-cluster-k8s-minor-version"
 )

--- a/pkg/apis/velero/v1/labels_annotations.go
+++ b/pkg/apis/velero/v1/labels_annotations.go
@@ -50,4 +50,8 @@ const (
 	// ResticVolumeNamespaceLabel is the label key used to identify which
 	// namespace a restic repository stores pod volume backups for.
 	ResticVolumeNamespaceLabel = "velero.io/volume-namespace"
+
+	// SourceClusterK8sVersionLabel is the label key used to identify the k8s
+	// major version of the backup 
+	SourceClusterK8sVersionLabel = "velero.io/source-cluster-k8s-version"
 )

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -587,6 +587,7 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 		backupController := controller.NewBackupController(
 			s.sharedInformerFactory.Velero().V1().Backups(),
 			s.veleroClient.VeleroV1(),
+			s.discoveryHelper,
 			backupper,
 			s.logger,
 			s.logLevel,

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -51,6 +51,7 @@ import (
 	kubeutil "github.com/vmware-tanzu/velero/pkg/util/kube"
 	"github.com/vmware-tanzu/velero/pkg/util/logging"
 	"github.com/vmware-tanzu/velero/pkg/volume"
+	// "github.com/vmware-tanzu/velero/pkg/discovery"
 )
 
 type backupController struct {
@@ -328,6 +329,7 @@ func (c *backupController) prepareBackupRequest(backup *velerov1api.Backup) *pkg
 		request.Labels = make(map[string]string)
 	}
 	request.Labels[velerov1api.StorageLocationLabel] = label.GetValidName(request.Spec.StorageLocation)
+	request.Labels[velerov1api.SourceClusterK8sVersionLabel] = label.GetValidName("placeholder-for-version")
 
 	// validate the included/excluded resources
 	for _, err := range collections.ValidateIncludesExcludes(request.Spec.IncludedResources, request.Spec.ExcludedResources) {

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -39,6 +39,7 @@ import (
 
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	pkgbackup "github.com/vmware-tanzu/velero/pkg/backup"
+	"github.com/vmware-tanzu/velero/pkg/discovery"
 	velerov1client "github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned/typed/velero/v1"
 	velerov1informers "github.com/vmware-tanzu/velero/pkg/generated/informers/externalversions/velero/v1"
 	velerov1listers "github.com/vmware-tanzu/velero/pkg/generated/listers/velero/v1"
@@ -51,12 +52,11 @@ import (
 	kubeutil "github.com/vmware-tanzu/velero/pkg/util/kube"
 	"github.com/vmware-tanzu/velero/pkg/util/logging"
 	"github.com/vmware-tanzu/velero/pkg/volume"
-	// "github.com/vmware-tanzu/velero/pkg/discovery"
 )
 
 type backupController struct {
 	*genericController
-
+	discoveryHelper          discovery.Helper
 	backupper                pkgbackup.Backupper
 	lister                   velerov1listers.BackupLister
 	client                   velerov1client.BackupsGetter
@@ -77,6 +77,7 @@ type backupController struct {
 func NewBackupController(
 	backupInformer velerov1informers.BackupInformer,
 	client velerov1client.BackupsGetter,
+	discoveryHelper discovery.Helper,
 	backupper pkgbackup.Backupper,
 	logger logrus.FieldLogger,
 	backupLogLevel logrus.Level,
@@ -92,6 +93,7 @@ func NewBackupController(
 ) Interface {
 	c := &backupController{
 		genericController:        newGenericController("backup", logger),
+		discoveryHelper:          discoveryHelper,
 		backupper:                backupper,
 		lister:                   backupInformer.Lister(),
 		client:                   client,
@@ -329,7 +331,11 @@ func (c *backupController) prepareBackupRequest(backup *velerov1api.Backup) *pkg
 		request.Labels = make(map[string]string)
 	}
 	request.Labels[velerov1api.StorageLocationLabel] = label.GetValidName(request.Spec.StorageLocation)
-	request.Labels[velerov1api.SourceClusterK8sVersionLabel] = label.GetValidName("placeholder-for-version")
+
+	// Getting all information of cluster version - useful for future skip-level migration
+	request.Labels[velerov1api.SourceClusterK8sVersionLabel] = label.GetValidName(c.discoveryHelper.ServerVersion().String())
+	request.Labels[velerov1api.SourceClusterK8sMajorVersionLabel] = label.GetValidName(c.discoveryHelper.ServerVersion().Major)
+	request.Labels[velerov1api.SourceClusterK8sMinorVersionLabel] = label.GetValidName(c.discoveryHelper.ServerVersion().Minor)
 
 	// validate the included/excluded resources
 	for _, err := range collections.ValidateIncludesExcludes(request.Spec.IncludedResources, request.Spec.ExcludedResources) {

--- a/pkg/controller/backup_sync_controller.go
+++ b/pkg/controller/backup_sync_controller.go
@@ -211,6 +211,7 @@ func (c *backupSyncController) run() {
 				backup.Labels = make(map[string]string)
 			}
 			backup.Labels[velerov1api.StorageLocationLabel] = label.GetValidName(backup.Spec.StorageLocation)
+			backup.Labels[velerov1api.SourceClusterK8sVersionLabel] = label.GetValidName("placeholder-for-version")
 
 			// attempt to create backup custom resource via API
 			backup, err = c.backupClient.Backups(backup.Namespace).Create(backup)

--- a/pkg/controller/backup_sync_controller.go
+++ b/pkg/controller/backup_sync_controller.go
@@ -211,7 +211,6 @@ func (c *backupSyncController) run() {
 				backup.Labels = make(map[string]string)
 			}
 			backup.Labels[velerov1api.StorageLocationLabel] = label.GetValidName(backup.Spec.StorageLocation)
-			backup.Labels[velerov1api.SourceClusterK8sVersionLabel] = label.GetValidName("placeholder-for-version")
 
 			// attempt to create backup custom resource via API
 			backup, err = c.backupClient.Backups(backup.Namespace).Create(backup)

--- a/pkg/discovery/helper.go
+++ b/pkg/discovery/helper.go
@@ -25,9 +25,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/restmapper"
-	"k8s.io/apimachinery/pkg/version"
 
 	kcmdutil "github.com/vmware-tanzu/velero/third_party/kubernetes/pkg/kubectl/cmd/util"
 )
@@ -65,11 +65,11 @@ type helper struct {
 	logger          logrus.FieldLogger
 
 	// lock guards mapper, resources and resourcesMap
-	lock         sync.RWMutex
-	mapper       meta.RESTMapper
-	resources    []*metav1.APIResourceList
-	resourcesMap map[schema.GroupVersionResource]metav1.APIResource
-	apiGroups    []metav1.APIGroup
+	lock          sync.RWMutex
+	mapper        meta.RESTMapper
+	resources     []*metav1.APIResourceList
+	resourcesMap  map[schema.GroupVersionResource]metav1.APIResource
+	apiGroups     []metav1.APIGroup
 	serverVersion *version.Info
 }
 

--- a/pkg/plugin/generated/RestoreItemAction.pb.go
+++ b/pkg/plugin/generated/RestoreItemAction.pb.go
@@ -24,10 +24,12 @@ type RestoreItemActionExecuteRequest struct {
 	ItemFromBackup []byte `protobuf:"bytes,4,opt,name=itemFromBackup,proto3" json:"itemFromBackup,omitempty"`
 }
 
-func (m *RestoreItemActionExecuteRequest) Reset()                    { *m = RestoreItemActionExecuteRequest{} }
-func (m *RestoreItemActionExecuteRequest) String() string            { return proto.CompactTextString(m) }
-func (*RestoreItemActionExecuteRequest) ProtoMessage()               {}
-func (*RestoreItemActionExecuteRequest) Descriptor() ([]byte, []int) { return fileDescriptor3, []int{0} }
+func (m *RestoreItemActionExecuteRequest) Reset()         { *m = RestoreItemActionExecuteRequest{} }
+func (m *RestoreItemActionExecuteRequest) String() string { return proto.CompactTextString(m) }
+func (*RestoreItemActionExecuteRequest) ProtoMessage()    {}
+func (*RestoreItemActionExecuteRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor3, []int{0}
+}
 
 func (m *RestoreItemActionExecuteRequest) GetPlugin() string {
 	if m != nil {

--- a/pkg/test/fake_discovery_helper.go
+++ b/pkg/test/fake_discovery_helper.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/discovery"
 )
 
@@ -31,6 +32,7 @@ type FakeDiscoveryHelper struct {
 	Mapper             meta.RESTMapper
 	AutoReturnResource bool
 	APIGroupsList      []metav1.APIGroup
+	ServerVersionData  *version.Info
 }
 
 func NewFakeDiscoveryHelper(autoReturnResource bool, resources map[schema.GroupVersionResource]schema.GroupVersionResource) *FakeDiscoveryHelper {
@@ -69,6 +71,22 @@ func NewFakeDiscoveryHelper(autoReturnResource bool, resources map[schema.GroupV
 	for group, resources := range apiResourceMap {
 		helper.ResourceList = append(helper.ResourceList, &metav1.APIResourceList{GroupVersion: group, APIResources: resources})
 	}
+
+	// FakeTest of version.Info
+
+	serverVersion := &version.Info{
+		Major:        "1",
+		Minor:        "16",
+		GitVersion:   "v1.16.4",
+		GitCommit:    "FakeTest",
+		GitTreeState: "",
+		BuildDate:    "",
+		GoVersion:    "",
+		Compiler:     "",
+		Platform:     "",
+	}
+
+	helper.ServerVersionData = serverVersion
 
 	return helper
 }
@@ -148,4 +166,8 @@ func NewFakeServerResourcesInterface(resourceList []*metav1.APIResourceList, fai
 		ReturnError:  returnError,
 	}
 	return helper
+}
+
+func (dh *FakeDiscoveryHelper) ServerVersion() *version.Info {
+	return dh.ServerVersionData
 }


### PR DESCRIPTION
Adding extra labels on backup CRD for future migration logic. This is another attempt in regards #2342 & #2343. Added make update and signoff and changelog. 