### PR TITLE
Revert workflow access token changes

### DIFF
--- a/.github/workflows/milestoned-issues.yml
+++ b/.github/workflows/milestoned-issues.yml
@@ -14,5 +14,5 @@ jobs:
           if: ${{ !github.event.issue.pull_request }}
           project: "${{ github.event.issue.milestone.title }}"
           column: "To Do"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GH_TOKEN }}
 

--- a/.github/workflows/opened-issues-triage.yml
+++ b/.github/workflows/opened-issues-triage.yml
@@ -12,4 +12,4 @@ jobs:
         with:
           project: "Velero Support Board"
           column: "New"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Per
https://github.com/alex-page/github-project-automation-plus/issues/51,
the `GITHUB_TOKEN` secret doesn't have the appropriate permissions to
manage the issue workflows at a repo level. Reverting to the previous
secret to get the workflows working again.

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>