### PR TITLE
Auto assign reviewers when PR is ready for review

### DIFF
--- a/.github/workflows/auto_assign_prs.yml
+++ b/.github/workflows/auto_assign_prs.yml
@@ -3,7 +3,7 @@ name: 'Auto Assign PR Reviewers'
 # This should mean PRs from forks are supported.
 on: 
   pull_request_target:
-    types: [opened, reopened, sychronized]
+    types: [opened, reopened, synchronize, ready_for_review]
 
 
 jobs: 


### PR DESCRIPTION
The workflow that we are using for auto-assigning reviewers to a PR did
not cover the event when a draft PR is marked as ready for review. This
change adds the `ready_for_review` activity type to the list of types to
use for triggering the workflow.

This change also fixes a typo in one of the other listed types
(`synchronize`).
See the [docs for more information](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request_target).

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>