### PR TITLE
Use Credential from BSL for restic commands 

### DIFF
--- a/changelogs/unreleased/3489-zubron
+++ b/changelogs/unreleased/3489-zubron
@@ -1,0 +1,1 @@
+Add support for restic to use per-BSL credentials. Velero will now serialize the secret referenced by the `Credential` field in the BSL and use this path when setting provider specific environment variables for restic commands. 

--- a/pkg/restic/aws_test.go
+++ b/pkg/restic/aws_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetS3ResticEnvVars(t *testing.T) {
+	testCases := []struct {
+		name     string
+		config   map[string]string
+		expected map[string]string
+	}{
+		{
+			name:     "when config is empty, no env vars are returned",
+			config:   map[string]string{},
+			expected: map[string]string{},
+		},
+		{
+			name: "when config contains profile key, profile env var is set with profile value",
+			config: map[string]string{
+				"profile": "profile-value",
+			},
+			expected: map[string]string{
+				"AWS_PROFILE": "profile-value",
+			},
+		},
+		{
+			name: "when config contains credentials file key, credentials file env var is set with credentials file value",
+			config: map[string]string{
+				"credentialsFile": "/tmp/credentials/path/to/secret",
+			},
+			expected: map[string]string{
+				"AWS_SHARED_CREDENTIALS_FILE": "/tmp/credentials/path/to/secret",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := getS3ResticEnvVars(tc.config)
+
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/pkg/restic/azure_test.go
+++ b/pkg/restic/azure_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restic
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// setAzureEnvironment sets the Azure credentials environment variable to the
+// given value and returns a function to restore it to its previous value
+func setAzureEnvironment(t *testing.T, value string) func() {
+	envVar := "AZURE_CREDENTIALS_FILE"
+	var cleanup func()
+
+	if original, exists := os.LookupEnv(envVar); exists {
+		cleanup = func() {
+			require.NoError(t, os.Setenv(envVar, original), "failed to reset %s environment variable", envVar)
+		}
+	} else {
+		cleanup = func() {
+			require.NoError(t, os.Unsetenv(envVar), "failed to reset %s environment variable", envVar)
+		}
+	}
+
+	require.NoError(t, os.Setenv(envVar, value), "failed to set %s environment variable", envVar)
+
+	return cleanup
+}
+
+func TestSelectCredentialsFile(t *testing.T) {
+	testCases := []struct {
+		name        string
+		config      map[string]string
+		environment string
+		expected    string
+	}{
+		{
+			name:     "when config is empty and environment variable is not set, no file is selected",
+			expected: "",
+		},
+		{
+			name: "when config contains credentials file and environment variable is not set, file from config is selected",
+			config: map[string]string{
+				"credentialsFile": "/tmp/credentials/path/to/secret",
+			},
+			expected: "/tmp/credentials/path/to/secret",
+		},
+		{
+			name:        "when config is empty and environment variable is set, file from environment is selected",
+			environment: "/credentials/file/from/env",
+			expected:    "/credentials/file/from/env",
+		},
+		{
+			name: "when config contains credentials file and environment variable is set, file from config is selected",
+			config: map[string]string{
+				"credentialsFile": "/tmp/credentials/path/to/secret",
+			},
+			environment: "/credentials/file/from/env",
+			expected:    "/tmp/credentials/path/to/secret",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cleanup := setAzureEnvironment(t, tc.environment)
+			defer cleanup()
+
+			selectedFile := selectCredentialsFile(tc.config)
+			require.Equal(t, tc.expected, selectedFile)
+		})
+	}
+}

--- a/pkg/restic/config.go
+++ b/pkg/restic/config.go
@@ -55,16 +55,13 @@ func getRepoPrefix(location *velerov1api.BackupStorageLocation) (string, error) 
 		prefix = layout.GetResticDir()
 	}
 
-	var provider = location.Spec.Provider
-	if !strings.Contains(provider, "/") {
-		provider = "velero.io/" + provider
-	}
+	backendType := getBackendType(location.Spec.Provider)
 
 	if repoPrefix := location.Spec.Config["resticRepoPrefix"]; repoPrefix != "" {
 		return repoPrefix, nil
 	}
 
-	switch BackendType(provider) {
+	switch backendType {
 	case AWSBackend:
 		var url string
 		switch {
@@ -89,6 +86,14 @@ func getRepoPrefix(location *velerov1api.BackupStorageLocation) (string, error) 
 	}
 
 	return "", errors.New("restic repository prefix (resticRepoPrefix) not specified in backup storage location's config")
+}
+
+func getBackendType(provider string) BackendType {
+	if !strings.Contains(provider, "/") {
+		provider = "velero.io/" + provider
+	}
+
+	return BackendType(provider)
 }
 
 // GetRepoIdentifier returns the string to be used as the value of the --repo flag in

--- a/pkg/restic/exec_commands.go
+++ b/pkg/restic/exec_commands.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 the Velero contributors.
+Copyright the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -47,14 +47,8 @@ type backupStatusLine struct {
 // GetSnapshotID runs a 'restic snapshots' command to get the ID of the snapshot
 // in the specified repo matching the set of provided tags, or an error if a
 // unique snapshot cannot be identified.
-func GetSnapshotID(repoIdentifier, passwordFile string, tags map[string]string, env []string, caCertFile string) (string, error) {
-	cmd := GetSnapshotCommand(repoIdentifier, passwordFile, tags)
-	if len(env) > 0 {
-		cmd.Env = env
-	}
-	cmd.CACertFile = caCertFile
-
-	stdout, stderr, err := exec.RunCommand(cmd.Cmd())
+func GetSnapshotID(snapshotIdCmd *Command) (string, error) {
+	stdout, stderr, err := exec.RunCommand(snapshotIdCmd.Cmd())
 	if err != nil {
 		return "", errors.Wrapf(err, "error running command, stderr=%s", stderr)
 	}

--- a/pkg/restic/exec_commands.go
+++ b/pkg/restic/exec_commands.go
@@ -44,9 +44,8 @@ type backupStatusLine struct {
 	TotalBytesProcessed int64 `json:"total_bytes_processed"`
 }
 
-// GetSnapshotID runs a 'restic snapshots' command to get the ID of the snapshot
-// in the specified repo matching the set of provided tags, or an error if a
-// unique snapshot cannot be identified.
+// GetSnapshotID runs provided 'restic snapshots' command to get the ID of a snapshot
+// and an error if a unique snapshot cannot be identified.
 func GetSnapshotID(snapshotIdCmd *Command) (string, error) {
 	stdout, stderr, err := exec.RunCommand(snapshotIdCmd.Cmd())
 	if err != nil {

--- a/pkg/restic/gcp.go
+++ b/pkg/restic/gcp.go
@@ -17,24 +17,17 @@ limitations under the License.
 package restic
 
 const (
-	// AWS specific environment variable
-	awsProfileEnvVar         = "AWS_PROFILE"
-	awsProfileKey            = "profile"
-	awsCredentialsFileEnvVar = "AWS_SHARED_CREDENTIALS_FILE"
+	// GCP specific environment variable
+	gcpCredentialsFileEnvVar = "GOOGLE_APPLICATION_CREDENTIALS"
 )
 
-// getS3ResticEnvVars gets the environment variables that restic
-// relies on (AWS_PROFILE) based on info in the provided object
-// storage location config map.
-func getS3ResticEnvVars(config map[string]string) (map[string]string, error) {
+// getGCPResticEnvVars gets the environment variables that restic relies
+// on based on info in the provided object storage location config map.
+func getGCPResticEnvVars(config map[string]string) (map[string]string, error) {
 	result := make(map[string]string)
 
 	if credentialsFile, ok := config[credentialsFileKey]; ok {
-		result[awsCredentialsFileEnvVar] = credentialsFile
-	}
-
-	if profile, ok := config[awsProfileKey]; ok {
-		result[awsProfileEnvVar] = profile
+		result[gcpCredentialsFileEnvVar] = credentialsFile
 	}
 
 	return result, nil

--- a/pkg/restic/gcp_test.go
+++ b/pkg/restic/gcp_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetGCPResticEnvVars(t *testing.T) {
+	testCases := []struct {
+		name     string
+		config   map[string]string
+		expected map[string]string
+	}{
+		{
+			name:     "when config is empty, no env vars are returned",
+			config:   map[string]string{},
+			expected: map[string]string{},
+		},
+		{
+			name: "when config contains credentials file key, credentials file env var is set with credentials file value",
+			config: map[string]string{
+				"credentialsFile": "/tmp/credentials/path/to/secret",
+			},
+			expected: map[string]string{
+				"GOOGLE_APPLICATION_CREDENTIALS": "/tmp/credentials/path/to/secret",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := getGCPResticEnvVars(tc.config)
+
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/pkg/restic/repository_keys_test.go
+++ b/pkg/restic/repository_keys_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepoKeySelector(t *testing.T) {
+	selector := RepoKeySelector()
+
+	require.Equal(t, credentialsSecretName, selector.Name)
+	require.Equal(t, credentialsKey, selector.Key)
+}

--- a/site/content/docs/main/api-types/backupstoragelocation.md
+++ b/site/content/docs/main/api-types/backupstoragelocation.md
@@ -22,6 +22,9 @@ spec:
   provider: aws
   objectStorage:
     bucket: myBucket
+  credential:
+    name: secret-name
+    key: key-in-secret
   config:
     region: us-west-2
     profile: "default"
@@ -45,4 +48,7 @@ The configurable parameters are as follows:
 | `accessMode` | String | `ReadWrite` | How Velero can access the backup storage location. Valid values are `ReadWrite`, `ReadOnly`. |
 | `backupSyncPeriod` | metav1.Duration | Optional Field | How frequently Velero should synchronize backups in object storage. Default is Velero's server backup sync period. Set this to `0s` to disable sync. |
 | `validationFrequency` | metav1.Duration | Optional Field | How frequently Velero should validate the object storage . Default is Velero's server validation frequency. Set this to `0s` to disable validation. Default 1 minute. |
+| `credential` | [corev1.SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#secretkeyselector-v1-core) | Optional Field | The credential information to be used with this location. |
+| `credential/name` | String | Optional Field | The name of the secret within the Velero namespace which contains the credential information. |
+| `credential/key` | String | Optional Field | The key to use within the secret. |
 {{< /table >}}

--- a/site/content/docs/main/locations.md
+++ b/site/content/docs/main/locations.md
@@ -22,8 +22,9 @@ This configuration design enables a number of different use cases, including:
 ## Limitations / Caveats
 
 - Velero supports multiple credentials for `BackupStorageLocations`, allowing you to specify the credentials to use with any `BackupStorageLocation`.
-  However, use of this feature requires support from object storage provider plugin.
-  [Plugins supported by the Velero team][5] support this feature.
+  However, use of this feature requires support within the plugin for the object storage provider you wish to use.
+  All [plugins provided by the Velero team][5] support this feature.
+  If you are using a plugin from another provider, please check their documentation to determine if this feature is supported.
 
 - Velero only supports a single set of credentials for `VolumeSnapshotLocations`.
   Velero will always use the credentials provided at install time (stored in the `cloud-credentials` secret) for volume snapshots.
@@ -70,6 +71,10 @@ velero backup create full-cluster-backup
 ```
 
 ### Have some Velero backups go to a bucket in an eastern USA region (default), and others go to a bucket in a western USA region
+
+In this example, two `BackupStorageLocations` will be created within the same account but in different regions.
+They will both use the credentials provided at install time and stored in the `cloud-credentials` secret.
+If you need to configure unique credentials for each `BackupStorageLocation`, please refer to the [later example][8].
 
 During server configuration:
 
@@ -171,12 +176,22 @@ During backup creation:
 velero backup create full-cluster-backup
 ```
 
-### Create a storage location that uses different credentials
+### Create a storage location that uses unique credentials
 
-If your object storage provider plugin supports it, it is possible to create additional `BackupStorageLocations` that use their own credentials.
-It is necessary to follow the instructions for your [object storage provider plugin][5] to install the plugin if not already installed, and create a file with the object storage credentials.
+It is possible to create additional `BackupStorageLocations` that use their own credentials.
+This enables you to save backups to another storage provider or to another account with the storage provider you are already using.
 
-Once you have created the credentials file, create a [Kubernetes Secret][6] in the Velero namespace that contains these credentials:
+If you create additional `BackupStorageLocations` without specifying the credentials to use, Velero will use the credentials provided at install time and stored in the `cloud-credentials` secret.
+Please see the [earlier example][9] for details on how to create multiple `BackupStorageLocations` that use the same credentials.
+
+#### Prerequisites
+- This feature requires support from the [object storage provider plugin][5] you wish to use.
+  All plugins provided by the Velero team support this feature.
+  If you are using a plugin from another provider, please check their documentation to determine if this is supported.
+- The [plugin for the object storage provider][5] you wish to use must be [installed][6].
+- You must create a file with the object storage credentials. Follow the instructions provided by your object storage provider plugin to create this file.
+
+Once you have installed the necessary plugin and created the credentials file, create a [Kubernetes Secret][6] in the Velero namespace that contains these credentials:
 
 ```shell
 kubectl create secret generic -n velero credentials --from-file=bsl=</path/to/credentialsfile>
@@ -218,4 +233,7 @@ To use this new `BackupStorageLocation` when performing a backup, use the flag `
 [3]: https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/blob/main/volumesnapshotlocation.md
 [4]: https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/blob/main/backupstoragelocation.md
 [5]: /plugins
-[6]: https://kubernetes.io/docs/concepts/configuration/secret/
+[6]: overview-plugins.md
+[7]: https://kubernetes.io/docs/concepts/configuration/secret/
+[8]: #create-a-storage-location-that-uses-unique-credentials
+[9]: #have-some-velero-backups-go-to-a-bucket-in-an-eastern-usa-region-default-and-others-go-to-a-bucket-in-a-western-usa-region

--- a/site/content/docs/main/troubleshooting.md
+++ b/site/content/docs/main/troubleshooting.md
@@ -178,8 +178,11 @@ Follow the below troubleshooting steps to confirm that Velero is using the corre
 
 Follow the below troubleshooting steps to confirm that Velero is using the correct credentials if using credentials specific to a [`BackupStorageLocation`][10]:
 1. Confirm that the object storage provider plugin being used supports multiple credentials.
-   If the error message contains `"config has invalid keys credentialsFile"`, the version of your object storage plugin does not yet support multiple credentials.
-   Object storage plugins [provided by the Velero team][11] support this feature, so update your plugin if you are using one of these.
+
+   If the logs from the Velero deployment contain the error message `"config has invalid keys credentialsFile"`, the version of your object storage plugin does not yet support multiple credentials.
+
+   The object storage plugins [provided by the Velero team][11] support this feature, so please update your plugin to the latest version if you see the above error message.
+
    If you are using a plugin from a different provider, please contact them for further advice.
 
 1. Confirm that the secret and key referenced by the `BackupStorageLocation` exists in the Velero namespace and has the correct content:
@@ -194,9 +197,11 @@ Follow the below troubleshooting steps to confirm that Velero is using the corre
    # Print the content of the secret and ensure it is correct
    kubectl -n velero get secret $BSL_SECRET -ojsonpath={.data.$BSL_SECRET_KEY} | base64 --decode
    ```
-   If the secret can't be found, the secret does not within the Velero namespace and must be created.
+   If the secret can't be found, the secret does not exist within the Velero namespace and must be created.
 
    If no output is produced when printing the contents of the secret, the key within the secret may not exist or may have no content.
+   Ensure that the key exists within the secret's data by checking the output from `kubectl -n velero describe secret $BSL_SECRET`.
+   If it does not exist, follow the instructions for [editing a Kubernetes secret][12] to add the base64 encoded credentials data.
 
 
 [1]: debugging-restores.md
@@ -210,4 +215,5 @@ Follow the below troubleshooting steps to confirm that Velero is using the corre
 [9]: https://kubectl.docs.kubernetes.io/pages/container_debugging/port_forward_to_pods.html
 [10]: locations.md
 [11]: /plugins
+[12]: https://kubernetes.io/docs/concepts/configuration/secret/#editing-a-secret
 [25]: https://kubernetes.slack.com/messages/velero

--- a/site/content/docs/main/troubleshooting.md
+++ b/site/content/docs/main/troubleshooting.md
@@ -181,7 +181,7 @@ Follow the below troubleshooting steps to confirm that Velero is using the corre
 
    If the logs from the Velero deployment contain the error message `"config has invalid keys credentialsFile"`, the version of your object storage plugin does not yet support multiple credentials.
 
-   The object storage plugins [provided by the Velero team][11] support this feature, so please update your plugin to the latest version if you see the above error message.
+   The object storage plugins [maintained by the Velero team][11] support this feature, so please update your plugin to the latest version if you see the above error message.
 
    If you are using a plugin from a different provider, please contact them for further advice.
 


### PR DESCRIPTION
# Please add a summary of your change
This change introduces support for restic to make use of per-BSL
credentials. It makes use of the `credentials.FileStore` introduced in
PR #3442 to write the BSL credentials to disk. To support per-BSL
credentials for restic, the environment for the restic commands needs to
be modified for each provider to ensure that the credentials are
provided via the correct provider specific environment variables.
This change introduces a new function `restic.CmdEnv` to check the BSL
provider and create the correct mapping of environment variables for
each provider.

Previously, AWS and GCP could rely on the environment variables in the
Velero deployments to obtain the credentials file, but now these
environment variables need to be set with the path to the serialized
credentials file if a credential is set on the BSL.

For Azure, the credentials file in the environment was loaded and parsed
to set the environment variables for restic. Now, we check if the BSL
has a credential, and if it does, load and parse that file instead.

This change also introduces a few other small improvements. Now that we
are fetching the BSL to check for the `Credential` field, we can use the
BSL directly to get the `CACert` which means that we can remove the
`GetCACert` function. Also, now that we have a way to serialize secrets
to disk, we can use the `credentials.FileStore` to get a temp file for
the restic repo password and remove the `restic.TempCredentialsFile`
function.

# Does your change fix a particular issue?

Part of fixing #3304.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [x] Updated the corresponding documentation in `site/content/docs/main`.