### PR TITLE
Add warning to velero version cmd.

### DIFF
--- a/changelogs/unreleased/3024-cvhariharan
+++ b/changelogs/unreleased/3024-cvhariharan
@@ -1,0 +1,1 @@
+Add warning to velero version cmd if the client and server versions mismatch. 

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/spf13/cobra v0.0.7
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
+	golang.org/x/mod v0.1.0
 	golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7
 	google.golang.org/genproto v0.0.0-20200731012542-8145dea6a485 // indirect
 	google.golang.org/grpc v1.31.0

--- a/go.sum
+++ b/go.sum
@@ -720,6 +720,7 @@ golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
+golang.org/x/mod v0.1.0 h1:sfUMP1Gu8qASkorDVjnMuvgJzwFbTZSeXFiGBYAVdl4=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20170915142106-8351a756f30f/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/pkg/cmd/cli/version/version.go
+++ b/pkg/cmd/cli/version/version.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017, 2019 the Velero contributors.
+Copyright 2020 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/mod/semver"
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/velero/pkg/buildinfo"
@@ -81,4 +82,15 @@ func printVersion(w io.Writer, clientOnly bool, kbClient kbclient.Client, server
 
 	fmt.Fprintln(w, "Server:")
 	fmt.Fprintf(w, "\tVersion: %s\n", serverStatus.Status.ServerVersion)
+
+	serverSemVer := semver.MajorMinor(serverStatus.Status.ServerVersion)
+	cliSemVer := semver.MajorMinor(buildinfo.Version)
+	if serverSemVer != cliSemVer {
+		upgrade := "client"
+		cmp := semver.Compare(cliSemVer, serverSemVer)
+		if cmp == 1 {
+			upgrade = "server"
+		}
+		fmt.Fprintf(w, "# WARNING: the client version does not match the server version. Please update %s\n", upgrade)
+	}
 }


### PR DESCRIPTION
Fixes #3017 

This PR adds a warning to`velero version` command. The warning is shown if the major and minor versions of the client and server mismatch.

If the client version is less than the server version
```
# WARNING: the client version does not match the server version. Please update the client
```
If the server version is less than the client version
```
# WARNING: the client version does not match the server version. Please update the server
```