### PR TITLE
update CI badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ If you are ready to jump in and test, add code, or help with documentation, foll
 
 See [the list of releases][6] to find out about feature changes.
 
-[1]: https://github.com/vmware-tanzu/velero/workflows/Master%20CI/badge.svg
-[2]: https://github.com/vmware-tanzu/velero/actions?query=workflow%3A"Master+CI"
+[1]: https://github.com/vmware-tanzu/velero/workflows/Main%20CI/badge.svg
+[2]: https://github.com/vmware-tanzu/velero/actions?query=workflow%3A"Main+CI"
 [4]: https://github.com/vmware-tanzu/velero/issues
 [6]: https://github.com/vmware-tanzu/velero/releases
 [9]: https://kubernetes.io/docs/setup/


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

Noticed the workflow name had been updated but the README badge was still pointing to the old one.