### PR TITLE
don't return an error from log hook if value is not an error type

### DIFF
--- a/changelogs/unreleased/2487-skriss
+++ b/changelogs/unreleased/2487-skriss
@@ -1,0 +1,1 @@
+bug fix: in error location logging hook, if the item logged under the `error` key doesn't implement the `error` interface, don't return an error since this is a valid scenario

--- a/pkg/util/logging/error_location_hook.go
+++ b/pkg/util/logging/error_location_hook.go
@@ -60,7 +60,9 @@ func (h *ErrorLocationHook) Fire(entry *logrus.Entry) error {
 
 	err, ok := errObj.(error)
 	if !ok {
-		return errors.New("object logged as error does not satisfy error interface")
+		// if the value isn't an error type, skip trying to get location info,
+		// and just let it be logged as whatever it was
+		return nil
 	}
 
 	if errorLocationer, ok := err.(errorLocationer); ok {

--- a/pkg/util/logging/error_location_hook_test.go
+++ b/pkg/util/logging/error_location_hook_test.go
@@ -47,7 +47,7 @@ func TestFire(t *testing.T) {
 			name:                "non-error logged in error field",
 			preEntryFields:      map[string]interface{}{logrus.ErrorKey: "not an error"},
 			expectedEntryFields: map[string]interface{}{logrus.ErrorKey: "not an error"},
-			expectedErr:         true,
+			expectedErr:         false,
 		},
 		{
 			name:           "pkg/errors error",


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

In our logging hook that attempts to get stack info from any errors logged, don't return an error if the item logged with the "error" key isn't an error type, since this is a valid scenario.