### PR TITLE
Checkout code on builder image workflow

### DIFF
--- a/.github/workflows/push-builder.yml
+++ b/.github/workflows/push-builder.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - uses: actions/checkout@master
+
     - name: Build
       run: make build-image
 


### PR DESCRIPTION
Building the builder image was failing on every merge to `main` because the code wasn't being checked out in the action.

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>