### PR TITLE
When creating backup from schedule, allow default name

### DIFF
--- a/changelogs/unreleased/2569-cblecker
+++ b/changelogs/unreleased/2569-cblecker
@@ -1,0 +1,1 @@
+when creating new backup from schedule from cli, allow backup name to be automatically generated

--- a/pkg/apis/velero/v1/schedule.go
+++ b/pkg/apis/velero/v1/schedule.go
@@ -16,7 +16,12 @@ limitations under the License.
 
 package v1
 
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import (
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 // ScheduleSpec defines the specification for a Velero schedule
 type ScheduleSpec struct {
@@ -94,4 +99,9 @@ type ScheduleList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []Schedule `json:"items"`
+}
+
+// TimestampedName returns the default backup name format based on the schedule
+func (s *Schedule) TimestampedName(timestamp time.Time) string {
+	return fmt.Sprintf("%s-%s", s.Name, timestamp.Format("20060102150405"))
 }

--- a/pkg/controller/schedule_controller.go
+++ b/pkg/controller/schedule_controller.go
@@ -288,7 +288,7 @@ func getNextRunTime(schedule *api.Schedule, cronSchedule cron.Schedule, asOf tim
 }
 
 func getBackup(item *api.Schedule, timestamp time.Time) *api.Backup {
-	name := fmt.Sprintf("%s-%s", item.Name, timestamp.Format("20060102150405"))
+	name := item.TimestampedName(timestamp)
 	backup := builder.
 		ForBackup(item.Namespace, name).
 		FromSchedule(item).


### PR DESCRIPTION
fixes #2453

There was a couple different places that I could see the extracted name generation function going. I chose to attach it to the schedule itself. Please advice if there is a different place it would be preferred.