### PR TITLE
Add status column to get BSL output

### DIFF
--- a/pkg/cmd/util/output/backup_storage_location_printer.go
+++ b/pkg/cmd/util/output/backup_storage_location_printer.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 the Velero contributors.
+Copyright 2018, 2020 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 )
 
 var (
@@ -30,11 +30,12 @@ var (
 		{Name: "Name", Type: "string", Format: "name"},
 		{Name: "Provider"},
 		{Name: "Bucket/Prefix"},
+		{Name: "Status"},
 		{Name: "Access Mode"},
 	}
 )
 
-func printBackupStorageLocationList(list *v1.BackupStorageLocationList) []metav1.TableRow {
+func printBackupStorageLocationList(list *velerov1api.BackupStorageLocationList) []metav1.TableRow {
 	rows := make([]metav1.TableRow, 0, len(list.Items))
 
 	for i := range list.Items {
@@ -43,7 +44,7 @@ func printBackupStorageLocationList(list *v1.BackupStorageLocationList) []metav1
 	return rows
 }
 
-func printBackupStorageLocation(location *v1.BackupStorageLocation) []metav1.TableRow {
+func printBackupStorageLocation(location *velerov1api.BackupStorageLocation) []metav1.TableRow {
 	row := metav1.TableRow{
 		Object: runtime.RawExtension{Object: location},
 	}
@@ -55,13 +56,19 @@ func printBackupStorageLocation(location *v1.BackupStorageLocation) []metav1.Tab
 
 	accessMode := location.Spec.AccessMode
 	if accessMode == "" {
-		accessMode = v1.BackupStorageLocationAccessModeReadWrite
+		accessMode = velerov1api.BackupStorageLocationAccessModeReadWrite
+	}
+
+	status := location.Status.Phase
+	if status == "" {
+		status = velerov1api.BackupStorageLocationPhaseAvailable
 	}
 
 	row.Cells = append(row.Cells,
 		location.Name,
 		location.Spec.Provider,
 		bucketAndPrefix,
+		status,
 		accessMode,
 	)
 

--- a/pkg/cmd/util/output/backup_storage_location_printer.go
+++ b/pkg/cmd/util/output/backup_storage_location_printer.go
@@ -61,7 +61,7 @@ func printBackupStorageLocation(location *velerov1api.BackupStorageLocation) []m
 
 	status := location.Status.Phase
 	if status == "" {
-		status = velerov1api.BackupStorageLocationPhaseAvailable
+		status = "Unknown"
 	}
 
 	row.Cells = append(row.Cells,


### PR DESCRIPTION
This closes https://github.com/vmware-tanzu/velero/issues/2489.

![image](https://user-images.githubusercontent.com/16508/80830975-ce45dc80-8b9e-11ea-85f3-ccb4328f8c33.png)

## Question
It seems to me as arbitrary to specify an empty status with `Available` as it would be with `Unavailable` - here: https://github.com/vmware-tanzu/velero/compare/master...carlisia:c-2489-bsl-column?expand=1#diff-c73073c993c3249edf0a5d8b6d30fa87R64

Should there be a third phase, maybe status `Unknown`? I'm not super set on this, we could make it available/unavailable.


Signed-off-by: Carlisia <carlisia@vmware.com>