### PR TITLE
Add Q&A discussion to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Velero Community Support
+    url: https://github.com/vmware-tanzu/velero/discussions/categories/community-support-q-a 
+    about: Please ask questions about Velero here.


### PR DESCRIPTION
This change customises the issue template chooser to include a link to
the Community Support Q&A discussion board. This lets users know that
there is another place to ask questions related to using Velero.

This change also disables the creation of blank issues to prevent issues
that don't follow either the bug or feature request templates from being
opened.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>