### PR TITLE
Ensure PVs and PVCs remain bound when doing a restore

### DIFF
--- a/changelogs/unreleased/3007-nrb
+++ b/changelogs/unreleased/3007-nrb
@@ -1,1 +1,1 @@
-Ensure that bound PVCs and PVs remaind bound on restore.
+Ensure that bound PVCs and PVs remain bound on restore.

--- a/changelogs/unreleased/3007-nrb
+++ b/changelogs/unreleased/3007-nrb
@@ -1,0 +1,1 @@
+Ensure that bound PVCs and PVs remaind bound on restore.

--- a/pkg/restore/pv_restorer.go
+++ b/pkg/restore/pv_restorer.go
@@ -49,7 +49,7 @@ func (r *pvRestorer) executePVAction(obj *unstructured.Unstructured) (*unstructu
 
 	// Delete only the ClaimRef's UID, as the namespace should be retained for deterministic mapping.
 	// UIDs should be removed for succesful restore as these are assigned by the Kubernetes controllers.
-	unstructured.RemoveNestedField(obj.Object, "spec", "claimRef", "UID")
+	unstructured.RemoveNestedField(obj.Object, "spec", "claimRef", "uid")
 
 	if boolptr.IsSetToFalse(r.snapshotVolumes) {
 		// The backup had snapshots disabled, so we can return early

--- a/pkg/restore/pv_restorer.go
+++ b/pkg/restore/pv_restorer.go
@@ -47,10 +47,6 @@ func (r *pvRestorer) executePVAction(obj *unstructured.Unstructured) (*unstructu
 		return nil, errors.New("PersistentVolume is missing its name")
 	}
 
-	// Delete only the ClaimRef's UID, as the namespace should be retained for deterministic mapping.
-	// UIDs should be removed for succesful restore as these are assigned by the Kubernetes controllers.
-	unstructured.RemoveNestedField(obj.Object, "spec", "claimRef", "uid")
-
 	if boolptr.IsSetToFalse(r.snapshotVolumes) {
 		// The backup had snapshots disabled, so we can return early
 		return obj, nil

--- a/pkg/restore/pv_restorer_test.go
+++ b/pkg/restore/pv_restorer_test.go
@@ -58,7 +58,7 @@ func TestExecutePVAction_NoSnapshotRestores(t *testing.T) {
 		},
 		{
 			name:        "ensure spec.claimRef UID is deleted",
-			obj:         NewTestUnstructured().WithName("pv-1").WithAnnotations("a", "b").WithSpec("someOtherField").WithSpecField("claimRef", map[string]interface{}{"UID": "a"}).Unstructured,
+			obj:         NewTestUnstructured().WithName("pv-1").WithAnnotations("a", "b").WithSpec("someOtherField").WithSpecField("claimRef", map[string]interface{}{"uid": "a"}).Unstructured,
 			restore:     builder.ForRestore(api.DefaultNamespace, "").RestorePVs(false).Result(),
 			backup:      defaultBackup().Phase(api.BackupPhaseInProgress).Result(),
 			expectedRes: NewTestUnstructured().WithAnnotations("a", "b").WithName("pv-1").WithSpec("someOtherField").WithSpecField("claimRef", map[string]interface{}{}).Unstructured,

--- a/pkg/restore/pv_restorer_test.go
+++ b/pkg/restore/pv_restorer_test.go
@@ -57,13 +57,6 @@ func TestExecutePVAction_NoSnapshotRestores(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			name:        "ensure spec.claimRef UID is deleted",
-			obj:         NewTestUnstructured().WithName("pv-1").WithAnnotations("a", "b").WithSpec("someOtherField").WithSpecField("claimRef", map[string]interface{}{"uid": "a"}).Unstructured,
-			restore:     builder.ForRestore(api.DefaultNamespace, "").RestorePVs(false).Result(),
-			backup:      defaultBackup().Phase(api.BackupPhaseInProgress).Result(),
-			expectedRes: NewTestUnstructured().WithAnnotations("a", "b").WithName("pv-1").WithSpec("someOtherField").WithSpecField("claimRef", map[string]interface{}{}).Unstructured,
-		},
-		{
 			name:        "ensure spec.storageClassName is retained",
 			obj:         NewTestUnstructured().WithName("pv-1").WithAnnotations("a", "b").WithSpec("storageClassName", "someOtherField").Unstructured,
 			restore:     builder.ForRestore(api.DefaultNamespace, "").RestorePVs(false).Result(),

--- a/pkg/restore/pv_restorer_test.go
+++ b/pkg/restore/pv_restorer_test.go
@@ -57,17 +57,11 @@ func TestExecutePVAction_NoSnapshotRestores(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			name:        "no spec should error",
-			obj:         NewTestUnstructured().WithName("pv-1").Unstructured,
-			restore:     builder.ForRestore(api.DefaultNamespace, "").Result(),
-			expectedErr: true,
-		},
-		{
-			name:        "ensure spec.claimRef is deleted",
-			obj:         NewTestUnstructured().WithName("pv-1").WithAnnotations("a", "b").WithSpec("claimRef", "someOtherField").Unstructured,
+			name:        "ensure spec.claimRef UID is deleted",
+			obj:         NewTestUnstructured().WithName("pv-1").WithAnnotations("a", "b").WithSpec("someOtherField").WithSpecField("claimRef", map[string]interface{}{"UID": "a"}).Unstructured,
 			restore:     builder.ForRestore(api.DefaultNamespace, "").RestorePVs(false).Result(),
 			backup:      defaultBackup().Phase(api.BackupPhaseInProgress).Result(),
-			expectedRes: NewTestUnstructured().WithAnnotations("a", "b").WithName("pv-1").WithSpec("someOtherField").Unstructured,
+			expectedRes: NewTestUnstructured().WithAnnotations("a", "b").WithName("pv-1").WithSpec("someOtherField").WithSpecField("claimRef", map[string]interface{}{}).Unstructured,
 		},
 		{
 			name:        "ensure spec.storageClassName is retained",
@@ -81,7 +75,7 @@ func TestExecutePVAction_NoSnapshotRestores(t *testing.T) {
 			obj:         NewTestUnstructured().WithName("pv-1").WithAnnotations("a", "b").WithSpec("claimRef", "storageClassName", "someOtherField").Unstructured,
 			restore:     builder.ForRestore(api.DefaultNamespace, "").RestorePVs(true).Result(),
 			backup:      defaultBackup().Phase(api.BackupPhaseInProgress).SnapshotVolumes(false).Result(),
-			expectedRes: NewTestUnstructured().WithName("pv-1").WithAnnotations("a", "b").WithSpec("storageClassName", "someOtherField").Unstructured,
+			expectedRes: NewTestUnstructured().WithName("pv-1").WithAnnotations("a", "b").WithSpec("claimRef", "storageClassName", "someOtherField").Unstructured,
 		},
 		{
 			name:    "restore.spec.restorePVs=false, return early",

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -959,7 +959,6 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 			return warnings, errs
 
 		case hasDeleteReclaimPolicy(obj.Object):
-			fmt.Printf("Has a delete policy!")
 			ctx.log.Infof("Dynamically re-provisioning persistent volume because it doesn't have a snapshot and its reclaim policy is Delete.")
 			ctx.pvsToProvision.Insert(name)
 

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -1830,7 +1830,7 @@ func TestRestorePersistentVolumes(t *testing.T) {
 			},
 		},
 		{
-			name:    "when a PV with a reclaim policy of retain has no snapshot and does not exist in-cluster, it gets restored, without its claim ref",
+			name:    "when a PV with a reclaim policy of retain has no snapshot and does not exist in-cluster, it gets restored, with its claim ref",
 			restore: defaultRestore().Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
@@ -1849,6 +1849,7 @@ func TestRestorePersistentVolumes(t *testing.T) {
 						ObjectMeta(
 							builder.WithLabels("velero.io/backup-name", "backup-1", "velero.io/restore-name", "restore-1"),
 						).
+						ClaimRef("ns-1", "pvc-1").
 						Result(),
 				),
 			},
@@ -2096,13 +2097,12 @@ func TestRestorePersistentVolumes(t *testing.T) {
 			want: []*test.APIResource{
 				test.PVs(
 					builder.ForPersistentVolume("source-pv").AWSEBSVolumeID("source-volume").ClaimRef("source-ns", "pvc-1").Result(),
-					// note that the renamed PV is not expected to have a claimRef in this test; that would be
-					// added after creation by the Kubernetes PV/PVC controller when it does a bind.
 					builder.ForPersistentVolume("renamed-source-pv").
 						ObjectMeta(
 							builder.WithAnnotations("velero.io/original-pv-name", "source-pv"),
 							builder.WithLabels("velero.io/backup-name", "backup-1", "velero.io/restore-name", "restore-1"),
-						).
+						// the namespace for this PV's claimRef should be the one that the PVC was remapped into.
+						).ClaimRef("target-ns", "pvc-1").
 						AWSEBSVolumeID("new-volume").
 						Result(),
 				),
@@ -2161,6 +2161,7 @@ func TestRestorePersistentVolumes(t *testing.T) {
 						ObjectMeta(
 							builder.WithLabels("velero.io/backup-name", "backup-1", "velero.io/restore-name", "restore-1"),
 						).
+						ClaimRef("target-ns", "pvc-1").
 						AWSEBSVolumeID("new-volume").
 						Result(),
 				),
@@ -2221,6 +2222,7 @@ func TestRestorePersistentVolumes(t *testing.T) {
 							builder.WithLabels("velero.io/backup-name", "backup-1", "velero.io/restore-name", "restore-1"),
 							builder.WithAnnotations("velero.io/original-pv-name", "source-pv"),
 						).
+						ClaimRef("target-ns", "pvc-1").
 						AWSEBSVolumeID("new-pvname").
 						Result(),
 				),
@@ -2340,13 +2342,12 @@ func TestRestorePersistentVolumes(t *testing.T) {
 			want: []*test.APIResource{
 				test.PVs(
 					builder.ForPersistentVolume("source-pv").AWSEBSVolumeID("source-volume").ClaimRef("source-ns", "pvc-1").Result(),
-					// note that the renamed PV is not expected to have a claimRef in this test; that would be
-					// added after creation by the Kubernetes PV/PVC controller when it does a bind.
 					builder.ForPersistentVolume("volumesnapshotter-renamed-source-pv").
 						ObjectMeta(
 							builder.WithAnnotations("velero.io/original-pv-name", "source-pv"),
 							builder.WithLabels("velero.io/backup-name", "backup-1", "velero.io/restore-name", "restore-1"),
 						).
+						ClaimRef("target-ns", "pvc-1").
 						AWSEBSVolumeID("new-volume").
 						Result(),
 				),


### PR DESCRIPTION
Fixes #2570 

This PR makes the following changes:

- Clears out the `Spec.ClaimRef.UID` and `Spec.ClaimRef.ResourceVersion` fields on a PersistentVolume when restoring, rather than completely removing the ClaimRef. This leaves the `Namespace` and `Name` intact, allowing the PersistentVolume to be re-bound to the newly restored PersistentVolumeClaim. Not doing so may lead to issues with data leakage as it's possible Kubernetes could bind the PersistentVolume to a PersistententVolumeClaim in another namespace if it matches the right conditions. See issue #2570 for discussion of this as well as [this upstream Kubernetes comment](https://github.com/kubernetes/kubernetes/issues/48609#issuecomment-314066616)
- Clears out the binding annotations set by the Kubernetes controller on PersistentVolumes and PersistentVolumeClaims. This is in order ensure specific logic is triggered that re-binds the objects based on name alone, rather than UID. Code for the controller in question can be found in [this file](https://github.com/kubernetes/kubernetes/blob/b86e725694e81b48ea36b11f647f28cf70a66210/pkg/controller/volume/persistentvolume/pv_controller.go)
- Updates most tests with the new logic.

The main cases of restoring a snapshotted volume against a cluster and remapping a volume have been tested, but reprovisioning volumes with restic has not yet been tested.

The issues that this fixes are not always encountered, but can happen on a busy cluster.