### PR TITLE
change dynamic client's List return type to UnstructuredList

### DIFF
--- a/pkg/backup/resource_backupper.go
+++ b/pkg/backup/resource_backupper.go
@@ -229,23 +229,11 @@ func (rb *defaultResourceBackupper) backupResource(group *metav1.APIResourceList
 			log.WithError(errors.WithStack(err)).Error("Error listing items")
 			continue
 		}
+		log.Infof("Retrieved %d items", len(unstructuredList.Items))
 
 		// do the backup
-		items, err := meta.ExtractList(unstructuredList)
-		if err != nil {
-			log.WithError(errors.WithStack(err)).Error("Error extracting list")
-			continue
-		}
-
-		log.Infof("Retrieved %d items", len(items))
-
-		for _, item := range items {
-			unstructured, ok := item.(runtime.Unstructured)
-			if !ok {
-				log.Errorf("Unexpected type %T", item)
-				continue
-			}
-			if rb.backupItem(log, gr, itemBackupper, unstructured) {
+		for _, item := range unstructuredList.Items {
+			if rb.backupItem(log, gr, itemBackupper, &item) {
 				backedUpItem = true
 			}
 		}

--- a/pkg/client/dynamic.go
+++ b/pkg/client/dynamic.go
@@ -19,7 +19,6 @@ package client
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
@@ -59,7 +58,7 @@ type Creator interface {
 // Lister lists objects.
 type Lister interface {
 	// List lists all the objects of a given resource.
-	List(metav1.ListOptions) (runtime.Object, error)
+	List(metav1.ListOptions) (*unstructured.UnstructuredList, error)
 }
 
 // Watcher watches objects.
@@ -101,7 +100,7 @@ func (d *dynamicResourceClient) Create(obj *unstructured.Unstructured) (*unstruc
 	return d.resourceClient.Create(obj, metav1.CreateOptions{})
 }
 
-func (d *dynamicResourceClient) List(options metav1.ListOptions) (runtime.Object, error) {
+func (d *dynamicResourceClient) List(options metav1.ListOptions) (*unstructured.UnstructuredList, error) {
 	return d.resourceClient.List(options)
 }
 

--- a/pkg/test/fake_dynamic.go
+++ b/pkg/test/fake_dynamic.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 
@@ -44,9 +43,9 @@ type FakeDynamicClient struct {
 
 var _ client.Dynamic = &FakeDynamicClient{}
 
-func (c *FakeDynamicClient) List(options metav1.ListOptions) (runtime.Object, error) {
+func (c *FakeDynamicClient) List(options metav1.ListOptions) (*unstructured.UnstructuredList, error) {
 	args := c.Called(options)
-	return args.Get(0).(runtime.Object), args.Error(1)
+	return args.Get(0).(*unstructured.UnstructuredList), args.Error(1)
 }
 
 func (c *FakeDynamicClient) Create(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

minor refactoring to change our dynamic client wrapper to return the same type as the upstream dynamic client, so we don't have to roundtrip to a `runtime.Object` and back again.

