### PR TITLE
Update links to point to main branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing
 
-Authors are expected to follow some guidelines when submitting PRs. Please see [our documentation](https://velero.io/docs/master/code-standards/) for details.
+Authors are expected to follow some guidelines when submitting PRs. Please see [our documentation](https://velero.io/docs/main/code-standards/) for details.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -11,7 +11,7 @@ This document defines the project governance for Velero.
 The following code repositories are governed by Velero community and maintained under the `vmware-tanzu\Velero` organization.
 
 * **[Velero](https://github.com/vmware-tanzu/velero):** Main Velero codebase
-* **[Helm Chart](https://github.com/vmware-tanzu/helm-charts/tree/master/charts/velero):** The Helm chart for the Velero server component
+* **[Helm Chart](https://github.com/vmware-tanzu/helm-charts/tree/main/charts/velero):** The Helm chart for the Velero server component
 * **[Velero CSI Plugin](https://github.com/vmware-tanzu/velero-plugin-for-csi):** This repository contains Velero plugins for snapshotting CSI backed PVCs using the CSI beta snapshot APIs
 * **[Velero Plugin for vSphere](https://github.com/vmware-tanzu/velero-plugin-for-vsphere):** This repository contains the Velero Plugin for vSphere. This plugin is a volume snapshotter plugin that provides crash-consistent snapshots of vSphere block volumes and backup of volume data into S3 compatible storage.
 * **[Velero Plugin for AWS](https://github.com/vmware-tanzu/velero-plugin-for-aws):** This repository contains the plugins to support running Velero on AWS, including the object store plugin and the volume snapshotter plugin
@@ -67,12 +67,12 @@ interested in implementing the proposal should be either deeply engaged in the
 proposal process or be an author of the proposal.
 
 The proposal should be documented as a separated markdown file pushed to the root of the 
-`design` folder in the [Velero](https://github.com/vmware-tanzu/velero/tree/master/design)
+`design` folder in the [Velero](https://github.com/vmware-tanzu/velero/tree/main/design)
 repository via PR. The name of the file should follow the name pattern `<short
 meaningful words joined by '-'>_design.md`, e.g:
 `restore-hooks-design.md`.
 
-Use the [Proposal Template](https://github.com/vmware-tanzu/velero/blob/master/design/_template.md) as a starting point.
+Use the [Proposal Template](https://github.com/vmware-tanzu/velero/blob/main/design/_template.md) as a starting point.
 
 ### Proposal Lifecycle
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,6 @@
 # Velero Maintainers
 
-[GOVERNANCE.md](https://github.com/vmware-tanzu/velero/blob/master/GOVERNANCE.md) describes governance guidelines and maintainer responsibilities.
+[GOVERNANCE.md](https://github.com/vmware-tanzu/velero/blob/main/GOVERNANCE.md) describes governance guidelines and maintainer responsibilities.
 
 ## Maintainers
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ This document provides a link to the [Velero Project board](https://app.zenhub.c
 Discussion on the roadmap can take place in threads under [Issues](https://github.com/vmware-tanzu/velero/issues) or in [community meetings](https://velero.io/community/). Please open and comment on an issue if you want to provide suggestions, use cases, and feedback to an item in the roadmap. Please review the roadmap to avoid potential duplicated effort.
 
 ### How to add an item to the roadmap?
-One of the most important aspects in any open source community is the concept of proposals. Large changes to the codebase and / or new features should be preceded by a [proposal](https://github.com/vmware-tanzu/velero/blob/master/GOVERNANCE.md#proposal-process) in our repo. 
+One of the most important aspects in any open source community is the concept of proposals. Large changes to the codebase and / or new features should be preceded by a [proposal](https://github.com/vmware-tanzu/velero/blob/main/GOVERNANCE.md#proposal-process) in our repo.
 For smaller enhancements, you can open an issue to track that initiative or feature request.
 We work with and rely on community feedback to focus our efforts to improve Velero and maintain a healthy roadmap.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,4 +4,4 @@ Thanks for trying out Velero! We welcome all feedback, find all the ways to conn
 
 - [Velero Community](https://velero.io/community/)
 
-You can find details on the Velero maintainers' support process [here](https://velero.io/docs/master/support-process/).
+You can find details on the Velero maintainers' support process [here](https://velero.io/docs/main/support-process/).

--- a/site/layouts/partials/contributors.html
+++ b/site/layouts/partials/contributors.html
@@ -11,7 +11,7 @@
                 href="{{ .Site.Params.Gh_repo }}/issues" class="light">GitHub issues page
           for {{ .Site.Title }}</a></strong>.</p>
     <p>The Velero project team welcomes contributions from the community, please see our <strong><a
-                href="https://velero.io/docs/master/start-contributing/" class="light">contributing
+                href="https://velero.io/docs/main/start-contributing/" class="light">contributing
           documentation</a></strong>.
     </p>
   </div>


### PR DESCRIPTION
A number of links still pointed to the old master branch and resulted in
404s. This updates those links to point to the new main branch.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>