### PR TITLE
Improvements to BSL logic

### DIFF
--- a/changelogs/unreleased/3172-carlisia
+++ b/changelogs/unreleased/3172-carlisia
@@ -1,0 +1,1 @@
+Set the BSL created at install time as the "default"

--- a/internal/storage/storagelocation.go
+++ b/internal/storage/storagelocation.go
@@ -30,10 +30,11 @@ import (
 
 // DefaultBackupLocationInfo holds server default backup storage location information
 type DefaultBackupLocationInfo struct {
-	// StorageLocation is the name of the backup storage location designated as the default
+	// StorageLocation is the name of the backup storage location designated as the default on the server side.
+	// Deprecated TODO(2.0)
 	StorageLocation string
-	// StoreValidationFrequency is the default validation frequency for any backup storage location
-	StoreValidationFrequency time.Duration
+	// ServerValidationFrequency is the server default validation frequency for all backup storage locations
+	ServerValidationFrequency time.Duration
 }
 
 // IsReadyToValidate calculates if a given backup storage location is ready to be validated.
@@ -44,16 +45,16 @@ type DefaultBackupLocationInfo struct {
 // This will always return "true" for the first attempt at validating a location, regardless of its validation frequency setting
 // Otherwise, it returns "ready" only when NOW is equal to or after the next validation time
 // (next validation time: last validation time + validation frequency)
-func IsReadyToValidate(bslValidationFrequency *metav1.Duration, lastValidationTime *metav1.Time, defaultLocationInfo DefaultBackupLocationInfo, log logrus.FieldLogger) bool {
-	validationFrequency := defaultLocationInfo.StoreValidationFrequency
+func IsReadyToValidate(bslValidationFrequency *metav1.Duration, lastValidationTime *metav1.Time, serverValidationFrequency time.Duration, log logrus.FieldLogger) bool {
+	validationFrequency := serverValidationFrequency
 	// If the bsl validation frequency is not specifically set, skip this block and continue, using the server's default
 	if bslValidationFrequency != nil {
 		validationFrequency = bslValidationFrequency.Duration
 	}
 
 	if validationFrequency < 0 {
-		log.Debugf("Validation period must be non-negative, changing from %d to %d", validationFrequency, defaultLocationInfo.StoreValidationFrequency)
-		validationFrequency = defaultLocationInfo.StoreValidationFrequency
+		log.Debugf("Validation period must be non-negative, changing from %d to %d", validationFrequency, validationFrequency)
+		validationFrequency = serverValidationFrequency
 	}
 
 	lastValidation := lastValidationTime

--- a/internal/storage/storagelocation_test.go
+++ b/internal/storage/storagelocation_test.go
@@ -42,7 +42,7 @@ func TestIsReadyToValidate(t *testing.T) {
 			name:                   "validate when true when validation frequency is zero and lastValidationTime is nil",
 			bslValidationFrequency: &metav1.Duration{Duration: 0},
 			defaultLocationInfo: DefaultBackupLocationInfo{
-				StoreValidationFrequency: 0,
+				ServerValidationFrequency: 0,
 			},
 			ready: true,
 		},
@@ -51,7 +51,7 @@ func TestIsReadyToValidate(t *testing.T) {
 			bslValidationFrequency: &metav1.Duration{Duration: 0},
 			lastValidationTime:     &metav1.Time{Time: time.Now()},
 			defaultLocationInfo: DefaultBackupLocationInfo{
-				StoreValidationFrequency: 0,
+				ServerValidationFrequency: 0,
 			},
 			ready: false,
 		},
@@ -59,7 +59,7 @@ func TestIsReadyToValidate(t *testing.T) {
 			name:                   "validate as per location setting, as that takes precedence, and always if it has never been validated before regardless of the frequency setting",
 			bslValidationFrequency: &metav1.Duration{Duration: 1 * time.Hour},
 			defaultLocationInfo: DefaultBackupLocationInfo{
-				StoreValidationFrequency: 0,
+				ServerValidationFrequency: 0,
 			},
 			ready: true,
 		},
@@ -67,7 +67,7 @@ func TestIsReadyToValidate(t *testing.T) {
 			name:                   "don't validate as per location setting, as it is set to zero and that takes precedence",
 			bslValidationFrequency: &metav1.Duration{Duration: 0},
 			defaultLocationInfo: DefaultBackupLocationInfo{
-				StoreValidationFrequency: 1,
+				ServerValidationFrequency: 1,
 			},
 			lastValidationTime: &metav1.Time{Time: time.Now()},
 			ready:              false,
@@ -75,14 +75,14 @@ func TestIsReadyToValidate(t *testing.T) {
 		{
 			name: "validate as per default setting when location setting is not set",
 			defaultLocationInfo: DefaultBackupLocationInfo{
-				StoreValidationFrequency: 1,
+				ServerValidationFrequency: 1,
 			},
 			ready: true,
 		},
 		{
 			name: "don't validate when default setting is set to zero and the location setting is not set",
 			defaultLocationInfo: DefaultBackupLocationInfo{
-				StoreValidationFrequency: 0,
+				ServerValidationFrequency: 0,
 			},
 			lastValidationTime: &metav1.Time{Time: time.Now()},
 			ready:              false,
@@ -92,7 +92,7 @@ func TestIsReadyToValidate(t *testing.T) {
 			bslValidationFrequency: &metav1.Duration{Duration: 1 * time.Second},
 			lastValidationTime:     &metav1.Time{Time: time.Now()},
 			defaultLocationInfo: DefaultBackupLocationInfo{
-				StoreValidationFrequency: 0,
+				ServerValidationFrequency: 0,
 			},
 			ready: false,
 		},
@@ -101,7 +101,7 @@ func TestIsReadyToValidate(t *testing.T) {
 			bslValidationFrequency: &metav1.Duration{Duration: 1 * time.Second},
 			lastValidationTime:     &metav1.Time{Time: time.Now().Add(-1 * time.Second)},
 			defaultLocationInfo: DefaultBackupLocationInfo{
-				StoreValidationFrequency: 0,
+				ServerValidationFrequency: 0,
 			},
 			ready: true,
 		},
@@ -110,7 +110,7 @@ func TestIsReadyToValidate(t *testing.T) {
 			bslValidationFrequency: &metav1.Duration{Duration: 1 * time.Second},
 			lastValidationTime:     &metav1.Time{Time: time.Now().Add(-2 * time.Second)},
 			defaultLocationInfo: DefaultBackupLocationInfo{
-				StoreValidationFrequency: 0,
+				ServerValidationFrequency: 0,
 			},
 			ready: true,
 		},
@@ -120,7 +120,7 @@ func TestIsReadyToValidate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 			log := velerotest.NewLogger()
-			actual := IsReadyToValidate(tt.bslValidationFrequency, tt.lastValidationTime, tt.defaultLocationInfo, log)
+			actual := IsReadyToValidate(tt.bslValidationFrequency, tt.lastValidationTime, tt.defaultLocationInfo.ServerValidationFrequency, log)
 			g.Expect(actual).To(BeIdenticalTo(tt.ready))
 		})
 	}

--- a/pkg/cmd/cli/backuplocation/get.go
+++ b/pkg/cmd/cli/backuplocation/get.go
@@ -57,6 +57,7 @@ func NewGetCommand(f client.Factory, use string) *cobra.Command {
 					if showDefaultOnly {
 						if location.Spec.Default {
 							locations.Items = append(locations.Items, *location)
+							break
 						}
 					} else {
 						locations.Items = append(locations.Items, *location)

--- a/pkg/cmd/cli/backuplocation/set.go
+++ b/pkg/cmd/cli/backuplocation/set.go
@@ -36,7 +36,7 @@ func NewSetCommand(f client.Factory, use string) *cobra.Command {
 
 	c := &cobra.Command{
 		Use:   use + " NAME",
-		Short: "Set a backup storage location",
+		Short: "Set specific features for a backup storage location",
 		Args:  cobra.ExactArgs(1),
 		Run: func(c *cobra.Command, args []string) {
 			cmd.CheckError(o.Complete(args, f))

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -101,6 +101,7 @@ const (
 )
 
 type serverConfig struct {
+	// TODO(2.0) Deprecate defaultBackupLocation
 	pluginDir, metricsAddress, defaultBackupLocation                        string
 	backupSyncPeriod, podVolumeOperationTimeout, resourceTerminatingTimeout time.Duration
 	defaultBackupTTL, storeValidationFrequency                              time.Duration
@@ -830,8 +831,8 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 		Client: s.mgr.GetClient(),
 		Scheme: s.mgr.GetScheme(),
 		DefaultBackupLocationInfo: storage.DefaultBackupLocationInfo{
-			StorageLocation:          s.config.defaultBackupLocation,
-			StoreValidationFrequency: s.config.storeValidationFrequency,
+			StorageLocation:           s.config.defaultBackupLocation,
+			ServerValidationFrequency: s.config.storeValidationFrequency,
 		},
 		NewPluginManager: newPluginManager,
 		NewBackupStore:   persistence.NewObjectBackupStore,

--- a/pkg/controller/backup_controller_test.go
+++ b/pkg/controller/backup_controller_test.go
@@ -156,7 +156,7 @@ func TestProcessBackupValidationFailures(t *testing.T) {
 		{
 			name:         "non-existent backup location fails validation",
 			backup:       defaultBackup().StorageLocation("nonexistent").Result(),
-			expectedErrs: []string{"a BackupStorageLocation CRD with the name specified in the backup spec needs to be created before this backup can be executed. Error: backupstoragelocations.velero.io \"nonexistent\" not found"},
+			expectedErrs: []string{"an existing backup storage location wasn't specified at backup creation time and the default 'nonexistent' wasn't found. Please address this issue (see `velero backup-location -h` for options) and create a new backup. Error: backupstoragelocations.velero.io \"nonexistent\" not found"},
 		},
 		{
 			name:           "backup for read-only backup location fails validation",

--- a/pkg/controller/backup_storage_location_controller_test.go
+++ b/pkg/controller/backup_storage_location_controller_test.go
@@ -87,8 +87,8 @@ var _ = Describe("Backup Storage Location Reconciler", func() {
 			Ctx:    ctx,
 			Client: fake.NewFakeClientWithScheme(scheme.Scheme, locations),
 			DefaultBackupLocationInfo: storage.DefaultBackupLocationInfo{
-				StorageLocation:          "location-1",
-				StoreValidationFrequency: 0,
+				StorageLocation:           "location-1",
+				ServerValidationFrequency: 0,
 			},
 			NewPluginManager: func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager },
 			NewBackupStore: func(loc *velerov1api.BackupStorageLocation, _ persistence.ObjectStoreGetter, _ logrus.FieldLogger) (persistence.BackupStore, error) {
@@ -156,8 +156,8 @@ var _ = Describe("Backup Storage Location Reconciler", func() {
 			Ctx:    ctx,
 			Client: fake.NewFakeClientWithScheme(scheme.Scheme, locations),
 			DefaultBackupLocationInfo: storage.DefaultBackupLocationInfo{
-				StorageLocation:          "default",
-				StoreValidationFrequency: 0,
+				StorageLocation:           "default",
+				ServerValidationFrequency: 0,
 			},
 			NewPluginManager: func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager },
 			NewBackupStore: func(loc *velerov1api.BackupStorageLocation, _ persistence.ObjectStoreGetter, _ logrus.FieldLogger) (persistence.BackupStore, error) {
@@ -229,8 +229,8 @@ var _ = Describe("Backup Storage Location Reconciler", func() {
 			Ctx:    ctx,
 			Client: fake.NewFakeClientWithScheme(scheme.Scheme, locations),
 			DefaultBackupLocationInfo: storage.DefaultBackupLocationInfo{
-				StorageLocation:          "default",
-				StoreValidationFrequency: 0,
+				StorageLocation:           "default",
+				ServerValidationFrequency: 0,
 			},
 			NewPluginManager: func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager },
 			NewBackupStore: func(loc *velerov1api.BackupStorageLocation, _ persistence.ObjectStoreGetter, _ logrus.FieldLogger) (persistence.BackupStore, error) {

--- a/pkg/controller/restore_controller.go
+++ b/pkg/controller/restore_controller.go
@@ -88,7 +88,6 @@ type restoreController struct {
 	kbClient               client.Client
 	snapshotLocationLister velerov1listers.VolumeSnapshotLocationLister
 	restoreLogLevel        logrus.Level
-	defaultBackupLocation  string
 	metrics                *metrics.ServerMetrics
 	logFormat              logging.Format
 	clock                  clock.Clock

--- a/pkg/install/resources.go
+++ b/pkg/install/resources.go
@@ -159,7 +159,8 @@ func BackupStorageLocation(namespace, provider, bucket, prefix string, config ma
 					CACert: caCert,
 				},
 			},
-			Config: config,
+			Config:  config,
+			Default: true,
 		},
 	}
 }

--- a/site/content/docs/main/locations.md
+++ b/site/content/docs/main/locations.md
@@ -79,13 +79,18 @@ velero backup-location create backups-secondary \
     --config region=us-west-1
 ```
 
-You can alter which backup storage location as default by setting the `--default` flag under the
-`velero backup-location set` command to configure another location to be the default backup storage location.
+A "default" backup storage location (BSL) is where backups get saved to when no BSL is specified at backup creation time.
+
+You can change the default backup storage location at any time by setting the `--default` flag using the
+`velero backup-location set` command and configure a different location to be the default.
+
+Examples:
+
 ```shell
 velero backup-location set backups-secondary --default
 ```
 
-Once the defaulted backup storage location existed under `velero backup-location get --default`, then changes the default backup storage location name by `velero server --default-backup-storage-location` takes no effects anymore because the velero backup storage location controller prefers to use velero client-side setting. However, if there is no defaulted backup storage location under `velero backup-location get --default`, then changes the default backup storage location name by `velero server --default-backup-storage-location` would work.
+
 
 During backup creation:
 

--- a/site/content/docs/main/upgrade-to-1.6.md
+++ b/site/content/docs/main/upgrade-to-1.6.md
@@ -71,7 +71,11 @@ If you're not yet running at least Velero v1.5, see the following:
         Version: v1.6.0
     ```
 
-1. We've deprecated the way to indicate the default backup storage location according to the backup storage location name on the velero server-side `velero server --default-backup-storage-location`, but instead configure the default backup storage location at the velero client-side, please refer to the [About locations][9] on how to indicate which backup storage location is the default one. Moreover, during the velero upgrading process, the velero backup storage location controller helps you configure which backup storage location name matches against the backup storage location name on the velero server-side `velero server --default-backup-storage-location`, then sets the BackupStorageLocation custom resource `.spec.default` to `true`.
+## Notes
+### Default backup storage location
+We have deprecated the way to indicate the default backup storage location. Previously, that was indicated according to the backup storage location name set on the velero server-side via the flag `velero server --default-backup-storage-location`. Now we configure the default backup storage location on the velero client-side. Please refer to the [About locations][9] on how to indicate which backup storage location is the default one. 
+
+After upgrading, if there is a previously created backup storage location with the name that matches what was defined on the server side as the default, it will be automatically set as the `default`.
 
 [0]: basic-install.md#install-the-cli
 [1]: https://velero.io/docs/v1.1.0/upgrade-to-1.1/


### PR DESCRIPTION
There's only 1 change in functionality in this PR, and it is the automatic setting of the BSL created at install time as the "default".

Summary:
- Some code, variable name, and documentation improvements.
- Added deprecation notices at some relevant points
- In the pkg/controller/backup_controller.go:
  - grouped together all the code related to getting the default BSL
  - improved (I think) the error message for when the default BSL is not found/doesn't exist
  - introduced an error message specifically for when the default location we try to fetch is one that was specified with the server flag. When this happens it is usually because it was never created. Having this message point out that the config came from the server will help people understand why this is happens. Might be useful since this is not very transparent or intuitive.
- In the pkg/install/resources.go, I'm setting the BSL created at installation time as the "default" one. This makes sense since it is the first created in the cluster, and also goes hand-in-hand with Velero automatically naming that BSL `default`.




Signed-off-by: Carlisia <carlisia@vmware.com>