### PR TITLE
create CRB with velero-<namespace>

### DIFF
--- a/changelogs/unreleased/2886-alaypatel07
+++ b/changelogs/unreleased/2886-alaypatel07
@@ -1,0 +1,1 @@
+cli: allow creating multiple instances of Velero across two different namespaces

--- a/pkg/install/resources.go
+++ b/pkg/install/resources.go
@@ -51,6 +51,7 @@ var (
 	DefaultResticPodMemRequest = "512Mi"
 	DefaultResticPodCPULimit   = "1000m"
 	DefaultResticPodMemLimit   = "1Gi"
+	DefaultVeleroNamespace     = "velero"
 )
 
 func labels() map[string]string {
@@ -106,7 +107,7 @@ func ServiceAccount(namespace string, annotations map[string]string) *corev1.Ser
 
 func ClusterRoleBinding(namespace string) *rbacv1beta1.ClusterRoleBinding {
 	crbName := "velero"
-	if namespace != "velero" {
+	if namespace != DefaultVeleroNamespace {
 		crbName = "velero-" + namespace
 	}
 	crb := &rbacv1beta1.ClusterRoleBinding{

--- a/pkg/install/resources.go
+++ b/pkg/install/resources.go
@@ -105,8 +105,12 @@ func ServiceAccount(namespace string, annotations map[string]string) *corev1.Ser
 }
 
 func ClusterRoleBinding(namespace string) *rbacv1beta1.ClusterRoleBinding {
+	crbName := "velero"
+	if namespace != "velero" {
+		crbName = "velero-" + namespace
+	}
 	crb := &rbacv1beta1.ClusterRoleBinding{
-		ObjectMeta: objectMeta("", "velero"),
+		ObjectMeta: objectMeta("", crbName),
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ClusterRoleBinding",
 			APIVersion: rbacv1beta1.SchemeGroupVersion.String(),

--- a/pkg/install/resources_test.go
+++ b/pkg/install/resources_test.go
@@ -44,7 +44,14 @@ func TestResources(t *testing.T) {
 	crb := ClusterRoleBinding("velero")
 	// The CRB is a cluster-scoped resource
 	assert.Equal(t, "", crb.ObjectMeta.Namespace)
+	assert.Equal(t, "velero", crb.ObjectMeta.Name)
 	assert.Equal(t, "velero", crb.Subjects[0].Namespace)
+
+	customNamespaceCRB := ClusterRoleBinding("foo")
+	// The CRB is a cluster-scoped resource
+	assert.Equal(t, "", customNamespaceCRB.ObjectMeta.Namespace)
+	assert.Equal(t, "velero-foo", customNamespaceCRB.ObjectMeta.Name)
+	assert.Equal(t, "foo", customNamespaceCRB.Subjects[0].Namespace)
 
 	sa := ServiceAccount("velero", map[string]string{"abcd": "cbd"})
 	assert.Equal(t, "velero", sa.ObjectMeta.Namespace)

--- a/pkg/install/resources_test.go
+++ b/pkg/install/resources_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestResources(t *testing.T) {
-	bsl := BackupStorageLocation("velero", "test", "test", "", make(map[string]string), []byte("test"))
+	bsl := BackupStorageLocation(DefaultVeleroNamespace, "test", "test", "", make(map[string]string), []byte("test"))
 
 	assert.Equal(t, "velero", bsl.ObjectMeta.Namespace)
 	assert.Equal(t, "test", bsl.Spec.Provider)
@@ -31,7 +31,7 @@ func TestResources(t *testing.T) {
 	assert.Equal(t, make(map[string]string), bsl.Spec.Config)
 	assert.Equal(t, []byte("test"), bsl.Spec.ObjectStorage.CACert)
 
-	vsl := VolumeSnapshotLocation("velero", "test", make(map[string]string))
+	vsl := VolumeSnapshotLocation(DefaultVeleroNamespace, "test", make(map[string]string))
 
 	assert.Equal(t, "velero", vsl.ObjectMeta.Namespace)
 	assert.Equal(t, "test", vsl.Spec.Provider)
@@ -41,7 +41,7 @@ func TestResources(t *testing.T) {
 
 	assert.Equal(t, "velero", ns.Name)
 
-	crb := ClusterRoleBinding("velero")
+	crb := ClusterRoleBinding(DefaultVeleroNamespace)
 	// The CRB is a cluster-scoped resource
 	assert.Equal(t, "", crb.ObjectMeta.Namespace)
 	assert.Equal(t, "velero", crb.ObjectMeta.Name)
@@ -53,7 +53,7 @@ func TestResources(t *testing.T) {
 	assert.Equal(t, "velero-foo", customNamespaceCRB.ObjectMeta.Name)
 	assert.Equal(t, "foo", customNamespaceCRB.Subjects[0].Namespace)
 
-	sa := ServiceAccount("velero", map[string]string{"abcd": "cbd"})
+	sa := ServiceAccount(DefaultVeleroNamespace, map[string]string{"abcd": "cbd"})
 	assert.Equal(t, "velero", sa.ObjectMeta.Namespace)
 	assert.Equal(t, "cbd", sa.ObjectMeta.Annotations["abcd"])
 }


### PR DESCRIPTION
This will allow creating multiple instances of velero,
across two different namespaces

fixes: #2834 