### PR TITLE
add new table shortcode

### DIFF
--- a/site/content/docs/main/api-types/backupstoragelocation.md
+++ b/site/content/docs/main/api-types/backupstoragelocation.md
@@ -33,6 +33,7 @@ The configurable parameters are as follows:
 
 #### Main config parameters
 
+{{< table caption="Main config parameters" >}}
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
 | `provider` | String | Required Field | The name for whichever object storage provider will be used to store the backups. See [your object storage provider's plugin documentation][0] for the appropriate value to use. |
@@ -44,6 +45,6 @@ The configurable parameters are as follows:
 | `accessMode` | String | `ReadWrite` | How Velero can access the backup storage location. Valid values are `ReadWrite`, `ReadOnly`. |
 | `backupSyncPeriod` | metav1.Duration | Optional Field | How frequently Velero should synchronize backups in object storage. Default is Velero's server backup sync period. Set this to `0s` to disable sync. |
 | `validationFrequency` | metav1.Duration | Optional Field | How frequently Velero should validate the object storage . Default is Velero's server validation frequency. Set this to `0s` to disable validation. Default 1 minute. |
-
+{{ </table> }}
 
 [0]: ../supported-providers.md

--- a/site/content/docs/main/api-types/volumesnapshotlocation.md
+++ b/site/content/docs/main/api-types/volumesnapshotlocation.md
@@ -32,10 +32,11 @@ The configurable parameters are as follows:
 
 #### Main config parameters
 
+{{< table caption="Main config parameters" >}}
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
 | `provider` | String | Required Field | The name for whichever storage provider will be used to create/store the volume snapshots. See [your volume snapshot provider's plugin documentation][0] for the appropriate value to use. |
 | `config` | map[string]string | None (Optional) |  Provider-specific configuration keys/values to be passed to the volume snapshotter plugin. See [your volume snapshot provider's plugin documentation][0] for details. |
-
+{{</table>}}
 
 [0]: ../supported-providers.md

--- a/site/content/docs/main/customize-installation.md
+++ b/site/content/docs/main/customize-installation.md
@@ -102,13 +102,14 @@ velero client config set features=
 
 At installation, Velero sets default resource requests and limits for the Velero pod and the restic pod, if you using the [restic integration](/docs/main/restic/).
 
-<table caption="Velero Customize resource requests and limits defaults" >
-  <tr><th>Setting</th><th>Velero pod defaults</th><th>restic pod defaults</th></tr>
-  <tr><td>CPU request</td><td>500m</td><td>500m</td></tr>
-  <tr><td>Memory requests</td><td>128Mi</td><td>512Mi</td></tr>
-  <tr><td>CPU limit</td><td>1000m (1 CPU)</td><td>1000m (1 CPU)</td></tr>
-  <tr><td>Memory limit</td><td>256Mi</td><td>1024Mi</td></tr>
-</table>
+{{< table caption="Velero Customize resource requests and limits defaults" >}}
+|Setting|Velero pod defaults|restic pod defaults|
+|--- |--- |--- |
+|CPU request|500m|500m|
+|Memory requests|128Mi|512Mi|
+|CPU limit|1000m (1 CPU)|1000m (1 CPU)|
+|Memory limit|256Mi|1024Mi|
+{{< /table >}}
 
 ### Install with custom resource requests and limits
 

--- a/site/content/docs/main/style-guide.md
+++ b/site/content/docs/main/style-guide.md
@@ -92,7 +92,7 @@ Many readers speak English as a second language. Avoid jargon and idioms to help
 |Create a new cluster.|Turn up a new cluster.|
 {{< /table >}}
 
-### Avoid statements statements about the future or that will soon be out of date
+### Avoid statements about the future or that will soon be out of date
 
 Avoid making promises or giving hints about the future. If you need to talk about
 a beta feature, put the text under a heading that identifies it as beta

--- a/site/content/docs/main/style-guide.md
+++ b/site/content/docs/main/style-guide.md
@@ -214,11 +214,7 @@ document, use the backtick (`` ` ``).
 |Do|Don't|
 |--- |--- |
 |The `kubeadm` tool bootstraps and provisions machines in a cluster.|`kubeadm` tool bootstraps and provisions machines in a cluster.|
-|The kube-scheduler is the default scheduler for|Do|Don't|
-|--- |--- |
-|Set the value of `imagePullPolicy` to `Always`.|Set the value of `imagePullPolicy` to "Always".|
-|Set the value of `image` to `nginx:1.16`.|Set the value of `image` to nginx:1.16.|
-|Set the value of the `replicas` field to `2`.|Set the value of the `replicas` field to 2.| Kubernetes.|kube-scheduler is the default scheduler for Kubernetes.|
+|The kube-scheduler is the default scheduler for Kubernetes.|kube-scheduler is the default scheduler for Kubernetes.|
 {{< /table >}}
 
 ### Use normal style for string and integer field values

--- a/site/content/docs/main/style-guide.md
+++ b/site/content/docs/main/style-guide.md
@@ -10,24 +10,24 @@ This page outlines writing style guidelines for the Velero documentation and you
 The Velero documentation uses the [kramdown](https://kramdown.gettalong.org/) Markdown renderer.
 
 ## Content best practices
-
-
 ### Use present tense
 
-<table caption="Do and Don't - Use present tense">
-  <tr><th>Do</th><th>Don't</th></tr>
-  <tr><td>This `command` starts a proxy.</td><td>This command will start a proxy.</td></tr>
-</table>
+{{< table caption="Do and Don't - Use present tense" >}}
+|Do|Don't|
+|--- |--- |
+|This `command` starts a proxy.|This command will start a proxy.|
+{{< /table >}}
 
 Exception: Use future or past tense if it is required to convey the correct meaning.
 
 ### Use active voice
 
-<table caption="Do and Don't - Use active voice" >
-  <tr><th>Do</th><th>Don't</th></tr>
-  <tr><td>You can explore the API using a browser.</td><td>The API can be explored using a browser.</td></tr>
-  <tr><td>The YAML file specifies the replica count.</td><td>The replica count is specified in the YAML file.</td></tr>
-</table>
+{{< table caption="Do and Don't - Use active voice" >}}
+|Do|Don't|
+|--- |--- |
+|You can explore the API using a browser.|The API can be explored using a browser.|
+|The YAML file specifies the replica count.|The replica count is specified in the YAML file.|
+{{< /table >}}
 
 Exception: Use passive voice if active voice leads to an awkward sentence construction.
 
@@ -35,30 +35,33 @@ Exception: Use passive voice if active voice leads to an awkward sentence constr
 
 Use simple and direct language. Avoid using unnecessary phrases, such as saying "please."
 
-<table caption="Do and Don't - Use simple and direct language" >
-<tr><th>Do</th><th>Don't</th></tr>
-<tr><td>To create a ReplicaSet, ...</td><td>In order to create a ReplicaSet, ...</td></tr>
-<tr><td>See the configuration file.</td><td>Please see the configuration file.</td></tr>
-<tr><td>View the Pods.</td><td>With this next command, we'll view the Pods.</td></tr>
-</table>
+{{< table caption="Do and Don't - Use simple and direct language" >}}
+|Do|Don't|
+|--- |--- |
+|To create a ReplicaSet, ...|In order to create a ReplicaSet, ...|
+|See the configuration file.|Please see the configuration file.|
+|View the Pods.|With this next command, we'll view the Pods.|
+{{< /table >}}
 
 ### Address the reader as "you"
 
-<table caption="Do and Don't - Addressing the reader" >
-<tr><th>Do</th><th>Don't</th></tr>
-<tr><td>You can create a Deployment by ...</td><td>We'll create a Deployment by ...</td></tr>
-<tr><td>In the preceding output, you can see...</td><td>In the preceding output, we can see ...</td></tr>
-</table>
+{{< table caption="Do and Don't - Addressing the reader" >}}
+|Do|Don't|
+|--- |--- |
+|You can create a Deployment by ...|We'll create a Deployment by ...|
+|In the preceding output, you can see...|In the preceding output, we can see ...|
+{{< /table >}}
 
 ### Avoid Latin phrases
 
 Prefer English terms over Latin abbreviations.
 
-<table caption="Do and Don't - Avoid Latin phrases" >
-<tr><th>Do</th><th>Don't</th></tr>
-<tr><td>For example, ...</td><td>e.g., ...</td></tr>
-<tr><td>That is, ...</td><td>i.e., ...</td></tr>
-</table>
+{{< table caption="Do and Don't - Avoid Latin phrases" >}}
+|Do|Don't|
+|--- |--- |
+|For example, ...|e.g., ...|
+|That is, ...|i.e., ...|
+{{< /table >}}
 
 Exception: Use "etc." for et cetera.
 
@@ -70,46 +73,46 @@ Exception: Use "etc." for et cetera.
 Using "we" in a sentence can be confusing, because the reader might not know
 whether they're part of the "we" you're describing.
 
-<table caption="Do and Don't - Patterns to avoid" >
-<tr><th>Do</th><th>Don't</th></tr>
-<tr><td>Version 1.4 includes ...</td><td>In version 1.4, we have added ...</td></tr>
-<tr><td>Kubernetes provides a new feature for ...</td><td>We provide a new feature ...</td></tr>
-<tr><td>This page teaches you how to use Pods.</td><td>In this page, we are going to learn about Pods.</td></tr>
-</table>
+{{< table caption="Do and Don't - Avoid using we" >}}
+|Do|Don't|
+|--- |--- |
+|Version 1.4 includes ...|In version 1.4, we have added ...|
+|Kubernetes provides a new feature for ...|We provide a new feature ...|
+|This page teaches you how to use Pods.|In this page, we are going to learn about Pods.|
+{{< /table >}}
 
 ### Avoid jargon and idioms
 
 Many readers speak English as a second language. Avoid jargon and idioms to help them understand better.
 
-<table caption="Do and Don't - Avoid jargon and idioms" >
-<tr><th>Do</th><th>Don't</th></tr>
-<tr><td>Internally, ...</td><td>Under the hood, ...</td></tr>
-<tr><td>Create a new cluster.</td><td>Turn up a new cluster.</td></tr>
-</table>
+{{< table caption="Do and Don't - Avoid jargon and idioms" >}}
+|Do|Don't|
+|--- |--- |
+|Internally, ...|Under the hood, ...|
+|Create a new cluster.|Turn up a new cluster.|
+{{< /table >}}
 
-### Avoid statements about the future
+### Avoid statements statements about the future or that will soon be out of date
 
 Avoid making promises or giving hints about the future. If you need to talk about
 a beta feature, put the text under a heading that identifies it as beta
 information.
 
-### Avoid statements that will soon be out of date
-
-Avoid words like “recently”, "currently" and "new." A feature that is new today might not be
+Also avoid words like “recently”, "currently" and "new." A feature that is new today might not be
 considered new in a few months.
 
-<table caption="Do and Don't - Avoid statements that will soon be out of date" >
-<tr><th>Do</th><th>Don't</th></tr>
-<tr><td>In version 1.4, ...</td><td>In the current version, ...</td></tr>
-<tr><td>The Federation feature provides ...</td><td>The new Federation feature provides ...</td></tr>
-</table>
+{{< table caption="Do and Don't - Avoid statements that will soon be out of date" >}}
+|Do|Don't|
+|--- |--- |
+|In version 1.4, ...|In the current version, ...|
+|The Federation feature provides ...|The new Federation feature provides ...|
+{{< /table >}}
 
 ### Language
 
 This documentation uses U.S. English spelling and grammar.
 
 ## Documentation formatting standards
-
 
 ### Use camel case for API objects
 
@@ -124,14 +127,15 @@ PodTemplateList, not Pod Template List.
 Refer to API objects without saying "object," unless omitting "object"
 leads to an awkward sentence construction.
 
-<table caption="Do and Don't - API objects" >
-<tr><th>Do</th><th>Don't</th></tr>
-<tr><td>The Pod has two containers.</td><td>The pod has two containers.</td></tr>
-<tr><td>The Deployment is responsible for ...</td><td>The Deployment object is responsible for ...</td></tr>
-<tr><td>A PodList is a list of Pods.</td><td>A Pod List is a list of pods.</td></tr>
-<tr><td>The two ContainerPorts ...</td><td>The two ContainerPort objects ...</td></tr>
-<tr><td>The two ContainerStateTerminated objects ...</td><td>The two ContainerStateTerminateds ...</td></tr>
-</table>
+{{< table caption="Do and Don't - Do and Don't - API objects" >}}
+|Do|Don't|
+|--- |--- |
+|The Pod has two containers.|The pod has two containers.|
+|The Deployment is responsible for ...|The Deployment object is responsible for ...|
+|A PodList is a list of Pods.|A Pod List is a list of pods.|
+|The two ContainerPorts ...|The two ContainerPort objects ...|
+|The two ContainerStateTerminated objects ...|The two ContainerStateTerminateds ...|
+{{< /table >}}
 
 ### Use angle brackets for placeholders
 
@@ -145,36 +149,39 @@ Use angle brackets for placeholders. Tell the reader what a placeholder represen
 
 ### Use bold for user interface elements
 
-<table caption="Do and Don't - Bold interface elements" markdown="1">
-<tr><th>Do</th><th>Don't</th></tr>
-<tr><td markdown="span">Click **Fork**.</td><td>Click "Fork".</td></tr>
-<tr><td markdown="span">Select **Other**.</td><td>Select "Other".</td></tr>
-</table>
+{{< table caption="Do and Don't - Bold interface elements" >}}
+|Do|Don't|
+|--- |--- |
+|Click **Fork**.|Click "Fork".|
+|Select **Other**.|Select "Other".|
+{{< /table >}}
 
 ### Use italics to define or introduce new terms
 
-<table caption="Do and Don't - Use italics for new terms" >
-<tr><th>Do</th><th>Don't</th></tr>
-<tr><td markdown="span">A _cluster_ is a set of nodes ...</td><td>A "cluster" is a set of nodes ...</td></tr>
-<tr><td markdown="span">These components form the _control plane_.</td><td markdown="span">These components form the **control plane**.</td></tr>
-</table>
+{{< table caption="Do and Don't - Use italics for new terms" >}}
+|Do|Don't|
+|--- |--- |
+|A _cluster_ is a set of nodes ...|A "cluster" is a set of nodes ...|
+|These components form the _control plane_.|These components form the **control plane**.|
+{{< /table >}}
 
 ### Use code style for filenames, directories, paths, object field names and namespaces
+{{< table caption="Do and Don't - Use code style for filenames, directories, paths, object field names and namespaces" >}}
+|Do|Don't|
+|--- |--- |
+|Open the `envars.yaml` file.|Open the envars.yaml file.|
+|Go to the `/docs/tutorials` directory.|Go to the /docs/tutorials directory.|
+|Open the `/_data/concepts.yaml` file.|Open the /\_data/concepts.yaml file.|
+{{< /table >}}
 
-<table caption="Do and Don't - Use code style for filenames, directories, paths, object field names and namespaces" >
-<tr><th>Do</th><th>Don't</th></tr>
-<tr><td markdown="span">Open the `envars.yaml` file.</td><td>Open the envars.yaml file.</td></tr>
-<tr><td markdown="span">Go to the `/docs/tutorials` directory.</td><td>Go to the /docs/tutorials directory.</td></tr>
-<tr><td markdown="span">Open the `/_data/concepts.yaml` file.</td><td markdown="span">Open the /\_data/concepts.yaml file.</td></tr>
-</table>
 
 ### Use punctuation inside quotes
-
-<table caption="Do and Don't - Use punctuation inside quotes" >
-<tr><th>Do</th><th>Don't</th></tr>
-<tr><td>events are recorded with an associated "stage."</td><td>events are recorded with an associated "stage".</td></tr>
-<tr><td>The copy is called a "fork."</td><td>The copy is called a "fork".</td></tr>
-</table>
+{{< table caption="Do and Don't - Use code style for filenames, directories, paths, object field names and namespaces" >}}
+|Do|Don't|
+|--- |--- |
+|events are recorded with an associated "stage."|events are recorded with an associated "stage".|
+|The copy is called a "fork."|The copy is called a "fork".|
+{{< /table >}}
 
 Exception: When the quoted word is a user input.
 
@@ -190,44 +197,52 @@ Example:
 For inline code in an HTML document, use the `<code>` tag. In a Markdown
 document, use the backtick (`` ` ``).
 
-<table caption="Do and Don't - Use code style for inline code and commands" >
-<tr><th>Do</th><th>Don't</th></tr>
-<tr><td markdown="span">The `kubectl run` command creates a Deployment.</td><td>The "kubectl run" command creates a Deployment.</td></tr>
-<tr><td markdown="span">For declarative management, use `kubectl apply`.</td><td>For declarative management, use "kubectl apply".</td></tr>
-<tr><td markdown="span">Use single backticks to enclose inline code. For example, `var example = true`.</td><td>Use two asterisks (`**`) or an underscore (`_`) to enclose inline code. For example, **var example = true**.</td></tr>
-<tr><td>Use triple backticks (\`\`\`) before and after a multi-line block of code for fenced code blocks.</td><td>Use multi-line blocks of code to create diagrams, flowcharts, or other illustrations.</td></tr>
-<tr><td>Use meaningful variable names that have a context.</td><td>Use variable names such as 'foo','bar', and 'baz' that are not meaningful and lack context.</td></tr>
-<tr><td>Remove trailing spaces in the code.</td><td>Add trailing spaces in the code, where these are important, because a screen reader will read out the spaces as well.</td></tr>
-</table>
+{{< table caption="Do and Don't - Use code style for filenames, directories, paths, object field names and namespaces" >}}
+|Do|Don't|
+|--- |--- |
+|The `kubectl run` command creates a Deployment.|The "kubectl run" command creates a Deployment.|
+|For declarative management, use `kubectl apply`.|For declarative management, use "kubectl apply".|
+|Use single backticks to enclose inline code. For example, `var example = true`.|Use two asterisks (`**`) or an underscore (`_`) to enclose inline code. For example, **var example = true**.|
+|Use triple backticks (\`\`\`) before and after a multi-line block of code for fenced code blocks.|Use multi-line blocks of code to create diagrams, flowcharts, or other illustrations.|
+|Use meaningful variable names that have a context.|Use variable names such as 'foo','bar', and 'baz' that are not meaningful and lack context.|
+|Remove trailing spaces in the code.|Add trailing spaces in the code, where these are important, because a screen reader will read out the spaces as well.|
+{{< /table >}}
 
 ### Starting a sentence with a component tool or component name
 
-<table caption="Do and Don't - Starting a sentence with a component tool or component name" >
-<tr><th>Do</th><th>Don't</th></tr>
-<tr><td markdown="span">The `kubeadm` tool bootstraps and provisions machines in a cluster.</td><td markdown="span">`kubeadm` tool bootstraps and provisions machines in a cluster.</td></tr>
-<tr><td>The kube-scheduler is the default scheduler for Kubernetes.</td><td>kube-scheduler is the default scheduler for Kubernetes.</td></tr>
-</table>
+{{< table caption="Do and Don't - Starting a sentence with a component tool or component name" >}}
+|Do|Don't|
+|--- |--- |
+|The `kubeadm` tool bootstraps and provisions machines in a cluster.|`kubeadm` tool bootstraps and provisions machines in a cluster.|
+|The kube-scheduler is the default scheduler for|Do|Don't|
+|--- |--- |
+|Set the value of `imagePullPolicy` to `Always`.|Set the value of `imagePullPolicy` to "Always".|
+|Set the value of `image` to `nginx:1.16`.|Set the value of `image` to nginx:1.16.|
+|Set the value of the `replicas` field to `2`.|Set the value of the `replicas` field to 2.| Kubernetes.|kube-scheduler is the default scheduler for Kubernetes.|
+{{< /table >}}
 
 ### Use normal style for string and integer field values
 
 For field values of type string or integer, use normal style without quotation marks.
 
-<table caption="Do and Don't - Use normal style for string and integer field values" >
-<tr><th>Do</th><th>Don't</th></tr>
-<tr><td markdown="span">Set the value of `imagePullPolicy` to `Always`.</td><td markdown="span">Set the value of `imagePullPolicy` to "Always".</td></tr>
-<tr><td markdown="span">Set the value of `image` to `nginx:1.16`.</td><td markdown="span">Set the value of `image` to nginx:1.16.</td></tr>
-<tr><td markdown="span">Set the value of the `replicas` field to `2`.</td><td markdown="span">Set the value of the `replicas` field to 2.</td></tr>
-</table>
+{{< table caption="Do and Don't - Use normal style for string and integer field values" >}}
+|Do|Don't|
+|--- |--- |
+|Set the value of `imagePullPolicy` to `Always`.|Set the value of `imagePullPolicy` to "Always".|
+|Set the value of `image` to `nginx:1.16`.|Set the value of `image` to nginx:1.16.|
+|Set the value of the `replicas` field to `2`.|Set the value of the `replicas` field to 2.|
+{{< /table >}}
 
 ## Code snippet formatting
 
 
 ### Don't include the command prompt
 
-<table caption="Do and Don't - Don't include the command prompt" >
-<tr><th>Do</th><th>Don't</th></tr>
-<tr><td>kubectl get pods</td><td>$ kubectl get pods</td></tr>
-</table>
+{{< table caption="Do and Don't - Don't include the command prompt" >}}
+|Do|Don't|
+|--- |--- |
+|kubectl get pods|$ kubectl get pods|
+{{< /table >}}
 
 ### Separate commands from output
 
@@ -249,46 +264,51 @@ nginx    1/1       Running   0          13s    10.200.0.4   worker0
 
 A list of Velero-specific terms and words to be used consistently across the site.
 
-<table caption="Velero.io word list" >
-<tr><th>Trem</th><th>Useage</th></tr>
-<tr><td>Kubernetes</td><td>Kubernetes should always be capitalized.</td></tr>
-<tr><td>Docker</td><td>Docker should always be capitalized.</td></tr>
-<tr><td>Velero</td><td>Velero should always be capitalized.</td></tr>
-<tr><td>VMware</td><td>VMware should always be correctly capitalized.</td></tr>
-<tr><td>On-premises</td><td>On-premises or on-prem rather than on-premise or other variations.</td></tr>
-<tr><td>Backup</td><td>Backup rather than back up, back-up or other variations.</td></tr>
-<tr><td>Plugin</td><td>Plugin rather than plug-in or other variations.</td></tr>
-<tr><td>Allowlist</td><td>Use allowlist instead of whitelist.</td></tr>
-<tr><td>Denylist</td><td>Use denylist instead of blacklist.</td></tr>
-</table>
+{{< table caption="Velero.io word list" >}}
+|Trem|Useage|
+|--- |--- |
+|Kubernetes|Kubernetes should always be capitalized.|
+|Docker|Docker should always be capitalized.|
+|Velero|Velero should always be capitalized.|
+|VMware|VMware should always be correctly capitalized.|
+|On-premises|On-premises or on-prem rather than on-premise or other variations.|
+|Backup|Backup rather than back up, back-up or other variations.|
+|Plugin|Plugin rather than plug-in or other variations.|
+|Allowlist|Use allowlist instead of whitelist.|
+|Denylist|Use denylist instead of blacklist.|
+{{< /table >}}
 
 ## Markdown elements
 
 ### Headings
 People accessing this documentation may use a screen reader or other assistive technology (AT). [Screen readers](https://en.wikipedia.org/wiki/Screen_reader) are linear output devices, they output items on a page one at a time. If there is a lot of content on a page, you can use headings to give the page an internal structure. A good page structure helps all readers to easily navigate the page or filter topics of interest.
 
-<table caption="Do and Don't - Headings" >
-<tr><th>Do</th><th>Don't</th></tr>
-<tr><td>Include a title on each page or blog post.</td><td>Include more than one title headings (#) in a page.</td></tr>
-<tr><td>Use ordered headings to provide a meaningful high-level outline of your content.</td><td>Use headings level 4 through 6, unless it is absolutely necessary. If your content is that detailed, it may need to be broken into separate articles.</td></tr>
-<tr><td markdown="span">Use sentence case for headings. For example, **Extend kubectl with plugins**</td><td markdown="span">Use title case for headings. For example, **Extend Kubectl With Plugins**</td></tr>
-</table>
+{{< table caption="Do and Don't - Headings" >}}
+|Do|Don't|
+|--- |--- |
+|Include a title on each page or blog post.|Include more than one title headings (#) in a page.|
+|Use ordered headings to provide a meaningful high-level outline of your content.|Use headings level 4 through 6, unless it is absolutely necessary. If your content is that detailed, it may need to be broken into separate articles.|
+|Use sentence case for headings. For example, **Extend kubectl with plugins**|Use title case for headings. For example, **Extend Kubectl With Plugins**|
+{{< /table >}}
 
 ### Paragraphs
 
-<table caption="Do and Don't - Paragraphs" >
-<tr><th>Do</th><th>Don't</th></tr>
-<tr><td>Try to keep paragraphs under 6 sentences.</td><td>Write long-winded paragraphs.</td></tr>
-<tr><td markdown="span">Use three hyphens (`---`) to create a horizontal rule for breaks in paragraph content.</td><td>Use horizontal rules for decoration.</td></tr>
-</table>
+{{< table caption="Do and Don't - Paragraphs" >}}
+
+|Do|Don't|
+|--- |--- |
+|Try to keep paragraphs under 6 sentences.|Write long-winded paragraphs.|
+|Use three hyphens (`---`) to create a horizontal rule for breaks in paragraph content.|Use horizontal rules for decoration.|
+{{< /table >}}
 
 ### Links
 
-<table caption="Do and Don't - Links" >
-<tr><th>Do</th><th>Don't</th></tr>
-<tr><td markdown="span">Write hyperlinks that give you context for the content they link to. For example: Certain ports are open on your machines. See [check required ports](#check-required-ports) for more details.</td><td markdown="span">Use ambiguous terms such as “click here”. For example: Certain ports are open on your machines. See [here](#check-required-ports) for more details.</td></tr>
-<tr><td markdown="span">Write Markdown-style links: `[link text](URL)`. For example: `[community meeting agenda](https://hackmd.io/Jq6F5zqZR7S80CeDWUklkA)` and the output is  [community meeting agenda](https://hackmd.io/Jq6F5zqZR7S80CeDWUklkA).</td><td markdown="span">Write HTML-style links: `<a href="/media/examples/link-element-example.css" target="_blank">Visit our tutorial!</a>`</td></tr>
-</table>
+{{< table caption="Do and Don't - Links" >}}
+|Do|Don't|
+|--- |--- |
+|Write hyperlinks that give you context for the content they link to. For example: Certain ports are open on your machines. See [check required ports](#check-required-ports) for more details.|Use ambiguous terms such as “click here”. For example: Certain ports are open on your machines. See [here](#check-required-ports) for more details.|
+|Write Markdown-style links: `[link text](URL)`. For example: `[community meeting agenda](https://hackmd.io/Jq6F5zqZR7S80CeDWUklkA)` and the output is  [community meeting agenda](https://hackmd.io/Jq6F5zqZR7S80CeDWUklkA).|Write HTML-style links: `Visit our tutorial!`|
+{{< /table >}}
 
 
 ### Lists
@@ -312,6 +332,16 @@ Website navigation links can also be marked up as list items; after all they are
 
 ### Tables
 
-The semantic purpose of a data table is to present tabular data. Sighted users can quickly scan the table but a screen reader goes through line by line. A table caption is used to create a descriptive title for a data table. Assistive technologies (AT) use the HTML table caption element to identify the table contents to the user within the page structure. For example, `<table caption="Do and Don't - Use present tense">`. To make tables accessible, use HTML formatting to create tables.
+The semantic purpose of a data table is to present tabular data. Sighted users can quickly scan the table but a screen reader goes through line by line. A table [caption](https://www.w3schools.com/tags/tag_caption.asp) is used to create a descriptive title for a data table. Assistive technologies (AT) use the HTML table caption element to identify the table contents to the user within the page structure.
 
-If you need to create a table and style table data with markdown, add `markdown="span"` to all `<td>` where the markdown interpreter should be applied.
+If you need to create a table, create the table in markdown and use the table [Hugo shortcode](https://gohugo.io/content-management/shortcodes/) to include a caption.
+
+```
+{{</* table caption="Configuration parameters" >}}
+Parameter | Description | Default
+:---------|:------------|:-------
+`timeout` | The timeout for requests | `30s`
+`logLevel` | The log level for log output | `INFO`
+{{< /table */>}}
+
+```

--- a/site/content/docs/main/style-guide.md
+++ b/site/content/docs/main/style-guide.md
@@ -341,3 +341,4 @@ Parameter | Description | Default
 {{< /table */>}}
 
 ```
+**Note:** This shortcode does not support markdown reference-style links. Use inline-style links in tables. See more information about [markdown link styles](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#links).

--- a/site/content/docs/main/supported-providers.md
+++ b/site/content/docs/main/supported-providers.md
@@ -7,26 +7,31 @@ Velero supports a variety of storage providers for different backup and snapshot
 
 ## Velero supported providers
 
+{{< table caption="Velero supported providers" >}}
+
 | Provider                          | Object Store        | Volume Snapshotter           | Plugin Provider Repo                    | Setup Instructions            |
 |-----------------------------------|---------------------|------------------------------|-----------------------------------------|-------------------------------|
-| [Amazon Web Services (AWS)][7]    | AWS S3              | AWS EBS                      | [Velero plugin for AWS][8]              | [AWS Plugin Setup][35]        |
-| [Google Cloud Platform (GCP)][11] | Google Cloud Storage| Google Compute Engine Disks  | [Velero plugin for GCP][12]             | [GCP Plugin Setup][36]        |
-| [Microsoft Azure][9]              | Azure Blob Storage  | Azure Managed Disks          | [Velero plugin for Microsoft Azure][10] | [Azure Plugin Setup][37]      |
-| [VMware vSphere][39]              | 🚫                  | vSphere Volumes              | [VMware vSphere][39]                    | [vSphere Plugin Setup][40]    |
-| [Container Storage Interface (CSI)][44]| 🚫                 | CSI Volumes                  | [Velero plugin for CSI][44]             | [CSI Plugin Setup][45]        |
+| [Amazon Web Services (AWS)](https://aws.amazon.com)    | AWS S3              | AWS EBS                      | [Velero plugin for AWS](https://github.com/vmware-tanzu/velero-plugin-for-aws)              | [AWS Plugin Setup](https://github.com/vmware-tanzu/velero-plugin-for-aws#setup)        |
+| [Google Cloud Platform (GCP)](https://cloud.google.com) | Google Cloud Storage| Google Compute Engine Disks  | [Velero plugin for GCP](https://github.com/vmware-tanzu/velero-plugin-for-gcp)             | [GCP Plugin Setup](https://github.com/vmware-tanzu/velero-plugin-for-gcp#setup)        |
+| [Microsoft Azure](https://azure.com)              | Azure Blob Storage  | Azure Managed Disks          | [Velero plugin for Microsoft Azure](https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure) | [Azure Plugin Setup](https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure#setup)      |
+| [VMware vSphere](https://github.com/vmware-tanzu/velero-plugin-for-vsphere)              | 🚫                  | vSphere Volumes              | [VMware vSphere](https://github.com/vmware-tanzu/velero-plugin-for-vsphere)                    | [vSphere Plugin Setup](https://github.com/vmware-tanzu/velero-plugin-for-vsphere#installing-the-plugin)    |
+| [Container Storage Interface (CSI)](https://github.com/vmware-tanzu/velero-plugin-for-csi/)| 🚫                 | CSI Volumes                  | [Velero plugin for CSI](https://github.com/vmware-tanzu/velero-plugin-for-csi/)             | [CSI Plugin Setup](website-guidelines.md)        |
+{{< /table >}}
 
-Contact: [#Velero Slack][28], [GitHub Issues][29]
+Contact: [#Velero Slack](https://kubernetes.slack.com/messages/velero), [GitHub Issues](https://github.com/vmware-tanzu/velero/issues)
 
 ## Community supported providers
+{{< table caption="Community supported providers" >}}
 
 | Provider                  | Object Store                 | Volume Snapshotter                 | Plugin Documentation   | Contact                         |
 |---------------------------|------------------------------|------------------------------------|------------------------|---------------------------------|
-| [AlibabaCloud][21]        | Alibaba Cloud OSS            | Alibaba Cloud                      | [AlibabaCloud][22]     | [GitHub Issue][23]              |
-| [DigitalOcean][15]        | DigitalOcean Object Storage  | DigitalOcean Volumes Block Storage | [StackPointCloud][16]  |                                 |
-| [Hewlett Packard][24]     | 🚫                           | HPE Storage                        | [Hewlett Packard][25]  | [Slack][26], [GitHub Issue][27] |
-| [OpenEBS][17]             | 🚫                           | OpenEBS CStor Volume               | [OpenEBS][18]          | [Slack][19], [GitHub Issue][20] |
-| [Portworx][31]            | 🚫                           | Portworx Volume                    | [Portworx][32]         | [Slack][33], [GitHub Issue][34] |
-| [Storj][41]               | Storj Object Storage         | 🚫                                 | [Storj][42]            | [GitHub Issue][43]              |
+| [AlibabaCloud](https://www.alibabacloud.com/)        | Alibaba Cloud OSS            | Alibaba Cloud                      | [AlibabaCloud](https://github.com/AliyunContainerService/velero-plugin)     | [GitHub Issue](https://github.com/AliyunContainerService/velero-plugin/issues)              |
+| [DigitalOcean](https://www.digitalocean.com/)        | DigitalOcean Object Storage  | DigitalOcean Volumes Block Storage | [StackPointCloud](https://github.com/StackPointCloud/ark-plugin-digitalocean)  |                                 |
+| [Hewlett Packard](https://www.hpe.com/us/en/storage.html)     | 🚫                           | HPE Storage                        | [Hewlett Packard](https://github.com/hpe-storage/velero-plugin)  | [Slack](https://slack.hpedev.io/), [GitHub Issue](https://github.com/hpe-storage/velero-plugin/issues) |
+| [OpenEBS](https://openebs.io/)             | 🚫                           | OpenEBS CStor Volume               | [OpenEBS](https://github.com/openebs/velero-plugin)          | [Slack](https://openebs-community.slack.com/), [GitHub Issue](https://github.com/openebs/velero-plugin/issues) |
+| [Portworx](https://portworx.com/)            | 🚫                           | Portworx Volume                    | [Portworx](https://docs.portworx.com/scheduler/kubernetes/ark.html)         | [Slack](https://portworx.slack.com/messages/px-k8s), [GitHub Issue](https://github.com/portworx/ark-plugin/issues) |
+| [Storj](https://storj.io)               | Storj Object Storage         | 🚫                                 | [Storj](https://github.com/storj-thirdparty/velero-plugin)            | [GitHub Issue](https://github.com/storj-thirdparty/velero-plugin/issues)              |
+{{< /table >}}
 
 ## S3-Compatible object store providers
 
@@ -56,40 +61,7 @@ In the case you want to take volume snapshots but didn't find a plugin for your 
 [4]: https://github.com/StackPointCloud/ark-plugin-digitalocean
 [5]: http://www.noobaa.com/
 [6]: https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/main/backupstoragelocation.md
-[7]: https://aws.amazon.com
-[8]: https://github.com/vmware-tanzu/velero-plugin-for-aws
-[9]: https://azure.com
-[10]: https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure
-[11]: https://cloud.google.com
-[12]: https://github.com/vmware-tanzu/velero-plugin-for-gcp
-[15]: https://www.digitalocean.com/
-[16]: https://github.com/StackPointCloud/ark-plugin-digitalocean
-[17]: https://openebs.io/
-[18]: https://github.com/openebs/velero-plugin
-[19]: https://openebs-community.slack.com/
-[20]: https://github.com/openebs/velero-plugin/issues
-[21]: https://www.alibabacloud.com/
-[22]: https://github.com/AliyunContainerService/velero-plugin
-[23]: https://github.com/AliyunContainerService/velero-plugin/issues
-[24]: https://www.hpe.com/us/en/storage.html
 [25]: https://github.com/hpe-storage/velero-plugin
-[26]: https://slack.hpedev.io/
-[27]: https://github.com/hpe-storage/velero-plugin/issues
-[28]: https://kubernetes.slack.com/messages/velero
-[29]: https://github.com/vmware-tanzu/velero/issues
 [30]: restic.md
-[31]: https://portworx.com/
-[32]: https://docs.portworx.com/scheduler/kubernetes/ark.html
-[33]: https://portworx.slack.com/messages/px-k8s
-[34]: https://github.com/portworx/ark-plugin/issues
-[35]: https://github.com/vmware-tanzu/velero-plugin-for-aws#setup
 [36]: https://github.com/vmware-tanzu/velero-plugin-for-gcp#setup
-[37]: https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure#setup
 [38]: https://www.cloudian.com/
-[39]: https://github.com/vmware-tanzu/velero-plugin-for-vsphere
-[40]: https://github.com/vmware-tanzu/velero-plugin-for-vsphere#installing-the-plugin
-[41]: https://storj.io
-[42]: https://github.com/storj-thirdparty/velero-plugin
-[43]: https://github.com/storj-thirdparty/velero-plugin/issues
-[44]: https://github.com/vmware-tanzu/velero-plugin-for-csi/
-[45]: https://velero.io/docs/v1.4/csi/

--- a/site/content/docs/main/website-guidelines.md
+++ b/site/content/docs/main/website-guidelines.md
@@ -25,7 +25,7 @@ For more information on how to run the website locally, please see our [Hugo doc
 
 ## Adding a blog post
 
-To add a blog post, create a new markdown (.MD) file in the `/site/content/posts/` folder. A blog poost requires the following front matter.
+To add a blog post, create a new markdown (.MD) file in the `/site/content/posts/` folder. A blog post requires the following front matter.
 
 ```yaml
 title: "Title of the blog"
@@ -42,4 +42,4 @@ tags: ['Velero Team', 'Nolan Brubaker']
 
 Include the `author_name` value in tags field so the page that lists the author's posts will work properly, for example https://velero.io/tags/carlisia-campos/.
 
-Ideally each blog will have a unique image to use on the blog home page, but if you do not include an image, the default Velero logo will be used instead. Use an image that is less than 70KB and add it to the `/site/static/img/posts` folder. 
+Ideally each blog will have a unique image to use on the blog home page, but if you do not include an image, the default Velero logo will be used instead. Use an image that is less than 70KB and add it to the `/site/static/img/posts` folder.

--- a/site/content/docs/v1.4/api-types/backupstoragelocation.md
+++ b/site/content/docs/v1.4/api-types/backupstoragelocation.md
@@ -33,6 +33,7 @@ The configurable parameters are as follows:
 
 #### Main config parameters
 
+{{< table caption="Main config parameters" >}}
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
 | `provider` | String | Required Field | The name for whichever object storage provider will be used to store the backups. See [your object storage provider's plugin documentation][0] for the appropriate value to use. |
@@ -43,6 +44,6 @@ The configurable parameters are as follows:
 | `config` | map[string]string | None (Optional) | Provider-specific configuration keys/values to be passed to the object store plugin. See [your object storage provider's plugin documentation][0] for details. |
 | `accessMode` | String | `ReadWrite` | How Velero can access the backup storage location. Valid values are `ReadWrite`, `ReadOnly`. |
 | `backupSyncPeriod` | metav1.Duration | Optional Field | How frequently Velero should synchronize backups in object storage. Default is Velero's server backup sync period. Set this to `0s` to disable sync. |
-
+{{</table>}}
 
 [0]: ../supported-providers.md

--- a/site/content/docs/v1.4/api-types/volumesnapshotlocation.md
+++ b/site/content/docs/v1.4/api-types/volumesnapshotlocation.md
@@ -32,10 +32,11 @@ The configurable parameters are as follows:
 
 #### Main config parameters
 
+{{< table caption="Main config parameters" >}}
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
 | `provider` | String | Required Field | The name for whichever storage provider will be used to create/store the volume snapshots. See [your volume snapshot provider's plugin documentation][0] for the appropriate value to use. |
 | `config` | map[string]string | None (Optional) |  Provider-specific configuration keys/values to be passed to the volume snapshotter plugin. See [your volume snapshot provider's plugin documentation][0] for details. |
-
+{{</table>}}
 
 [0]: ../supported-providers.md

--- a/site/content/docs/v1.4/customize-installation.md
+++ b/site/content/docs/v1.4/customize-installation.md
@@ -93,13 +93,14 @@ velero client config set features=
 
 At installation, Velero sets default resource requests and limits for the Velero pod and the restic pod, if you using the [restic integration](/docs/main/restic/). In Velero versions before 1.4.2, restic pod defaults were not set at install.
 
-<table caption="Velero Customize resource requests and limits defaults" >
-  <tr><th>Setting</th><th>Velero pod defaults</th><th>restic pod defaults (Velero 1.4.2 and later)</th></tr>
-  <tr><td>CPU request</td><td>500m</td><td>500m</td></tr>
-  <tr><td>Memory requests</td><td>128Mi</td><td>512Mi</td></tr>
-  <tr><td>CPU limit</td><td>1000m (1 CPU)</td><td>1000m (1 CPU)</td></tr>
-  <tr><td>Memory limit</td><td>256Mi</td><td>1024Mi</td></tr>
-</table>
+{{< table caption="Velero Customize resource requests and limits defaults" >}}
+|Setting|Velero pod defaults|restic pod defaults|
+|--- |--- |--- |
+|CPU request|500m|500m|
+|Memory requests|128Mi|512Mi|
+|CPU limit|1000m (1 CPU)|1000m (1 CPU)|
+|Memory limit|256Mi|1024Mi|
+{{< /table >}}
 
 ### Install with custom resource requests and limits
 

--- a/site/content/docs/v1.4/supported-providers.md
+++ b/site/content/docs/v1.4/supported-providers.md
@@ -7,26 +7,31 @@ Velero supports a variety of storage providers for different backup and snapshot
 
 ## Velero supported providers
 
+{{< table caption="Velero supported providers" >}}
+
 | Provider                          | Object Store        | Volume Snapshotter           | Plugin Provider Repo                    | Setup Instructions            |
 |-----------------------------------|---------------------|------------------------------|-----------------------------------------|-------------------------------|
-| [Amazon Web Services (AWS)][7]    | AWS S3              | AWS EBS                      | [Velero plugin for AWS][8]              | [AWS Plugin Setup][35]        |
-| [Google Cloud Platform (GCP)][11] | Google Cloud Storage| Google Compute Engine Disks  | [Velero plugin for GCP][12]             | [GCP Plugin Setup][36]        |
-| [Microsoft Azure][9]              | Azure Blob Storage  | Azure Managed Disks          | [Velero plugin for Microsoft Azure][10] | [Azure Plugin Setup][37]      |
-| [VMware vSphere][39]              | 🚫                  | vSphere Volumes              | [VMware vSphere][39]                    | [vSphere Plugin Setup][40]    |
-| [Container Storage Interface (CSI)]| 🚫                 | CSI Volumes                  | [Velero plugin for CSI][44]             | [CSI Plugin Setup][45]        |
+| [Amazon Web Services (AWS)](https://aws.amazon.com)    | AWS S3              | AWS EBS                      | [Velero plugin for AWS](https://github.com/vmware-tanzu/velero-plugin-for-aws)              | [AWS Plugin Setup](https://github.com/vmware-tanzu/velero-plugin-for-aws#setup)        |
+| [Google Cloud Platform (GCP)](https://cloud.google.com) | Google Cloud Storage| Google Compute Engine Disks  | [Velero plugin for GCP](https://github.com/vmware-tanzu/velero-plugin-for-gcp)             | [GCP Plugin Setup](https://github.com/vmware-tanzu/velero-plugin-for-gcp#setup)        |
+| [Microsoft Azure](https://azure.com)              | Azure Blob Storage  | Azure Managed Disks          | [Velero plugin for Microsoft Azure](https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure) | [Azure Plugin Setup](https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure#setup)      |
+| [VMware vSphere](https://github.com/vmware-tanzu/velero-plugin-for-vsphere)              | 🚫                  | vSphere Volumes              | [VMware vSphere](https://github.com/vmware-tanzu/velero-plugin-for-vsphere)                    | [vSphere Plugin Setup](https://github.com/vmware-tanzu/velero-plugin-for-vsphere#installing-the-plugin)    |
+| [Container Storage Interface (CSI)](https://github.com/vmware-tanzu/velero-plugin-for-csi/)| 🚫                 | CSI Volumes                  | [Velero plugin for CSI](https://github.com/vmware-tanzu/velero-plugin-for-csi/)             | [CSI Plugin Setup](website-guidelines.md)        |
+{{< /table >}}
 
-Contact: [#Velero Slack][28], [GitHub Issues][29]
+Contact: [#Velero Slack](https://kubernetes.slack.com/messages/velero), [GitHub Issues](https://github.com/vmware-tanzu/velero/issues)
 
 ## Community supported providers
+{{< table caption="Community supported providers" >}}
 
 | Provider                  | Object Store                 | Volume Snapshotter                 | Plugin Documentation   | Contact                         |
 |---------------------------|------------------------------|------------------------------------|------------------------|---------------------------------|
-| [AlibabaCloud][21]        | Alibaba Cloud OSS            | Alibaba Cloud                      | [AlibabaCloud][22]     | [GitHub Issue][23]              |
-| [DigitalOcean][15]        | DigitalOcean Object Storage  | DigitalOcean Volumes Block Storage | [StackPointCloud][16]  |                                 |
-| [Hewlett Packard][24]     | 🚫                           | HPE Storage                        | [Hewlett Packard][25]  | [Slack][26], [GitHub Issue][27] |
-| [OpenEBS][17]             | 🚫                           | OpenEBS CStor Volume               | [OpenEBS][18]          | [Slack][19], [GitHub Issue][20] |
-| [Portworx][31]            | 🚫                           | Portworx Volume                    | [Portworx][32]         | [Slack][33], [GitHub Issue][34] |
-| [Storj][41]               | Storj Object Storage         | 🚫                                 | [Storj][42]            | [GitHub Issue][43]              |
+| [AlibabaCloud](https://www.alibabacloud.com/)        | Alibaba Cloud OSS            | Alibaba Cloud                      | [AlibabaCloud](https://github.com/AliyunContainerService/velero-plugin)     | [GitHub Issue](https://github.com/AliyunContainerService/velero-plugin/issues)              |
+| [DigitalOcean](https://www.digitalocean.com/)        | DigitalOcean Object Storage  | DigitalOcean Volumes Block Storage | [StackPointCloud](https://github.com/StackPointCloud/ark-plugin-digitalocean)  |                                 |
+| [Hewlett Packard](https://www.hpe.com/us/en/storage.html)     | 🚫                           | HPE Storage                        | [Hewlett Packard](https://github.com/hpe-storage/velero-plugin)  | [Slack](https://slack.hpedev.io/), [GitHub Issue](https://github.com/hpe-storage/velero-plugin/issues) |
+| [OpenEBS](https://openebs.io/)             | 🚫                           | OpenEBS CStor Volume               | [OpenEBS](https://github.com/openebs/velero-plugin)          | [Slack](https://openebs-community.slack.com/), [GitHub Issue](https://github.com/openebs/velero-plugin/issues) |
+| [Portworx](https://portworx.com/)            | 🚫                           | Portworx Volume                    | [Portworx](https://docs.portworx.com/scheduler/kubernetes/ark.html)         | [Slack](https://portworx.slack.com/messages/px-k8s), [GitHub Issue](https://github.com/portworx/ark-plugin/issues) |
+| [Storj](https://storj.io)               | Storj Object Storage         | 🚫                                 | [Storj](https://github.com/storj-thirdparty/velero-plugin)            | [GitHub Issue](https://github.com/storj-thirdparty/velero-plugin/issues)              |
+{{< /table >}}
 
 ## S3-Compatible object store providers
 
@@ -56,40 +61,7 @@ In the case you want to take volume snapshots but didn't find a plugin for your 
 [4]: https://github.com/StackPointCloud/ark-plugin-digitalocean
 [5]: http://www.noobaa.com/
 [6]: https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/main/backupstoragelocation.md
-[7]: https://aws.amazon.com
-[8]: https://github.com/vmware-tanzu/velero-plugin-for-aws
-[9]: https://azure.com
-[10]: https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure
-[11]: https://cloud.google.com
-[12]: https://github.com/vmware-tanzu/velero-plugin-for-gcp
-[15]: https://www.digitalocean.com/
-[16]: https://github.com/StackPointCloud/ark-plugin-digitalocean
-[17]: https://openebs.io/
-[18]: https://github.com/openebs/velero-plugin
-[19]: https://openebs-community.slack.com/
-[20]: https://github.com/openebs/velero-plugin/issues
-[21]: https://www.alibabacloud.com/
-[22]: https://github.com/AliyunContainerService/velero-plugin
-[23]: https://github.com/AliyunContainerService/velero-plugin/issues
-[24]: https://www.hpe.com/us/en/storage.html
 [25]: https://github.com/hpe-storage/velero-plugin
-[26]: https://slack.hpedev.io/
-[27]: https://github.com/hpe-storage/velero-plugin/issues
-[28]: https://kubernetes.slack.com/messages/velero
-[29]: https://github.com/vmware-tanzu/velero/issues
 [30]: restic.md
-[31]: https://portworx.com/
-[32]: https://docs.portworx.com/scheduler/kubernetes/ark.html
-[33]: https://portworx.slack.com/messages/px-k8s
-[34]: https://github.com/portworx/ark-plugin/issues
-[35]: https://github.com/vmware-tanzu/velero-plugin-for-aws#setup
 [36]: https://github.com/vmware-tanzu/velero-plugin-for-gcp#setup
-[37]: https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure#setup
 [38]: https://www.cloudian.com/
-[39]: https://github.com/vmware-tanzu/velero-plugin-for-vsphere
-[40]: https://github.com/vmware-tanzu/velero-plugin-for-vsphere#installing-the-plugin
-[41]: https://storj.io
-[42]: https://github.com/storj-thirdparty/velero-plugin
-[43]: https://github.com/storj-thirdparty/velero-plugin/issues
-[44]: https://github.com/vmware-tanzu/velero-plugin-for-csi/
-[45]: https://velero.io/docs/v1.4/csi/

--- a/site/layouts/shortcodes/table.html
+++ b/site/layouts/shortcodes/table.html
@@ -1,0 +1,10 @@
+<!--
+# Original youtube shortcode
+# https://github.com/kubernetes/website/blob/master/layouts/shortcodes/table.html
+-->
+{{ $hasCaption := isset .Params "caption" }}
+{{ $caption    := .Get "caption" }}
+{{ $captionEl  := printf "<table><caption style=\"display: none;\">%s</caption>" $caption }}
+{{ $table      := .Inner | markdownify }}
+{{ $html       := cond $hasCaption ($table | replaceRE "<table>" $captionEl) $table | safeHTML }}
+{{ $html }}

--- a/site/layouts/shortcodes/table.html
+++ b/site/layouts/shortcodes/table.html
@@ -1,5 +1,5 @@
 <!--
-# Original youtube shortcode
+# Original table shortcode
 # https://github.com/kubernetes/website/blob/master/layouts/shortcodes/table.html
 -->
 {{ $hasCaption := isset .Params "caption" }}


### PR DESCRIPTION
Signed-off-by: Abigail McCarthy <mabigail@vmware.com>

Adds new short code for handling tables and making it easier to add table captions to improve accessibility.

Notes:
* Passing tables through a short code means that we can't use link references in tables (see changes to supported-providers.md for what i mean). There is no easy way to pass the markdown renderer the info to make reference links work
