### PR TITLE
Add the ability to set the allowPrivilegeEscalation property on the Restic restore helper via plugin ConfigMap

### DIFF
--- a/changelogs/unreleased/2792-doughepi
+++ b/changelogs/unreleased/2792-doughepi
@@ -1,1 +1,1 @@
-Add the ability to set the allowPrivilegeEscalation flag in the securityContext for the Restore restore helper.
+Add the ability to set the allowPrivilegeEscalation flag in the securityContext for the Restic restore helper.

--- a/changelogs/unreleased/2792-doughepi
+++ b/changelogs/unreleased/2792-doughepi
@@ -1,0 +1,1 @@
+Add the ability to set the allowPrivilegeEscalation flag in the securityContext for the Restore restore helper.

--- a/pkg/restore/restic_restore_action.go
+++ b/pkg/restore/restic_restore_action.go
@@ -130,9 +130,9 @@ func (a *ResticRestoreAction) Execute(input *velero.RestoreItemActionExecuteInpu
 		)
 	}
 
-	runAsRoot, runAsGroup := getSecurityContext(log, config)
+	runAsRoot, runAsGroup, allowPrivilegeEscalation := getSecurityContext(log, config)
 
-	securityContext, err := kube.ParseSecurityContext(runAsRoot, runAsGroup)
+	securityContext, err := kube.ParseSecurityContext(runAsRoot, runAsGroup, allowPrivilegeEscalation)
 	if err != nil {
 		log.Errorf("Using default resource values, couldn't parse resource requirements: %s.", err)
 	}
@@ -219,14 +219,14 @@ func getResourceLimits(log logrus.FieldLogger, config *corev1.ConfigMap) (string
 	return config.Data["cpuLimit"], config.Data["memLimit"]
 }
 
-// getSecurityContext extracts securityContext runAsUser and runAsGroup from a ConfigMap.
-func getSecurityContext(log logrus.FieldLogger, config *corev1.ConfigMap) (string, string) {
+// getSecurityContext extracts securityContext runAsUser, runAsGroup, and allowPrivilegeEscalation from a ConfigMap.
+func getSecurityContext(log logrus.FieldLogger, config *corev1.ConfigMap) (string, string, string) {
 	if config == nil {
 		log.Debug("No config found for plugin")
-		return "", ""
+		return "", "", ""
 	}
 
-	return config.Data["secCtxRunAsUser"], config.Data["secCtxRunAsGroup"]
+	return config.Data["secCtxRunAsUser"], config.Data["secCtxRunAsGroup"], config.Data["secCtxAllowPrivilegeEscalation"]
 }
 
 // TODO eventually this can move to pkg/plugin/framework since it'll be used across multiple

--- a/pkg/restore/restic_restore_action_test.go
+++ b/pkg/restore/restic_restore_action_test.go
@@ -111,7 +111,7 @@ func TestResticRestoreActionExecute(t *testing.T) {
 		defaultCPURequestLimit, defaultMemRequestLimit, // limits
 	)
 
-	securityContext, _ := kube.ParseSecurityContext("", "")
+	securityContext, _ := kube.ParseSecurityContext("", "", "")
 
 	var (
 		restoreName = "my-restore"

--- a/pkg/util/kube/security_context.go
+++ b/pkg/util/kube/security_context.go
@@ -23,7 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func ParseSecurityContext(runAsUser string, runAsGroup string) (corev1.SecurityContext, error) {
+func ParseSecurityContext(runAsUser string, runAsGroup string, allowPrivilegeEscalation string) (corev1.SecurityContext, error) {
 	securityContext := corev1.SecurityContext{}
 
 	if runAsUser != "" {
@@ -42,6 +42,15 @@ func ParseSecurityContext(runAsUser string, runAsGroup string) (corev1.SecurityC
 		}
 
 		securityContext.RunAsGroup = &parsedRunAsGroup
+	}
+
+	if allowPrivilegeEscalation != "" {
+		parsedAllowPrivilegeEscalation, err := strconv.ParseBool(allowPrivilegeEscalation)
+		if err != nil {
+			return securityContext, errors.WithStack(errors.Errorf(`Security context allowPrivilegeEscalation "%s" is not a boolean`, allowPrivilegeEscalation))
+		}
+
+		securityContext.AllowPrivilegeEscalation = &parsedAllowPrivilegeEscalation
 	}
 
 	return securityContext, nil

--- a/pkg/util/kube/security_context_test.go
+++ b/pkg/util/kube/security_context_test.go
@@ -17,11 +17,12 @@ limitations under the License.
 package kube
 
 import (
-	"github.com/vmware-tanzu/velero/pkg/util/boolptr"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/vmware-tanzu/velero/pkg/util/boolptr"
 )
 
 func TestParseSecurityContext(t *testing.T) {

--- a/pkg/util/kube/security_context_test.go
+++ b/pkg/util/kube/security_context_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kube
 
 import (
+	"github.com/vmware-tanzu/velero/pkg/util/boolptr"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,14 +39,14 @@ func TestParseSecurityContext(t *testing.T) {
 		{"valid security context", args{"1001", "999", "true"}, false, &corev1.SecurityContext{
 			RunAsUser:                pointInt64(1001),
 			RunAsGroup:               pointInt64(999),
-			AllowPrivilegeEscalation: pointBool(true),
+			AllowPrivilegeEscalation: boolptr.True(),
 		}},
 		{
 			"another valid security context",
 			args{"1001", "999", "false"}, false, &corev1.SecurityContext{
 				RunAsUser:                pointInt64(1001),
 				RunAsGroup:               pointInt64(999),
-				AllowPrivilegeEscalation: pointBool(false),
+				AllowPrivilegeEscalation: boolptr.False(),
 			},
 		},
 		{"security context without runAsGroup", args{"1001", "", ""}, false, &corev1.SecurityContext{
@@ -76,10 +77,6 @@ func TestParseSecurityContext(t *testing.T) {
 			assert.Equal(t, tt.expected.RunAsGroup, got.RunAsGroup)
 		})
 	}
-}
-
-func pointBool(b bool) *bool {
-	return &b
 }
 
 func pointInt64(i int64) *int64 {


### PR DESCRIPTION
Signed-off-by: Piper Dougherty doughertypiper@gmail.com

Adds the ability to set the `allowPrivilegeEscalation` attribute in the `securityContext` for the Restic restore helper container. Adding the key-value pair `secCtxAllowPrivilegeEscalation: false` in the data section of the Restic plugin configuration ConfigMap is sufficient to pass the attribute to the helper InitContainer when restoring a pod with a Restic managed persistent volume. See the Velero Helm chart section [for this parameter](https://github.com/vmware-tanzu/helm-charts/blob/196e15c8d6bb728c9f5bce0725ff22ebf235e340/charts/velero/values.yaml#L250) for more information.

This was needed because our team implements Gatekeeper/Open Policy Agent policy that restricts container privilege escalation. We can configure the security policy to ignore the namespace that Velero lives in, but we cannot tell it to ignore the InitContainer that Velero uses to restore Restic managed persistent volumes since that lives in the user namespace being restored. Excluding the user namespace from Gatekeeper/Open Policy Agent control would obviously defeat the point of having the policy in the first place. 

This does not change the default behavior of the restoration helper for users that do not specify a value for the new configuration setting.

TODO:

- [ ] Update Velero Helm chart documentation with the new config option.