### PR TITLE
🏃‍♂️ remove go mod download from Dockerfile for build speedup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,6 @@ WORKDIR /go/src/github.com/vmware-tanzu/velero
 
 COPY . /go/src/github.com/vmware-tanzu/velero
 
-RUN go mod download
-
 RUN apt-get update && apt-get install -y bzip2
 
 FROM --platform=$BUILDPLATFORM builder-env as builder


### PR DESCRIPTION
Signed-off-by: Ashish Amarnath <ashisham@vmware.com>

This saves at least 30s from the build.