### PR TITLE
Add namespace parameter in restic's code

### DIFF
--- a/changelogs/unreleased/3476-sfelix-orange
+++ b/changelogs/unreleased/3476-sfelix-orange
@@ -1,0 +1,1 @@
+Add namespace parameter in Restic's code

--- a/pkg/cmd/cli/restic/server.go
+++ b/pkg/cmd/cli/restic/server.go
@@ -126,7 +126,7 @@ func newResticServer(logger logrus.FieldLogger, factory client.Factory, metricAd
 	// filter to only pods scheduled on this node.
 	podInformer := corev1informers.NewFilteredPodInformer(
 		kubeClient,
-		metav1.NamespaceAll,
+		os.Getenv("NAMESPACE_NAME"),
 		0,
 		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 		func(opts *metav1.ListOptions) {
@@ -250,7 +250,7 @@ func (s *resticServer) validatePodVolumesHostPath() error {
 		}
 	}
 
-	pods, err := s.kubeClient.CoreV1().Pods("").List(s.ctx, metav1.ListOptions{FieldSelector: fmt.Sprintf("spec.nodeName=%s,status.phase=Running", os.Getenv("NODE_NAME"))})
+	pods, err := s.kubeClient.CoreV1().Pods(os.Getenv("NAMESPACE_NAME")).List(s.ctx, metav1.ListOptions{FieldSelector: fmt.Sprintf("spec.nodeName=%s,status.phase=Running", os.Getenv("NODE_NAME"))})
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/site/content/docs/main/namespace.md
+++ b/site/content/docs/main/namespace.md
@@ -19,4 +19,8 @@ velero client config set namespace=<NAMESPACE_VALUE>
 
 Alternatively, you may use the global `--namespace` flag with any operational command to tell Velero where to run.
 
+## Customize the targeted namespace
+
+In the YAML deployment file using Velero's image, define the environment variable NAMESPACE_NAME to specify the namespace in which you want Velero to backup resources.
+
 [0]: basic-install.md#install-the-cli


### PR DESCRIPTION
This intends to be able to target specific namespaces when
having non-admin privileges.

When running velero as a non-admin user, listing pods from
other namespace is forbidden. The use of an environment variable in
the YAML deployment file allows to target a specific namespace in which
we want to list pods.

Thank you for contributing to Velero!

[ X ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
[ X ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
[ X ] Updated the corresponding documentation in `site/content/docs/main`.