### PR TITLE
add VMware vSphere plugin to documentation

### DIFF
--- a/site/_plugin-list/10-vsphere.md
+++ b/site/_plugin-list/10-vsphere.md
@@ -4,6 +4,5 @@ link: https://github.com/vmware-tanzu/velero-plugin-for-vsphere
 object-storage: false
 volumesnapshotter: true
 local-storage: true
-prototype: true
 ---
 This repository contains a volume snapshotter plugin to support running Velero on VMware vSphere.

--- a/site/docs/master/supported-providers.md
+++ b/site/docs/master/supported-providers.md
@@ -21,6 +21,7 @@ Contact: [#Velero Slack][28], [GitHub Issues][29]
 | [Hewlett Packard][24]     | 🚫                           | HPE Storage                        | [Hewlett Packard][25]  | [Slack][26], [GitHub Issue][27] |
 | [OpenEBS][17]             | 🚫                           | OpenEBS CStor Volume               | [OpenEBS][18]          | [Slack][19], [GitHub Issue][20] |
 | [Portworx][31]            | 🚫                           | Portworx Volume                    | [Portworx][32]         | [Slack][33], [GitHub Issue][34] |
+| [VMware vSphere][39]      | 🚫                           | vSphere Volumes                    | [VMware vSphere][39]   | [GitHub Issue][40]              |
 
 ## S3-Compatible object store providers
 
@@ -80,3 +81,5 @@ In the case you want to take volume snapshots but didn't find a plugin for your 
 [36]: https://github.com/vmware-tanzu/velero-plugin-for-gcp#setup
 [37]: https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure#setup
 [38]: https://www.cloudian.com/
+[39]: https://github.com/vmware-tanzu/velero-plugin-for-vsphere
+[40]: https://github.com/vmware-tanzu/velero-plugin-for-vsphere/issues/new

--- a/site/docs/master/supported-providers.md
+++ b/site/docs/master/supported-providers.md
@@ -16,11 +16,11 @@ Contact: [#Velero Slack][28], [GitHub Issues][29]
 
 | Provider                  | Object Store                 | Volume Snapshotter                 | Plugin Documentation   | Contact                         |
 |---------------------------|------------------------------|------------------------------------|------------------------|---------------------------------|
-| [Portworx][31]            | 🚫                           | Portworx Volume                    | [Portworx][32]         | [Slack][33], [GitHub Issue][34] |
-| [DigitalOcean][15]        | DigitalOcean Object Storage  | DigitalOcean Volumes Block Storage | [StackPointCloud][16]  |                                 |
-| [OpenEBS][17]             | 🚫                           | OpenEBS CStor Volume               | [OpenEBS][18]          | [Slack][19], [GitHub Issue][20] |
 | [AlibabaCloud][21]        | Alibaba Cloud OSS            | Alibaba Cloud                      | [AlibabaCloud][22]     | [GitHub Issue][23]              |
+| [DigitalOcean][15]        | DigitalOcean Object Storage  | DigitalOcean Volumes Block Storage | [StackPointCloud][16]  |                                 |
 | [Hewlett Packard][24]     | 🚫                           | HPE Storage                        | [Hewlett Packard][25]  | [Slack][26], [GitHub Issue][27] |
+| [OpenEBS][17]             | 🚫                           | OpenEBS CStor Volume               | [OpenEBS][18]          | [Slack][19], [GitHub Issue][20] |
+| [Portworx][31]            | 🚫                           | Portworx Volume                    | [Portworx][32]         | [Slack][33], [GitHub Issue][34] |
 
 ## S3-Compatible object store providers
 

--- a/site/docs/v1.3.2/supported-providers.md
+++ b/site/docs/v1.3.2/supported-providers.md
@@ -21,6 +21,7 @@ Contact: [#Velero Slack][28], [GitHub Issues][29]
 | [Hewlett Packard][24]     | 🚫                           | HPE Storage                        | [Hewlett Packard][25]  | [Slack][26], [GitHub Issue][27] |
 | [OpenEBS][17]             | 🚫                           | OpenEBS CStor Volume               | [OpenEBS][18]          | [Slack][19], [GitHub Issue][20] |
 | [Portworx][31]            | 🚫                           | Portworx Volume                    | [Portworx][32]         | [Slack][33], [GitHub Issue][34] |
+| [VMware vSphere][39]      | 🚫                           | vSphere Volumes                    | [VMware vSphere][39]   | [GitHub Issue][40]              |
 
 ## S3-Compatible object store providers
 
@@ -80,3 +81,5 @@ In the case you want to take volume snapshots but didn't find a plugin for your 
 [36]: https://github.com/vmware-tanzu/velero-plugin-for-gcp#setup
 [37]: https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure#setup
 [38]: https://www.cloudian.com/
+[39]: https://github.com/vmware-tanzu/velero-plugin-for-vsphere
+[40]: https://github.com/vmware-tanzu/velero-plugin-for-vsphere/issues/new

--- a/site/docs/v1.3.2/supported-providers.md
+++ b/site/docs/v1.3.2/supported-providers.md
@@ -16,11 +16,11 @@ Contact: [#Velero Slack][28], [GitHub Issues][29]
 
 | Provider                  | Object Store                 | Volume Snapshotter                 | Plugin Documentation   | Contact                         |
 |---------------------------|------------------------------|------------------------------------|------------------------|---------------------------------|
-| [Portworx][31]            | 🚫                           | Portworx Volume                    | [Portworx][32]         | [Slack][33], [GitHub Issue][34] |
-| [DigitalOcean][15]        | DigitalOcean Object Storage  | DigitalOcean Volumes Block Storage | [StackPointCloud][16]  |                                 |
-| [OpenEBS][17]             | 🚫                           | OpenEBS CStor Volume               | [OpenEBS][18]          | [Slack][19], [GitHub Issue][20] |
 | [AlibabaCloud][21]        | Alibaba Cloud OSS            | Alibaba Cloud                      | [AlibabaCloud][22]     | [GitHub Issue][23]              |
+| [DigitalOcean][15]        | DigitalOcean Object Storage  | DigitalOcean Volumes Block Storage | [StackPointCloud][16]  |                                 |
 | [Hewlett Packard][24]     | 🚫                           | HPE Storage                        | [Hewlett Packard][25]  | [Slack][26], [GitHub Issue][27] |
+| [OpenEBS][17]             | 🚫                           | OpenEBS CStor Volume               | [OpenEBS][18]          | [Slack][19], [GitHub Issue][20] |
+| [Portworx][31]            | 🚫                           | Portworx Volume                    | [Portworx][32]         | [Slack][33], [GitHub Issue][34] |
 
 ## S3-Compatible object store providers
 


### PR DESCRIPTION
closes #2356 
closes #1697 (this issue is now obsolete since we now have a proper VolumeSnapshotter plugin)

As part of this, I alphabetized the plugins in the "Community supported providers" section for ease of lookup.

relevant preview links:

https://deploy-preview-2452--velero.netlify.app/docs/v1.3.2/supported-providers/
https://deploy-preview-2452--velero.netlify.app/plugins/