### PR TITLE
Download restic binary using curl

### DIFF
--- a/hack/download-restic.sh
+++ b/hack/download-restic.sh
@@ -49,9 +49,9 @@ fi
 # TODO: when the new restic version is released, make ppc64le to be also downloaded from their github releases.
 #  This has been merged and will be applied to next release: https://github.com/restic/restic/pull/2342
 if [[ "${GOARCH}" = "ppc64le" ]]; then
-    wget --timeout=1 --tries=5 --quiet https://oplab9.parqtec.unicamp.br/pub/ppc64el/restic/restic-${RESTIC_VERSION} -O ${restic_bin}
+    curl -s --retry 5 -L https://oplab9.parqtec.unicamp.br/pub/ppc64el/restic/restic-${RESTIC_VERSION} -o ${restic_bin}
 else
-    wget --quiet https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_${GOOS}_${GOARCH}.bz2
+    curl -s -L https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_${GOOS}_${GOARCH}.bz2 -O
     bunzip2 restic_${RESTIC_VERSION}_${GOOS}_${GOARCH}.bz2
     mv restic_${RESTIC_VERSION}_${GOOS}_${GOARCH} ${restic_bin}
 fi


### PR DESCRIPTION
With #3327, the restic binary for the Tilt Velero image is downloaded on
the local machine using the `./hack/download-restic.sh` script. This
script relies on `wget` being availabe on the local machine. `wget` is
not commonly available on macOS but `curl` is. This change modifies the
`./hack/download-restic.sh` script to use `curl` instead as it is
available on both Linux and macOS and is available in our `golang`
docker build image.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>