### PR TITLE
Add velero-volume-controller as an implemented choice of velero restic 3rd party controller

### DIFF
--- a/site/docs/master/restic.md
+++ b/site/docs/master/restic.md
@@ -410,7 +410,7 @@ within each restored volume, under `.velero`, whose name is the UID of the Veler
 1. Once all such files are found, the init container's process terminates successfully and the pod moves
 on to running other init containers/the main containers.
 
-## 3rd party controller
+## 3rd party controllers
 
 ### Monitor backup annotation
 
@@ -420,9 +420,9 @@ To solve this, a controller was written by Thomann Bits&Beats: [velero-pvc-watch
 
 ### Add backup annotation
 
-Velero hasn't provided a do-one-command or automatic way to backup all volume resources in the cluster without annotation.
+Velero does not currently provide a single command or automatic way to backup all volume resources in the cluster without annotating pods or pod templates.
 
-To solve this, [velero-volume-controller][10] helps to achieve this goal by adding backup annotation to pods with volumes automatically.
+The [velero-volume-controller][10] written by duyanghao helps to solve this problem by adding backup annotation to pods with volumes automatically.
 
 [1]: https://github.com/restic/restic
 [2]: customize-installation.md#enable-restic-integration

--- a/site/docs/master/restic.md
+++ b/site/docs/master/restic.md
@@ -418,6 +418,12 @@ Velero does not currently provide a mechanism to detect persistent volume claims
 
 To solve this, a controller was written by Thomann Bits&Beats: [velero-pvc-watcher][7]
 
+### Add backup annotation
+
+Velero hasn't provided a do-one-command or automatic way to backup all volume resources in the cluster without annotation.
+
+To solve this, [velero-volume-controller][10] helps to achieve this goal by adding backup annotation to pods with volumes automatically.
+
 [1]: https://github.com/restic/restic
 [2]: customize-installation.md#enable-restic-integration
 [3]: https://github.com/vmware-tanzu/velero/releases/
@@ -427,3 +433,4 @@ To solve this, a controller was written by Thomann Bits&Beats: [velero-pvc-watch
 [7]: https://github.com/bitsbeats/velero-pvc-watcher
 [8]: https://docs.microsoft.com/en-us/azure/aks/azure-files-dynamic-pv
 [9]: https://github.com/restic/restic/issues/1800
+[10]: https://github.com/duyanghao/velero-volume-controller

--- a/site/docs/v1.3.1/restic.md
+++ b/site/docs/v1.3.1/restic.md
@@ -410,7 +410,7 @@ within each restored volume, under `.velero`, whose name is the UID of the Veler
 1. Once all such files are found, the init container's process terminates successfully and the pod moves
 on to running other init containers/the main containers.
 
-## 3rd party controller
+## 3rd party controllers
 
 ### Monitor backup annotation
 
@@ -420,9 +420,9 @@ To solve this, a controller was written by Thomann Bits&Beats: [velero-pvc-watch
 
 ### Add backup annotation
 
-Velero hasn't provided a do-one-command or automatic way to backup all volume resources in the cluster without annotation.
+Velero does not currently provide a single command or automatic way to backup all volume resources in the cluster without annotating pods or pod templates.
 
-To solve this, [velero-volume-controller][10] helps to achieve this goal by adding backup annotation to pods with volumes automatically.
+The [velero-volume-controller][10] written by duyanghao helps to solve this problem by adding backup annotation to pods with volumes automatically.
 
 [1]: https://github.com/restic/restic
 [2]: customize-installation.md#enable-restic-integration

--- a/site/docs/v1.3.1/restic.md
+++ b/site/docs/v1.3.1/restic.md
@@ -418,6 +418,12 @@ Velero does not currently provide a mechanism to detect persistent volume claims
 
 To solve this, a controller was written by Thomann Bits&Beats: [velero-pvc-watcher][7]
 
+### Add backup annotation
+
+Velero hasn't provided a do-one-command or automatic way to backup all volume resources in the cluster without annotation.
+
+To solve this, [velero-volume-controller][10] helps to achieve this goal by adding backup annotation to pods with volumes automatically.
+
 [1]: https://github.com/restic/restic
 [2]: customize-installation.md#enable-restic-integration
 [3]: https://github.com/vmware-tanzu/velero/releases/
@@ -427,3 +433,4 @@ To solve this, a controller was written by Thomann Bits&Beats: [velero-pvc-watch
 [7]: https://github.com/bitsbeats/velero-pvc-watcher
 [8]: https://docs.microsoft.com/en-us/azure/aks/azure-files-dynamic-pv
 [9]: https://github.com/restic/restic/issues/1800
+[10]: https://github.com/duyanghao/velero-volume-controller


### PR DESCRIPTION
Closes #2375 

[velero-volume-controller](https://github.com/duyanghao/velero-volume-controller) is a Kubernetes controller for velero that detects and adds relevant backup annotation to pods with volumes, which helps to build an automatic way to backup all volume resources in the cluster.

Signed-off-by: duyanghao <1294057873@qq.com>