### PR TITLE
Ignore config/crd/crds/crds.go file in codespell

### DIFF
--- a/.github/workflows/pr-codespell.yml
+++ b/.github/workflows/pr-codespell.yml
@@ -13,7 +13,8 @@ jobs:
     - name: Codespell
       uses: codespell-project/actions-codespell@master
       with:
-        skip: .git,*.png,*.jpg,*.woff,*.ttf,*.gif,*.ico
+        # ignore the config/.../crd.go file as it's generated binary data that is edited elswhere.
+        skip: .git,*.png,*.jpg,*.woff,*.ttf,*.gif,*.ico,config/crd/crds/crds.go
         ignore_words_list: iam,aks,ist,bridget,ue
         check_filenames: true
         check_hidden: true


### PR DESCRIPTION
This file is generated and has binary contents that we shouldn't be
modifying anyway.

This change was because of a [failing CI run](https://github.com/vmware-tanzu/velero/pull/3127/checks?check_run_id=1526308843) that I can't manually set to passing and the author themselves can't actually fix in the file, so I made a separate PR to address the change.

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>