### PR TITLE
🏃‍♂️ update setup-kind github actions CI

### DIFF
--- a/.github/workflows/crds-verify-k8s-1-16-9.yaml
+++ b/.github/workflows/crds-verify-k8s-1-16-9.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: engineerd/setup-kind@v0.4.0
+    - uses: engineerd/setup-kind@v0.5.0
       with:
           image: "kindest/node:v1.16.9"
     - name: Testing

--- a/.github/workflows/crds-verify-k8s-1-17-0.yaml
+++ b/.github/workflows/crds-verify-k8s-1-17-0.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: engineerd/setup-kind@v0.4.0
+    - uses: engineerd/setup-kind@v0.5.0
       with:
           image: "kindest/node:v1.17.0"
     - name: Testing

--- a/.github/workflows/crds-verify-k8s-1-18-4.yaml
+++ b/.github/workflows/crds-verify-k8s-1-18-4.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: engineerd/setup-kind@v0.4.0
+    - uses: engineerd/setup-kind@v0.5.0
       with:
           image: "kindest/node:v1.18.4"
     - name: Testing

--- a/changelogs/unreleased/3085-ashish-amarnath
+++ b/changelogs/unreleased/3085-ashish-amarnath
@@ -1,0 +1,1 @@
+🏃‍♂️ update setup-kind github actions CI


### PR DESCRIPTION
Signed-off-by: Ashish Amarnath <ashisham@vmware.com>

The CI jobs that use KinD clusters to validate Velero CRDs are currently failing
- https://github.com/vmware-tanzu/velero/pull/3084/checks?check_run_id=1409398125
- https://github.com/vmware-tanzu/velero/pull/3084/checks?check_run_id=1409398205
- https://github.com/vmware-tanzu/velero/pull/3084/checks?check_run_id=1409398200

This PR fixes those CI job failures by updating `engineerd/setup-kind` from `v0.4.0` to `v0.5.0` 