### PR TITLE
Add --cacert flag to velero cli commands

### DIFF
--- a/changelogs/unreleased/2364-mansam
+++ b/changelogs/unreleased/2364-mansam
@@ -1,0 +1,1 @@
+Added a `--cacert` flag to the velero client describe, download, and logs commands to allow passing a path to a certificate to use when verifying TLS connections to object storage. Also added a corresponding client config option called `cacert` which takes a path to a certificate bundle to use as a default when `--cacert` is not specified.

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -111,17 +111,17 @@ func (c VeleroConfig) Features() []string {
 	return strings.Split(features, ",")
 }
 
-func (c VeleroConfig) CACertPath() string {
+func (c VeleroConfig) CACertFile() string {
 	val, ok := c[ConfigKeyCACert]
 	if !ok {
 		return ""
 	}
-	caCertPath, ok := val.(string)
+	caCertFile, ok := val.(string)
 	if !ok {
 		return ""
 	}
 
-	return caCertPath
+	return caCertFile
 }
 
 func configFileName() string {

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -28,6 +28,7 @@ import (
 const (
 	ConfigKeyNamespace = "namespace"
 	ConfigKeyFeatures  = "features"
+	ConfigKeyCACert    = "cacert"
 )
 
 // VeleroConfig is a map of strings to interface{} for deserializing Velero client config options.
@@ -108,6 +109,19 @@ func (c VeleroConfig) Features() []string {
 	}
 
 	return strings.Split(features, ",")
+}
+
+func (c VeleroConfig) CACertPath() string {
+	val, ok := c[ConfigKeyCACert]
+	if !ok {
+		return ""
+	}
+	caCertPath, ok := val.(string)
+	if !ok {
+		return ""
+	}
+
+	return caCertPath
 }
 
 func configFileName() string {

--- a/pkg/cmd/cli/backup/describe.go
+++ b/pkg/cmd/cli/backup/describe.go
@@ -38,6 +38,12 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 		insecureSkipTLSVerify bool
 	)
 
+	config, err := client.LoadConfig()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: Error reading config file: %v\n", err)
+	}
+	caCertPath := config.CACertPath()
+
 	c := &cobra.Command{
 		Use:   use + " [NAME1] [NAME2] [NAME...]",
 		Short: "Describe backups",
@@ -72,7 +78,7 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 					fmt.Fprintf(os.Stderr, "error getting PodVolumeBackups for backup %s: %v\n", backup.Name, err)
 				}
 
-				s := output.DescribeBackup(&backup, deleteRequestList.Items, podVolumeBackupList.Items, details, veleroClient, insecureSkipTLSVerify)
+				s := output.DescribeBackup(&backup, deleteRequestList.Items, podVolumeBackupList.Items, details, veleroClient, insecureSkipTLSVerify, caCertPath)
 				if first {
 					first = false
 					fmt.Print(s)
@@ -87,6 +93,6 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 	c.Flags().StringVarP(&listOptions.LabelSelector, "selector", "l", listOptions.LabelSelector, "only show items matching this label selector")
 	c.Flags().BoolVar(&details, "details", details, "display additional detail in the command output")
 	c.Flags().BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", insecureSkipTLSVerify, "If true, the object store's TLS certificate will not be checked for validity. This is insecure and susceptible to man-in-the-middle attacks. Not recommended for production.")
-
+	c.Flags().StringVar(&caCertPath, "cacert", caCertPath, "path to a certificate bundle to use when verifying TLS connections")
 	return c
 }

--- a/pkg/cmd/cli/backup/describe.go
+++ b/pkg/cmd/cli/backup/describe.go
@@ -42,7 +42,7 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "WARNING: Error reading config file: %v\n", err)
 	}
-	caCertPath := config.CACertPath()
+	caCertFile := config.CACertFile()
 
 	c := &cobra.Command{
 		Use:   use + " [NAME1] [NAME2] [NAME...]",
@@ -78,7 +78,7 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 					fmt.Fprintf(os.Stderr, "error getting PodVolumeBackups for backup %s: %v\n", backup.Name, err)
 				}
 
