### PR TITLE
Use label to select Velero deployment in plugin cmd

### DIFF
--- a/changelogs/unreleased/3447-codegold79
+++ b/changelogs/unreleased/3447-codegold79
@@ -1,0 +1,1 @@
+Use label to select Velero deployment in plugin cmd

--- a/pkg/cmd/cli/plugin/add.go
+++ b/pkg/cmd/cli/plugin/add.go
@@ -37,8 +37,8 @@ import (
 
 const (
 	pluginsVolumeName = "plugins"
-	veleroDeployment  = "velero"
 	veleroContainer   = "velero"
+	veleroLabel = "component=velero"
 )
 
 func NewAddCommand(f client.Factory) *cobra.Command {
@@ -57,7 +57,7 @@ func NewAddCommand(f client.Factory) *cobra.Command {
 				cmd.CheckError(err)
 			}
 
-			veleroDeploy, err := kubeClient.AppsV1().Deployments(f.Namespace()).Get(context.TODO(), veleroDeployment, metav1.GetOptions{})
+			veleroDeploy, err := veleroDeployment(context.TODO(), kubeClient, f.Namespace())
 			if err != nil {
 				cmd.CheckError(err)
 			}

--- a/pkg/cmd/cli/plugin/add.go
+++ b/pkg/cmd/cli/plugin/add.go
@@ -38,7 +38,6 @@ import (
 const (
 	pluginsVolumeName = "plugins"
 	veleroContainer   = "velero"
-	veleroLabel = "component=velero"
 )
 
 func NewAddCommand(f client.Factory) *cobra.Command {

--- a/pkg/cmd/cli/plugin/helpers.go
+++ b/pkg/cmd/cli/plugin/helpers.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+const veleroLabel = "component=velero"
+
 // veleroDeployment returns a Velero deployment object, selected using a label.
 func veleroDeployment(ctx context.Context, kubeClient kubernetes.Interface, namespace string) (*appsv1api.Deployment, error) {
 	deployList, err := kubeClient.

--- a/pkg/cmd/cli/plugin/helpers.go
+++ b/pkg/cmd/cli/plugin/helpers.go
@@ -22,18 +22,21 @@ import (
 	"github.com/pkg/errors"
 	appsv1api "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
-)
 
-const veleroLabel = "component=velero"
+	"github.com/vmware-tanzu/velero/pkg/install"
+)
 
 // veleroDeployment returns a Velero deployment object, selected using a label.
 func veleroDeployment(ctx context.Context, kubeClient kubernetes.Interface, namespace string) (*appsv1api.Deployment, error) {
+	veleroLabels := labels.FormatLabels(install.Labels())
+
 	deployList, err := kubeClient.
 		AppsV1().
 		Deployments(namespace).
 		List(ctx, metav1.ListOptions{
-			LabelSelector: veleroLabel,
+			LabelSelector: veleroLabels,
 		})
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/cli/plugin/helpers.go
+++ b/pkg/cmd/cli/plugin/helpers.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2017 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	appsv1api "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// veleroDeployment returns a Velero deployment object, selected using a label.
+func veleroDeployment(ctx context.Context, kubeClient kubernetes.Interface, namespace string) (*appsv1api.Deployment, error) {
+	deployList, err := kubeClient.
+		AppsV1().
+		Deployments(namespace).
+		List(ctx, metav1.ListOptions{
+			LabelSelector: veleroLabel,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(deployList.Items) < 1 {
+		return nil, errors.New("Velero deployment not found")
+	}
+
+	return &deployList.Items[0], nil
+}

--- a/pkg/cmd/cli/plugin/helpers.go
+++ b/pkg/cmd/cli/plugin/helpers.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 the Velero contributors.
+Copyright The Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/cmd/cli/plugin/remove.go
+++ b/pkg/cmd/cli/plugin/remove.go
@@ -41,7 +41,7 @@ func NewRemoveCommand(f client.Factory) *cobra.Command {
 				cmd.CheckError(err)
 			}
 
-			veleroDeploy, err := kubeClient.AppsV1().Deployments(f.Namespace()).Get(context.TODO(), veleroDeployment, metav1.GetOptions{})
+			veleroDeploy, err := veleroDeployment(context.TODO(), kubeClient, f.Namespace())
 			if err != nil {
 				cmd.CheckError(err)
 			}

--- a/pkg/install/deployment.go
+++ b/pkg/install/deployment.go
@@ -140,7 +140,7 @@ func Deployment(namespace string, opts ...podTemplateOption) *appsv1.Deployment 
 		args = append(args, "--default-volumes-to-restic=true")
 	}
 
-	containerLabels := labels()
+	containerLabels := Labels()
 	containerLabels["deploy"] = "velero"
 
 	deployment := &appsv1.Deployment{

--- a/pkg/install/resources.go
+++ b/pkg/install/resources.go
@@ -54,7 +54,7 @@ var (
 	DefaultVeleroNamespace     = "velero"
 )
 
-func labels() map[string]string {
+func Labels() map[string]string {
 	return map[string]string{
 		"component": "velero",
 	}
@@ -89,7 +89,7 @@ func objectMeta(namespace, name string) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
 		Name:      name,
 		Namespace: namespace,
-		Labels:    labels(),
+		Labels:    Labels(),
 	}
 }
 
@@ -236,7 +236,7 @@ func AllCRDs() *unstructured.UnstructuredList {
 	resources.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "List"})
 
 	for _, crd := range crds.CRDs {
-		crd.SetLabels(labels())
+		crd.SetLabels(Labels())
 		appendUnstructured(resources, crd)
 	}
 


### PR DESCRIPTION
Closes #3088.

Modfied pkg/cmd/cli/plugin package files add.go and get.go. Instead of finding a Velero deployment using the name, "velero", used a label, "component=velero".

The Velero Helm chart will be modified to include the "component=velero" label. See [vmware-tanzu/helm-chart PR215](https://github.com/vmware-tanzu/helm-charts/pull/215).

Signed-off-by: F. Gold <fgold@vmware.com>