### PR TITLE
feat: support set BackupStorageLocation(BSL) CA certificate

### DIFF
--- a/changelogs/unreleased/3167-jenting
+++ b/changelogs/unreleased/3167-jenting
@@ -1,1 +1,1 @@
-feat: support sets BackupStorageLocation CA certificate by `velero backup-location set --cacert`
+feat: support setting BackupStorageLocation CA certificate via `velero backup-location set --cacert`

--- a/changelogs/unreleased/3167-jenting
+++ b/changelogs/unreleased/3167-jenting
@@ -1,0 +1,1 @@
+feat: support sets BackupStorageLocation CA certificate by `velero backup-location set --cacert`

--- a/design/cli-install-changes.md
+++ b/design/cli-install-changes.md
@@ -116,7 +116,7 @@ Commands/flags for backup locations.
       set
         --default string                                  sets the default backup storage location (default "default") (NEW, -- was `server --default-backup-storage-location; could be set as an annotation on the BSL)
         --credentials mapStringString                     sets the name of the corresponding credentials secret for a provider. Format is provider:credentials-secret-name. (NEW)
-        --cacert mapStringString                          configuration to use for creating a secret containing a custom certificate for an S3 location of a plugin provider. Format is provider:path-to-file. (NEW)
+        --cacert-file mapStringString                     configuration to use for creating a secret containing a custom certificate for an S3 location of a plugin provider. Format is provider:path-to-file. (NEW)
 
       create                                              NAME [flags]
         --default                                         Sets this new location to be the new default backup location. Default is false. (NEW) 
@@ -131,7 +131,7 @@ Commands/flags for backup locations.
         --provider string                                 name of the backup storage provider (e.g. aws, azure, gcp)
         --show-labels                                     show labels in the last column
         --credentials mapStringString                     sets the name of the corresponding credentials secret for a provider. Format is provider:credentials-secret-name. (NEW)
-        --cacert mapStringString                          configuration to use for creating a secret containing a custom certificate for an S3 location of a plugin provider. Format is provider:path-to-file. (NEW)
+        --cacert-file mapStringString                     configuration to use for creating a secret containing a custom certificate for an S3 location of a plugin provider. Format is provider:path-to-file. (NEW)
 
       get                                                 Display backup storage locations
         --default                                         displays the current default backup storage location (NEW)
@@ -276,7 +276,7 @@ The value for these flags will be stored as annotations.
 
 #### Handling CA certs
 
-In anticipation of a new configuration implementation to handle custom CA certs (as per design doc https://github.com/vmware-tanzu/velero/blob/main/design/custom-ca-support.md), a new flag `velero backup-location create/set --cacert mapStringString` is proposed. It sets the configuration to use for creating a secret containing a custom certificate for an S3 location of a plugin provider. Format is provider:path-to-file.
+In anticipation of a new configuration implementation to handle custom CA certs (as per design doc https://github.com/vmware-tanzu/velero/blob/main/design/custom-ca-support.md), a new flag `velero storage-location create/set --cacert-file mapStringString` is proposed. It sets the configuration to use for creating a secret containing a custom certificate for an S3 location of a plugin provider. Format is provider:path-to-file.
 
 See discussion https://github.com/vmware-tanzu/velero/pull/2259#discussion_r384700723 for more clarification.
 

--- a/design/cli-install-changes.md
+++ b/design/cli-install-changes.md
@@ -116,7 +116,7 @@ Commands/flags for backup locations.
       set
         --default string                                  sets the default backup storage location (default "default") (NEW, -- was `server --default-backup-storage-location; could be set as an annotation on the BSL)
         --credentials mapStringString                     sets the name of the corresponding credentials secret for a provider. Format is provider:credentials-secret-name. (NEW)
-        --cacert-file mapStringString                     configuration to use for creating a secret containing a custom certificate for an S3 location of a plugin provider. Format is provider:path-to-file. (NEW)
+        --cacert mapStringString                          configuration to use for creating a secret containing a custom certificate for an S3 location of a plugin provider. Format is provider:path-to-file. (NEW)
 
       create                                              NAME [flags]
         --default                                         Sets this new location to be the new default backup location. Default is false. (NEW) 
@@ -131,7 +131,7 @@ Commands/flags for backup locations.
         --provider string                                 name of the backup storage provider (e.g. aws, azure, gcp)
         --show-labels                                     show labels in the last column
         --credentials mapStringString                     sets the name of the corresponding credentials secret for a provider. Format is provider:credentials-secret-name. (NEW)
-        --cacert-file mapStringString                     configuration to use for creating a secret containing a custom certificate for an S3 location of a plugin provider. Format is provider:path-to-file. (NEW)
+        --cacert mapStringString                          configuration to use for creating a secret containing a custom certificate for an S3 location of a plugin provider. Format is provider:path-to-file. (NEW)
 
       get                                                 Display backup storage locations
         --default                                         displays the current default backup storage location (NEW)
@@ -276,7 +276,7 @@ The value for these flags will be stored as annotations.
 
 #### Handling CA certs
 
-In anticipation of a new configuration implementation to handle custom CA certs (as per design doc https://github.com/vmware-tanzu/velero/blob/main/design/custom-ca-support.md), a new flag `velero storage-location create/set --cacert-file mapStringString` is proposed. It sets the configuration to use for creating a secret containing a custom certificate for an S3 location of a plugin provider. Format is provider:path-to-file.
+In anticipation of a new configuration implementation to handle custom CA certs (as per design doc https://github.com/vmware-tanzu/velero/blob/main/design/custom-ca-support.md), a new flag `velero backup-location create/set --cacert mapStringString` is proposed. It sets the configuration to use for creating a secret containing a custom certificate for an S3 location of a plugin provider. Format is provider:path-to-file.
 
 See discussion https://github.com/vmware-tanzu/velero/pull/2259#discussion_r384700723 for more clarification.
 


### PR DESCRIPTION
Add a new flag `--cacert` under `velero backup-location set` to allow configures the CA certificate of BSL.

In `velero install` and `velero backup-location create`, the flag is `--cacert`.
To make it compatible, change the CLI design doc from `--cacert-file` to `--cacert`.

The only drawback of this new flag proposal is that the user can't remove the `cacert` setting from velero CLI directly if the  BSL changes it's setting from w/ TLS to w/o TLS.

partial fixes #2425
ref to #2419