### PR TITLE
Add header info + fix broken tags

### DIFF
--- a/site/docs/master/code-standards.md
+++ b/site/docs/master/code-standards.md
@@ -14,6 +14,14 @@ Add that to the PR.
 
 If a PR does not warrant a changelog, the CI check for a changelog can be skipped by applying a `changelog-not-required` label on the PR.
 
+## Copyright header 
+
+Whenever a source code file is being modified, the copyright notice should be updated to our standard copyright notice. That is, it should read “Copyright [insert current year] the Velero contributors.” 
+
+For new files, the entire copyright and license header must be added.
+
+Please note that doc files do not need a copyright header.
+
 ## Code
 
 - Log messages are capitalized.
@@ -36,7 +44,7 @@ If a PR does not warrant a changelog, the CI check for a changelog can be skippe
 
 For imports, we use the following convention:
 
-<group><version><api | client | informer | ...>
+`<group><version><api | client | informer | ...>`
 
 Example:
 

--- a/site/docs/v1.2.0/code-standards.md
+++ b/site/docs/v1.2.0/code-standards.md
@@ -34,7 +34,7 @@ Add that to the PR.
 
 For imports, we use the following convention:
 
-<group><version><api | client | informer | ...>
+`<group><version><api | client | informer | ...>`
 
 Example:
 

--- a/site/docs/v1.3.0/code-standards.md
+++ b/site/docs/v1.3.0/code-standards.md
@@ -34,7 +34,7 @@ Add that to the PR.
 
 For imports, we use the following convention:
 
-<group><version><api | client | informer | ...>
+`<group><version><api | client | informer | ...>`
 
 Example:
 

--- a/site/docs/v1.4/code-standards.md
+++ b/site/docs/v1.4/code-standards.md
@@ -12,6 +12,14 @@ changelog.
 
 Add that to the PR.
 
+## Copyright header 
+
+Whenever a source code file is being modified, the copyright notice should be updated to our standard copyright notice. That is, it should read “Copyright [insert current year] the Velero contributors.” 
+
+For new files, the entire copyright and license header must be added.
+
+Please note that doc files do not need a copyright header.
+
 ## Code
 
 - Log messages are capitalized.
@@ -34,7 +42,7 @@ Add that to the PR.
 
 For imports, we use the following convention:
 
-<group><version><api | client | informer | ...>
+`<group><version><api | client | informer | ...>`
 
 Example:
 


### PR DESCRIPTION
This page was broken on all versions: https://velero.io/docs/master/code-standards/#imports

I fixed it while I was adding instructions for the updating the header on code files.

Signed-off-by: Carlisia <carlisia@vmware.com>