-				s := output.DescribeBackup(&backup, deleteRequestList.Items, podVolumeBackupList.Items, details, veleroClient, insecureSkipTLSVerify, caCertPath)
+				s := output.DescribeBackup(&backup, deleteRequestList.Items, podVolumeBackupList.Items, details, veleroClient, insecureSkipTLSVerify, caCertFile)
 				if first {
 					first = false
 					fmt.Print(s)
@@ -93,6 +93,6 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 	c.Flags().StringVarP(&listOptions.LabelSelector, "selector", "l", listOptions.LabelSelector, "only show items matching this label selector")
 	c.Flags().BoolVar(&details, "details", details, "display additional detail in the command output")
 	c.Flags().BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", insecureSkipTLSVerify, "If true, the object store's TLS certificate will not be checked for validity. This is insecure and susceptible to man-in-the-middle attacks. Not recommended for production.")
-	c.Flags().StringVar(&caCertPath, "cacert", caCertPath, "path to a certificate bundle to use when verifying TLS connections")
+	c.Flags().StringVar(&caCertFile, "cacert", caCertFile, "path to a certificate bundle to use when verifying TLS connections")
 	return c
 }

--- a/pkg/cmd/cli/backup/download.go
+++ b/pkg/cmd/cli/backup/download.go
@@ -39,7 +39,7 @@ func NewDownloadCommand(f client.Factory) *cobra.Command {
 		fmt.Fprintf(os.Stderr, "WARNING: Error reading config file: %v\n", err)
 	}
 	o := NewDownloadOptions()
-	o.caCertPath = config.CACertPath()
+	o.caCertFile = config.CACertFile()
 
 	c := &cobra.Command{
 		Use:   "download NAME",
@@ -64,7 +64,7 @@ type DownloadOptions struct {
 	Timeout               time.Duration
 	InsecureSkipTLSVerify bool
 	writeOptions          int
-	caCertPath            string
+	caCertFile            string
 }
 
 func NewDownloadOptions() *DownloadOptions {
@@ -78,7 +78,7 @@ func (o *DownloadOptions) BindFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&o.Force, "force", o.Force, "forces the download and will overwrite file if it exists already")
 	flags.DurationVar(&o.Timeout, "timeout", o.Timeout, "maximum time to wait to process download request")
 	flags.BoolVar(&o.InsecureSkipTLSVerify, "insecure-skip-tls-verify", o.InsecureSkipTLSVerify, "If true, the object store's TLS certificate will not be checked for validity. This is insecure and susceptible to man-in-the-middle attacks. Not recommended for production.")
-	flags.StringVar(&o.caCertPath, "cacert", o.caCertPath, "path to a certificate bundle to use when verifying TLS connections")
+	flags.StringVar(&o.caCertFile, "cacert", o.caCertFile, "path to a certificate bundle to use when verifying TLS connections")
 
 }
 
@@ -122,7 +122,7 @@ func (o *DownloadOptions) Run(c *cobra.Command, f client.Factory) error {
 	}
 	defer backupDest.Close()
 
