### PR TITLE
🐛 Use CRD version prior to remap_crd_version backup item action

### DIFF
--- a/changelogs/unreleased/2683-ashish-amarnath
+++ b/changelogs/unreleased/2683-ashish-amarnath
@@ -1,0 +1,1 @@
+capture version of the CRD prior before invoking the remap_crd_version backup item action

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -160,6 +160,12 @@ func (ib *itemBackupper) backupItem(logger logrus.FieldLogger, obj runtime.Unstr
 		}
 	}
 
+	// capture the version of the object before invoking plugin actions as the plugin may update
+	// the group version of the object.
+	// group version of this object
+	// Used on filepath to backup up all groups and versions
+	version := resourceVersion(obj)
+
 	updatedObj, err := ib.executeActions(log, obj, groupResource, name, namespace, metadata)
 	if err != nil {
 		backupErrs = append(backupErrs, err)
@@ -204,10 +210,6 @@ func (ib *itemBackupper) backupItem(logger logrus.FieldLogger, obj runtime.Unstr
 		return false, kubeerrs.NewAggregate(backupErrs)
 	}
 
-	// group version of this object
-	// Used on filepath to backup up all groups and versions
-	version := resourceVersion(obj)
-
 	// Getting the preferred group version of this resource
 	preferredVersion := preferredGVR.Version
 
@@ -250,6 +252,7 @@ func (ib *itemBackupper) backupItem(logger logrus.FieldLogger, obj runtime.Unstr
 
 	// backing up the preferred version backup without API Group version on path -  this is for backward compability
 
+	log.Debugf("Resource %s/%s, version= %s, preferredVersion=%s", groupResource.String(), name, version, preferredVersion)
 	if version == preferredVersion {
 		if namespace != "" {
 			filePath = filepath.Join(velerov1api.ResourcesDir, groupResource.String(), velerov1api.NamespaceScopedDir, namespace, name+".json")
@@ -272,7 +275,6 @@ func (ib *itemBackupper) backupItem(logger logrus.FieldLogger, obj runtime.Unstr
 		if _, err := ib.tarWriter.Write(itemBytes); err != nil {
 			return false, errors.WithStack(err)
 		}
-
 	}
 
 	return true, nil

--- a/pkg/backup/remap_crd_version_action_test.go
+++ b/pkg/backup/remap_crd_version_action_test.go
@@ -170,6 +170,7 @@ func TestRemapCRDVersionActionData(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, "apiextensions.k8s.io/v1beta1", item.UnstructuredContent()["apiVersion"])
+			assert.Equal(t, crd.Kind, item.GetObjectKind().GroupVersionKind().GroupKind().Kind)
 			name, _, err := unstructured.NestedString(item.UnstructuredContent(), "metadata", "name")
 			require.NoError(t, err)
 			assert.Equal(t, crd.Name, name)

--- a/pkg/kuberesource/kuberesource.go
+++ b/pkg/kuberesource/kuberesource.go
@@ -23,7 +23,7 @@ import (
 var (
 	ClusterRoleBindings       = schema.GroupResource{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings"}
 	ClusterRoles              = schema.GroupResource{Group: "rbac.authorization.k8s.io", Resource: "clusterroles"}
-	CustomResourceDefinitions = schema.GroupResource{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"}
+	CustomResourceDefinitions = schema.GroupResource{Group: "apiextensions.k8s.io", Resource: "CustomResourceDefinition"}
 	Jobs                      = schema.GroupResource{Group: "batch", Resource: "jobs"}
 	Namespaces                = schema.GroupResource{Group: "", Resource: "namespaces"}
 	PersistentVolumeClaims    = schema.GroupResource{Group: "", Resource: "persistentvolumeclaims"}


### PR DESCRIPTION
Signed-off-by: Ashish Amarnath <ashisham@vmware.com>


Fixes: #2682 

Captures the version of the CRD before the `remap_crd_version` backup item action plugin updates the version.
This ensures that check at [item_backupper.go#L253](https://github.com/vmware-tanzu/velero/blob/master/pkg/backup/item_backupper.go#L253) is satisfied and that the manifest in the backup is persisted under `<BACKUP_ROOT>/resource/customresourcedefinitions.apiextensions.k8s.io/cluster` where it is expected to restore correctly

