### PR TITLE
don't error during backup when additional items returned by plugin don't exist

### DIFF
--- a/changelogs/unreleased/2595-skriss
+++ b/changelogs/unreleased/2595-skriss
@@ -1,0 +1,1 @@
+log a warning instead of erroring if an additional item returned from a plugin can't be found in the Kubernetes API

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -1723,7 +1723,7 @@ func TestBackupActionAdditionalItems(t *testing.T) {
 		},
 
 		{
-			name:   "if there's an error backing up additional items, the item the action was run for isn't backed up",
+			name:   "if additional items aren't found in the API, they're skipped and the original item is still backed up",
 			backup: defaultBackup().Result(),
 			apiResources: []*test.APIResource{
 				test.Pods(
@@ -1746,8 +1746,10 @@ func TestBackupActionAdditionalItems(t *testing.T) {
 				},
 			},
 			want: []string{
+				"resources/pods/namespaces/ns-1/pod-1.json",
 				"resources/pods/namespaces/ns-2/pod-2.json",
 				"resources/pods/namespaces/ns-3/pod-3.json",
+				"resources/pods/v1-preferredversion/namespaces/ns-1/pod-1.json",
 				"resources/pods/v1-preferredversion/namespaces/ns-2/pod-2.json",
 				"resources/pods/v1-preferredversion/namespaces/ns-3/pod-3.json",
 			},

--- a/pkg/cmd/util/output/backup_describer.go
+++ b/pkg/cmd/util/output/backup_describer.go
@@ -70,11 +70,9 @@ func DescribeBackup(
 			}
 		}
 
-		if status.Phase == velerov1api.BackupPhasePartiallyFailed {
-			d.Println()
-			d.Printf("Errors:\t%d\n", status.Errors)
-			d.Printf("Warnings:\t%d\n", status.Warnings)
-		}
+		d.Println()
+		d.Printf("Errors:\t%d\n", status.Errors)
+		d.Printf("Warnings:\t%d\n", status.Warnings)
 
 		d.Println()
 		DescribeBackupSpec(d, backup.Spec)

--- a/pkg/cmd/util/output/restore_printer.go
+++ b/pkg/cmd/util/output/restore_printer.go
@@ -30,8 +30,8 @@ var (
 		{Name: "Name", Type: "string", Format: "name"},
 		{Name: "Backup"},
 		{Name: "Status"},
-		{Name: "Warnings"},
 		{Name: "Errors"},
+		{Name: "Warnings"},
 		{Name: "Created"},
 		{Name: "Selector"},
 	}
@@ -60,8 +60,8 @@ func printRestore(restore *v1.Restore) []metav1.TableRow {
 		restore.Name,
 		restore.Spec.BackupName,
 		status,
-		restore.Status.Warnings,
 		restore.Status.Errors,
+		restore.Status.Warnings,
 		restore.CreationTimestamp.Time,
 		metav1.FormatLabelSelector(restore.Spec.LabelSelector),
 	)


### PR DESCRIPTION
closes #1878 
closes #2269 

This PR changes the backup code to log a warning instead of returning an error if an additional item returned by a backup item action plugin can't be found in the Kubernetes API. It also changes `velero backup get/describe` to always display warning/error count, rather than doing it selectively based on phase.