### PR TITLE
Use controller-runtime client to get restic secrets

### DIFF
--- a/pkg/builder/secret_builder.go
+++ b/pkg/builder/secret_builder.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 the Velero contributors.
+Copyright the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -53,5 +53,11 @@ func (b *SecretBuilder) ObjectMeta(opts ...ObjectMetaOpt) *SecretBuilder {
 		opt(b.object)
 	}
 
+	return b
+}
+
+// Data sets the Secret data.
+func (b *SecretBuilder) Data(data map[string][]byte) *SecretBuilder {
+	b.object.Data = data
 	return b
 }

--- a/pkg/builder/secret_key_selector_builder.go
+++ b/pkg/builder/secret_key_selector_builder.go
@@ -1,0 +1,43 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	corev1api "k8s.io/api/core/v1"
+)
+
+// SecretKeySelectorBuilder builds SecretKeySelector objects.
+type SecretKeySelectorBuilder struct {
+	object *corev1api.SecretKeySelector
+}
+
+// ForSecretKeySelector is the constructor for a SecretKeySelectorBuilder.
+func ForSecretKeySelector(name string, key string) *SecretKeySelectorBuilder {
+	return &SecretKeySelectorBuilder{
+		object: &corev1api.SecretKeySelector{
+			LocalObjectReference: corev1api.LocalObjectReference{
+				Name: name,
+			},
+			Key: key,
+		},
+	}
+}
+
+// Result returns the built SecretKeySelector.
+func (b *SecretKeySelectorBuilder) Result() *corev1api.SecretKeySelector {
+	return b.object
+}

--- a/pkg/cmd/cli/backuplocation/create.go
+++ b/pkg/cmd/cli/backuplocation/create.go
@@ -27,12 +27,12 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	corev1api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/builder"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/flag"
@@ -178,13 +178,8 @@ func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
 					CACert: caCertData,
 				},
 			},
-			Config: o.Config.Data(),
-			Credential: &corev1api.SecretKeySelector{
-				LocalObjectReference: corev1api.LocalObjectReference{
-					Name: secretName,
-				},
-				Key: secretKey,
-			},
+			Config:              o.Config.Data(),
+			Credential:          builder.ForSecretKeySelector(secretName, secretKey).Result(),
 			Default:             o.DefaultBackupStorageLocation,
 			AccessMode:          velerov1api.BackupStorageLocationAccessMode(o.AccessMode.String()),
 			BackupSyncPeriod:    backupSyncPeriod,

--- a/pkg/cmd/cli/backuplocation/set.go
+++ b/pkg/cmd/cli/backuplocation/set.go
@@ -25,11 +25,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	corev1api "k8s.io/api/core/v1"
 
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/builder"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/flag"
@@ -139,13 +139,8 @@ func (o *SetOptions) Run(c *cobra.Command, f client.Factory) error {
 	location.Spec.Default = o.DefaultBackupStorageLocation
 	location.Spec.StorageType.ObjectStorage.CACert = caCertData
 
-	for k, v := range o.Credential.Data() {
-		location.Spec.Credential = &corev1api.SecretKeySelector{
-			LocalObjectReference: corev1api.LocalObjectReference{
-				Name: k,
-			},
-			Key: v,
-		}
+	for name, key := range o.Credential.Data() {
+		location.Spec.Credential = builder.ForSecretKeySelector(name, key).Result()
 		break
 	}
 

--- a/pkg/cmd/cli/snapshotlocation/create.go
+++ b/pkg/cmd/cli/snapshotlocation/create.go
@@ -24,10 +24,10 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	corev1api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/builder"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/flag"
@@ -113,14 +113,9 @@ func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
 			Labels:    o.Labels.Data(),
 		},
 		Spec: api.VolumeSnapshotLocationSpec{
-			Provider: o.Provider,
-			Config:   o.Config.Data(),
-			Credential: &corev1api.SecretKeySelector{
-				LocalObjectReference: corev1api.LocalObjectReference{
-					Name: o.secretName,
-				},
-				Key: o.secretKey,
-			},
+			Provider:   o.Provider,
+			Config:     o.Config.Data(),
+			Credential: builder.ForSecretKeySelector(o.secretName, o.secretKey).Result(),
 		},
 	}
 

--- a/pkg/cmd/cli/snapshotlocation/set.go
+++ b/pkg/cmd/cli/snapshotlocation/set.go
@@ -23,11 +23,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	corev1api "k8s.io/api/core/v1"
 
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/builder"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/flag"
@@ -99,13 +99,8 @@ func (o *SetOptions) Run(c *cobra.Command, f client.Factory) error {
 		return errors.WithStack(err)
 	}
 
