### PR TITLE
Optimize build image container

### DIFF
--- a/hack/build-image/Dockerfile
+++ b/hack/build-image/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2018, 2019, 2020 the Velero contributors.
+# Copyright 2018, 2019, 2020, 2021 the Velero contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15
+FROM bitnami/golang:1.15
 
 ARG GOPROXY
 
@@ -20,11 +20,30 @@ ENV GO111MODULE=on
 # Use a proxy for go modules to reduce the likelihood of various hosts being down and breaking the build
 ENV GOPROXY=${GOPROXY}
 
+# Perform base actions first for things that will not change often so we don't
+# need to create new image layers as often.
+RUN apt-get update && apt-get install -y \
+  unzip \
+  curl \
+  git \
+  bash \
+  && rm -rf /var/lib/apt/lists/*
+
+# get golangci-lint
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
+
+# get goimports (the revision is pinned so we don't indiscriminately update, but the particular commit
+# is not important)
+RUN go get golang.org/x/tools/cmd/goimports@11e9d9cc0042e6bd10337d4d2c3e5d9295508e7d
+
+# get controller-tools
+RUN go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0
+
 # get code-generation tools (for now keep in GOPATH since they're not fully modules-compatible yet)
-RUN mkdir -p /go/src/k8s.io
-WORKDIR /go/src/k8s.io
-RUN git config --global advice.detachedHead false
-RUN git clone -b v0.18.4 https://github.com/kubernetes/code-generator
+WORKDIR /root
+RUN mkdir -p /go/src/k8s.io && \
+    git config --global advice.detachedHead false && \
+    git clone --depth 1 -b v0.18.4 https://github.com/kubernetes/code-generator /go/src/k8s.io/code-generator
 
 RUN wget --quiet https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_linux_amd64.tar.gz && \
     tar -zxvf kubebuilder_2.3.1_linux_amd64.tar.gz && \
@@ -33,32 +52,22 @@ RUN wget --quiet https://github.com/kubernetes-sigs/kubebuilder/releases/downloa
     export PATH=$PATH:/usr/local/kubebuilder/bin && \
     rm kubebuilder_2.3.1_linux_amd64.tar.gz
 
-# get controller-tools
-RUN go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0
-
-# get goimports (the revision is pinned so we don't indiscriminately update, but the particular commit
-# is not important)
-RUN go get golang.org/x/tools/cmd/goimports@11e9d9cc0042e6bd10337d4d2c3e5d9295508e7d
-
 # get protoc compiler and golang plugin
-WORKDIR /root
-RUN apt-get update && apt-get install -y unzip
 RUN wget --quiet https://github.com/protocolbuffers/protobuf/releases/download/v3.9.1/protoc-3.9.1-linux-x86_64.zip && \
     unzip protoc-3.9.1-linux-x86_64.zip && \
     mv bin/protoc /usr/bin/protoc && \
-    chmod +x /usr/bin/protoc
-RUN go get github.com/golang/protobuf/protoc-gen-go@v1.0.0
+    chmod +x /usr/bin/protoc && \
+    rm protoc-3.9.1-linux-x86_64.zip && \
+    go get github.com/golang/protobuf/protoc-gen-go@v1.0.0
 
 # get goreleaser
 RUN wget --quiet https://github.com/goreleaser/goreleaser/releases/download/v0.120.8/goreleaser_Linux_x86_64.tar.gz && \
     tar xvf goreleaser_Linux_x86_64.tar.gz && \
     mv goreleaser /usr/bin/goreleaser && \
-    chmod +x /usr/bin/goreleaser
-
-# get golangci-lint
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
+    chmod +x /usr/bin/goreleaser && \
+    rm goreleaser_Linux_x86_64.tar.gz
 
 # install kubectl
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
-RUN chmod +x ./kubectl
-RUN mv ./kubectl /usr/local/bin
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/local/bin

--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -30,7 +30,7 @@ fi
 
 # Enable GL_DEBUG line below for debug messages for golangci-lint
 # export GL_DEBUG=loader,gocritic,env
-CMD="golangci-lint run -E ${LINTERS} $action -c  $HACK_DIR/../golangci.yaml"
+CMD="CGO_ENABLED=0 golangci-lint run -v -E ${LINTERS} $action -c  $HACK_DIR/../golangci.yaml"
 echo "Running $CMD"
 
 eval $CMD


### PR DESCRIPTION
# Please add a summary of your change

This changes the build-image Dockerfile to optimize image size and
operations that are performed for each layer. It brings the current
image size down from ~1.52GB to ~1.28GB.

Optimizations include:
* Switch to bitnami/golang:1.15 base image
* Reorder to steps to move the less likely to change layers lower
* Combine RUN lines that are part of the same task into one to reduce
  layers

# Does your change fix a particular issue?

No tracking issue filed, but happy to add one if folks feel it is needed.

I noticed the build-image container created when doing something as
simple as `make lint` was quite large and took awhile. This was my
attempt to optimize things.

/kind changelog-not-required

# Please indicate you've done the following:

[X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
[X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
[-] Updated the corresponding documentation in `site/content/docs/main`.