### PR TITLE
Skipping validation for volumesnapshotlocation for backup if snapshotvolume set to false

### DIFF
--- a/changelogs/unreleased/2450-mynktl
+++ b/changelogs/unreleased/2450-mynktl
@@ -1,0 +1,1 @@
+Support to skip VSL validation for the backup having SnapshotVolumes set to false or created with `--snapshot-volumes=false`

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -41,6 +41,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	"github.com/vmware-tanzu/velero/pkg/podexec"
 	"github.com/vmware-tanzu/velero/pkg/restic"
+	"github.com/vmware-tanzu/velero/pkg/util/boolptr"
 	"github.com/vmware-tanzu/velero/pkg/volume"
 )
 
@@ -399,7 +400,7 @@ const (
 func (ib *defaultItemBackupper) takePVSnapshot(obj runtime.Unstructured, log logrus.FieldLogger) error {
 	log.Info("Executing takePVSnapshot")
 
-	if ib.backupRequest.Spec.SnapshotVolumes != nil && !*ib.backupRequest.Spec.SnapshotVolumes {
+	if boolptr.IsSetToFalse(ib.backupRequest.Spec.SnapshotVolumes) {
 		log.Info("Backup has volume snapshots disabled; skipping volume snapshot action.")
 		return nil
 	}

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -51,6 +51,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/metrics"
 	"github.com/vmware-tanzu/velero/pkg/persistence"
 	"github.com/vmware-tanzu/velero/pkg/plugin/clientmgmt"
+	"github.com/vmware-tanzu/velero/pkg/util/boolptr"
 	"github.com/vmware-tanzu/velero/pkg/util/collections"
 	"github.com/vmware-tanzu/velero/pkg/util/encode"
 	kubeutil "github.com/vmware-tanzu/velero/pkg/util/kube"
@@ -403,7 +404,7 @@ func (c *backupController) validateAndGetSnapshotLocations(backup *velerov1api.B
 	providerLocations := make(map[string]*velerov1api.VolumeSnapshotLocation)
 
 	// if snapshotVolume is set to false then we don't need to validate volumesnapshotlocation
-	if backup.Spec.SnapshotVolumes != nil && !*backup.Spec.SnapshotVolumes {
+	if boolptr.IsSetToFalse(backup.Spec.SnapshotVolumes) {
 		return nil, nil
 	}
 

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -397,9 +397,15 @@ func (c *backupController) prepareBackupRequest(backup *velerov1api.Backup) *pkg
 // - a given provider's default location name is added to .spec.volumeSnapshotLocations if one
 //   is not explicitly specified for the provider (if there's only one location for the provider,
 //   it will automatically be used)
+// if backup has snapshotVolume disabled then it returns empty VSL
 func (c *backupController) validateAndGetSnapshotLocations(backup *velerov1api.Backup) (map[string]*velerov1api.VolumeSnapshotLocation, []string) {
 	errors := []string{}
 	providerLocations := make(map[string]*velerov1api.VolumeSnapshotLocation)
+
+	// if snapshotVolume is set to false then we don't need to validate volumesnapshotlocation
+	if backup.Spec.SnapshotVolumes != nil && !*backup.Spec.SnapshotVolumes {
+		return nil, nil
+	}
 
 	for _, locationName := range backup.Spec.VolumeSnapshotLocations {
 		// validate each locationName exists as a VolumeSnapshotLocation

--- a/pkg/controller/backup_controller_test.go
+++ b/pkg/controller/backup_controller_test.go
@@ -767,6 +767,46 @@ func TestValidateAndGetSnapshotLocations(t *testing.T) {
 			expectedVolumeSnapshotLocationNames: []string{"aws-us-west-1", "some-name"},
 			expectedSuccess:                     true,
 		},
+		{
+			name:   "location name does not correspond to any existing location and snapshotvolume disabled; should return empty VSL and no error",
+			backup: defaultBackup().Phase(velerov1api.BackupPhaseNew).VolumeSnapshotLocations("random-name").SnapshotVolumes(false).Result(),
+			locations: []*velerov1api.VolumeSnapshotLocation{
+				builder.ForVolumeSnapshotLocation(velerov1api.DefaultNamespace, "aws-us-east-1").Provider("aws").Result(),
+				builder.ForVolumeSnapshotLocation(velerov1api.DefaultNamespace, "aws-us-west-1").Provider("aws").Result(),
+				builder.ForVolumeSnapshotLocation(velerov1api.DefaultNamespace, "some-name").Provider("fake-provider").Result(),
+			},
+			expectedVolumeSnapshotLocationNames: nil,
+			expectedSuccess:                     true,
+		},
+		{
+			name:   "duplicate locationName per provider and snapshotvolume disabled; should return empty VSL and no error",
+			backup: defaultBackup().Phase(velerov1api.BackupPhaseNew).VolumeSnapshotLocations("aws-us-west-1", "aws-us-west-1").SnapshotVolumes(false).Result(),
+			locations: []*velerov1api.VolumeSnapshotLocation{
+				builder.ForVolumeSnapshotLocation(velerov1api.DefaultNamespace, "aws-us-east-1").Provider("aws").Result(),
+				builder.ForVolumeSnapshotLocation(velerov1api.DefaultNamespace, "aws-us-west-1").Provider("aws").Result(),
+			},
+			expectedVolumeSnapshotLocationNames: nil,
+			expectedSuccess:                     true,
+		},
+		{
+			name:   "no location name for the provider exists, only one VSL created and snapshotvolume disabled; should return empty VSL and no error",
+			backup: defaultBackup().Phase(velerov1api.BackupPhaseNew).SnapshotVolumes(false).Result(),
+			locations: []*velerov1api.VolumeSnapshotLocation{
+				builder.ForVolumeSnapshotLocation(velerov1api.DefaultNamespace, "aws-us-east-1").Provider("aws").Result(),
+			},
+			expectedVolumeSnapshotLocationNames: nil,
+			expectedSuccess:                     true,
+		},
+		{
+			name:   "multiple location names for a provider, no default location and backup has no location defined, but snapshotvolume disabled, should return empty VSL and no error",
+			backup: defaultBackup().Phase(velerov1api.BackupPhaseNew).SnapshotVolumes(false).Result(),
+			locations: []*velerov1api.VolumeSnapshotLocation{
+				builder.ForVolumeSnapshotLocation(velerov1api.DefaultNamespace, "aws-us-west-1").Provider("aws").Result(),
+				builder.ForVolumeSnapshotLocation(velerov1api.DefaultNamespace, "aws-us-east-1").Provider("aws").Result(),
+			},
+			expectedVolumeSnapshotLocationNames: nil,
+			expectedSuccess:                     true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Changes:
- If backup has snapshotvolume then `validateAndGetSnapshotLocations` skip validating VSL and returns empty VSL list with success.

Existing behavior:
- if velero is configured with multiple VSL with the same provider but no default VSL configured, then one needs to provide VSL during backup creation, with snapshotvolume disabled, otherwise backup will fail with status.phase `FailedValidation`. 

If one wants to use restic for the volume backup then he/she doesn't need to provide VSL for the backup.

Signed-off-by: mayank <mayank.patel@mayadata.io>