### PR TITLE
Upgrade to Docker provided buildx action for CI

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,12 +22,17 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: all
+
     - name: Set up Docker Buildx
       id: buildx
-      uses: crazy-max/ghaction-docker-buildx@v3
+      uses: docker/setup-buildx-action@v1
       with:
-        buildx-version: latest
-        qemu-version: latest
+        version: latest
 
     - name: Build
       run: make local
@@ -36,8 +41,13 @@ jobs:
       run: make test
 
     # Only try to publish the container image from the root repo; forks don't have permission to do so and will always get failures.
+    - name: Login to DockerHub
+      if: github.repository == 'vmware-tanzu/velero'
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USER }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
     - name: Publish container image
       if: github.repository == 'vmware-tanzu/velero'
-      run: |
-        docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
-        ./hack/docker-push.sh
+      run: ./hack/docker-push.sh


### PR DESCRIPTION
The [previous buildx action](https://github.com/crazy-max/ghaction-docker-buildx#moved-to-docker-organization) that we were using has been archived and
users are recommended to switch to the new action provided by Docker.
The previous action also included setting up QEMU. This is now provided
as a separate action which needs to be run separately.
This change also replaces the direct use of `docker login` with the new
`login-action`. This new action also handles logging out once the build
is complete.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>