-	err = downloadrequest.Stream(veleroClient.VeleroV1(), f.Namespace(), o.Name, v1.DownloadTargetKindBackupContents, backupDest, o.Timeout, o.InsecureSkipTLSVerify, o.caCertPath)
+	err = downloadrequest.Stream(veleroClient.VeleroV1(), f.Namespace(), o.Name, v1.DownloadTargetKindBackupContents, backupDest, o.Timeout, o.InsecureSkipTLSVerify, o.caCertFile)
 	if err != nil {
 		os.Remove(o.Output)
 		cmd.CheckError(err)

--- a/pkg/cmd/cli/backup/download.go
+++ b/pkg/cmd/cli/backup/download.go
@@ -34,7 +34,13 @@ import (
 )
 
 func NewDownloadCommand(f client.Factory) *cobra.Command {
+	config, err := client.LoadConfig()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: Error reading config file: %v\n", err)
+	}
 	o := NewDownloadOptions()
+	o.caCertPath = config.CACertPath()
+
 	c := &cobra.Command{
 		Use:   "download NAME",
 		Short: "Download a backup",
@@ -58,6 +64,7 @@ type DownloadOptions struct {
 	Timeout               time.Duration
 	InsecureSkipTLSVerify bool
 	writeOptions          int
+	caCertPath            string
 }
 
 func NewDownloadOptions() *DownloadOptions {
@@ -71,6 +78,8 @@ func (o *DownloadOptions) BindFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&o.Force, "force", o.Force, "forces the download and will overwrite file if it exists already")
 	flags.DurationVar(&o.Timeout, "timeout", o.Timeout, "maximum time to wait to process download request")
 	flags.BoolVar(&o.InsecureSkipTLSVerify, "insecure-skip-tls-verify", o.InsecureSkipTLSVerify, "If true, the object store's TLS certificate will not be checked for validity. This is insecure and susceptible to man-in-the-middle attacks. Not recommended for production.")
+	flags.StringVar(&o.caCertPath, "cacert", o.caCertPath, "path to a certificate bundle to use when verifying TLS connections")
+
 }
 
 func (o *DownloadOptions) Validate(c *cobra.Command, args []string, f client.Factory) error {
@@ -113,7 +122,7 @@ func (o *DownloadOptions) Run(c *cobra.Command, f client.Factory) error {
 	}
 	defer backupDest.Close()
 
-	err = downloadrequest.Stream(veleroClient.VeleroV1(), f.Namespace(), o.Name, v1.DownloadTargetKindBackupContents, backupDest, o.Timeout, o.InsecureSkipTLSVerify)
+	err = downloadrequest.Stream(veleroClient.VeleroV1(), f.Namespace(), o.Name, v1.DownloadTargetKindBackupContents, backupDest, o.Timeout, o.InsecureSkipTLSVerify, o.caCertPath)
 	if err != nil {
 		os.Remove(o.Output)
 		cmd.CheckError(err)

--- a/pkg/cmd/cli/backup/logs.go
+++ b/pkg/cmd/cli/backup/logs.go
@@ -17,6 +17,7 @@ limitations under the License.
 package backup
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -31,8 +32,14 @@ import (
 )
 
 func NewLogsCommand(f client.Factory) *cobra.Command {
+	config, err := client.LoadConfig()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: Error reading config file: %v\n", err)
+	}
+
 	timeout := time.Minute
 	insecureSkipTLSVerify := false
+	caCertPath := config.CACertPath()
 
 	c := &cobra.Command{
 		Use:   "logs BACKUP",
@@ -59,13 +66,13 @@ func NewLogsCommand(f client.Factory) *cobra.Command {
 					"until the backup has a phase of Completed or Failed and try again.", backupName)
 			}
 
-			err = downloadrequest.Stream(veleroClient.VeleroV1(), f.Namespace(), backupName, v1.DownloadTargetKindBackupLog, os.Stdout, timeout, insecureSkipTLSVerify)
+			err = downloadrequest.Stream(veleroClient.VeleroV1(), f.Namespace(), backupName, v1.DownloadTargetKindBackupLog, os.Stdout, timeout, insecureSkipTLSVerify, caCertPath)
 			cmd.CheckError(err)
 		},
 	}
 
 	c.Flags().DurationVar(&timeout, "timeout", timeout, "how long to wait to receive logs")
 	c.Flags().BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", insecureSkipTLSVerify, "If true, the object store's TLS certificate will not be checked for validity. This is insecure and susceptible to man-in-the-middle attacks. Not recommended for production.")
-
+	c.Flags().StringVar(&caCertPath, "cacert", caCertPath, "path to a certificate bundle to use when verifying TLS connections")
 	return c
 }

--- a/pkg/cmd/cli/backup/logs.go
+++ b/pkg/cmd/cli/backup/logs.go
@@ -39,7 +39,7 @@ func NewLogsCommand(f client.Factory) *cobra.Command {
 
 	timeout := time.Minute
 	insecureSkipTLSVerify := false
-	caCertPath := config.CACertPath()
+	caCertFile := config.CACertFile()
 
 	c := &cobra.Command{
 		Use:   "logs BACKUP",
@@ -66,13 +66,13 @@ func NewLogsCommand(f client.Factory) *cobra.Command {
 					"until the backup has a phase of Completed or Failed and try again.", backupName)
 			}
 
-			err = downloadrequest.Stream(veleroClient.VeleroV1(), f.Namespace(), backupName, v1.DownloadTargetKindBackupLog, os.Stdout, timeout, insecureSkipTLSVerify, caCertPath)
+			err = downloadrequest.Stream(veleroClient.VeleroV1(), f.Namespace(), backupName, v1.DownloadTargetKindBackupLog, os.Stdout, timeout, insecureSkipTLSVerify, caCertFile)
 			cmd.CheckError(err)
 		},
 	}
 
 	c.Flags().DurationVar(&timeout, "timeout", timeout, "how long to wait to receive logs")
 	c.Flags().BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", insecureSkipTLSVerify, "If true, the object store's TLS certificate will not be checked for validity. This is insecure and susceptible to man-in-the-middle attacks. Not recommended for production.")
