### PR TITLE
docs: add metadata to resource-filtering.md

### DIFF
--- a/site/content/docs/main/resource-filtering.md
+++ b/site/content/docs/main/resource-filtering.md
@@ -1,4 +1,7 @@
-# Resource Filtering
+---
+title: "Resource filtering"
+layout: docs
+---
 
 *Filter objects by namespace, type, or labels.*
 

--- a/site/content/docs/v1.4/resource-filtering.md
+++ b/site/content/docs/v1.4/resource-filtering.md
@@ -1,4 +1,7 @@
-# Resource Filtering
+---
+title: "Resource filtering"
+layout: docs
+---
 
 *Filter objects by namespace, type, or labels.*
 


### PR DESCRIPTION
This metadata is required by hugo to discover the content in the
documentation website, without which a `Page not found` is shown to the
viewer.

Fixes: #2831

Signed-off-by: Imran Pochi <imran@kinvolk.io>