### PR TITLE
Don't fail backup deletion if downloading tarball fails

### DIFF
--- a/changelogs/unreleased/2993-zubron
+++ b/changelogs/unreleased/2993-zubron
@@ -1,0 +1,1 @@
+Fixed an issue where the deletion of a backup would fail if the backup tarball couldn't be downloaded from object storage. Now the tarball is only downloaded if there are associated DeleteItemAction plugins and if downloading the tarball fails, the plugins are skipped.

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -734,6 +734,10 @@ func persistBackup(backup *pkgbackup.Request,
 }
 
 func closeAndRemoveFile(file *os.File, log logrus.FieldLogger) {
+	if file == nil {
+		log.Debug("Skipping removal of file due to nil file pointer")
+		return
+	}
 	if err := file.Close(); err != nil {
 		log.WithError(err).WithField("file", file.Name()).Error("error closing file")
 	}

--- a/pkg/controller/backup_deletion_controller.go
+++ b/pkg/controller/backup_deletion_controller.go
@@ -305,12 +305,11 @@ func (c *backupDeletionController) processRequest(req *velerov1api.DeleteBackupR
 	if len(actions) > 0 {
 		// Download the tarball
 		backupFile, err := downloadToTempFile(backup.Name, backupStore, log)
+		defer closeAndRemoveFile(backupFile, c.logger)
 
 		if err != nil {
 			log.WithError(err).Errorf("Unable to download tarball for backup %s, skipping associated DeleteItemAction plugins", backup.Name)
 		} else {
-			defer closeAndRemoveFile(backupFile, c.logger)
-
 			ctx := &delete.Context{
 				Backup:          backup,
 				BackupReader:    backupFile,
@@ -327,7 +326,6 @@ func (c *backupDeletionController) processRequest(req *velerov1api.DeleteBackupR
 				return errors.Wrap(err, "error invoking delete item actions")
 			}
 		}
-
 	}
 
 	if backupStore != nil {

--- a/pkg/controller/backup_deletion_controller.go
+++ b/pkg/controller/backup_deletion_controller.go
@@ -295,13 +295,6 @@ func (c *backupDeletionController) processRequest(req *velerov1api.DeleteBackupR
 		errs = append(errs, err.Error())
 	}
 
-	// Download the tarball
-	backupFile, err := downloadToTempFile(backup.Name, backupStore, log)
-	if err != nil {
-		return errors.Wrap(err, "error downloading backup")
-	}
-	defer closeAndRemoveFile(backupFile, c.logger)
-
 	actions, err := pluginManager.GetDeleteItemActions()
 	log.Debugf("%d actions before invoking actions", len(actions))
 	if err != nil {
@@ -309,20 +302,32 @@ func (c *backupDeletionController) processRequest(req *velerov1api.DeleteBackupR
 	}
 	// don't defer CleanupClients here, since it was already called above.
 
-	ctx := &delete.Context{
-		Backup:          backup,
-		BackupReader:    backupFile,
-		Actions:         actions,
-		Log:             c.logger,
-		DiscoveryHelper: c.helper,
-		Filesystem:      filesystem.NewFileSystem(),
-	}
+	if len(actions) > 0 {
+		// Download the tarball
+		backupFile, err := downloadToTempFile(backup.Name, backupStore, log)
 
-	// Optimization: wrap in a gofunc? Would be useful for large backups with lots of objects.
-	// but what do we do with the error returned? We can't just swallow it as that may lead to dangling resources.
-	err = delete.InvokeDeleteActions(ctx)
-	if err != nil {
-		return errors.Wrap(err, "error invoking delete item actions")
+		if err != nil {
+			log.WithError(err).Errorf("Unable to download tarball for backup %s, skipping associated DeleteItemAction plugins", backup.Name)
+		} else {
+			defer closeAndRemoveFile(backupFile, c.logger)
+
+			ctx := &delete.Context{
+				Backup:          backup,
+				BackupReader:    backupFile,
+				Actions:         actions,
+				Log:             c.logger,
+				DiscoveryHelper: c.helper,
+				Filesystem:      filesystem.NewFileSystem(),
+			}
+
+			// Optimization: wrap in a gofunc? Would be useful for large backups with lots of objects.
+			// but what do we do with the error returned? We can't just swallow it as that may lead to dangling resources.
+			err = delete.InvokeDeleteActions(ctx)
+			if err != nil {
+				return errors.Wrap(err, "error invoking delete item actions")
+			}
+		}
+
 	}
 
 	if backupStore != nil {


### PR DESCRIPTION
Previously, we would always attempt to download the tarball for a backup
for processing DeleteItemAction plugins, even if there weren't any.
This caused an issue for some users in the case where the backup tarball
had been deleted from object storage as the backup deletion would fail.

Now, we only attempt to download the tarball in the case where there are
DeleteItemAction plugins. If downloading that tarball fails, we log
the error, skip the processing of the DeleteItemAction plugins and
proceed with the rest of the deletion.

Fixes #2980 

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>