### PR TITLE
🏃‍♂️ Setup crd validation github action on k8s versions

### DIFF
--- a/.github/workflows/crds-verify-k8s-1-16-9.yaml
+++ b/.github/workflows/crds-verify-k8s-1-16-9.yaml
@@ -1,0 +1,20 @@
+name: "Verify Velero CRDs on k8s 1.16.9"
+on: [pull_request]
+
+jobs:
+  kind:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: engineerd/setup-kind@v0.4.0
+      with:
+          image: "kindest/node:v1.16.9"
+    - name: Testing
+      run: |
+        kubectl cluster-info
+        kubectl get pods -n kube-system
+        kubectl version
+        echo "current-context:" $(kubectl config current-context)
+        echo "environment-kubeconfig:" ${KUBECONFIG}
+        make local
+        ./_output/bin/linux/amd64/velero install --crds-only --dry-run -oyaml | kubectl apply -f -

--- a/.github/workflows/crds-verify-k8s-1-17-0.yaml
+++ b/.github/workflows/crds-verify-k8s-1-17-0.yaml
@@ -1,0 +1,20 @@
+name: "Verify Velero CRDs on k8s 1.17"
+on: [pull_request]
+
+jobs:
+  kind:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: engineerd/setup-kind@v0.4.0
+      with:
+          image: "kindest/node:v1.17.0"
+    - name: Testing
+      run: |
+        kubectl cluster-info
+        kubectl get pods -n kube-system
+        kubectl version
+        echo "current-context:" $(kubectl config current-context)
+        echo "environment-kubeconfig:" ${KUBECONFIG}
+        make local
+        ./_output/bin/linux/amd64/velero install --crds-only --dry-run -oyaml | kubectl apply -f -

--- a/.github/workflows/crds-verify-k8s-1-18-4.yaml
+++ b/.github/workflows/crds-verify-k8s-1-18-4.yaml
@@ -1,0 +1,20 @@
+name: "Verify Velero CRDs on k8s 1.18.4"
+on: [pull_request]
+
+jobs:
+  kind:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: engineerd/setup-kind@v0.4.0
+      with:
+          image: "kindest/node:v1.18.4"
+    - name: Testing
+      run: |
+        kubectl cluster-info
+        kubectl get pods -n kube-system
+        kubectl version
+        echo "current-context:" $(kubectl config current-context)
+        echo "environment-kubeconfig:" ${KUBECONFIG}
+        make local
+        ./_output/bin/linux/amd64/velero install --crds-only --dry-run -oyaml | kubectl apply -f -

--- a/changelogs/unreleased/2805-ashish-amarnath
+++ b/changelogs/unreleased/2805-ashish-amarnath
@@ -1,0 +1,1 @@
+Setup crd validation github action on k8s versions


### PR DESCRIPTION
Signed-off-by: Ashish Amarnath <ashisham@vmware.com>

- Adding github actions to test Velero CRDs can be successfully applied to a kubernetes cluster.
- These actions are setup to run on every PR.
- Added 3 different instead of one GH action running the verification in a loop or multiple jobs to run them in parallel
- Once this PR is merged, will mark CRD verification for kubernetes 1.17 and 1.16.9 as mandatory for PR to merge.
- CRD verification on a kubernetes 1.18.4 cluster currently fails and will be made mandatory after the root cause has been identified.