### PR TITLE
Don't check non-code labeled PRs for changelogs

### DIFF
--- a/.github/workflows/pr-changelog-check.yml
+++ b/.github/workflows/pr-changelog-check.yml
@@ -11,5 +11,5 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Changelog check
-      if: ${{ !contains(github.event.pull_request.labels.*.name, 'changelog-not-required') }}
+      if: ${{ !(contains(github.event.pull_request.labels.*.name, 'changelog-not-required') || contains(github.event.pull_request.labels.*.name, 'Design') || contains(github.event.pull_request.labels.*.name, 'Website') || contains(github.event.pull_request.labels.*.name, 'Documentation'))}}
       run: ./hack/changelog-check.sh


### PR DESCRIPTION
The labels 'Documentation', 'Website', and 'Design' are all for PRs
exclusively related to those things, not code, so they don't need to be
checked for changelogs or have the extra label applied.

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>