### PR TITLE
Add option to bypass calls to pvLister

### DIFF
--- a/changelogs/unreleased/3477-sfelix-orange
+++ b/changelogs/unreleased/3477-sfelix-orange
@@ -1,0 +1,1 @@
+Add option to bypass calls to pvLister

--- a/pkg/util/kube/utils.go
+++ b/pkg/util/kube/utils.go
@@ -19,6 +19,7 @@ package kube
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/pkg/errors"
@@ -124,6 +125,10 @@ func GetVolumeDirectory(pod *corev1api.Pod, volumeName string, pvcLister corev1l
 	pvc, err := pvcLister.PersistentVolumeClaims(pod.Namespace).Get(volume.VolumeSource.PersistentVolumeClaim.ClaimName)
 	if err != nil {
 		return "", errors.WithStack(err)
+	}
+
+	if os.Getenv("ONLY_CSI") == "True" {
+		return pvc.Spec.VolumeName + "/mount", nil
 	}
 
 	pv, err := pvLister.Get(pvc.Spec.VolumeName)

--- a/site/content/docs/main/csi.md
+++ b/site/content/docs/main/csi.md
@@ -72,6 +72,10 @@ When the Velero backup expires, the VolumeSnapshot objects will be deleted and t
 
 For more details on how each plugin works, see the [CSI plugin repo][2]'s documentation.
 
+## Bypass the volumes type check when using only CSI volumes in a multi-tenant environment
+
+In a multi-tenant environment, the use of class pvLister can cause some permission issues. If using only CSI volumes, defining the environment variable ONLY_CSI=True in the docker-compose.yml file using Velero's image will allow to bypass the call to pvLister.
+
 [1]: customize-installation.md#enable-server-side-features
 [2]: https://github.com/vmware-tanzu/velero-plugin-for-csi/
 [3]: https://hub.docker.com/repository/docker/velero/velero-plugin-for-csi


### PR DESCRIPTION
This intends to bypass calls to pvLister in function
GetVolumeDirectory when we know all volumes are CSI.

If running velero as a non-admin user on a cluster, the call
to pvLister can cause errors for namespaces which are not
assigned to the user. If all volumes are CSI, there is no
need to use pvLister The use of an environment variable in 
the docker-compose.yml allows to bypass the call to pvLister.

Thank you for contributing to Velero!

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [x] Updated the corresponding documentation in `site/content/docs/main`.