### PR TITLE
Add documentation for --cacert feature

### DIFF
--- a/site/_data/master-toc.yml
+++ b/site/_data/master-toc.yml
@@ -17,7 +17,7 @@ toc:
         url: /upgrade-to-1.3
       - page: Supported providers
         url: /supported-providers
-      - page: Evaluation install 
+      - page: Evaluation install
         url: /contributions/minio
       - page: Restic integration
         url: /restic
@@ -41,6 +41,8 @@ toc:
         url: /hooks
       - page: CSI Support (beta)
         url: /csi
+      - page: Verifying Self-signed Certificates
+        url: /self-signed-certificates
   - title: Plugins
     subfolderitems:
       - page: Overview

--- a/site/docs/master/api-types/backupstoragelocation.md
+++ b/site/docs/master/api-types/backupstoragelocation.md
@@ -36,6 +36,7 @@ The configurable parameters are as follows:
 | `objectStorage` | ObjectStorageLocation | Required Field | Specification of the object storage for the given provider. |
 | `objectStorage/bucket` | String | Required Field | The storage bucket where backups are to be uploaded. |
 | `objectStorage/prefix` | String | Optional Field | The directory inside a storage bucket where backups are to be uploaded. |
+| `objectStorage/caCert` | String | Optional Field | A base64 encoded CA bundle to be used when verifying TLS connections |
 | `config` | map[string]string | None (Optional) | Provider-specific configuration keys/values to be passed to the object store plugin. See [your object storage provider's plugin documentation][0] for details. |
 | `accessMode` | String | `ReadWrite` | How Velero can access the backup storage location. Valid values are `ReadWrite`, `ReadOnly`. |
 | `backupSyncPeriod` | metav1.Duration | Optional Field | How frequently Velero should synchronize backups in object storage. Default is Velero's server backup sync period. Set this to `0s` to disable sync. |

--- a/site/docs/master/customize-installation.md
+++ b/site/docs/master/customize-installation.md
@@ -10,6 +10,7 @@
   - [Do not configure a backup storage location during install](#do-not-configure-a-backup-storage-location-during-install)
   - [Install an additional volume snapshot provider](#install-an-additional-volume-snapshot-provider)
   - [Generate YAML only](#generate-yaml-only)
+  - [Use a storage provider secured by a self-signed certificate](#use-a-storage-provider-secured-by-a-self-signed-certificate)
   - [Additional options](#additional-options)
   - [Optional Velero CLI configurations](#optional-velero-cli-configurations)
     - [Enabling shell autocompletion](#enabling-shell-autocompletion)
@@ -93,6 +94,11 @@ To generate the YAML without applying it to your cluster, use the `--dry-run -o 
 This is useful for applying bespoke customizations, integrating with a GitOps workflow, etc.
 
 If you are installing Velero in Kubernetes 1.14.x or earlier, you need to use `kubectl apply`'s `--validate=false` option when applying the generated configuration to your cluster. See [issue 2077][7] and [issue 2311][8] for more context.
+
+## Use a storage provider secured by a self-signed certificate
+
+If you intend to use Velero with a storage provider that is secured by a self-signed certificate,
+you may need to instruct Velero to trust that certificate. See [use Velero with a storage provider secured by a self-signed certificate][9] for details.
 
 ## Additional options
 
@@ -245,3 +251,4 @@ If you get an error like `complete:13: command not found: compdef`, then add the
 [6]: velero-install.md#usage
 [7]: https://github.com/vmware-tanzu/velero/issues/2077
 [8]: https://github.com/vmware-tanzu/velero/issues/2311
+[9]: self-signed-certificates.md

--- a/site/docs/master/self-signed-certificates.md
+++ b/site/docs/master/self-signed-certificates.md
@@ -1,0 +1,31 @@
+# Use Velero with a storage provider secured by a self-signed certificate
+
+If you are using an S3-Compatible storage provider that is secured with a self-signed certificate, connections to the object store may fail with a `certificate signed by unknown authority` message.
+In order to proceed, a certificate bundle may be provided when adding the storage provider.
+
+## Trusting a self-signed certificate during installation
+
+When using the `velero install` command, you can use the `--cacert` flag to provide a path
+to a PEM-encoded certificate bundle to trust.
+
+```bash
+velero install \
+    --plugins <PLUGIN_CONTAINER_IMAGE [PLUGIN_CONTAINER_IMAGE]>
+    --provider <YOUR_PROVIDER> \
+    --bucket <YOUR_BUCKET> \
+    --secret-file <PATH_TO_FILE> \
+    --cacert <PATH_TO_CA_BUNDLE>
+```
+
+Velero will then automatically use the provided CA bundle to verify TLS connections to
+that storage provider when backing up and restoring.
+
+## Trusting a self-signed certificate with the Velero client
+
+To use the describe, download, or logs commands to access a backup or restore contained
+in storage secured by a self-signed certificate as in the above example, you must use
+the `--cacert` flag to provide a path to the certificate to be trusted.
+
+```bash
+velero backup describe my-backup --cacert <PATH_TO_CA_BUNDLE>
+```


### PR DESCRIPTION
This is documentation for the `--cacert` feature added in the following PRs:

https://github.com/vmware-tanzu/velero/pull/2353
https://github.com/vmware-tanzu/velero/pull/2364
https://github.com/vmware-tanzu/velero/pull/2368

@skriss Please let me know if you think this is sufficient or needs to be expanded.

Fixes https://github.com/vmware-tanzu/velero/issues/2396