### PR TITLE
v1.4 upgrade instructions

### DIFF
--- a/site/docs/master/upgrade-to-1.4.md
+++ b/site/docs/master/upgrade-to-1.4.md
@@ -1,17 +1,18 @@
-# Upgrading to Velero 1.3
+# Upgrading to Velero 1.4
 
 ## Prerequisites
 
-- Velero [v1.3.1][5], [v1.3.0][4] or [v1.2][3] installed.
+- Velero [v1.3.x][4] installed.
 
-If you're not yet running at least Velero v1.2, see the following:
+If you're not yet running at least Velero v1.3, see the following:
 
 - [Upgrading to v1.1][1]
 - [Upgrading to v1.2][2]
+- [Upgrading to v1.3][3]
 
 ## Instructions
 
-1. Install the Velero v1.3 command-line interface (CLI) by following the [instructions here][0].
+1. Install the Velero v1.4 command-line interface (CLI) by following the [instructions here][0].
 
     Verify that you've properly installed it by running:
 
@@ -23,7 +24,7 @@ If you're not yet running at least Velero v1.2, see the following:
 
     ```bash
     Client:
-        Version: v1.3.2
+        Version: v1.4.0-beta.1
         Git commit: <git SHA>
     ```
 
@@ -31,13 +32,19 @@ If you're not yet running at least Velero v1.2, see the following:
 
     ```bash
     kubectl set image deployment/velero \
-        velero=velero/velero:v1.3.2 \
+        velero=velero/velero:v1.4.0-beta.1 \
         --namespace velero
 
     # optional, if using the restic daemon set
     kubectl set image daemonset/restic \
-        restic=velero/velero:v1.3.2 \
+        restic=velero/velero:v1.4.0-beta.1 \
         --namespace velero
+    ```
+
+1. Update the Velero custom resource definitions (CRDs) to include the new backup progress fields:
+
+    ```bash
+    velero install --crds-only --dry-run -o yaml | kubectl apply -f -
     ```
 
 1. Confirm that the deployment is up and running with the correct version by running:
@@ -50,16 +57,15 @@ If you're not yet running at least Velero v1.2, see the following:
 
     ```bash
     Client:
-        Version: v1.3.2
+        Version: v1.4.0-beta.1
         Git commit: <git SHA>
 
     Server:
-        Version: v1.3.2
+        Version: v1.4.0-beta.1
     ```
 
 [0]: basic-install.md#install-the-cli
 [1]: https://velero.io/docs/v1.1.0/upgrade-to-1.1/
 [2]: https://velero.io/docs/v1.2.0/upgrade-to-1.2/
-[3]: https://github.com/vmware-tanzu/velero/releases/tag/v1.2.0
-[4]: https://github.com/vmware-tanzu/velero/releases/tag/v1.3.0
-[5]: https://github.com/vmware-tanzu/velero/releases/tag/v1.3.1
+[3]: https://velero.io/docs/v1.3.2/upgrade-to-1.3/
+[4]: https://github.com/vmware-tanzu/velero/releases/tag/v1.3.2


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

closes #2495 

Will keep this in draft until just before the release of the beta to avoid any confusion to users. And we'll obviously have to update this again for the GA release.

Do you all think I should include plugin upgrade instructions here as well? We don't really have a clear process yet for how to communicate new plugin versions and upgrades. Also, we may not want to include instructions only for the ones we maintain, since we're trying not to give them preference. So, open to suggestions here..