### PR TITLE
Use correct suffix for Labeler config file

### DIFF
--- a/.github/workflows/auto_assign_prs.yml
+++ b/.github/workflows/auto_assign_prs.yml
@@ -21,4 +21,4 @@ jobs:
       - uses: actions/labeler@v3
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          configuration-path: .github/labels.yaml
+          configuration-path: .github/labels.yml


### PR DESCRIPTION
The labeler action was failing as it was looking for
`.github/labels.yaml` but the file has the suffix `.yml`. This change
fixes the path used by the labeler action.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>