### PR TITLE
Check for errors on restic backup command

### DIFF
--- a/changelogs/unreleased/2863-dymurray
+++ b/changelogs/unreleased/2863-dymurray
@@ -1,0 +1,1 @@
+Check for errors on restic backup command

--- a/pkg/restic/exec_commands.go
+++ b/pkg/restic/exec_commands.go
@@ -90,7 +90,10 @@ func RunBackup(backupCmd *Command, log logrus.FieldLogger, updateFunc func(veler
 	cmd.Stdout = stdoutBuf
 	cmd.Stderr = stderrBuf
 
-	cmd.Start()
+	err := cmd.Start()
+	if err != nil {
+		return stdoutBuf.String(), stderrBuf.String(), err
+	}
 
 	go func() {
 		ticker := time.NewTicker(backupProgressCheckInterval)
@@ -120,7 +123,10 @@ func RunBackup(backupCmd *Command, log logrus.FieldLogger, updateFunc func(veler
 		}
 	}()
 
-	cmd.Wait()
+	err = cmd.Wait()
+	if err != nil {
+		return stdoutBuf.String(), stderrBuf.String(), err
+	}
 	quit <- struct{}{}
 
 	summary, err := getSummaryLine(stdoutBuf.Bytes())


### PR DESCRIPTION
Signed-off-by: Dylan Murray <dymurray@redhat.com>

Currently, the restic backup code is eating the errors on the backup command. When a restic backup goes wrong and there's nothing in stdout/stderr the error is always:
```
unable to find summary in restic backup command output
```

By checking for the error, we will at the least get the exit code of the command.