### PR TITLE
add secrets to kuberesource

### DIFF
--- a/pkg/kuberesource/kuberesource.go
+++ b/pkg/kuberesource/kuberesource.go
@@ -30,6 +30,7 @@ var (
 	PersistentVolumes         = schema.GroupResource{Group: "", Resource: "persistentvolumes"}
 	Pods                      = schema.GroupResource{Group: "", Resource: "pods"}
 	ServiceAccounts           = schema.GroupResource{Group: "", Resource: "serviceaccounts"}
+	Secrets                   = schema.GroupResource{Group: "", Resource: "secrets"}
 	VolumeSnapshotClasses     = schema.GroupResource{Group: "snapshot.storage.k8s.io", Resource: "volumesnapshotclasses"}
 	VolumeSnapshots           = schema.GroupResource{Group: "snapshot.storage.k8s.io", Resource: "volumesnapshots"}
 	VolumeSnapshotContents    = schema.GroupResource{Group: "snapshot.storage.k8s.io", Resource: "volumesnapshotcontents"}


### PR DESCRIPTION
add secrets to kuberesource

CSI plugin for velero will use this to return secrets as additional
resource while backing up CSI objects

Signed-off-by: Ashish Amarnath <ashisham@vmware.com>