### PR TITLE
Enable Prow commands when opening or readying PRs

### DIFF
--- a/.github/workflows/prow-action.yml
+++ b/.github/workflows/prow-action.yml
@@ -4,6 +4,10 @@ name: "Prow github actions"
 on:
   issue_comment:
     types: [created]
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
 
 jobs:
   execute:


### PR DESCRIPTION
Originally this only triggered on issue comments, but it should also work on the PR opening/ready for review events.
 
Signed-off-by: Nolan Brubaker <brubakern@vmware.com>