### PR TITLE
Update the number of reviewers for PRs/add Bridget

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,7 +1,11 @@
 addReviewers: true
 addAssignees: author
 
+# Set this to the length of the reviewers list because the default was not including everyone
+numberOfReviewers: 4
+
 reviewers:
   - nrb
   - ashish-amarnath
   - carlisia
+  - zubron


### PR DESCRIPTION
There's some bug in leaving the number of reviewers at the default that I can't identify by reading the TypeScript of the action, so try setting it equal to the length of the list manually.

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>