### PR TITLE
Add --cacert flag to the installer

### DIFF
--- a/changelogs/unreleased/2368-mansam
+++ b/changelogs/unreleased/2368-mansam
@@ -1,0 +1,1 @@
+Added a --cacert flag to the install command to provide the CA bundle to use when verifying TLS connections to object storage

--- a/pkg/install/resources.go
+++ b/pkg/install/resources.go
@@ -137,7 +137,7 @@ func Namespace(namespace string) *corev1.Namespace {
 	}
 }
 
-func BackupStorageLocation(namespace, provider, bucket, prefix string, config map[string]string) *v1.BackupStorageLocation {
+func BackupStorageLocation(namespace, provider, bucket, prefix string, config map[string]string, caCert []byte) *v1.BackupStorageLocation {
 	return &v1.BackupStorageLocation{
 		ObjectMeta: objectMeta(namespace, "default"),
 		TypeMeta: metav1.TypeMeta{
@@ -150,6 +150,7 @@ func BackupStorageLocation(namespace, provider, bucket, prefix string, config ma
 				ObjectStorage: &v1.ObjectStorageLocation{
 					Bucket: bucket,
 					Prefix: prefix,
+					CACert: caCert,
 				},
 			},
 			Config: config,
@@ -217,6 +218,7 @@ type VeleroOptions struct {
 	DefaultResticMaintenanceFrequency time.Duration
 	Plugins                           []string
 	NoDefaultBackupLocation           bool
+	CACertData                        []byte
 }
 
 func AllCRDs() *unstructured.UnstructuredList {
@@ -252,7 +254,7 @@ func AllResources(o *VeleroOptions) (*unstructured.UnstructuredList, error) {
 	}
 
 	if !o.NoDefaultBackupLocation {
-		bsl := BackupStorageLocation(o.Namespace, o.ProviderName, o.Bucket, o.Prefix, o.BSLConfig)
+		bsl := BackupStorageLocation(o.Namespace, o.ProviderName, o.Bucket, o.Prefix, o.BSLConfig, o.CACertData)
 		appendUnstructured(resources, bsl)
 	}
 

--- a/pkg/install/resources_test.go
+++ b/pkg/install/resources_test.go
@@ -23,12 +23,13 @@ import (
 )
 
 func TestResources(t *testing.T) {
-	bsl := BackupStorageLocation("velero", "test", "test", "", make(map[string]string))
+	bsl := BackupStorageLocation("velero", "test", "test", "", make(map[string]string), []byte("test"))
 
 	assert.Equal(t, "velero", bsl.ObjectMeta.Namespace)
 	assert.Equal(t, "test", bsl.Spec.Provider)
 	assert.Equal(t, "test", bsl.Spec.StorageType.ObjectStorage.Bucket)
 	assert.Equal(t, make(map[string]string), bsl.Spec.Config)
+	assert.Equal(t, []byte("test"), bsl.Spec.ObjectStorage.CACert)
 
 	vsl := VolumeSnapshotLocation("velero", "test", make(map[string]string))
 


### PR DESCRIPTION
Fixes https://github.com/vmware-tanzu/velero/issues/2333

Allows setting the cacert field on the BSL during
the install process using the file at the path
specified by the --cacert field.

Signed-off-by: Sam Lucidi <slucidi@redhat.com>