### PR TITLE
Update docs to include schedule backup example

### DIFF
--- a/site/content/docs/main/backup-reference.md
+++ b/site/content/docs/main/backup-reference.md
@@ -19,26 +19,44 @@ To backup resources of specific Kind in a specific order, use option --ordered-r
 velero backup create backupName --include-cluster-resources=true --ordered-resources 'pods=ns1/pod1,ns1/pod2;persistentvolumes=pv4,pv8' --include-namespaces=ns1
 velero backup create backupName --ordered-resources 'statefulsets=ns1/sts1,ns1/sts0' --include-namespaces=ns1
 ```
-## Set Scheduled Backups
+## Schedule a Backup
 
-The **schedule** operation allows you to back up your data at recurring intervals. These intervals are specified by a Cron expression.
-
-```
-velero schedule create NAME --schedule [flags]
-```
-
-For example, to create a backup that runs every day at 3 am run
+The **schedule** operation allows you to create a backup of your data at a specified time, defined by a [Cron expression](https://en.wikipedia.org/wiki/Cron).
 
 ```
-velero create schedule schedule-name --schedule="0 0 3 * * *"
+velero schedule create NAME --schedule="* * * * *" [flags]
 ```
 
-This command will create the backup within Velero, but it will not trigger until the next time it's specified interval, 3am. Scheduled backups are saved with the name `<SCHEDULE NAME>-<TIMESTAMP>`, where `<TIMESTAMP>` is formatted as *YYYYMMDDhhmmss*.
-
-Once you create the backup, you can then trigger it whenever you want by running
+Cron schedules use the following format.
 
 ```
-velero backup create --from-schedule schedule-name
+# ┌───────────── minute (0 - 59)
+# │ ┌───────────── hour (0 - 23)
+# │ │ ┌───────────── day of the month (1 - 31)
+# │ │ │ ┌───────────── month (1 - 12)
+# │ │ │ │ ┌───────────── day of the week (0 - 6) (Sunday to Saturday;
+# │ │ │ │ │                                   7 is also Sunday on some systems)
+# │ │ │ │ │
+# │ │ │ │ │
+# * * * * *
 ```
 
-This command will immediately trigger a new backup based on your template for `schedule-name`. This will not affect the backup schedule, and another backup will trigger at the scheduled time.
+For example, the command below creates a backup that runs every day at 3am.
+
+```
+velero schedule create example-schedule --schedule="0 3 * * *"
+```
+
+This command will create the backup, `example-schedule`, within Velero, but the backup will not be taken until the next scheduled time, 3am. Backups created by a schedule are saved with the name `<SCHEDULE NAME>-<TIMESTAMP>`, where `<TIMESTAMP>` is formatted as *YYYYMMDDhhmmss*. For a full list of available configuration flags use the Velero CLI help command.
+
+```
+velero schedule create --help
+```
+
+Once you create the scheduled backup, you can then trigger it manually using the `velero backup` command.
+
+```
+velero backup create --from-schedule example-schedule
+```
+
+This command will immediately trigger a new backup based on your template for `example-schedule`. This will not affect the backup schedule, and another backup will trigger at the scheduled time.

--- a/site/content/docs/main/backup-reference.md
+++ b/site/content/docs/main/backup-reference.md
@@ -19,3 +19,26 @@ To backup resources of specific Kind in a specific order, use option --ordered-r
 velero backup create backupName --include-cluster-resources=true --ordered-resources 'pods=ns1/pod1,ns1/pod2;persistentvolumes=pv4,pv8' --include-namespaces=ns1
 velero backup create backupName --ordered-resources 'statefulsets=ns1/sts1,ns1/sts0' --include-namespaces=ns1
 ```
+## Set Scheduled Backups
+
+The **schedule** operation allows you to back up your data at recurring intervals. These intervals are specified by a Cron expression.
+
+```
+velero schedule create NAME --schedule [flags]
+```
+
+For example, to create a backup that runs every day at 3 am run
+
+```
+velero create schedule backupName --schedule="0 0 3 ? * *"
+```
+
+This command will create the backup within Velero, but it will not trigger until the next time it's specified interval, 3am. Scheduled backups are saved with the name `<SCHEDULE NAME>-<TIMESTAMP>`, where `<TIMESTAMP>` is formatted as *YYYYMMDDhhmmss*.
+
+Once you create the backup, you can then trigger it whenever you want by running
+
+```
+velero backup create --from-schedule backupName
+```
+
+This command will immediately trigger a new backup based on your template for `backupName`. This will not affect the backup schedule, and another backup will trigger at the scheduled time.

