### PR TITLE
Install CA certificates in Tilt Docker image

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -109,6 +109,9 @@ local_resource(
 # Note: we need a distro with a bash shell to exec into the Velero container
 tilt_dockerfile_header = """
 FROM ubuntu:focal as tilt
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y ca-certificates tzdata && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /
 COPY --from=tilt-helper /start.sh .
 COPY --from=tilt-helper /restart.sh .


### PR DESCRIPTION
# Please add a summary of your change
HTTPS requests were failing due to the ca-certificates package not being
installed in the Tilt image.

This change takes the command to install this package from our main
Dockerfile (which also includes installing tzdata).

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

# Please indicate you've done the following:
- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [x] Updated the corresponding documentation in `site/content/docs/main`.