### PR TITLE
Fix for docs redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   base = "site/"
   command = "hugo --gc --minify --baseURL $BASE_URL"
-  publish = "public"
+  publish = "site/public"
 
 [context.production.environment]
   HUGO_VERSION = "0.73.0"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   base = "site/"
   command = "hugo --gc --minify --baseURL $BASE_URL"
-  publish = "site/public"
+  publish = "public"
 
 [context.production.environment]
   HUGO_VERSION = "0.73.0"

--- a/site/config.yaml
+++ b/site/config.yaml
@@ -88,7 +88,7 @@ enableGitInfo: true
 permalinks:
   posts: "/blog/:slug/"
 outputs:
-  home: ["HTML"]
+  home: [ "HTML", "REDIRECTS" ]
   section: ["HTML"]
   page: ["HTML"]
   taxonomy: ["HTML"]
@@ -104,3 +104,11 @@ markup:
     noClasses: true
     style: monokai
     tabWidth: 4
+
+mediaTypes:
+  "text/netlify":
+    delimiter: ""
+outputFormats:
+  REDIRECTS:
+    mediaType: "text/netlify"
+    baseName: "_redirects"

--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   {{ $options := (dict "targetPath" "styles.css" "outputStyle" "compressed" "enableSourceMap" true) }}
   {{ $styles := resources.Get "styles.scss" | toCSS $options | resources.Fingerprint }}
-  <link rel="stylesheet" href="{{ $styles.Permalink | relURL }}" integrity="{{ $styles.Data.Integrity }}">
+  <link rel="stylesheet" href="{{ $styles.RelPermalink }}" integrity="{{ $styles.Data.Integrity }}">
   {{ block "title" . }}<title>{{ .Site.Title }} {{ .Page.Title }}</title>{{ end }}
 </head>
 <body id="{{ .CurrentSection.Params.id }}">

--- a/site/layouts/docs/docs.html
+++ b/site/layouts/docs/docs.html
@@ -14,11 +14,6 @@
   <title>{{ .Site.Title }} Docs - {{ .Title }}</title>
 {{ end }}
 
-{{ if not (isset .CurrentSection.Params "version") }}
-  {{ $latest_url := replace .Permalink "/docs" (printf "/docs/%s" .Site.Params.latest) | relURL }}
-  <meta http-equiv="refresh" content="0; URL={{ $latest_url }}" />
-{{ end }}
-
 <body id="docs">
 <div class="container-fluid site-outer-container">
   <div class="site-container">

--- a/site/layouts/index.redirects
+++ b/site/layouts/index.redirects
@@ -1,5 +1,13 @@
 {{ $versions := site.Params.versions }}
 {{ $latest   := site.Params.latest }}
-/docs    /docs/{{ $latest }}     301!
-/docs/latest     /docs/{{ $latest }}
-/docs/latest/*     /docs/{{ $latest }}/:splat
+/docs                          /docs/{{ $latest }}     301!
+/docs/latest                   /docs/{{ $latest }}
+/docs/latest/*                 /docs/{{ $latest }}/:splat
+/docs/troubleshooting          /docs/{{ $latest }}/troubleshooting
+/docs/supported-providers      /docs/{{ $latest }}/supported-providers
+/docs/zenhub                   /docs/{{ $latest }}/zenhub
+/docs/install-overview         /docs/{{ $latest }}/basic-install
+/docs/start-contributing       /docs/{{ $latest }}/start-contributing
+/docs/customize-installation   /docs/{{ $latest }}/customize-installation
+/docs/faq                      /docs/{{ $latest }}/faq
+/docs/csi                      /docs/{{ $latest }}/csi

--- a/site/layouts/index.redirects
+++ b/site/layouts/index.redirects
@@ -1,0 +1,5 @@
+{{ $versions := site.Params.versions }}
+{{ $latest   := site.Params.latest }}
+/docs    /docs/{{ $latest }}     301!
+/docs/latest     /docs/{{ $latest }}
+/docs/latest/*     /docs/{{ $latest }}/:splat

--- a/site/layouts/index.redirects
+++ b/site/layouts/index.redirects
@@ -11,3 +11,4 @@
 /docs/customize-installation   /docs/{{ $latest }}/customize-installation
 /docs/faq                      /docs/{{ $latest }}/faq
 /docs/csi                      /docs/{{ $latest }}/csi
+/docs/restic                      /docs/{{ $latest }}/restic

--- a/site/layouts/partials/head-docs.html
+++ b/site/layouts/partials/head-docs.html
@@ -6,6 +6,6 @@
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   {{ $options := (dict "targetPath" "styles.css" "outputStyle" "compressed" "enableSourceMap" true) }}
   {{ $styles := resources.Get "styles.scss" | toCSS $options | resources.Fingerprint }}
-  <link rel="stylesheet" href="{{ $styles.Permalink | relURL }}" integrity="{{ $styles.Data.Integrity }}">
+  <link rel="stylesheet" href="{{ $styles.RelPermalink }}" integrity="{{ $styles.Data.Integrity }}">
   {{/* TODO  {% seo %}*/}}
 </head>


### PR DESCRIPTION
This will fix issue #2824, re-add the previously working short urls, and move the redirect logic for the latest docs version to a separate redirects file instead of being built into the docs page.  

Fixes: #2824 