### PR TITLE
Exclude vols mounting secrets and configmaps from defaultVolumesToRestic

### DIFF
--- a/changelogs/unreleased/2762-ashish-amarnath
+++ b/changelogs/unreleased/2762-ashish-amarnath
@@ -1,0 +1,1 @@
+Exclude volumes mounting secrets and configmaps from defaulting volume backups to restic

--- a/pkg/restic/common.go
+++ b/pkg/restic/common.go
@@ -170,6 +170,14 @@ func GetPodVolumesUsingRestic(pod *corev1api.Pod, defaultVolumesToRestic bool) [
 		if pv.HostPath != nil {
 			continue
 		}
+		// don't backup volumes mounting secrets. Secrets will be backed up separately.
+		if pv.Secret != nil {
+			continue
+		}
+		// don't backup volumes mounting config maps. Config maps will be backed up separately.
+		if pv.ConfigMap != nil {
+			continue
+		}
 		// don't backup volumes that are included in the exclude list.
 		if contains(volsToExclude, pv.Name) {
 			continue


### PR DESCRIPTION
Signed-off-by: Ashish Amarnath <ashisham@vmware.com>

We don't want to include volumes mounting secrets and config maps from defaulting volume backups to restic.
Both secrets and configmaps will both be backed up as individual resources.