### PR TITLE
Add metrics for restic back up operation

### DIFF
--- a/changelogs/unreleased/2719-ashish-amarnath
+++ b/changelogs/unreleased/2719-ashish-amarnath
@@ -1,0 +1,1 @@
+add metrics for restic back up operation

--- a/pkg/controller/pod_volume_backup_controller_test.go
+++ b/pkg/controller/pod_volume_backup_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/metrics"
 	velerotest "github.com/vmware-tanzu/velero/pkg/test"
 )
 
@@ -156,6 +157,7 @@ func TestPVBHandler(t *testing.T) {
 			c := &podVolumeBackupController{
 				genericController: newGenericController("pod-volume-backup", velerotest.NewLogger()),
 				nodeName:          controllerNode,
+				metrics:           metrics.NewResticServerMetrics(),
 			}
 
 			c.pvbHandler(test.obj)


### PR DESCRIPTION
Signed-off-by: Ashish Amarnath <ashisham@vmware.com>

Changes in this PR:
1. Start a metrics server in the restic daemonset pods.
1. Create and register the following metrics for:
    - total number of pod volume backups enqueued
    - total number of pod volume backups processed
    - Latency of restic backup operation both as a histogram and a gauge.
1. Publish metrics in the pod_volume_backup_controller.