--- a/site/content/docs/main/backup-reference.md
+++ b/site/content/docs/main/backup-reference.md
@@ -30,7 +30,7 @@ velero schedule create NAME --schedule [flags]
 For example, to create a backup that runs every day at 3 am run
 
 ```
-velero create schedule backupName --schedule="0 0 3 ? * *"
+velero create schedule schedule-name --schedule="0 0 3 * * *"
 ```
 
 This command will create the backup within Velero, but it will not trigger until the next time it's specified interval, 3am. Scheduled backups are saved with the name `<SCHEDULE NAME>-<TIMESTAMP>`, where `<TIMESTAMP>` is formatted as *YYYYMMDDhhmmss*.
@@ -38,7 +38,7 @@ This command will create the backup within Velero, but it will not trigger until
 Once you create the backup, you can then trigger it whenever you want by running
 
 ```
-velero backup create --from-schedule backupName
+velero backup create --from-schedule schedule-name
 ```
 
-This command will immediately trigger a new backup based on your template for `backupName`. This will not affect the backup schedule, and another backup will trigger at the scheduled time.
+This command will immediately trigger a new backup based on your template for `schedule-name`. This will not affect the backup schedule, and another backup will trigger at the scheduled time.

--- a/site/content/docs/main/how-velero-works.md
+++ b/site/content/docs/main/how-velero-works.md
@@ -26,7 +26,7 @@ Note that cluster backups are not strictly atomic. If Kubernetes objects are bei
 
 The **schedule** operation allows you to back up your data at recurring intervals. You can create a scheduled backup at any time, and the first backup is then performed at the schedule's specified interval. These intervals are specified by a Cron expression.
 
-Velero saves backups created from a schedule with the name `<SCHEDULE NAME>-<TIMESTAMP>`, where `<TIMESTAMP>` is formatted as *YYYYMMDDhhmmss*. For more information see the [Backup Reference documentation](backup-reference.mdd).
+Velero saves backups created from a schedule with the name `<SCHEDULE NAME>-<TIMESTAMP>`, where `<TIMESTAMP>` is formatted as *YYYYMMDDhhmmss*. For more information see the [Backup Reference documentation](backup-reference.md).
 
 ## Restores
 

--- a/site/content/docs/main/how-velero-works.md
+++ b/site/content/docs/main/how-velero-works.md
@@ -24,7 +24,7 @@ Note that cluster backups are not strictly atomic. If Kubernetes objects are bei
 
 ## Scheduled backups
 
-The **schedule** operation allows you to back up your data at recurring intervals. The first backup is performed when the schedule is first created, and subsequent backups happen at the schedule's specified interval. These intervals are specified by a Cron expression.
+The **schedule** operation allows you to back up your data at recurring intervals. You can create a scheduled backup at any time, and the first backup is then performed at schedule's specified interval. These intervals are specified by a Cron expression.
 
 Scheduled backups are saved with the name `<SCHEDULE NAME>-<TIMESTAMP>`, where `<TIMESTAMP>` is formatted as *YYYYMMDDhhmmss*.
 

--- a/site/content/docs/main/how-velero-works.md
+++ b/site/content/docs/main/how-velero-works.md
@@ -24,9 +24,9 @@ Note that cluster backups are not strictly atomic. If Kubernetes objects are bei
 
 ## Scheduled backups
 
-The **schedule** operation allows you to back up your data at recurring intervals. You can create a scheduled backup at any time, and the first backup is then performed at schedule's specified interval. These intervals are specified by a Cron expression.
+The **schedule** operation allows you to back up your data at recurring intervals. You can create a scheduled backup at any time, and the first backup is then performed at the schedule's specified interval. These intervals are specified by a Cron expression.
 
-Scheduled backups are saved with the name `<SCHEDULE NAME>-<TIMESTAMP>`, where `<TIMESTAMP>` is formatted as *YYYYMMDDhhmmss*.
+Velero saves backups created from a schedule with the name `<SCHEDULE NAME>-<TIMESTAMP>`, where `<TIMESTAMP>` is formatted as *YYYYMMDDhhmmss*. For more information see the [Backup Reference documentation](backup-reference.mdd).
 
 ## Restores
 


### PR DESCRIPTION
Signed-off-by: Abigail McCarthy <mabigail@vmware.com>

This updates the docs to include an example of scheduled backups and more info on how schedule back ups are triggered. 

Fixes #2164

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [x] Updated the corresponding documentation in `site/content/docs/main`.