### PR TITLE
Modify InitContainer-checking function which potentially incurs error

### DIFF
--- a/changelogs/unreleased/3196-shellwedance
+++ b/changelogs/unreleased/3196-shellwedance
@@ -1,0 +1,1 @@
+Modify InitContainer checking function logic which potentially incurs error.

--- a/pkg/controller/pod_volume_restore_controller.go
+++ b/pkg/controller/pod_volume_restore_controller.go
@@ -220,10 +220,13 @@ func isPodOnNode(pod *corev1api.Pod, node string) bool {
 }
 
 func isResticInitContainerRunning(pod *corev1api.Pod) bool {
-
 	// Restic wait container can be anywhere in the list of init containers, but must be running.
 	i := getResticInitContainerIndex(pod)
-	return i >= 0 && pod.Status.InitContainerStatuses[i].State.Running != nil
+	if i >= 0 {
+		return pod.Status.InitContainerStatuses[i].State.Running != nil
+	}
+
+	return false
 }
 
 func getResticInitContainerIndex(pod *corev1api.Pod) int {


### PR DESCRIPTION
`getResticInitContainerIndex` function returns `-1` when a given pod does not have restic init container.
In above case, `isResticInitContainerRunning` fails due to out of range error.
(Obviously restic plugin container will be restarted, but container logs will be lost)

I modified `isResticInitContainerRunning` not to incur out of range error.

Signed-off-by: Taeuk Kim <taeuk_kim@tmax.co.kr>