### PR TITLE
🐛  Do not run ItemAction plugins for unresolvable types for all types

### DIFF
--- a/changelogs/unreleased/3059-ashish-amarnath
+++ b/changelogs/unreleased/3059-ashish-amarnath
@@ -1,0 +1,1 @@
+🐛  ItemAction plugins for unresolvable types should not be run for all types

--- a/pkg/util/collections/includes_excludes.go
+++ b/pkg/util/collections/includes_excludes.go
@@ -201,7 +201,10 @@ func GetResourceIncludesExcludes(helper discovery.Helper, includes, excludes []s
 		func(item string) string {
 			gvr, _, err := helper.ResourceFor(schema.ParseGroupResource(item).WithVersion(""))
 			if err != nil {
-				return ""
+				// If we can't resolve it, return it as-is. This prevents the generated
+				// includes-excludes list from including *everything*, if none of the includes
+				// can be resolved. ref. https://github.com/vmware-tanzu/velero/issues/2461
+				return item
 			}
 
 			gr := gvr.GroupResource()


### PR DESCRIPTION
Signed-off-by: Ashish Amarnath <ashisham@vmware.com>

Fixes: #2461 

PR https://github.com/vmware-tanzu/velero/pull/2462 addressed the issue for BackupItemAction plugins only.
This PR applies the same fix to RestoreItemActions and DeleteItemAction plugins.