### PR TITLE
Revert "Install ca-certificates for ARM based container builds. (#2481)"

### DIFF
--- a/Dockerfile-velero-arm
+++ b/Dockerfile-velero-arm
@@ -14,8 +14,6 @@
 
 FROM arm32v7/ubuntu:bionic
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
-
 ADD /bin/linux/arm/restic /usr/bin/restic
 
 ADD /bin/linux/arm/velero /velero

--- a/Dockerfile-velero-arm64
+++ b/Dockerfile-velero-arm64
@@ -14,8 +14,6 @@
 
 FROM arm64v8/ubuntu:bionic
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
-
 ADD /bin/linux/arm64/restic /usr/bin/restic
 
 ADD /bin/linux/arm64/velero /velero

--- a/changelogs/unreleased/2481-twoequaldots
+++ b/changelogs/unreleased/2481-twoequaldots
@@ -1,1 +1,0 @@
-Install `ca-certificates` in ARM based containers.


### PR DESCRIPTION
This reverts commit 0e5ca82dba08c799f6b0f5e2b3479cb20eb3c3ee.

We discovered that #2481 breaks the ARM container builds (see https://github.com/vmware-tanzu/velero/pull/2481#issuecomment-621982600), so we need to back it out for now.