### PR TITLE
doc: Use inline markdown links in tables

### DIFF
--- a/site/content/docs/main/api-types/backupstoragelocation.md
+++ b/site/content/docs/main/api-types/backupstoragelocation.md
@@ -36,15 +36,13 @@ The configurable parameters are as follows:
 {{< table caption="Main config parameters" >}}
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
-| `provider` | String | Required Field | The name for whichever object storage provider will be used to store the backups. See [your object storage provider's plugin documentation][0] for the appropriate value to use. |
+| `provider` | String | Required Field | The name for whichever object storage provider will be used to store the backups. See [your object storage provider's plugin documentation](../supported-providers) for the appropriate value to use. |
 | `objectStorage` | ObjectStorageLocation | Required Field | Specification of the object storage for the given provider. |
 | `objectStorage/bucket` | String | Required Field | The storage bucket where backups are to be uploaded. |
 | `objectStorage/prefix` | String | Optional Field | The directory inside a storage bucket where backups are to be uploaded. |
 | `objectStorage/caCert` | String | Optional Field | A base64 encoded CA bundle to be used when verifying TLS connections |
-| `config` | map[string]string | None (Optional) | Provider-specific configuration keys/values to be passed to the object store plugin. See [your object storage provider's plugin documentation][0] for details. |
+| `config` | map[string]string | None (Optional) | Provider-specific configuration keys/values to be passed to the object store plugin. See [your object storage provider's plugin documentation](../supported-providers) for details. |
 | `accessMode` | String | `ReadWrite` | How Velero can access the backup storage location. Valid values are `ReadWrite`, `ReadOnly`. |
 | `backupSyncPeriod` | metav1.Duration | Optional Field | How frequently Velero should synchronize backups in object storage. Default is Velero's server backup sync period. Set this to `0s` to disable sync. |
 | `validationFrequency` | metav1.Duration | Optional Field | How frequently Velero should validate the object storage . Default is Velero's server validation frequency. Set this to `0s` to disable validation. Default 1 minute. |
-{{ </table> }}
-
-[0]: ../supported-providers.md
+{{< /table >}}

--- a/site/content/docs/main/api-types/volumesnapshotlocation.md
+++ b/site/content/docs/main/api-types/volumesnapshotlocation.md
@@ -35,8 +35,6 @@ The configurable parameters are as follows:
 {{< table caption="Main config parameters" >}}
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
-| `provider` | String | Required Field | The name for whichever storage provider will be used to create/store the volume snapshots. See [your volume snapshot provider's plugin documentation][0] for the appropriate value to use. |
-| `config` | map[string]string | None (Optional) |  Provider-specific configuration keys/values to be passed to the volume snapshotter plugin. See [your volume snapshot provider's plugin documentation][0] for details. |
-{{</table>}}
-
-[0]: ../supported-providers.md
+| `provider` | String | Required Field | The name for whichever storage provider will be used to create/store the volume snapshots. See [your volume snapshot provider's plugin documentation](../supported-providers) for the appropriate value to use. |
+| `config` | map string string | None (Optional) |  Provider-specific configuration keys/values to be passed to the volume snapshotter plugin. See [your volume snapshot provider's plugin documentation](../supported-providers) for details. |
+{{< /table >}}

--- a/site/content/docs/v1.5/api-types/backupstoragelocation.md
+++ b/site/content/docs/v1.5/api-types/backupstoragelocation.md
@@ -36,15 +36,13 @@ The configurable parameters are as follows:
 {{< table caption="Main config parameters" >}}
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
-| `provider` | String | Required Field | The name for whichever object storage provider will be used to store the backups. See [your object storage provider's plugin documentation][0] for the appropriate value to use. |
+| `provider` | String | Required Field | The name for whichever object storage provider will be used to store the backups. See [your object storage provider's plugin documentation](../supported-providers) for the appropriate value to use. |
 | `objectStorage` | ObjectStorageLocation | Required Field | Specification of the object storage for the given provider. |
 | `objectStorage/bucket` | String | Required Field | The storage bucket where backups are to be uploaded. |
 | `objectStorage/prefix` | String | Optional Field | The directory inside a storage bucket where backups are to be uploaded. |
 | `objectStorage/caCert` | String | Optional Field | A base64 encoded CA bundle to be used when verifying TLS connections |
-| `config` | map[string]string | None (Optional) | Provider-specific configuration keys/values to be passed to the object store plugin. See [your object storage provider's plugin documentation][0] for details. |
+| `config` | map[string]string | None (Optional) | Provider-specific configuration keys/values to be passed to the object store plugin. See [your object storage provider's plugin documentation](../supported-providers) for details. |
 | `accessMode` | String | `ReadWrite` | How Velero can access the backup storage location. Valid values are `ReadWrite`, `ReadOnly`. |
 | `backupSyncPeriod` | metav1.Duration | Optional Field | How frequently Velero should synchronize backups in object storage. Default is Velero's server backup sync period. Set this to `0s` to disable sync. |
 | `validationFrequency` | metav1.Duration | Optional Field | How frequently Velero should validate the object storage . Default is Velero's server validation frequency. Set this to `0s` to disable validation. Default 1 minute. |
-{{ </table> }}
-
-[0]: ../supported-providers.md
+{{< /table >}}

--- a/site/content/docs/v1.5/api-types/volumesnapshotlocation.md
+++ b/site/content/docs/v1.5/api-types/volumesnapshotlocation.md
@@ -35,8 +35,6 @@ The configurable parameters are as follows:
 {{< table caption="Main config parameters" >}}
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
-| `provider` | String | Required Field | The name for whichever storage provider will be used to create/store the volume snapshots. See [your volume snapshot provider's plugin documentation][0] for the appropriate value to use. |
-| `config` | map[string]string | None (Optional) |  Provider-specific configuration keys/values to be passed to the volume snapshotter plugin. See [your volume snapshot provider's plugin documentation][0] for details. |
-{{</table>}}
-
-[0]: ../supported-providers.md
+| `provider` | String | Required Field | The name for whichever storage provider will be used to create/store the volume snapshots. See [your volume snapshot provider's plugin documentation](../supported-providers) for the appropriate value to use. |
+| `config` | map string string | None (Optional) |  Provider-specific configuration keys/values to be passed to the volume snapshotter plugin. See [your volume snapshot provider's plugin documentation](../supported-providers) for details. |
+{{< /table >}}

--- a/site/layouts/shortcodes/table.html
+++ b/site/layouts/shortcodes/table.html
@@ -5,6 +5,6 @@
 {{ $hasCaption := isset .Params "caption" }}
 {{ $caption    := .Get "caption" }}
 {{ $captionEl  := printf "<table><caption style=\"display: none;\">%s</caption>" $caption }}
-{{ $table      := .Inner | markdownify }}
+{{ $table      := .Inner | .Page.RenderString }}
 {{ $html       := cond $hasCaption ($table | replaceRE "<table>" $captionEl) $table | safeHTML }}
 {{ $html }}


### PR DESCRIPTION
It seems that Hugo does not support reference-style links. See the generated doc at velero.io:
https://velero.io/docs/v1.5/api-types/volumesnapshotlocation/#parameter-reference

note: I haven't take the time yet to test it with a hugo build