### PR TITLE
Hidden the velero create/delete/describe/get sub-commands

### DIFF
--- a/changelogs/unreleased/3208-jenting
+++ b/changelogs/unreleased/3208-jenting
@@ -1,0 +1,1 @@
+Hidden the `velero create/delete/describe/get` sub-commands

--- a/pkg/cmd/cli/create/create.go
+++ b/pkg/cmd/cli/create/create.go
@@ -29,9 +29,10 @@ import (
 
 func NewCommand(f client.Factory) *cobra.Command {
 	c := &cobra.Command{
-		Use:   "create",
-		Short: "Create velero resources",
-		Long:  "Create velero resources",
+		Use:    "create",
+		Short:  "Create velero resources",
+		Long:   "Create velero resources",
+		Hidden: true,
 	}
 
 	c.AddCommand(

--- a/pkg/cmd/cli/delete/delete.go
+++ b/pkg/cmd/cli/delete/delete.go
@@ -28,9 +28,10 @@ import (
 
 func NewCommand(f client.Factory) *cobra.Command {
 	c := &cobra.Command{
-		Use:   "delete",
-		Short: "Delete velero resources",
-		Long:  "Delete velero resources",
+		Use:    "delete",
+		Short:  "Delete velero resources",
+		Long:   "Delete velero resources",
+		Hidden: true,
 	}
 
 	backupCommand := backup.NewDeleteCommand(f, "backup")

--- a/pkg/cmd/cli/describe/describe.go
+++ b/pkg/cmd/cli/describe/describe.go
@@ -27,9 +27,10 @@ import (
 
 func NewCommand(f client.Factory) *cobra.Command {
 	c := &cobra.Command{
-		Use:   "describe",
-		Short: "Describe velero resources",
-		Long:  "Describe velero resources",
+		Use:    "describe",
+		Short:  "Describe velero resources",
+		Long:   "Describe velero resources",
+		Hidden: true,
 	}
 
 	backupCommand := backup.NewDescribeCommand(f, "backups")

--- a/pkg/cmd/cli/get/get.go
+++ b/pkg/cmd/cli/get/get.go
@@ -30,9 +30,10 @@ import (
 
 func NewCommand(f client.Factory) *cobra.Command {
 	c := &cobra.Command{
-		Use:   "get",
-		Short: "Get velero resources",
-		Long:  "Get velero resources",
+		Use:    "get",
+		Short:  "Get velero resources",
+		Long:   "Get velero resources",
+		Hidden: true,
 	}
 
 	backupCommand := backup.NewGetCommand(f, "backups")

--- a/pkg/cmd/velero/velero.go
+++ b/pkg/cmd/velero/velero.go
@@ -63,11 +63,7 @@ func NewCommand(name string) *cobra.Command {
 		Short: "Back up and restore Kubernetes cluster resources.",
 		Long: `Velero is a tool for managing disaster recovery, specifically for Kubernetes
 cluster resources. It provides a simple, configurable, and operationally robust
-way to back up your application state and associated data.
-
-If you're familiar with kubectl, Velero supports a similar model, allowing you to
-execute commands such as 'velero get backup' and 'velero create schedule'. The same
-operations can also be performed as 'velero backup get' and 'velero schedule create'.`,
+way to back up your application state and associated data.`,
 		// PersistentPreRun will run before all subcommands EXCEPT in the following conditions:
 		//  - a subcommand defines its own PersistentPreRun function
 		//  - the command is run without arguments or with --help and only prints the usage info

--- a/site/content/docs/main/contributions/oracle-config.md
+++ b/site/content/docs/main/contributions/oracle-config.md
@@ -39,9 +39,6 @@ Velero is a tool for managing disaster recovery, specifically for Kubernetes
 cluster resources. It provides a simple, configurable, and operationally robust
 way to back up your application state and associated data.
 
-If you're familiar with kubectl, Velero supports a similar model, allowing you to
-execute commands such as 'velero backup get' and 'velero schedule create'.
-
 Usage:
   velero [command]
 ```

--- a/site/content/docs/main/contributions/oracle-config.md
+++ b/site/content/docs/main/contributions/oracle-config.md
@@ -40,8 +40,7 @@ cluster resources. It provides a simple, configurable, and operationally robust
 way to back up your application state and associated data.
 
 If you're familiar with kubectl, Velero supports a similar model, allowing you to
-execute commands such as 'velero get backup' and 'velero create schedule'. The same
-operations can also be performed as 'velero backup get' and 'velero schedule create'.
+execute commands such as 'velero backup get' and 'velero schedule create'.
 
 Usage:
   velero [command]


### PR DESCRIPTION
According to the [CLI design doc](https://github.com/vmware-tanzu/velero/blob/master/design/cli-install-changes.md#commands), the Velero organization commands with the format:
```
velero [resource] [operation] [flags]
```

Therefore, hidden the `velero create/delete/describe/get` sub-commands.
Now, with this PR, the velero available sub-commands are
```
Usage:
  velero [command]

Available Commands:
  backup            Work with backups
  backup-location   Work with backup storage locations
  bug               Report a Velero bug
  client            Velero client related commands
  completion        Output shell completion code for the specified shell (bash or zsh).
  help              Help about any command
  install           Install Velero
  plugin            Work with plugins
  restic            Work with restic
  restore           Work with restores
  schedule          Work with schedules
  snapshot-location Work with snapshot locations
  version           Print the velero version and associated image
```

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>