### PR TITLE
fix: rename the PV if VolumeSnapshotter has modified the PV name

### DIFF
--- a/changelogs/unreleased/2835-pawanpraka1
+++ b/changelogs/unreleased/2835-pawanpraka1
@@ -1,0 +1,1 @@
+rename the PV if VolumeSnapshotter has modified the PV name

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -866,6 +866,11 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 					return warnings, errs
 				}
 				obj = updatedObj
+
+				// VolumeSnapshotter has modified the PV name, we should rename the PV
+				if oldName != obj.GetName() {
+					shouldRenamePV = true
+				}
 			}
 
 			if shouldRenamePV {


### PR DESCRIPTION
When VolumeSnapshotter sets the PV name via SetVolumeID and PV is
not there in the cluster, velero does not rename the PV. Which causes
the pvc to be in the lost state as pvc points to the old PV but pv object
has been renamed by VolumeSnapshotter.

Signed-off-by: Pawan <pawan@mayadata.io>