### PR TITLE
Pass default-volumes-to-restic flag from create schedule to backup

### DIFF
--- a/changelogs/unreleased/2776-ashish-amarnath
+++ b/changelogs/unreleased/2776-ashish-amarnath
@@ -1,0 +1,1 @@
+Pass default-volumes-to-restic flag from create schedule to backup

--- a/pkg/cmd/cli/schedule/create.go
+++ b/pkg/cmd/cli/schedule/create.go
@@ -133,6 +133,7 @@ func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
 				TTL:                     metav1.Duration{Duration: o.BackupOptions.TTL},
 				StorageLocation:         o.BackupOptions.StorageLocation,
 				VolumeSnapshotLocations: o.BackupOptions.SnapshotLocations,
+				DefaultVolumesToRestic:  o.BackupOptions.DefaultVolumesToRestic.Value,
 			},
 			Schedule: o.Schedule,
 		},


### PR DESCRIPTION
Signed-off-by: Ashish Amarnath <ashisham@vmware.com>

Fixes: #2781 

This PR passes the `--default-volumes-to-restic` from the `velero schedule create` to the `BackupSpec`