### PR TITLE
Automate adding opened issues to the triage board

### DIFF
--- a/.github/workflows/opened-issues-triage.yml
+++ b/.github/workflows/opened-issues-triage.yml
@@ -1,0 +1,15 @@
+name: Move new issues into Triage
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  automate-project-columns:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.3.0
+        with:
+          project: "Velero Support Triage Board"
+          column: "Needs Triage"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
If this works on the core repo, I'll add it to the rest of the plugin repos & helm chart.

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>