### PR TITLE
doc: fix feature flag EnableCSI on velero backup describe command only

### DIFF
--- a/site/content/docs/main/csi.md
+++ b/site/content/docs/main/csi.md
@@ -31,7 +31,7 @@ velero install \
 ...
 ```
 
-To include the status of CSI objects associated with a Velero backup or restore in `velero backup describe` or `velero restore describe` output, run `velero client config set features=EnableCSI`.
+To include the status of CSI objects associated with a Velero backup in `velero backup describe` output, run `velero client config set features=EnableCSI`.
 See [Enabling Features][1] for more information about managing client-side feature flags.
 
 # Implementation Choices

--- a/site/content/docs/v1.4/csi.md
+++ b/site/content/docs/v1.4/csi.md
@@ -31,7 +31,7 @@ velero install \
 ...
 ```
 
-To include the status of CSI objects associated with a Velero backup or restore in `velero backup describe` or `velero restore describe` output, run `velero client config set features=EnableCSI`.
+To include the status of CSI objects associated with a Velero backup in `velero backup describe` output, run `velero client config set features=EnableCSI`.
 See [Enabling Features][1] for more information about managing client-side feature flags.
 
 # Implementation Choices


### PR DESCRIPTION
From the design spec https://github.com/vmware-tanzu/velero/blob/main/design/csi-snapshots.md
I did not see the CSI information will add into `velero restore describe --details`, so I think the doc is incorrect.
Also, I have check the current code, the `EnableCSI` feature flag only on `velero backup describe --details`.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>