### PR TITLE
Replace NewObjectBackupStore with interface

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -578,6 +578,7 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 			s.kubeClient,
 			s.config.defaultBackupLocation,
 			newPluginManager,
+			persistence.NewObjectBackupStoreGetter(),
 			s.logger,
 		)
 
@@ -620,6 +621,7 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 			s.config.formatFlag.Parse(),
 			csiVSLister,
 			csiVSCLister,
+			persistence.NewObjectBackupStoreGetter(),
 		)
 
 		return controllerRunInfo{
@@ -676,6 +678,7 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 			csiVSCLister,
 			s.csiSnapshotClient,
 			newPluginManager,
+			persistence.NewObjectBackupStoreGetter(),
 			s.metrics,
 			s.discoveryHelper,
 		)
@@ -713,6 +716,7 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 			s.logger,
 			s.logLevel,
 			newPluginManager,
+			persistence.NewObjectBackupStoreGetter(),
 			s.metrics,
 			s.config.formatFlag.Parse(),
 		)
@@ -747,6 +751,7 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 			s.mgr.GetClient(),
 			s.sharedInformerFactory.Velero().V1().Backups().Lister(),
 			newPluginManager,
+			persistence.NewObjectBackupStoreGetter(),
 			s.logger,
 		)
 
@@ -824,9 +829,9 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 			StorageLocation:           s.config.defaultBackupLocation,
 			ServerValidationFrequency: s.config.storeValidationFrequency,
 		},
-		NewPluginManager: newPluginManager,
-		NewBackupStore:   persistence.NewObjectBackupStore,
-		Log:              s.logger,
+		NewPluginManager:  newPluginManager,
+		BackupStoreGetter: persistence.NewObjectBackupStoreGetter(),
+		Log:               s.logger,
 	}
 	if err := bslr.SetupWithManager(s.mgr); err != nil {
 		s.logger.Fatal(err, "unable to create controller", "controller", controller.BackupStorageLocation)

--- a/pkg/controller/backup_controller_test.go
+++ b/pkg/controller/backup_controller_test.go
@@ -818,11 +818,9 @@ func TestProcessBackupCompletions(t *testing.T) {
 				metrics:                metrics.NewServerMetrics(),
 				clock:                  clock.NewFakeClock(now),
 				newPluginManager:       func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager },
-				newBackupStore: func(*velerov1api.BackupStorageLocation, persistence.ObjectStoreGetter, logrus.FieldLogger) (persistence.BackupStore, error) {
-					return backupStore, nil
-				},
-				backupper:  backupper,
-				formatFlag: formatFlag,
+				backupStoreGetter:      NewFakeSingleObjectBackupStoreGetter(backupStore),
+				backupper:              backupper,
+				formatFlag:             formatFlag,
 			}
 
 			pluginManager.On("GetBackupItemActions").Return(nil, nil)

--- a/pkg/controller/backup_deletion_controller_test.go
+++ b/pkg/controller/backup_deletion_controller_test.go
@@ -75,6 +75,7 @@ func TestBackupDeletionControllerProcessQueueItem(t *testing.T) {
 		nil, // csiSnapshotContentLister
 		nil, // csiSnapshotClient
 		nil, // new plugin manager func
+		persistence.NewObjectBackupStoreGetter(),
 		metrics.NewServerMetrics(),
 		nil, // discovery helper
 	).(*backupDeletionController)
@@ -172,15 +173,12 @@ func setupBackupDeletionControllerTest(t *testing.T, objects ...runtime.Object) 
 			nil, // csiSnapshotContentLister
 			nil, // csiSnapshotClient
 			func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager },
+			NewFakeSingleObjectBackupStoreGetter(backupStore),
 			metrics.NewServerMetrics(),
 			nil, // discovery helper
 		).(*backupDeletionController),
 
 		req: req,
-	}
-
-	data.controller.newBackupStore = func(*velerov1api.BackupStorageLocation, persistence.ObjectStoreGetter, logrus.FieldLogger) (persistence.BackupStore, error) {
-		return backupStore, nil
 	}
 
 	pluginManager.On("CleanupClients").Return(nil)
