### PR TITLE
Modify InitContainer checking function that potentially incurs error

### DIFF
--- a/changelogs/unreleased/3198-shellwedance
+++ b/changelogs/unreleased/3198-shellwedance
@@ -1,0 +1,1 @@
+Add restic initContainer length check in pod volume restore to prevent restic plugin container disappear in runtime

--- a/pkg/controller/pod_volume_restore_controller.go
+++ b/pkg/controller/pod_volume_restore_controller.go
@@ -220,10 +220,11 @@ func isPodOnNode(pod *corev1api.Pod, node string) bool {
 }
 
 func isResticInitContainerRunning(pod *corev1api.Pod) bool {
-
 	// Restic wait container can be anywhere in the list of init containers, but must be running.
 	i := getResticInitContainerIndex(pod)
-	return i >= 0 && pod.Status.InitContainerStatuses[i].State.Running != nil
+	return i >= 0 &&
+		len(pod.Status.InitContainerStatuses)-1 >= i &&
+		pod.Status.InitContainerStatuses[i].State.Running != nil
 }
 
 func getResticInitContainerIndex(pod *corev1api.Pod) int {

--- a/pkg/controller/pod_volume_restore_controller_test.go
+++ b/pkg/controller/pod_volume_restore_controller_test.go
@@ -590,6 +590,26 @@ func TestIsResticContainerRunning(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "pod with restic init container with empty InitContainerStatuses should return 0",
+			pod: &corev1api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "pod-1",
+				},
+				Spec: corev1api.PodSpec{
+					InitContainers: []corev1api.Container{
+						{
+							Name: restic.InitContainer,
+						},
+					},
+				},
+				Status: corev1api.PodStatus{
+					InitContainerStatuses: []corev1api.ContainerStatus{},
+				},
+			},
+			expected: false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Added an `if` conditional that checks the length of `pod.Status.InitContainerStatus` to prevent potential error.
- When length of `pod.Status.InitContainerStatus` is 0, index out of range error occurs.
- This runtime error kills Restic plugin container and gets rid of previous logs after restart.



Signed-off-by: Taeuk Kim <taeuk_kim@tmax.co.kr>