### PR TITLE
Fix path to crds.go file in codespell config

### DIFF
--- a/.github/workflows/pr-codespell.yml
+++ b/.github/workflows/pr-codespell.yml
@@ -14,7 +14,7 @@ jobs:
       uses: codespell-project/actions-codespell@master
       with:
         # ignore the config/.../crd.go file as it's generated binary data that is edited elswhere.
-        skip: .git,*.png,*.jpg,*.woff,*.ttf,*.gif,*.ico,config/crd/crds/crds.go
+        skip: .git,*.png,*.jpg,*.woff,*.ttf,*.gif,*.ico,./config/crd/crds/crds.go
         ignore_words_list: iam,aks,ist,bridget,ue
         check_filenames: true
         check_hidden: true


### PR DESCRIPTION
This changes the codespell action config to use a relative path for the
generated crds.go file as the current pattern used fails the check used
by codespell (which uses the `fnmatch` module).

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>