### PR TITLE
restore proper lowercase/plural CRD resource

### DIFF
--- a/changelogs/unreleased/2949-sseago
+++ b/changelogs/unreleased/2949-sseago
@@ -1,0 +1,1 @@
+Restore CRD Resource name to fix CRD wait functionality.

--- a/pkg/backup/remap_crd_version_action.go
+++ b/pkg/backup/remap_crd_version_action.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
-	"github.com/vmware-tanzu/velero/pkg/kuberesource"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 )
 
@@ -111,7 +110,7 @@ func fetchV1beta1CRD(name string, betaCRDClient apiextv1beta1client.CustomResour
 	// See https://github.com/kubernetes/kubernetes/issues/3030. Unsure why this is happening here and not in main Velero;
 	// probably has to do with List calls and Dynamic client vs typed client
 	// Set these all the time, since they shouldn't ever be different, anyway
-	betaCRD.Kind = kuberesource.CustomResourceDefinitions.Resource
+	betaCRD.Kind = "CustomResourceDefinition"
 	betaCRD.APIVersion = apiextv1beta1.SchemeGroupVersion.String()
 
 	m, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&betaCRD)

--- a/pkg/kuberesource/kuberesource.go
+++ b/pkg/kuberesource/kuberesource.go
@@ -23,7 +23,7 @@ import (
 var (
 	ClusterRoleBindings       = schema.GroupResource{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings"}
 	ClusterRoles              = schema.GroupResource{Group: "rbac.authorization.k8s.io", Resource: "clusterroles"}
-	CustomResourceDefinitions = schema.GroupResource{Group: "apiextensions.k8s.io", Resource: "CustomResourceDefinition"}
+	CustomResourceDefinitions = schema.GroupResource{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"}
 	Jobs                      = schema.GroupResource{Group: "batch", Resource: "jobs"}
 	Namespaces                = schema.GroupResource{Group: "", Resource: "namespaces"}
 	PersistentVolumeClaims    = schema.GroupResource{Group: "", Resource: "persistentvolumeclaims"}


### PR DESCRIPTION
Fixes https://github.com/vmware-tanzu/velero/issues/2948

This commit restores the proper resource string
"customresourcedefinitions" for CRD. The prior change to
"CustomResourceDefinition" was made because this was being used
in another place to populate the CRD "Kind" field in
remap_crd_version_action.go -- there, just use the correct Kind
string instead of pulling from Resource. Using the Kind string in place of Resource was breaking the "wait for CRDs to be ready" functionality, as well as the "refresh discovery helper after loading CRDs" bit.