### PR TITLE
Close issues after 35 total days of inactivity.

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,24 @@
+name: "Close stale issues and PRs"
+on:
+  schedule:
+    # First of every month
+    - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: "This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days. If a Velero team member has requested log or more information, please provide the output of the shared commands."
+          close-issue-message: "This issue was closed because it has been stalled for 5 days with no activity."
+          days-before-issue-stale: 30
+          days-before-issue-close: 5
+          # Disable stale PRs for now; they can remain open.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          # Only issues made after Feb 09 2021.
+          start-date: "2021-09-02T00:00:00"
+          # Only make issues stale if they have these labels. Comma separated.
+          only-labels: "Needs info,Duplicate"


### PR DESCRIPTION
Enables the [stale action](https://github.com/actions/stale) on duplicate and issues that need info, but have none.

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>