@@ -1133,6 +1131,7 @@ func TestBackupDeletionControllerDeleteExpiredRequests(t *testing.T) {
 				nil, // csiSnapshotContentLister
 				nil, // csiSnapshotClient
 				nil, // new plugin manager func
+				persistence.NewObjectBackupStoreGetter(),
 				metrics.NewServerMetrics(),
 				nil, // discovery helper,
 			).(*backupDeletionController)

--- a/pkg/controller/backup_storage_location_controller.go
+++ b/pkg/controller/backup_storage_location_controller.go
@@ -44,8 +44,8 @@ type BackupStorageLocationReconciler struct {
 	DefaultBackupLocationInfo storage.DefaultBackupLocationInfo
 	// use variables to refer to these functions so they can be
 	// replaced with fakes for testing.
-	NewPluginManager func(logrus.FieldLogger) clientmgmt.Manager
-	NewBackupStore   func(*velerov1api.BackupStorageLocation, persistence.ObjectStoreGetter, logrus.FieldLogger) (persistence.BackupStore, error)
+	NewPluginManager  func(logrus.FieldLogger) clientmgmt.Manager
+	BackupStoreGetter persistence.ObjectBackupStoreGetter
 
 	Log logrus.FieldLogger
 }
@@ -95,7 +95,7 @@ func (r *BackupStorageLocationReconciler) Reconcile(req ctrl.Request) (ctrl.Resu
 			continue
 		}
 
-		backupStore, err := r.NewBackupStore(location, pluginManager, log)
+		backupStore, err := r.BackupStoreGetter.Get(location, pluginManager, log)
 		if err != nil {
 			log.WithError(err).Error("Error getting a backup store")
 			continue

--- a/pkg/controller/backup_storage_location_controller_test.go
+++ b/pkg/controller/backup_storage_location_controller_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/vmware-tanzu/velero/internal/storage"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/builder"
-	"github.com/vmware-tanzu/velero/pkg/persistence"
 	persistencemocks "github.com/vmware-tanzu/velero/pkg/persistence/mocks"
 	"github.com/vmware-tanzu/velero/pkg/plugin/clientmgmt"
 	pluginmocks "github.com/vmware-tanzu/velero/pkg/plugin/mocks"
@@ -87,12 +86,9 @@ var _ = Describe("Backup Storage Location Reconciler", func() {
 				StorageLocation:           "location-1",
 				ServerValidationFrequency: 0,
 			},
-			NewPluginManager: func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager },
-			NewBackupStore: func(loc *velerov1api.BackupStorageLocation, _ persistence.ObjectStoreGetter, _ logrus.FieldLogger) (persistence.BackupStore, error) {
-				// this gets populated just below, prior to exercising the method under test
-				return backupStores[loc.Name], nil
-			},
-			Log: velerotest.NewLogger(),
+			NewPluginManager:  func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager },
+			BackupStoreGetter: NewFakeObjectBackupStoreGetter(backupStores),
+			Log:               velerotest.NewLogger(),
 		}
 
 		actualResult, err := r.Reconcile(ctrl.Request{
@@ -156,12 +152,9 @@ var _ = Describe("Backup Storage Location Reconciler", func() {
 				StorageLocation:           "default",
 				ServerValidationFrequency: 0,
 			},
-			NewPluginManager: func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager },
-			NewBackupStore: func(loc *velerov1api.BackupStorageLocation, _ persistence.ObjectStoreGetter, _ logrus.FieldLogger) (persistence.BackupStore, error) {
-				// this gets populated just below, prior to exercising the method under test
-				return backupStores[loc.Name], nil
-			},
-			Log: velerotest.NewLogger(),
+			NewPluginManager:  func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager },
+			BackupStoreGetter: NewFakeObjectBackupStoreGetter(backupStores),
+			Log:               velerotest.NewLogger(),
 		}
 
 		actualResult, err := r.Reconcile(ctrl.Request{
@@ -229,12 +222,9 @@ var _ = Describe("Backup Storage Location Reconciler", func() {
 				StorageLocation:           "default",
 				ServerValidationFrequency: 0,
 			},
-			NewPluginManager: func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager },
-			NewBackupStore: func(loc *velerov1api.BackupStorageLocation, _ persistence.ObjectStoreGetter, _ logrus.FieldLogger) (persistence.BackupStore, error) {
-				// this gets populated just below, prior to exercising the method under test
-				return backupStores[loc.Name], nil
-			},
-			Log: velerotest.NewLogger(),
+			NewPluginManager:  func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager },
+			BackupStoreGetter: NewFakeObjectBackupStoreGetter(backupStores),
+			Log:               velerotest.NewLogger(),
 		}
 
 		actualResult, err := r.Reconcile(ctrl.Request{

--- a/pkg/controller/download_request_controller_test.go
+++ b/pkg/controller/download_request_controller_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/builder"
 	"github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned/fake"
 	informers "github.com/vmware-tanzu/velero/pkg/generated/informers/externalversions"
-	"github.com/vmware-tanzu/velero/pkg/persistence"
 	persistencemocks "github.com/vmware-tanzu/velero/pkg/persistence/mocks"
 	"github.com/vmware-tanzu/velero/pkg/plugin/clientmgmt"
 	pluginmocks "github.com/vmware-tanzu/velero/pkg/plugin/mocks"
@@ -64,6 +63,7 @@ func newDownloadRequestTestHarness(t *testing.T, fakeClient client.Client) *down
 			fakeClient,
 			informerFactory.Velero().V1().Backups().Lister(),
 			func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager },
+			NewFakeSingleObjectBackupStoreGetter(backupStore),
 			velerotest.NewLogger(),
 		).(*downloadRequestController)
 	)
