### PR TITLE
Adjust restic timeout and pod values up

### DIFF
--- a/changelogs/unreleased/2696-nrb
+++ b/changelogs/unreleased/2696-nrb
@@ -1,0 +1,1 @@
+Adjust restic default time out to 4 hours and base pod resource requests to 500m CPU/512Mi memory.

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -84,7 +84,7 @@ const (
 	defaultMetricsAddress = ":8085"
 
 	defaultBackupSyncPeriod           = time.Minute
-	defaultPodVolumeOperationTimeout  = 60 * time.Minute
+	defaultPodVolumeOperationTimeout  = 240 * time.Minute
 	defaultResourceTerminatingTimeout = 10 * time.Minute
 
 	// server's client default qps and burst

--- a/pkg/install/resources.go
+++ b/pkg/install/resources.go
@@ -47,10 +47,10 @@ var (
 	DefaultVeleroPodMemRequest = "128Mi"
 	DefaultVeleroPodCPULimit   = "1000m"
 	DefaultVeleroPodMemLimit   = "256Mi"
-	DefaultResticPodCPURequest = "0"
-	DefaultResticPodMemRequest = "0"
-	DefaultResticPodCPULimit   = "0"
-	DefaultResticPodMemLimit   = "0"
+	DefaultResticPodCPURequest = "500m"
+	DefaultResticPodMemRequest = "512Mi"
+	DefaultResticPodCPULimit   = "100Mi"
+	DefaultResticPodMemLimit   = "1024Mi"
 )
 
 func labels() map[string]string {

--- a/pkg/install/resources.go
+++ b/pkg/install/resources.go
@@ -49,8 +49,8 @@ var (
 	DefaultVeleroPodMemLimit   = "256Mi"
 	DefaultResticPodCPURequest = "500m"
 	DefaultResticPodMemRequest = "512Mi"
-	DefaultResticPodCPULimit   = "100Mi"
-	DefaultResticPodMemLimit   = "1024Mi"
+	DefaultResticPodCPULimit   = "1000m"
+	DefaultResticPodMemLimit   = "1Gi"
 )
 
 func labels() map[string]string {


### PR DESCRIPTION
@ashish-amarnath You had tested restic loads, and stated that 500m/512Mi was what allowed the workload to finish in a timely fashion for 100GB.

However, I noticed that in https://github.com/vmware-tanzu/velero/blob/master/pkg/util/kube/resource_requirements.go#L28, we treat a `"0"` value as unbounded, so I'm wondering - wouldn't a 500m/512Mi set have been a _reduced_ limit? Or do we need to set a request of 500m/512Mi, and leave the limit unbounded?

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>