### PR TITLE
Add support for default-volumes-to-restic when creating schedules

### DIFF
--- a/changelogs/unreleased/2775-TeutoNet
+++ b/changelogs/unreleased/2775-TeutoNet
@@ -1,0 +1,1 @@
+Add support for default-volumes-to-restic when creating schedules

--- a/pkg/cmd/cli/schedule/create.go
+++ b/pkg/cmd/cli/schedule/create.go
@@ -130,6 +130,7 @@ func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
 				IncludeClusterResources: o.BackupOptions.IncludeClusterResources.Value,
 				LabelSelector:           o.BackupOptions.Selector.LabelSelector,
 				SnapshotVolumes:         o.BackupOptions.SnapshotVolumes.Value,
+				DefaultVolumesToRestic:  o.BackupOptions.DefaultVolumesToRestic.Value,
 				TTL:                     metav1.Duration{Duration: o.BackupOptions.TTL},
 				StorageLocation:         o.BackupOptions.StorageLocation,
 				VolumeSnapshotLocations: o.BackupOptions.SnapshotLocations,


### PR DESCRIPTION
When creating schedules with `--default-volumes-to-restic=true` Volumes werent backup by restic. I add the Option to the BackupTemplate and it seem to work now.