### PR TITLE
Add milestoned issues to their respective board

### DIFF
--- a/.github/workflows/milestoned-issues.yml
+++ b/.github/workflows/milestoned-issues.yml
@@ -1,0 +1,18 @@
+name: Add issues with a milestone to the milestone's board
+
+on:
+  issues:
+    types: [milestoned]
+
+jobs:
+  automate-project-columns:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.3.0
+        with:
+          # Do NOT add PRs to the board, as that's duplication. Their corresponding issue should be on the board.
+          if: ${{ !github.event.issue.pull_request }}
+          project: "${{ github.event.issue.milestone.title }}"
+          column: "To Do"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
As long as a milestone and the board have the same title, then this
workflow should take care of adding an issue into the GitHub Project
board when an existing issue is given a milestone.

It does NOT support checking for a milestone when an issue is edited or
created though, due to limitations on GitHub Actions syntax right now -
there's not a great way to validate against an empty `milestone` object
at the moment, per https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>