### PR TITLE
Auto-assign github PR reviewers and assignee

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,7 @@
+addReviewers: true
+addAssignees: author
+
+reviewers:
+  - nrb
+  - ashish-amarnath
+  - carlisia

--- a/.github/workflows/auto_assign_prs.yml
+++ b/.github/workflows/auto_assign_prs.yml
@@ -1,0 +1,9 @@
+name: 'Auto Assign PRs'
+on: pull_request
+
+jobs: add-reviewers:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: kentaro-m/auto-assign-action@v1.1.1
+      with: 
+        configuration-path: ".github/auto_assign.yml"


### PR DESCRIPTION
Use a GitHub Action to automatically assign GitHub PRs to the author, as
well as add reviewers.

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>