-	c.Flags().StringVar(&caCertPath, "cacert", caCertPath, "path to a certificate bundle to use when verifying TLS connections")
+	c.Flags().StringVar(&caCertFile, "cacert", caCertFile, "path to a certificate bundle to use when verifying TLS connections")
 	return c
 }

--- a/pkg/cmd/cli/restore/describe.go
+++ b/pkg/cmd/cli/restore/describe.go
@@ -37,6 +37,12 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 		insecureSkipTLSVerify bool
 	)
 
+	config, err := client.LoadConfig()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: Error reading config file: %v\n", err)
+	}
+	caCertPath := config.CACertPath()
+
 	c := &cobra.Command{
 		Use:   use + " [NAME1] [NAME2] [NAME...]",
 		Short: "Describe restores",
@@ -65,7 +71,7 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 					fmt.Fprintf(os.Stderr, "error getting PodVolumeRestores for restore %s: %v\n", restore.Name, err)
 				}
 
-				s := output.DescribeRestore(&restore, podvolumeRestoreList.Items, details, veleroClient, insecureSkipTLSVerify)
+				s := output.DescribeRestore(&restore, podvolumeRestoreList.Items, details, veleroClient, insecureSkipTLSVerify, caCertPath)
 				if first {
 					first = false
 					fmt.Print(s)
@@ -80,6 +86,7 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 	c.Flags().StringVarP(&listOptions.LabelSelector, "selector", "l", listOptions.LabelSelector, "only show items matching this label selector")
 	c.Flags().BoolVar(&details, "details", details, "display additional detail in the command output")
 	c.Flags().BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", insecureSkipTLSVerify, "If true, the object store's TLS certificate will not be checked for validity. This is insecure and susceptible to man-in-the-middle attacks. Not recommended for production.")
+	c.Flags().StringVar(&caCertPath, "cacert", caCertPath, "path to a certificate bundle to use when verifying TLS connections")
 
 	return c
 }

--- a/pkg/cmd/cli/restore/describe.go
+++ b/pkg/cmd/cli/restore/describe.go
@@ -41,7 +41,7 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "WARNING: Error reading config file: %v\n", err)
 	}
-	caCertPath := config.CACertPath()
+	caCertFile := config.CACertFile()
 
 	c := &cobra.Command{
 		Use:   use + " [NAME1] [NAME2] [NAME...]",
@@ -71,7 +71,7 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 					fmt.Fprintf(os.Stderr, "error getting PodVolumeRestores for restore %s: %v\n", restore.Name, err)
 				}
 
-				s := output.DescribeRestore(&restore, podvolumeRestoreList.Items, details, veleroClient, insecureSkipTLSVerify, caCertPath)
+				s := output.DescribeRestore(&restore, podvolumeRestoreList.Items, details, veleroClient, insecureSkipTLSVerify, caCertFile)
 				if first {
 					first = false
 					fmt.Print(s)
@@ -86,7 +86,7 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 	c.Flags().StringVarP(&listOptions.LabelSelector, "selector", "l", listOptions.LabelSelector, "only show items matching this label selector")
 	c.Flags().BoolVar(&details, "details", details, "display additional detail in the command output")
 	c.Flags().BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", insecureSkipTLSVerify, "If true, the object store's TLS certificate will not be checked for validity. This is insecure and susceptible to man-in-the-middle attacks. Not recommended for production.")
-	c.Flags().StringVar(&caCertPath, "cacert", caCertPath, "path to a certificate bundle to use when verifying TLS connections")
+	c.Flags().StringVar(&caCertFile, "cacert", caCertFile, "path to a certificate bundle to use when verifying TLS connections")
 
 	return c
 }

