### PR TITLE
🐛  fix passing LDFLAGS across build stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,7 @@ ARG GIT_TREE_STATE
 ENV CGO_ENABLED=0 \
     GO111MODULE=on \
     GOPROXY=${GOPROXY} \
-    LDFLAGS="-X ${PKG}/pkg/buildinfo.Version=${VERSION}" \
-    LDFLAGS="${LDFLAGS} -X ${PKG}/pkg/buildinfo.GitSHA=${GIT_SHA}" \
-    LDFLAGS="${LDFLAGS} -X ${PKG}/pkg/buildinfo.GitTreeState=${GIT_TREE_STATE}"
+    LDFLAGS="-X ${PKG}/pkg/buildinfo.Version=${VERSION} -X ${PKG}/pkg/buildinfo.GitSHA=${GIT_SHA} -X ${PKG}/pkg/buildinfo.GitTreeState=${GIT_TREE_STATE}"
 
 WORKDIR /go/src/github.com/vmware-tanzu/velero
 

--- a/changelogs/unreleased/2853-ashish-amarnath
+++ b/changelogs/unreleased/2853-ashish-amarnath
@@ -1,0 +1,1 @@
+🐛 fix passing LDFLAGS across build stages


### PR DESCRIPTION
Signed-off-by: Ashish Amarnath <ashisham@vmware.com>

Fixes: #2851 


Now this works
```bash
docker run -ti ashishamarnath/velero:ft-0 bash
nobody@05bcb28fe995:/$ ./velero version --client-only
Client:
	Version: ft-0
	Git commit: 20ac6037478bc67b53e5921ee05d0777c734fc21
nobody@05bcb28fe995:/$
```