### PR TITLE
Unify labels across GitHub Actions

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -2,17 +2,18 @@ area:
   - "Cloud/AWS"
   - "Cloud/GCP"
   - "Cloud/Azure"
+  - "Design"
   - "Plugins"
 
 # Labels that can be applied to PRs with the /kind command
 kind:
   - "changelog-not-required"
-  - "Tech debt"
+  - "tech-debt"
 
 # Works with https://github.com/actions/labeler/
 # Below this line, the keys are labels to be applied, and the values are the file globs to match against.
 # Anything in the `design` directory gets the `Design` label.
-Design:
+Area/Design:
   - design/*
 
 # Anything in the site directory gets the website label *EXCEPT* docs
@@ -27,7 +28,7 @@ Dependencies:
 
 # Anything that has plugin infra will be labeled.
 # Individual plugins don't necessarily live here, though
-Plugins:
+Area/Plugins:
   - "pkg/plugins/**/*"
 
 has-unit-tests:

--- a/.github/workflows/pr-changelog-check.yml
+++ b/.github/workflows/pr-changelog-check.yml
@@ -11,5 +11,5 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Changelog check
-      if: ${{ !(contains(github.event.pull_request.labels.*.name, 'changelog-not-required') || contains(github.event.pull_request.labels.*.name, 'Design') || contains(github.event.pull_request.labels.*.name, 'Website') || contains(github.event.pull_request.labels.*.name, 'Documentation'))}}
+      if: ${{ !(contains(github.event.pull_request.labels.*.name, 'kind/changelog-not-required') || contains(github.event.pull_request.labels.*.name, 'Design') || contains(github.event.pull_request.labels.*.name, 'Website') || contains(github.event.pull_request.labels.*.name, 'Documentation'))}}
       run: ./hack/changelog-check.sh


### PR DESCRIPTION
The prow-action plugin will pre-pend `area` or `kind` to labels, so
unify them into a common format.

/kind changelog-not-required

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>