--- a/pkg/cmd/cli/restore/logs.go
+++ b/pkg/cmd/cli/restore/logs.go
@@ -39,7 +39,7 @@ func NewLogsCommand(f client.Factory) *cobra.Command {
 
 	timeout := time.Minute
 	insecureSkipTLSVerify := false
-	caCertPath := config.CACertPath()
+	caCertFile := config.CACertFile()
 
 	c := &cobra.Command{
 		Use:   "logs RESTORE",
@@ -66,14 +66,14 @@ func NewLogsCommand(f client.Factory) *cobra.Command {
 					"until the restore has a phase of Completed or Failed and try again.", restoreName)
 			}
 
-			err = downloadrequest.Stream(veleroClient.VeleroV1(), f.Namespace(), restoreName, v1.DownloadTargetKindRestoreLog, os.Stdout, timeout, insecureSkipTLSVerify, caCertPath)
+			err = downloadrequest.Stream(veleroClient.VeleroV1(), f.Namespace(), restoreName, v1.DownloadTargetKindRestoreLog, os.Stdout, timeout, insecureSkipTLSVerify, caCertFile)
 			cmd.CheckError(err)
 		},
 	}
 
 	c.Flags().DurationVar(&timeout, "timeout", timeout, "how long to wait to receive logs")
 	c.Flags().BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", insecureSkipTLSVerify, "If true, the object store's TLS certificate will not be checked for validity. This is insecure and susceptible to man-in-the-middle attacks. Not recommended for production.")
-	c.Flags().StringVar(&caCertPath, "cacert", caCertPath, "path to a certificate bundle to use when verifying TLS connections")
+	c.Flags().StringVar(&caCertFile, "cacert", caCertFile, "path to a certificate bundle to use when verifying TLS connections")
 
 	return c
 }

--- a/pkg/cmd/cli/restore/logs.go
+++ b/pkg/cmd/cli/restore/logs.go
@@ -17,6 +17,7 @@ limitations under the License.
 package restore
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -31,8 +32,14 @@ import (
 )
 
 func NewLogsCommand(f client.Factory) *cobra.Command {
+	config, err := client.LoadConfig()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: Error reading config file: %v\n", err)
+	}
+
 	timeout := time.Minute
 	insecureSkipTLSVerify := false
+	caCertPath := config.CACertPath()
 
 	c := &cobra.Command{
 		Use:   "logs RESTORE",
@@ -59,13 +66,14 @@ func NewLogsCommand(f client.Factory) *cobra.Command {
 					"until the restore has a phase of Completed or Failed and try again.", restoreName)
 			}
 
-			err = downloadrequest.Stream(veleroClient.VeleroV1(), f.Namespace(), restoreName, v1.DownloadTargetKindRestoreLog, os.Stdout, timeout, insecureSkipTLSVerify)
+			err = downloadrequest.Stream(veleroClient.VeleroV1(), f.Namespace(), restoreName, v1.DownloadTargetKindRestoreLog, os.Stdout, timeout, insecureSkipTLSVerify, caCertPath)
 			cmd.CheckError(err)
 		},
 	}
 
 	c.Flags().DurationVar(&timeout, "timeout", timeout, "how long to wait to receive logs")
 	c.Flags().BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", insecureSkipTLSVerify, "If true, the object store's TLS certificate will not be checked for validity. This is insecure and susceptible to man-in-the-middle attacks. Not recommended for production.")
+	c.Flags().StringVar(&caCertPath, "cacert", caCertPath, "path to a certificate bundle to use when verifying TLS connections")
 
 	return c
 }

