### PR TITLE
fix EnableAPIGroupersions output log format

### DIFF
--- a/changelogs/unreleased/2882-jenting
+++ b/changelogs/unreleased/2882-jenting
@@ -1,0 +1,1 @@
+fix EnableAPIGroupersions output log format

--- a/pkg/discovery/helper.go
+++ b/pkg/discovery/helper.go
@@ -156,7 +156,7 @@ func (h *helper) Refresh() error {
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		h.logger.Info("The '%s' feature flag was specified, using all API group versions.", velerov1api.APIGroupVersionsFeatureFlag)
+		h.logger.Infof("The '%s' feature flag was specified, using all API group versions.", velerov1api.APIGroupVersionsFeatureFlag)
 		serverResources = serverAllResources
 	} else {
 		// ServerPreferredResources() returns only preferred APIGroup - this is the default since no feature flag has been passed


### PR DESCRIPTION
from
```
The '%s' feature flag was specified, using all API group versions.EnableAPIGroupVersions
```

to
```
The 'EnableAPIGroupVersions' feature flag was specified, using all API group versions.
```

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>