### PR TITLE
bug fix: pass ca cert file to restic stats command on restore

### DIFF
--- a/pkg/restic/exec_commands.go
+++ b/pkg/restic/exec_commands.go
@@ -185,7 +185,7 @@ func getSummaryLine(b []byte) ([]byte, error) {
 // RunRestore runs a `restic restore` command and monitors the volume size to
 // provide progress updates to the caller.
 func RunRestore(restoreCmd *Command, log logrus.FieldLogger, updateFunc func(velerov1api.PodVolumeOperationProgress)) (string, string, error) {
-	snapshotSize, err := getSnapshotSize(restoreCmd.RepoIdentifier, restoreCmd.PasswordFile, restoreCmd.Args[0], restoreCmd.Env)
+	snapshotSize, err := getSnapshotSize(restoreCmd.RepoIdentifier, restoreCmd.PasswordFile, restoreCmd.CACertFile, restoreCmd.Args[0], restoreCmd.Env)
 	if err != nil {
 		return "", "", errors.Wrap(err, "error getting snapshot size")
 	}
@@ -231,9 +231,10 @@ func RunRestore(restoreCmd *Command, log logrus.FieldLogger, updateFunc func(vel
 	return stdout, stderr, err
 }
 
-func getSnapshotSize(repoIdentifier, passwordFile, snapshotID string, env []string) (int64, error) {
+func getSnapshotSize(repoIdentifier, passwordFile, caCertFile, snapshotID string, env []string) (int64, error) {
 	cmd := StatsCommand(repoIdentifier, passwordFile, snapshotID)
 	cmd.Env = env
+	cmd.CACertFile = caCertFile
 
 	stdout, stderr, err := exec.RunCommand(cmd.Cmd())
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

closes #2562 

Leaving in draft while we await testing (see #2562)

For restic restores, the CA cert file is written to disk here: https://github.com/vmware-tanzu/velero/blob/master/pkg/controller/pod_volume_restore_controller.go#L296-L315

The file/flag is correctly added to the `restic restore` command here: https://github.com/vmware-tanzu/velero/blob/master/pkg/controller/pod_volume_restore_controller.go#L345

The function I changed is then called here: https://github.com/vmware-tanzu/velero/blob/master/pkg/controller/pod_volume_restore_controller.go#L365-L367