--- a/pkg/cmd/util/downloadrequest/downloadrequest_test.go
+++ b/pkg/cmd/util/downloadrequest/downloadrequest_test.go
@@ -151,7 +151,7 @@ func TestStream(t *testing.T) {
 			output := new(bytes.Buffer)
 			errCh := make(chan error)
 			go func() {
-				err := Stream(client.VeleroV1(), "namespace", "name", test.kind, output, timeout, false)
+				err := Stream(client.VeleroV1(), "namespace", "name", test.kind, output, timeout, false, "")
 				errCh <- err
 			}()
 

--- a/pkg/cmd/util/output/backup_describer.go
+++ b/pkg/cmd/util/output/backup_describer.go
@@ -39,7 +39,7 @@ func DescribeBackup(
 	details bool,
 	veleroClient clientset.Interface,
 	insecureSkipTLSVerify bool,
-	caCertPath string,
+	caCertFile string,
 ) string {
 	return Describe(func(d *Describer) {
 		d.DescribeMetadata(backup.ObjectMeta)
@@ -76,7 +76,7 @@ func DescribeBackup(
 		DescribeBackupSpec(d, backup.Spec)
 
 		d.Println()
-		DescribeBackupStatus(d, backup, details, veleroClient, insecureSkipTLSVerify, caCertPath)
+		DescribeBackupStatus(d, backup, details, veleroClient, insecureSkipTLSVerify, caCertFile)
 
 		if len(deleteRequests) > 0 {
 			d.Println()

--- a/pkg/cmd/util/output/restore_describer.go
+++ b/pkg/cmd/util/output/restore_describer.go
@@ -31,7 +31,7 @@ import (
 	pkgrestore "github.com/vmware-tanzu/velero/pkg/restore"
 )
 
-func DescribeRestore(restore *v1.Restore, podVolumeRestores []v1.PodVolumeRestore, details bool, veleroClient clientset.Interface, insecureSkipTLSVerify bool) string {
+func DescribeRestore(restore *v1.Restore, podVolumeRestores []v1.PodVolumeRestore, details bool, veleroClient clientset.Interface, insecureSkipTLSVerify bool, caCertPath string) string {
 	return Describe(func(d *Describer) {
 		d.DescribeMetadata(restore.ObjectMeta)
 
@@ -56,7 +56,7 @@ func DescribeRestore(restore *v1.Restore, podVolumeRestores []v1.PodVolumeRestor
 			}
 		}
 
-		describeRestoreResults(d, restore, veleroClient, insecureSkipTLSVerify)
+		describeRestoreResults(d, restore, veleroClient, insecureSkipTLSVerify, caCertPath)
 
 		d.Println()
 		d.Printf("Backup:\t%s\n", restore.Spec.BackupName)
@@ -114,7 +114,7 @@ func DescribeRestore(restore *v1.Restore, podVolumeRestores []v1.PodVolumeRestor
 	})
 }
 
-func describeRestoreResults(d *Describer, restore *v1.Restore, veleroClient clientset.Interface, insecureSkipTLSVerify bool) {
+func describeRestoreResults(d *Describer, restore *v1.Restore, veleroClient clientset.Interface, insecureSkipTLSVerify bool, caCertPath string) {
 	if restore.Status.Warnings == 0 && restore.Status.Errors == 0 {
 		return
 	}
@@ -122,7 +122,7 @@ func describeRestoreResults(d *Describer, restore *v1.Restore, veleroClient clie
 	var buf bytes.Buffer
 	var resultMap map[string]pkgrestore.Result
 
-	if err := downloadrequest.Stream(veleroClient.VeleroV1(), restore.Namespace, restore.Name, v1.DownloadTargetKindRestoreResults, &buf, downloadRequestTimeout, insecureSkipTLSVerify); err != nil {
+	if err := downloadrequest.Stream(veleroClient.VeleroV1(), restore.Namespace, restore.Name, v1.DownloadTargetKindRestoreResults, &buf, downloadRequestTimeout, insecureSkipTLSVerify, caCertPath); err != nil {
 		d.Printf("Warnings:\t<error getting warnings: %v>\n\nErrors:\t<error getting errors: %v>\n", err, err)
 		return
 	}

--- a/pkg/cmd/util/output/restore_describer.go
+++ b/pkg/cmd/util/output/restore_describer.go
@@ -31,7 +31,7 @@ import (
 	pkgrestore "github.com/vmware-tanzu/velero/pkg/restore"
 )
 
-func DescribeRestore(restore *v1.Restore, podVolumeRestores []v1.PodVolumeRestore, details bool, veleroClient clientset.Interface, insecureSkipTLSVerify bool, caCertPath string) string {
+func DescribeRestore(restore *v1.Restore, podVolumeRestores []v1.PodVolumeRestore, details bool, veleroClient clientset.Interface, insecureSkipTLSVerify bool, caCertFile string) string {
 	return Describe(func(d *Describer) {
 		d.DescribeMetadata(restore.ObjectMeta)
 
@@ -56,7 +56,7 @@ func DescribeRestore(restore *v1.Restore, podVolumeRestores []v1.PodVolumeRestor
 			}
 		}
 
-		describeRestoreResults(d, restore, veleroClient, insecureSkipTLSVerify, caCertPath)
+		describeRestoreResults(d, restore, veleroClient, insecureSkipTLSVerify, caCertFile)
 
 		d.Println()
 		d.Printf("Backup:\t%s\n", restore.Spec.BackupName)


### PR DESCRIPTION
Fixes https://github.com/vmware-tanzu/velero/issues/2330

Adds a --cacert flag to the log and describe commands
that takes a path to a PEM-encoded certificate bundle
as an alternative to --insecure-skip-tls-verify for
dealing with self-signed certificates.

Signed-off-by: Sam Lucidi <slucidi@redhat.com>

