### PR TITLE
ca-certificates is needed to work with aws s3 - missing on arm/ppc

### DIFF
--- a/Dockerfile-velero-arm
+++ b/Dockerfile-velero-arm
@@ -14,6 +14,10 @@
 
 FROM arm32v7/ubuntu:focal
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
 ADD /bin/linux/arm/restic /usr/bin/restic
 
 ADD /bin/linux/arm/velero /velero

--- a/Dockerfile-velero-arm64
+++ b/Dockerfile-velero-arm64
@@ -14,6 +14,10 @@
 
 FROM arm64v8/ubuntu:focal
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
 ADD /bin/linux/arm64/restic /usr/bin/restic
 
 ADD /bin/linux/arm64/velero /velero

--- a/Dockerfile-velero-ppc64le
+++ b/Dockerfile-velero-ppc64le
@@ -16,6 +16,10 @@ FROM ppc64le/ubuntu:focal
 
 LABEL maintainer="Prajyot Parab <prajyot.parab@ibm.com>"
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
 ADD /bin/linux/ppc64le/restic /usr/bin/restic
 
 ADD /bin/linux/ppc64le/velero /velero


### PR DESCRIPTION
The package is present on amd64, but not on arm/arm64 and ppc

Signed-off-by: mickkael <19755421+mickkael@users.noreply.github.com>