### PR TITLE
Raise logging level for PV deletion timeout

### DIFF
--- a/changelogs/unreleased/3316-MadhavJivrajani
+++ b/changelogs/unreleased/3316-MadhavJivrajani
@@ -1,0 +1,1 @@
+Change the logging level of PV deletion timeout from Debug to Warn

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -663,7 +663,7 @@ func (ctx *restoreContext) shouldRestore(name string, pvClient client.Dynamic) (
 	})
 
 	if err == wait.ErrWaitTimeout {
-		pvLogger.Debug("timeout reached waiting for persistent volume to delete")
+		pvLogger.Warn("timeout reached waiting for persistent volume to delete")
 	}
 
 	return shouldRestore, err


### PR DESCRIPTION
Changed the logging level from Debug to Warn for PV deletion timeout in pkg/restore/restore.go.
Fix #2923 

Signed-off-by: Madhav Jivrajani <madhav.jiv@gmail.com>