### PR TITLE
Include --validate=false in upgrade instructions

### DIFF
--- a/site/content/docs/main/upgrade-to-1.5.md
+++ b/site/content/docs/main/upgrade-to-1.5.md
@@ -38,6 +38,8 @@ If you're not yet running at least Velero v1.4, see the following:
     velero install --crds-only --dry-run -o yaml | kubectl apply -f -
     ```
 
+    **NOTE:** If you are upgrading Velero in Kubernetes 1.14.x or earlier, you will need to use `kubectl apply`'s `--validate=false` option when applying the CRD configuration above. See [issue 2077][6] and [issue 2311][7] for more context.
+
 1. Update the container image used by the Velero deployment and, optionally, the restic daemon set:
 
     ```bash
@@ -74,4 +76,5 @@ If you're not yet running at least Velero v1.4, see the following:
 [3]: https://velero.io/docs/v1.3.2/upgrade-to-1.3/
 [4]: https://velero.io/docs/v1.4/upgrade-to-1.4/
 [5]: https://github.com/vmware-tanzu/velero/releases/tag/v1.4.2
-
+[6]: https://github.com/vmware-tanzu/velero/issues/2077
+[7]: https://github.com/vmware-tanzu/velero/issues/2311

--- a/site/content/docs/v1.4/upgrade-to-1.4.md
+++ b/site/content/docs/v1.4/upgrade-to-1.4.md
@@ -50,6 +50,8 @@ If you're not yet running at least Velero v1.3, see the following:
     velero install --crds-only --dry-run -o yaml | kubectl apply -f -
     ```
 
+    **NOTE:** If you are upgrading Velero in Kubernetes 1.14.x or earlier, you will need to use `kubectl apply`'s `--validate=false` option when applying the CRD configuration above. See [issue 2077][5] and [issue 2311][6] for more context.
+
 1. Confirm that the deployment is up and running with the correct version by running:
 
     ```bash
@@ -72,3 +74,5 @@ If you're not yet running at least Velero v1.3, see the following:
 [2]: https://velero.io/docs/v1.2.0/upgrade-to-1.2/
 [3]: https://velero.io/docs/v1.3.2/upgrade-to-1.3/
 [4]: https://github.com/vmware-tanzu/velero/releases/tag/v1.3.2
+[5]: https://github.com/vmware-tanzu/velero/issues/2077
+[6]: https://github.com/vmware-tanzu/velero/issues/2311

--- a/site/content/docs/v1.5/upgrade-to-1.5.md
+++ b/site/content/docs/v1.5/upgrade-to-1.5.md
@@ -38,6 +38,8 @@ If you're not yet running at least Velero v1.4, see the following:
     velero install --crds-only --dry-run -o yaml | kubectl apply -f -
     ```
 
+    **NOTE:** If you are upgrading Velero in Kubernetes 1.14.x or earlier, you will need to use `kubectl apply`'s `--validate=false` option when applying the CRD configuration above. See [issue 2077][6] and [issue 2311][7] for more context.
+
 1. Update the container image used by the Velero deployment and, optionally, the restic daemon set:
 
     ```bash
@@ -74,4 +76,5 @@ If you're not yet running at least Velero v1.4, see the following:
 [3]: https://velero.io/docs/v1.3.2/upgrade-to-1.3/
 [4]: https://velero.io/docs/v1.4/upgrade-to-1.4/
 [5]: https://github.com/vmware-tanzu/velero/releases/tag/v1.4.2
-
+[6]: https://github.com/vmware-tanzu/velero/issues/2077
+[7]: https://github.com/vmware-tanzu/velero/issues/2311


### PR DESCRIPTION
We instruct users to update the CRDs when upgrading to 1.4 and 1.5 which
involves using `kubectl apply` to apply the CRD configuration. The CRD
configuration generated by `velero install` includes fields which are
not valid when running Kubernetes v1.14 or earlier. We instruct users to
work around this when doing a customised velero install, but not when
upgrading to newer versions. This change updates the upgrade
instructions for v1.4 and v1.5 to include the use of `--validate=false`
flag when running `kubectl apply`.

See #2077 and #2311 for more context.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>