### PR TITLE
Show format version on velero backup describe

### DIFF
--- a/changelogs/unreleased/2901-jenting
+++ b/changelogs/unreleased/2901-jenting
@@ -1,0 +1,1 @@
+Use format version instead of version on `velero backup describe` since version has been deprecated

--- a/pkg/cmd/util/output/backup_describer.go
+++ b/pkg/cmd/util/output/backup_describer.go
@@ -232,7 +232,8 @@ func DescribeBackupSpec(d *Describer, spec velerov1api.BackupSpec) {
 func DescribeBackupStatus(d *Describer, backup *velerov1api.Backup, details bool, veleroClient clientset.Interface, insecureSkipTLSVerify bool, caCertPath string) {
 	status := backup.Status
 
-	d.Printf("Backup Format Version:\t%d\n", status.Version)
+	// Status.Version has been deprecated, use Status.FormatVersion
+	d.Printf("Backup Format Version:\t%s\n", status.FormatVersion)
 
 	d.Println()
 	// "<n/a>" output should only be applicable for backups that failed validation


### PR DESCRIPTION
The `status.Version` has been deprecated, use `status.FormatVersion` instead on `velero backup describe`.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>