### PR TITLE
clarify the wording for restore describe for namespaces included

### DIFF
--- a/changelogs/unreleased/1918-raghavendrabhat
+++ b/changelogs/unreleased/1918-raghavendrabhat
@@ -1,0 +1,4 @@
+clarify the wording for restore describe for namespaces included
+
+Instead of showing it as "*" explicitly mention that all the namespaces
+from the backup object are included.

--- a/pkg/cmd/util/output/restore_describer.go
+++ b/pkg/cmd/util/output/restore_describer.go
@@ -65,7 +65,9 @@ func DescribeRestore(restore *v1.Restore, podVolumeRestores []v1.PodVolumeRestor
 		d.Printf("Namespaces:\n")
 		var s string
 		if len(restore.Spec.IncludedNamespaces) == 0 {
-			s = "*"
+			s = "All namespaces found in the backup"
+		} else if len(restore.Spec.IncludedNamespaces) == 1 && restore.Spec.IncludedNamespaces[0] == "*" {
+			s = "All namespaces found in the backup"
 		} else {
 			s = strings.Join(restore.Spec.IncludedNamespaces, ", ")
 		}

--- a/pkg/cmd/util/output/restore_describer.go
+++ b/pkg/cmd/util/output/restore_describer.go
@@ -67,7 +67,7 @@ func DescribeRestore(restore *v1.Restore, podVolumeRestores []v1.PodVolumeRestor
 		if len(restore.Spec.IncludedNamespaces) == 0 {
 			s = "all namespaces found in the backup"
 		} else if len(restore.Spec.IncludedNamespaces) == 1 && restore.Spec.IncludedNamespaces[0] == "*" {
-			s = "All namespaces found in the backup"
+			s = "all namespaces found in the backup"
 		} else {
 			s = strings.Join(restore.Spec.IncludedNamespaces, ", ")
 		}

--- a/pkg/cmd/util/output/restore_describer.go
+++ b/pkg/cmd/util/output/restore_describer.go
@@ -65,7 +65,7 @@ func DescribeRestore(restore *v1.Restore, podVolumeRestores []v1.PodVolumeRestor
 		d.Printf("Namespaces:\n")
 		var s string
 		if len(restore.Spec.IncludedNamespaces) == 0 {
-			s = "All namespaces found in the backup"
+			s = "all namespaces found in the backup"
 		} else if len(restore.Spec.IncludedNamespaces) == 1 && restore.Spec.IncludedNamespaces[0] == "*" {
 			s = "All namespaces found in the backup"
 		} else {


### PR DESCRIPTION
Instead of showing it as "*" explicitly mention that all the namespaces
from the backup object are included.

refer to https://github.com/vmware-tanzu/velero/issues/1918

Signed-off-by: Raghavendra M <raghavendra@redhat.com>