### PR TITLE
Update in-code documentation to show resources can be specified with group name

### DIFF
--- a/pkg/plugin/velero/shared.go
+++ b/pkg/plugin/velero/shared.go
@@ -32,15 +32,15 @@ type ResourceSelector struct {
 	// All namespaces in IncludedNamespaces, *except* those in
 	// this slice, will be matched.
 	ExcludedNamespaces []string
-	// IncludedResources is a slice of resources to match. Resources
-	// may be specified as full names (e.g. "services") or abbreviations
-	// (e.g. "svc"). All resources in this slice, except those in
-	// ExcludedResources, will be matched. A nil/empty slice matches
+	// IncludedResources is a slice of resources to match. Resources may be specified
+	// as full names (e.g. "services"), abbreviations (e.g. "svc"), or with the
+	// groups they are in (e.g. "ingresses.extensions"). All resources in this slice,
+	// except those in ExcludedResources, will be matched. A nil/empty slice matches
 	// all resources.
 	IncludedResources []string
-	// ExcludedResources is a slice of resources to exclude.
-	// Resources may be specified as full names (e.g. "services") or
-	// abbreviations (e.g. "svc"). All resources in IncludedResources,
+	// ExcludedResources is a slice of resources to exclude. Resources may be specified
+	// as full names (e.g. "services"), abbreviations (e.g. "svc"), or with the
+	// groups they are in (e.g. "ingresses.extensions"). All resources in IncludedResources,
 	// *except* those in this slice, will be matched.
 	ExcludedResources []string
 	// LabelSelector is a string representation of a selector to apply


### PR DESCRIPTION
Signed-off-by: F. Gold <fgold@vmware.com>

# Summary of change

Updated in-code documentation to show resources can be specified with group names, for example, instead of using "ingresses", one can use "ingresses.extensions" or "ingresses.networking.k8s.io".

# Does your change fix a particular issue?

Yes, we had a problem (reported in #3491) where when we indicated in a custom plugin that a kind, "Ingress" should be skipped. However, only the "ingress.extensions" version was skipped, but the "ingress.networking.k8s.io" was restored. By being able to include the group name in the resource selector list, we were able to ensure both ingress types were skipped. The fix was not a code change but a clarification in the comments that it is possible to include group name, even though the slice is a slice of "IncludedResources".

Fixes #3491 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