@@ -71,10 +71,6 @@ func newDownloadRequestTestHarness(t *testing.T, fakeClient client.Client) *down
 	clockTime, err := time.Parse(time.RFC1123, time.RFC1123)
 	require.NoError(t, err)
 	controller.clock = clock.NewFakeClock(clockTime)
-
-	controller.newBackupStore = func(*velerov1api.BackupStorageLocation, persistence.ObjectStoreGetter, logrus.FieldLogger) (persistence.BackupStore, error) {
-		return backupStore, nil
-	}
 
 	pluginManager.On("CleanupClients").Return()
 

--- a/pkg/controller/restore_controller_test.go
+++ b/pkg/controller/restore_controller_test.go
@@ -117,13 +117,10 @@ func TestFetchBackupInfo(t *testing.T) {
 				logger,
 				logrus.InfoLevel,
 				func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager },
+				NewFakeSingleObjectBackupStoreGetter(backupStore),
 				metrics.NewServerMetrics(),
 				formatFlag,
 			).(*restoreController)
-
-			c.newBackupStore = func(*velerov1api.BackupStorageLocation, persistence.ObjectStoreGetter, logrus.FieldLogger) (persistence.BackupStore, error) {
-				return backupStore, nil
-			}
 
 			if test.backupStoreError == nil {
 				for _, itm := range test.informerLocations {
@@ -212,6 +209,7 @@ func TestProcessQueueItemSkips(t *testing.T) {
 				logger,
 				logrus.InfoLevel,
 				nil,
+				persistence.NewObjectBackupStoreGetter(),
 				metrics.NewServerMetrics(),
 				formatFlag,
 			).(*restoreController)
@@ -438,13 +436,11 @@ func TestProcessQueueItem(t *testing.T) {
 				logger,
 				logrus.InfoLevel,
 				func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager },
+				NewFakeSingleObjectBackupStoreGetter(backupStore),
 				metrics.NewServerMetrics(),
 				formatFlag,
 			).(*restoreController)
 
-			c.newBackupStore = func(*velerov1api.BackupStorageLocation, persistence.ObjectStoreGetter, logrus.FieldLogger) (persistence.BackupStore, error) {
-				return backupStore, nil
-			}
 			c.clock = clock.NewFakeClock(now)
 			if test.location != nil {
 				require.NoError(t, fakeClient.Create(context.Background(), test.location))
@@ -670,6 +666,7 @@ func TestvalidateAndCompleteWhenScheduleNameSpecified(t *testing.T) {
 		logger,
 		logrus.DebugLevel,
 		nil,
+		persistence.NewObjectBackupStoreGetter(),
 		nil,
 		formatFlag,
 	).(*restoreController)

--- a/pkg/persistence/object_store.go
+++ b/pkg/persistence/object_store.go
@@ -90,7 +90,21 @@ type ObjectStoreGetter interface {
 	GetObjectStore(provider string) (velero.ObjectStore, error)
 }
 
-func NewObjectBackupStore(location *velerov1api.BackupStorageLocation, objectStoreGetter ObjectStoreGetter, logger logrus.FieldLogger) (BackupStore, error) {
+// ObjectBackupStoreGetter is a type that can get a velero.BackupStore for a
+// given BackupStorageLocation and ObjectStore.
+type ObjectBackupStoreGetter interface {
+	Get(location *velerov1api.BackupStorageLocation, objectStoreGetter ObjectStoreGetter, logger logrus.FieldLogger) (BackupStore, error)
+}
+
+type objectBackupStoreGetter struct{}
+
+// NewObjectBackupStoreGetter returns a ObjectBackupStoreGetter that can get a
+// default velero.BackupStore.
+func NewObjectBackupStoreGetter() ObjectBackupStoreGetter {
+	return &objectBackupStoreGetter{}
+}
+
+func (b *objectBackupStoreGetter) Get(location *velerov1api.BackupStorageLocation, objectStoreGetter ObjectStoreGetter, logger logrus.FieldLogger) (BackupStore, error) {
 	if location.Spec.ObjectStorage == nil {
 		return nil, errors.New("backup storage location does not use object storage")
 	}

--- a/pkg/persistence/object_store_test.go
+++ b/pkg/persistence/object_store_test.go
@@ -604,10 +604,10 @@ func (osg objectStoreGetter) GetObjectStore(provider string) (velero.ObjectStore
 	return res, nil
 }
 
-// TestNewObjectBackupStore runs the NewObjectBackupStore constructor and ensures
-// that an ObjectBackupStore is constructed correctly or an appropriate error is
-// returned.
-func TestNewObjectBackupStore(t *testing.T) {
+// TestNewObjectBackupStore runs the NewObjectBackupStoreGetter constructor and ensures
+// that it provides a BackupStore with a correctly constructed ObjectBackupStore or
+// that an appropriate error is returned.
+func TestNewObjectBackupStoreGetter(t *testing.T) {
 	tests := []struct {
 		name              string
 		location          *velerov1api.BackupStorageLocation
@@ -661,7 +661,8 @@ func TestNewObjectBackupStore(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			res, err := NewObjectBackupStore(tc.location, tc.objectStoreGetter, velerotest.NewLogger())
+			getter := NewObjectBackupStoreGetter()
+			res, err := getter.Get(tc.location, tc.objectStoreGetter, velerotest.NewLogger())
 			if tc.wantErr != "" {
 				require.Equal(t, tc.wantErr, err.Error())
 			} else {


### PR DESCRIPTION
In preparation for modifying the instantiation of `BackupStores` to be
able to load credentials, change the function `NewObjectBackupStore` to
be an interface that is passed in to all controllers.

Previously, the function to get a new backup store was configurable but
for many controllers was fixed to use `NewObjectBackupStore`. This
change introduces an interface for getting the backup store and wraps
the functionality from `NewObjectBackupStore` in a type which implements
this interface. This will allow more flexibility when introducing
credentials for a specific backup store as it will allow us to create a
new `ObjectBackupStoreGetter` type which can be configured to add
credentials config when creating the ObjectBackupStore without needing
to change the API used by the controllers.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>