### PR TITLE
Fix project automation

### DIFF
--- a/.github/workflows/opened-issues-triage.yml
+++ b/.github/workflows/opened-issues-triage.yml
@@ -12,4 +12,4 @@ jobs:
         with:
           project: "Velero Support Triage Board"
           column: "Needs Triage"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/opened-issues-triage.yml
+++ b/.github/workflows/opened-issues-triage.yml
@@ -11,5 +11,5 @@ jobs:
       - uses: alex-page/github-project-automation-plus@v0.3.0
         with:
           project: "Velero Support Triage Board"
-          column: "Needs Triage"
+          column: "Needs triage"
           repo-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
This will fix the GH action that automates adding a new issue into the triage project board.

What was needed:
- A personal GH token with full repo access (read/write). I created one under my account, named `GH_TOKEN` (does not need to match the key name below)*
- Add a secret key/value pair to the Velero repo with a key value same as the value for `repo-token` (`secrets.GH_TOKEN`), and the created token value (https://github.com/vmware-tanzu/velero/settings/secrets/actions). This step will need to be repeated in each repo that will push issues into the board.


* Note 1: there is no option to create a GH token for an organization. Ideally we would have a "bot" account to use for such purposes. We [were using one](https://github.com/vmware-tanzu/helm-charts/issues/20) of my personal tokens for the helm release process.
Note 2: it is not possible to use  GH default `secrets.GITHUB_TOKEN` because it only scopes at the repository level.

Signed-off-by: Carlisia <carlisia@vmware.com>