### PR TITLE
Better name format for init containers

### DIFF
--- a/pkg/builder/container_builder.go
+++ b/pkg/builder/container_builder.go
@@ -44,29 +44,30 @@ func ForPluginContainer(image string, pullPolicy corev1api.PullPolicy) *Containe
 }
 
 // getName returns the 'name' component of a docker
-// image that includes its reposiroty name, and transforms the combined
+// image that includes the entire string except the registry name, and transforms the combined
 // string into a DNS-1123 compatible name.
 func getName(image string) string {
 	slashIndex := strings.Index(image, "/")
-	slashCount := strings.Count(image[slashIndex:], "/")
-	colonIndex := strings.LastIndex(image, ":")
+	slashCount := 0
+	if slashIndex >= 0 {
+		slashCount = strings.Count(image[slashIndex:], "/")
+	}
 
-	// this removes the registry name when there is one, but keeps the repository name
 	start := 0
-	if slashCount == 1 {
-		start = 0
-	} else {
-		// this will be the first character after the first found slash
+	if slashCount > 1 || slashIndex == 0 {
+		// always start after the first slash when there is a registry name
+		// or if the string starts with a slash.
 		start = slashIndex + 1
 	}
 
 	// this removes the tag
+	colonIndex := strings.LastIndex(image, ":")
 	end := len(image)
 	if colonIndex > 0 {
 		end = colonIndex
 	}
 
-	return strings.Replace(image[start:end], "/", "-", 1) // this makes it DNS-1123 compatible
+	return strings.Replace(image[start:end], "/", "-", -1) // this makes it DNS-1123 compatible
 }
 
 // Result returns the built Container.

--- a/pkg/builder/container_builder.go
+++ b/pkg/builder/container_builder.go
@@ -44,23 +44,29 @@ func ForPluginContainer(image string, pullPolicy corev1api.PullPolicy) *Containe
 }
 
 // getName returns the 'name' component of a docker
-// image (i.e. everything after the last '/' and before
-// any subsequent ':')
+// image that includes its reposiroty name, and transforms the combined
+// string into a DNS-1123 compatible name.
 func getName(image string) string {
-	slashIndex := strings.LastIndex(image, "/")
+	slashIndex := strings.Index(image, "/")
+	slashCount := strings.Count(image[slashIndex:], "/")
 	colonIndex := strings.LastIndex(image, ":")
 
+	// this removes the registry name when there is one, but keeps the repository name
 	start := 0
-	if slashIndex > 0 {
+	if slashCount == 1 {
+		start = 0
+	} else {
+		// this will be the first character after the first found slash
 		start = slashIndex + 1
 	}
 
+	// this removes the tag
 	end := len(image)
-	if colonIndex > slashIndex {
+	if colonIndex > 0 {
 		end = colonIndex
 	}
 
-	return image[start:end]
+	return strings.Replace(image[start:end], "/", "-", 1) // this makes it DNS-1123 compatible
 }
 
 // Result returns the built Container.

--- a/pkg/builder/container_builder_test.go
+++ b/pkg/builder/container_builder_test.go
@@ -30,27 +30,27 @@ func TestGetName(t *testing.T) {
 		{
 			name:     "image name with registry hostname and tag",
 			image:    "gcr.io/my-repo/my-image:latest",
-			expected: "my-image",
+			expected: "my-repo-my-image",
 		},
 		{
 			name:     "image name with registry hostname, without tag",
 			image:    "gcr.io/my-repo/my-image",
-			expected: "my-image",
+			expected: "my-repo-my-image",
 		},
 		{
 			name:     "image name without registry hostname, with tag",
 			image:    "my-repo/my-image:latest",
-			expected: "my-image",
+			expected: "my-repo-my-image",
 		},
 		{
 			name:     "image name without registry hostname, without tag",
 			image:    "my-repo/my-image",
-			expected: "my-image",
+			expected: "my-repo-my-image",
 		},
 		{
 			name:     "image name with registry hostname and port, and tag",
 			image:    "mycustomregistry.io:8080/my-repo/my-image:latest",
-			expected: "my-image",
+			expected: "my-repo-my-image",
 		},
 	}
 

--- a/pkg/builder/container_builder_test.go
+++ b/pkg/builder/container_builder_test.go
@@ -52,6 +52,31 @@ func TestGetName(t *testing.T) {
 			image:    "mycustomregistry.io:8080/my-repo/my-image:latest",
 			expected: "my-repo-my-image",
 		},
+		{
+			name:     "image name with no / in it",
+			image:    "my-image",
+			expected: "my-image",
+		},
+		{
+			name:     "image name starting with / in it",
+			image:    "/my-image",
+			expected: "my-image",
+		},
+		{
+			name:     "image name with repo starting with a / as first char",
+			image:    "/my-repo/my-image",
+			expected: "my-repo-my-image",
+		},
+		{
+			name:     "image name with registry hostname, etoomany slashes, without tag",
+			image:    "gcr.io/my-repo/mystery/another/my-image",
+			expected: "my-repo-mystery-another-my-image",
+		},
+		{
+			name:     "image name with registry hostname starting with a / will include the registry name ¯\\_(ツ)_/¯",
+			image:    "/gcr.io/my-repo/mystery/another/my-image",
+			expected: "gcr.io-my-repo-mystery-another-my-image",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## What:

Instead of using the image name as a container init name, make it so the name include the repository name, and make the string DNS-1123 compatible (no slashes).

No change in logic and no compatibility issues.

## Why:

There can be plugins from different providers that are named the same. In this case, when attempting to add a second plugin with the same image name as an existing one, Velero will fail. See this example:

```
❯ velero plugin add storjlabs/velero-plugin
```

```
❯ velero plugin add digitalocean/velero-plugin
An error occurred: Deployment.apps "velero" is invalid: spec.template.spec.initContainers[2].name: Duplicate value: "velero-plugin"
```

That's because we attempt to name the init container `velero-plugin` in both cases.

## Solution:

The concatenate repository name + image name would be the name of the init container. Example:

`storjlabs-velero-plugin`

`digitalocean-velero-plugin`

Signed-off-by: Carlisia <carlisia@vmware.com>