-	for k, v := range o.Credential.Data() {
-		location.Spec.Credential = &corev1api.SecretKeySelector{
-			LocalObjectReference: corev1api.LocalObjectReference{
-				Name: k,
-			},
-			Key: v,
-		}
+	for name, key := range o.Credential.Data() {
+		location.Spec.Credential = builder.ForSecretKeySelector(name, key).Result()
 		break
 	}
 

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 the Velero contributors.
+Copyright the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	corev1api "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,10 +41,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
-	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
 
 	snapshotv1beta1api "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1beta1"
 	snapshotv1beta1client "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned"
@@ -286,6 +285,8 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 
 	scheme := runtime.NewScheme()
 	velerov1api.AddToScheme(scheme)
+	corev1api.AddToScheme(scheme)
+
 	mgr, err := ctrl.NewManager(clientConfig, ctrl.Options{
 		Scheme: scheme,
 	})
@@ -478,28 +479,10 @@ func (s *server) initRestic() error {
 		return err
 	}
 
-	// use a stand-alone secrets informer so we can filter to only the restic credentials
-	// secret(s) within the velero namespace
-	//
-	// note: using an informer to access the single secret for all velero-managed
-	// restic repositories is overkill for now, but will be useful when we move
-	// to fully-encrypted backups and have unique keys per repository.
-	secretsInformer := corev1informers.NewFilteredSecretInformer(
-		s.kubeClient,
-		s.namespace,
-		0,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
-		func(opts *metav1.ListOptions) {
-			opts.FieldSelector = fmt.Sprintf("metadata.name=%s", restic.CredentialsSecretName)
-		},
-	)
-	go secretsInformer.Run(s.ctx.Done())
-
 	res, err := restic.NewRepositoryManager(
 		s.ctx,
 		s.namespace,
 		s.veleroClient,
-		secretsInformer,
 		s.sharedInformerFactory.Velero().V1().ResticRepositories(),
 		s.veleroClient.VeleroV1(),
 		s.mgr.GetClient(),

--- a/pkg/controller/backup_controller_test.go
+++ b/pkg/controller/backup_controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 the Velero contributors.
+Copyright the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -181,9 +181,9 @@ func TestProcessBackupValidationFailures(t *testing.T) {
 
 			var fakeClient kbclient.Client
 			if test.backupLocation != nil {
-				fakeClient = newFakeClient(t, test.backupLocation)
+				fakeClient = velerotest.NewFakeControllerRuntimeClient(t, test.backupLocation)
 			} else {
-				fakeClient = newFakeClient(t)
+				fakeClient = velerotest.NewFakeControllerRuntimeClient(t)
 			}
 
 			c := &backupController{
@@ -246,7 +246,7 @@ func TestBackupLocationLabel(t *testing.T) {
 				clientset       = fake.NewSimpleClientset(test.backup)
 				sharedInformers = informers.NewSharedInformerFactory(clientset, 0)
 				logger          = logging.DefaultLogger(logrus.DebugLevel, formatFlag)
-				fakeClient      = newFakeClient(t)
+				fakeClient      = velerotest.NewFakeControllerRuntimeClient(t)
 			)
 
 			apiServer := velerotest.NewAPIServer(t)
@@ -306,7 +306,7 @@ func TestDefaultBackupTTL(t *testing.T) {
 		formatFlag := logging.FormatText
 		var (
 			clientset       = fake.NewSimpleClientset(test.backup)
-			fakeClient      = newFakeClient(t)
+			fakeClient      = velerotest.NewFakeControllerRuntimeClient(t)
 			logger          = logging.DefaultLogger(logrus.DebugLevel, formatFlag)
 			sharedInformers = informers.NewSharedInformerFactory(clientset, 0)
 		)
@@ -783,9 +783,9 @@ func TestProcessBackupCompletions(t *testing.T) {
 			var fakeClient kbclient.Client
 			// add the test's backup storage location if it's different than the default
 			if test.backupLocation != nil && test.backupLocation != defaultBackupLocation {
-				fakeClient = newFakeClient(t, test.backupLocation)
+				fakeClient = velerotest.NewFakeControllerRuntimeClient(t, test.backupLocation)
 			} else {
-				fakeClient = newFakeClient(t)
+				fakeClient = velerotest.NewFakeControllerRuntimeClient(t)
 			}
 
 			apiServer := velerotest.NewAPIServer(t)

--- a/pkg/controller/backup_deletion_controller_test.go
+++ b/pkg/controller/backup_deletion_controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 the Velero contributors.
+Copyright the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -144,7 +144,7 @@ func setupBackupDeletionControllerTest(t *testing.T, objects ...runtime.Object) 
 
 	var (
 		client            = fake.NewSimpleClientset(append(objects, req)...)
-		fakeClient        = newFakeClient(t, objects...)
+		fakeClient        = velerotest.NewFakeControllerRuntimeClient(t, objects...)
 		sharedInformers   = informers.NewSharedInformerFactory(client, 0)
 		volumeSnapshotter = &velerotest.FakeVolumeSnapshotter{SnapshotsTaken: sets.NewString()}
 		pluginManager     = &pluginmocks.Manager{}
@@ -1112,7 +1112,7 @@ func TestBackupDeletionControllerDeleteExpiredRequests(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset()
-			fakeClient := newFakeClient(t)
+			fakeClient := velerotest.NewFakeControllerRuntimeClient(t)
 			sharedInformers := informers.NewSharedInformerFactory(client, 0)
 
 			controller := NewBackupDeletionController(

--- a/pkg/controller/backup_sync_controller_test.go
+++ b/pkg/controller/backup_sync_controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017, 2020 the Velero contributors.
+Copyright the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -335,7 +335,7 @@ func TestBackupSyncControllerRun(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			var (
 				client          = fake.NewSimpleClientset()
-				fakeClient      = newFakeClient(t)
+				fakeClient      = velerotest.NewFakeControllerRuntimeClient(t)
 				sharedInformers = informers.NewSharedInformerFactory(client, 0)
 				pluginManager   = &pluginmocks.Manager{}
 				backupStores    = make(map[string]*persistencemocks.BackupStore)
@@ -558,7 +558,7 @@ func TestDeleteOrphanedBackups(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			var (
 				client          = fake.NewSimpleClientset()
-				fakeClient      = newFakeClient(t)
+				fakeClient      = velerotest.NewFakeControllerRuntimeClient(t)
 				sharedInformers = informers.NewSharedInformerFactory(client, 0)
 			)
 
@@ -652,7 +652,7 @@ func TestStorageLabelsInDeleteOrphanedBackups(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			var (
 				client          = fake.NewSimpleClientset()
-				fakeClient      = newFakeClient(t)
+				fakeClient      = velerotest.NewFakeControllerRuntimeClient(t)
 				sharedInformers = informers.NewSharedInformerFactory(client, 0)
 			)
 

--- a/pkg/controller/download_request_controller_test.go
+++ b/pkg/controller/download_request_controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 the Velero contributors.
+Copyright the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -246,9 +246,9 @@ func TestProcessDownloadRequest(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var fakeClient client.Client
 			if tc.backupLocation != nil {
-				fakeClient = newFakeClient(t, tc.backupLocation)
+				fakeClient = velerotest.NewFakeControllerRuntimeClient(t, tc.backupLocation)
 			} else {
-				fakeClient = newFakeClient(t)
+				fakeClient = velerotest.NewFakeControllerRuntimeClient(t)
 			}
 
 			harness := newDownloadRequestTestHarness(t, fakeClient)

--- a/pkg/controller/gc_controller_test.go
+++ b/pkg/controller/gc_controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017, 2019 the Velero contributors.
+Copyright the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -251,9 +251,9 @@ func TestGCControllerProcessQueueItem(t *testing.T) {
 
 			var fakeClient kbclient.Client
 			if test.backupLocation != nil {
-				fakeClient = newFakeClient(t, test.backupLocation)
+				fakeClient = velerotest.NewFakeControllerRuntimeClient(t, test.backupLocation)
 			} else {
-				fakeClient = newFakeClient(t)
+				fakeClient = velerotest.NewFakeControllerRuntimeClient(t)
 			}
 
 			controller := NewGCController(

--- a/pkg/controller/restore_controller_test.go
+++ b/pkg/controller/restore_controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 the Velero contributors.
+Copyright the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ func TestFetchBackupInfo(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			var (
 				client          = fake.NewSimpleClientset()
-				fakeClient      = newFakeClient(t)
+				fakeClient      = velerotest.NewFakeControllerRuntimeClient(t)
 				restorer        = &fakeRestorer{}
 				sharedInformers = informers.NewSharedInformerFactory(client, 0)
 				logger          = velerotest.NewLogger()
@@ -409,7 +409,7 @@ func TestProcessQueueItem(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			var (
 				client          = fake.NewSimpleClientset()
-				fakeClient      = newFakeClient(t)
+				fakeClient      = velerotest.NewFakeControllerRuntimeClient(t)
 				restorer        = &fakeRestorer{}
 				sharedInformers = informers.NewSharedInformerFactory(client, 0)
 				logger          = velerotest.NewLogger()

--- a/pkg/controller/suite_test.go
+++ b/pkg/controller/suite_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 the Velero contributors.
+Copyright the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -27,16 +27,12 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/persistence"
 	persistencemocks "github.com/vmware-tanzu/velero/pkg/persistence/mocks"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"github.com/stretchr/testify/require"
 
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 
@@ -98,6 +94,7 @@ type testEnvironment struct {
 // This function should be called only once for each package you're running tests within,
 // usually the environment is initialized in a suite_test.go file within a `BeforeSuite` ginkgo block.
 func newTestEnvironment() *testEnvironment {
+	// scheme.Scheme is initialized with all native Kubernetes types
 	err := velerov1api.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -131,12 +128,6 @@ func (t *testEnvironment) startManager() error {
 func (t *testEnvironment) stop() error {
 	cancel()
 	return env.Stop()
-}
-
-func newFakeClient(t *testing.T, initObjs ...runtime.Object) client.Client {
-	err := velerov1api.AddToScheme(scheme.Scheme)
-	require.NoError(t, err)
-	return fake.NewFakeClientWithScheme(scheme.Scheme, initObjs...)
 }
 
 type fakeSingleObjectBackupStoreGetter struct {

--- a/pkg/restic/common.go
+++ b/pkg/restic/common.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/builder"
 	velerov1listers "github.com/vmware-tanzu/velero/pkg/generated/listers/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/label"
 	"github.com/vmware-tanzu/velero/pkg/util/filesystem"
@@ -246,10 +247,7 @@ func TempCredentialsFile(client kbclient.Client, veleroNamespace, repoName strin
 	// When we move to full-backup encryption, we'll likely have a separate key per restic repo
 	// (all within the Velero server's namespace) so repoKeySelector will need to select the key
 	// for that repo.
-	repoKeySelector := &corev1api.SecretKeySelector{
-		LocalObjectReference: corev1api.LocalObjectReference{Name: CredentialsSecretName},
-		Key:                  CredentialsKey,
-	}
+	repoKeySelector := builder.ForSecretKeySelector(CredentialsSecretName, CredentialsKey).Result()
 
 	repoKey, err := kube.GetSecretKey(client, veleroNamespace, repoKeySelector)
 	if err != nil {

--- a/pkg/test/fake_controller_runtime_client.go
+++ b/pkg/test/fake_controller_runtime_client.go
@@ -1,0 +1,38 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1api "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	k8sfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+)
+
+func NewFakeControllerRuntimeClient(t *testing.T, initObjs ...runtime.Object) client.Client {
+	scheme := runtime.NewScheme()
+	err := velerov1api.AddToScheme(scheme)
+	require.NoError(t, err)
+	err = corev1api.AddToScheme(scheme)
+	require.NoError(t, err)
+	return k8sfake.NewFakeClientWithScheme(scheme, initObjs...)
+}

--- a/pkg/util/kube/secrets.go
+++ b/pkg/util/kube/secrets.go
@@ -1,0 +1,51 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	corev1api "k8s.io/api/core/v1"
+	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetSecret(client kbclient.Client, namespace, name string) (*corev1api.Secret, error) {
+	secret := &corev1api.Secret{}
+	if err := client.Get(context.TODO(), kbclient.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}, secret); err != nil {
+		return nil, err
+	}
+
+	return secret, nil
+}
+
+func GetSecretKey(client kbclient.Client, namespace string, selector *corev1api.SecretKeySelector) ([]byte, error) {
+	secret, err := GetSecret(client, namespace, selector.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	key, found := secret.Data[selector.Key]
+	if !found {
+		return nil, errors.Errorf("%q secret is missing data for key %q", selector.Name, selector.Key)
+	}
+
+	return key, nil
+}

--- a/pkg/util/kube/secrets_test.go
+++ b/pkg/util/kube/secrets_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1api "k8s.io/api/core/v1"
+
+	"github.com/vmware-tanzu/velero/pkg/builder"
+	velerotest "github.com/vmware-tanzu/velero/pkg/test"
+)
+
+func TestGetSecretKey(t *testing.T) {
+	testCases := []struct {
+		name         string
+		secrets      []*corev1api.Secret
+		namespace    string
+		selector     *corev1api.SecretKeySelector
+		expectedData string
+		expectedErr  string
+	}{
+		{
+			name: "error is returned when secret doesn't exist",
+			secrets: []*corev1api.Secret{
+				builder.ForSecret("ns-1", "secret1").Data(map[string][]byte{
+					"key1": []byte("ns1-secretdata1"),
+				}).Result(),
+			},
+			namespace: "ns-1",
+			selector: &corev1api.SecretKeySelector{
+				LocalObjectReference: corev1api.LocalObjectReference{
+					Name: "non-existent-secret",
+				},
+				Key: "key2",
+			},
+			expectedErr: "secrets \"non-existent-secret\" not found",
+		},
+		{
+			name: "error is returned when key is missing from secret",
+			secrets: []*corev1api.Secret{
+				builder.ForSecret("ns-1", "secret1").Data(map[string][]byte{
+					"key1": []byte("ns1-secretdata1"),
+				}).Result(),
+			},
+			namespace: "ns-1",
+			selector: &corev1api.SecretKeySelector{
+				LocalObjectReference: corev1api.LocalObjectReference{
+					Name: "secret1",
+				},
+				Key: "non-existent-key",
+			},
+			expectedErr: "\"secret1\" secret is missing data for key \"non-existent-key\"",
+		},
+		{
+			name: "key specified in selector is returned",
+			secrets: []*corev1api.Secret{
+				builder.ForSecret("ns-1", "secret1").Data(map[string][]byte{
+					"key1": []byte("ns1-secretdata1"),
+					"key2": []byte("ns1-secretdata2"),
+				}).Result(),
+				builder.ForSecret("ns-2", "secret1").Data(map[string][]byte{
+					"key1": []byte("ns2-secretdata1"),
+					"key2": []byte("ns2-secretdata2"),
+				}).Result(),
+			},
+			namespace: "ns-2",
+			selector: &corev1api.SecretKeySelector{
+				LocalObjectReference: corev1api.LocalObjectReference{
+					Name: "secret1",
+				},
+				Key: "key2",
+			},
+			expectedData: "ns2-secretdata2",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := velerotest.NewFakeControllerRuntimeClient(t)
+
+			for _, secret := range tc.secrets {
+				require.NoError(t, fakeClient.Create(context.Background(), secret))
+			}
+
+			data, err := GetSecretKey(fakeClient, tc.namespace, tc.selector)
+			if tc.expectedErr != "" {
+				require.Nil(t, data)
+				require.EqualError(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedData, string(data))
+			}
+		})
+	}
+}

--- a/pkg/util/kube/secrets_test.go
+++ b/pkg/util/kube/secrets_test.go
@@ -43,13 +43,8 @@ func TestGetSecretKey(t *testing.T) {
 					"key1": []byte("ns1-secretdata1"),
 				}).Result(),
 			},
-			namespace: "ns-1",
-			selector: &corev1api.SecretKeySelector{
-				LocalObjectReference: corev1api.LocalObjectReference{
-					Name: "non-existent-secret",
-				},
-				Key: "key2",
-			},
+			namespace:   "ns-1",
+			selector:    builder.ForSecretKeySelector("non-existent-secret", "key2").Result(),
 			expectedErr: "secrets \"non-existent-secret\" not found",
 		},
 		{
@@ -59,13 +54,8 @@ func TestGetSecretKey(t *testing.T) {
 					"key1": []byte("ns1-secretdata1"),
 				}).Result(),
 			},
-			namespace: "ns-1",
-			selector: &corev1api.SecretKeySelector{
-				LocalObjectReference: corev1api.LocalObjectReference{
-					Name: "secret1",
-				},
-				Key: "non-existent-key",
-			},
+			namespace:   "ns-1",
+			selector:    builder.ForSecretKeySelector("secret1", "non-existent-key").Result(),
 			expectedErr: "\"secret1\" secret is missing data for key \"non-existent-key\"",
 		},
 		{
@@ -80,13 +70,8 @@ func TestGetSecretKey(t *testing.T) {
 					"key2": []byte("ns2-secretdata2"),
 				}).Result(),
 			},
-			namespace: "ns-2",
-			selector: &corev1api.SecretKeySelector{
-				LocalObjectReference: corev1api.LocalObjectReference{
-					Name: "secret1",
-				},
-				Key: "key2",
-			},
+			namespace:    "ns-2",
+			selector:     builder.ForSecretKeySelector("secret1", "key2").Result(),
 			expectedData: "ns2-secretdata2",
 		},
 	}


### PR DESCRIPTION
Instead of using a SecretInformer for fetching secrets for restic, use
the cached client provided by the controller-runtime manager.

In order to use this client, the scheme for Secrets must be added to the
scheme used by the manager so this is added when creating the manager in
both the velero and restic servers.

This change also refactors some of the tests to add a shared utility for
creating a fake controller-runtime client which is now used among all
tests which use that client. This has been added to ensure that all
tests use the same client with the same scheme.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>