### PR TITLE
Revert "🐛 fix file perissions on the manifest JSON in backup archive (#2685)

### DIFF
--- a/changelogs/unreleased/2685-ashish-amarnath
+++ b/changelogs/unreleased/2685-ashish-amarnath
@@ -1,1 +1,0 @@
-update file permissions on JSON manifests in the backup archive

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -264,7 +264,7 @@ func (ib *itemBackupper) backupItem(logger logrus.FieldLogger, obj runtime.Unstr
 			Name:     filePath,
 			Size:     int64(len(itemBytes)),
 			Typeflag: tar.TypeReg,
-			Mode:     0644,
+			Mode:     0755,
 			ModTime:  time.Now(),
 		}
 


### PR DESCRIPTION
Without execute permissions, the restore process will not be able to extract and open the manifests.
This will cause restore to fail with errors like 
```
time="2020-07-10T01:03:51Z" level=info msg="starting restore" logSource="pkg/controller/restore_controller.go:461" restore=velero/csi-b2-20200709180350
time="2020-07-10T01:03:51Z" level=info msg="Starting restore of backup velero/csi-b2" logSource="pkg/restore/restore.go:345" restore=velero/csi-b2-20200709180350
time="2020-07-10T01:03:51Z" level=info msg="error copying: open /tmp/194149917/resources/persistentvolumes/cluster/pvc-7b133566-c37a-4834-b1fb-251d4097190e.json: permission denied" logSource="pkg/archive/extractor.go:107" restore=velero/csi-b2-20200709180350
time="2020-07-10T01:03:51Z" level=info msg="error unzipping and extracting: open /tmp/194149917/resources/persistentvolumes/cluster/pvc-7b133566-c37a-4834-b1fb-251d4097190e.json: permission denied" logSource="pkg/restore/restore.go:349" restore=velero/csi-b2-20200709180350
time="2020-07-10T01:03:51Z" level=info msg="restore completed" logSource="pkg/controller/restore_controller.go:476" restore=velero/csi-b2-20200709180350
```

The permissions were never `0644` https://github.com/vmware-tanzu/velero/blob/901f8e13025248e33af29068a950b5d201f0bf70/pkg/backup/item_backupper.go#L205
This change should not have been made.