### PR TITLE
Add CII Best Practices badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![100]
 
-[![Build Status][1]][2]
+[![Build Status][1]][2] [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3811/badge)](https://bestpractices.coreinfrastructure.org/projects/3811)
+
 
 ## Overview
 


### PR DESCRIPTION
This adds the CII Best Practices badge to the README, showing that Velero adheres to the same best practices as many other open source projects.

Signed-off-by: jonasrosland <jrosland@vmware.com>