### PR TITLE
Use pull_request_target event to auto-assign reviewers

### DIFF
--- a/.github/workflows/auto_assign_prs.yml
+++ b/.github/workflows/auto_assign_prs.yml
@@ -1,5 +1,10 @@
 name: 'Auto Assign PR Reviewers'
-on: pull_request
+# pull_request_target means that this will run on pull requests, but in the context of the base repo.
+# This should mean PRs from forks are supported.
+on: 
+  pull_request_target:
+    types: [opened, reopened, sychronized]
+
 
 jobs: 
   add-reviews:


### PR DESCRIPTION
Signed-off-by: Nolan Brubaker <brubakern@vmware.com>