### PR TITLE
Always use groupResource.String() when logging (fixes #2795)

### DIFF
--- a/changelogs/unreleased/2796-bgagnon
+++ b/changelogs/unreleased/2796-bgagnon
@@ -1,0 +1,1 @@
+Fix inconsistent type for the "resource" structured logging field

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -73,7 +73,7 @@ func (ib *itemBackupper) backupItem(logger logrus.FieldLogger, obj runtime.Unstr
 	name := metadata.GetName()
 
 	log := logger.WithField("name", name)
-	log = log.WithField("resource", groupResource)
+	log = log.WithField("resource", groupResource.String())
 	log = log.WithField("namespace", namespace)
 
 	if metadata.GetLabels()["velero.io/exclude-from-backup"] == "true" {


### PR DESCRIPTION
This aligns this `resource` logging field injection with the rest of the code base, and fixes #2795.