### PR TITLE
Install ca-certificates for ARM based container builds.

### DIFF
--- a/Dockerfile-velero-arm
+++ b/Dockerfile-velero-arm
@@ -14,6 +14,8 @@
 
 FROM arm32v7/ubuntu:bionic
 
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
+
 ADD /bin/linux/arm/restic /usr/bin/restic
 
 ADD /bin/linux/arm/velero /velero

--- a/Dockerfile-velero-arm64
+++ b/Dockerfile-velero-arm64
@@ -14,6 +14,8 @@
 
 FROM arm64v8/ubuntu:bionic
 
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
+
 ADD /bin/linux/arm64/restic /usr/bin/restic
 
 ADD /bin/linux/arm64/velero /velero

--- a/changelogs/unreleased/2481-twoequaldots
+++ b/changelogs/unreleased/2481-twoequaldots
@@ -1,0 +1,1 @@
+Install `ca-certificates` in ARM based containers.


### PR DESCRIPTION
To help with bug reported in issue #2466 , I've modified the Dockerfile for ARM based containers to install `ca-certificates`

EDIT (@ashish-amarnath )
Fixes: #2466