### PR TITLE
Add GitHub links to team member list

### DIFF
--- a/site/_contributors/01-steve-kriss.md
+++ b/site/_contributors/01-steve-kriss.md
@@ -2,5 +2,6 @@
 first_name: Steve
 last_name: Kriss
 image: /img/contributors/steve-kriss.png
+github_handle: skriss
 ---
 Tech Lead

--- a/site/_contributors/02-ashish-amarnath.md
+++ b/site/_contributors/02-ashish-amarnath.md
@@ -2,5 +2,6 @@
 first_name: Ashish
 last_name: Amarnath
 image: /img/contributors/ashish-amarnath.png
+github_handle: ashish-amarnath
 ---
 Engineer

--- a/site/_contributors/02-carlisia-campos.md
+++ b/site/_contributors/02-carlisia-campos.md
@@ -2,5 +2,6 @@
 first_name: Carlisia
 last_name: Campos
 image: /img/contributors/carlisia-campos.png
+github_handle: carlisia
 ---
 Engineer

--- a/site/_contributors/02-nolan-brubaker.md
+++ b/site/_contributors/02-nolan-brubaker.md
@@ -2,5 +2,6 @@
 first_name: Nolan
 last_name: Brubaker
 image: /img/contributors/nolan-brubaker.png
+github_handle: nrb
 ---
 Engineer

--- a/site/_contributors/04-tim-hinderliter.md
+++ b/site/_contributors/04-tim-hinderliter.md
@@ -2,5 +2,6 @@
 first_name: Tim
 last_name: Hinderliter
 image: /img/contributors/tim-hinderliter.png
+github_handle: timh
 ---
 Engineering Manager

--- a/site/_contributors/05-stephanie-bauman.md
+++ b/site/_contributors/05-stephanie-bauman.md
@@ -2,5 +2,6 @@
 first_name: Stephanie
 last_name: Bauman
 image: /img/contributors/stephanie-bauman.png
+github_handle: stephbman
 ---
 Product Manager

--- a/site/_includes/contributors.html
+++ b/site/_includes/contributors.html
@@ -17,7 +17,7 @@
       <div class="media thumbnail-item">
         <img src="{{ person.image }}" class="rounded-circle" alt="Person" />
         <div class="media-body align-self-center">
-          <h6><a href="#">{{ person.first_name }} {{ person.last_name }}</a></h6>
+          <h6><a href="https://github.com/{{ person.github_handle }}">{{ person.first_name }} {{ person.last_name }}</a></h6>
         {{ person.content | markdownify }}    
         </div>
       </div>


### PR DESCRIPTION
This will change the non-relevant links for each team member to proper links to GitHub user pages.

Signed-off-by: jonasrosland <jrosland@vmware.com>