### PR TITLE
increment restic volumesnapshot count after successful pvb create

### DIFF
--- a/changelogs/unreleased/2542-ashish-amarnath
+++ b/changelogs/unreleased/2542-ashish-amarnath
@@ -1,0 +1,1 @@
+increment restic volumesnapshot count after successful pvb create

--- a/pkg/restic/backupper.go
+++ b/pkg/restic/backupper.go
@@ -158,11 +158,11 @@ func (b *backupper) BackupPodVolumes(backup *velerov1api.Backup, pod *corev1api.
 		}
 
 		volumeBackup := newPodVolumeBackup(backup, pod, volume, repo.Spec.ResticIdentifier, pvc)
-		numVolumeSnapshots++
 		if volumeBackup, err = b.repoManager.veleroClient.VeleroV1().PodVolumeBackups(volumeBackup.Namespace).Create(volumeBackup); err != nil {
 			errs = append(errs, err)
 			continue
 		}
+		numVolumeSnapshots++
 	}
 
 ForEachVolume:


### PR DESCRIPTION
Signed-off-by: Ashish Amarnath <ashisham@vmware.com>

The failure to create PVB objects could be causing restic volumesnapshot operations to time out.