### PR TITLE
Remove pull request processing from prow action

### DIFF
--- a/.github/workflows/prow-action.yml
+++ b/.github/workflows/prow-action.yml
@@ -4,10 +4,6 @@ name: "Prow github actions"
 on:
   issue_comment:
     types: [created]
-  pull_request:
-    types:
-      - opened
-      - ready_for_review
 
 jobs:
   execute:


### PR DESCRIPTION
The prow action does not support running commands except for /lgtm in
PRs.

See [the PR handling code](https://github.com/jpmcb/prow-github-actions/blob/aa22d2e104410810ee1d8a7f0fb7421ae3663626/src/pullReq/handlePullReq.ts#L22-L32)