### PR TITLE
Fix path + add helpful message

### DIFF
--- a/hack/verify-generated-crd-code.sh
+++ b/hack/verify-generated-crd-code.sh
@@ -22,8 +22,8 @@ ${HACK_DIR}/update-generated-crd-code.sh --verify-only
 if ! git diff --exit-code config/crd/crds/crds.go >/dev/null; then
   # revert changes to state before running CRD generation to stay consistent
   # with code-generator `--verify-only` option which discards generated changes
-  git checkout config/crd/bases
+  git checkout config/crd
 
-  echo "CRD verification - failed! Generated CRDs are out-of-date, please run 'make update'."
+  echo "CRD verification - failed! Generated CRDs are out-of-date, please run 'make update' and 'git add' the generated file(s)."
   exit 1
 fi


### PR DESCRIPTION
All the yaml files and also the generated `crds.go` file go under `config/crd`, the `config/crd/bases` only contains the yaml files. This PR fixes that and extends the warning to a more helpful message.

Signed-off-by: Carlisia <carlisia@vmware.com>