### PR TITLE
Add documentation for file format versioning

### DIFF
--- a/site/docs/master/output-file-format.md
+++ b/site/docs/master/output-file-format.md
@@ -106,7 +106,7 @@ In order to accommodate this, Velero follows [Semantic Versioning](http://semver
 
 Minor and patch versions will indicate backwards-compatible changes that previous versions of Velero can restore, including new directories or files.
 
-A major version would indicate that a version Velero older than the version that created the backup could restore it.
+A major version would indicate that a version Velero older than the version that created the backup could restore it, usually because of moved or renamed directories or files.
 
 Major versions of the file format are tied to major versions of Velero, though they are not necessarily in sync - Velero 3.0 may still use backup file format 2.0, as an example.
 

--- a/site/docs/master/output-file-format.md
+++ b/site/docs/master/output-file-format.md
@@ -102,7 +102,7 @@ resources/
 
 The Velero output file format is intended to be relatively stable, but may change over time in order to support new features.
 
-In order to accomodate this, Velero follows [Semantic Versioning](http://semver.org/) for the file format version.
+In order to accommodate this, Velero follows [Semantic Versioning](http://semver.org/) for the file format version.
 
 Minor and patch versions will indicate backwards-compatible changes that previous versions of Velero can restore, including new directories or files.
 

--- a/site/docs/master/output-file-format.md
+++ b/site/docs/master/output-file-format.md
@@ -106,7 +106,8 @@ In order to accommodate this, Velero follows [Semantic Versioning](http://semver
 
 Minor and patch versions will indicate backwards-compatible changes that previous versions of Velero can restore, including new directories or files.
 
-A major version would indicate that a version Velero older than the version that created the backup could restore it, usually because of moved or renamed directories or files.
+A major version would indicate that a version of Velero older than the version that created the backup could not restore it, usually because of moved or renamed directories or files.
 
-Major versions of the file format are tied to major versions of Velero, though they are not necessarily in sync - Velero 3.0 may still use backup file format 2.0, as an example.
+Major versions of the file format will be incremented with major version releases of Velero.
+However, a major version release of Velero does not necessarily mean that the backup format version changed - Velero 3.0 could still use backup file format 2.0, as an example.
 

--- a/site/docs/master/output-file-format.md
+++ b/site/docs/master/output-file-format.md
@@ -97,3 +97,16 @@ resources/
                 ...
     ...
 ```
+
+## Output File Format Versioning
+
+The Velero output file format is intended to be relatively stable, but may change over time in order to support new features.
+
+In order to accomodate this, Velero follows [Semantic Versioning](http://semver.org/) for the file format version.
+
+Minor and patch versions will indicate backwards-compatible changes that previous versions of Velero can restore, including new directories or files.
+
+A major version would indicate that a version Velero older than the version that created the backup could restore it.
+
+Major versions of the file format are tied to major versions of Velero, though they are not necessarily in sync - Velero 3.0 may still use backup file format 2.0, as an example.
+


### PR DESCRIPTION
As discussed in https://github.com/vmware-tanzu/velero/pull/2373#discussion_r403182400 and [during the April 14 2020 community meeting](https://hackmd.io/Jq6F5zqZR7S80CeDWUklkA?view#Discussion-Topics1) we need some definition of when to bump the backup file format version.

This is an attempt at laying out rules for doing so.

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>