### PR TITLE
Fix broken docker login action

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -41,13 +41,8 @@ jobs:
       run: make test
 
     # Only try to publish the container image from the root repo; forks don't have permission to do so and will always get failures.
-    - name: Login to DockerHub
-      if: github.repository == 'vmware-tanzu/velero'
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKERHUB_USER }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
     - name: Publish container image
       if: github.repository == 'vmware-tanzu/velero'
-      run: ./hack/docker-push.sh
+      run: |
+        docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
+        ./hack/docker-push.sh


### PR DESCRIPTION
PR #3110 introduced a new action for performing the login to Dockerhub
as part of image building and pushing however there is an error with the
configuration and the credentials are not being passed through
correctly. This change reverts to the previous log in approach.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>