### PR TITLE
Log when a hook timeout duration can't be parsed

### DIFF
--- a/changelogs/unreleased/2610-nrb
+++ b/changelogs/unreleased/2610-nrb
@@ -1,0 +1,1 @@
+When a timeout string can't be parsed, log the error as a warning instead of silently consuming the error.

--- a/pkg/backup/item_hook_handler_test.go
+++ b/pkg/backup/item_hook_handler_test.go
@@ -575,7 +575,7 @@ func TestGetPodExecHookFromAnnotations(t *testing.T) {
 				},
 			},
 			{
-				name: "invalid timeout is ignored",
+				name: "invalid timeout is logged",
 				annotations: map[string]string{
 					phasedKey(phase, podBackupHookCommandAnnotationKey): "/usr/bin/foo",
 					phasedKey(phase, podBackupHookTimeoutAnnotationKey): "invalid",
@@ -599,7 +599,8 @@ func TestGetPodExecHookFromAnnotations(t *testing.T) {
 
 		for _, test := range tests {
 			t.Run(fmt.Sprintf("%s (phase=%q)", test.name, phase), func(t *testing.T) {
-				hook := getPodExecHookFromAnnotations(test.annotations, phase)
+				l := velerotest.NewLogger()
+				hook := getPodExecHookFromAnnotations(test.annotations, phase, l)
 				assert.Equal(t, test.expectedHook, hook)
 			})
 		}


### PR DESCRIPTION
Fixes #2599

This doesn't fundamentally change behavior, but surfaces the behavior for the user.

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>