### PR TITLE
Upgrade restic from v0.9.6 to v0.12.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ see: https://velero.io/docs/main/build-from-source/#making-images-and-updating-v
 endef
 
 # The version of restic binary to be downloaded for power architecture
-RESTIC_VERSION ?= 0.9.6
+RESTIC_VERSION ?= 0.12.0
 
 CLI_PLATFORMS ?= linux-amd64 linux-arm linux-arm64 darwin-amd64 windows-amd64 linux-ppc64le
 BUILDX_PLATFORMS ?= $(subst -,/,$(ARCH))

--- a/Tiltfile
+++ b/Tiltfile
@@ -103,7 +103,7 @@ local_resource(
 
 local_resource(
     "restic_binary",
-    cmd = 'cd ' + '.' + ';mkdir -p _tiltbuild/restic; BIN=velero GOOS=' + local_goos + ' GOARCH=amd64 RESTIC_VERSION=0.9.6 OUTPUT_DIR=_tiltbuild/restic ./hack/download-restic.sh',
+    cmd = 'cd ' + '.' + ';mkdir -p _tiltbuild/restic; BIN=velero GOOS=' + local_goos + ' GOARCH=amd64 RESTIC_VERSION=0.12.0 OUTPUT_DIR=_tiltbuild/restic ./hack/download-restic.sh',
 )
 
 # Note: we need a distro with a bash shell to exec into the Velero container

--- a/changelogs/unreleased/3528-ashish-amarnath
+++ b/changelogs/unreleased/3528-ashish-amarnath
@@ -1,0 +1,1 @@
+Upgrade restic from v0.9.6 to v0.12.0.

--- a/hack/download-restic.sh
+++ b/hack/download-restic.sh
@@ -46,14 +46,8 @@ if [[ -z "${RESTIC_VERSION}" ]]; then
     exit 1
 fi
 
-# TODO: when the new restic version is released, make ppc64le to be also downloaded from their github releases.
-#  This has been merged and will be applied to next release: https://github.com/restic/restic/pull/2342
-if [[ "${GOARCH}" = "ppc64le" ]]; then
-    curl -s --retry 5 -L https://oplab9.parqtec.unicamp.br/pub/ppc64el/restic/restic-${RESTIC_VERSION} -o ${restic_bin}
-else
-    curl -s -L https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_${GOOS}_${GOARCH}.bz2 -O
-    bunzip2 restic_${RESTIC_VERSION}_${GOOS}_${GOARCH}.bz2
-    mv restic_${RESTIC_VERSION}_${GOOS}_${GOARCH} ${restic_bin}
-fi
+curl -s -L https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_${GOOS}_${GOARCH}.bz2 -O
+bunzip2 restic_${RESTIC_VERSION}_${GOOS}_${GOARCH}.bz2
+mv restic_${RESTIC_VERSION}_${GOOS}_${GOARCH} ${restic_bin}
 
 chmod +x ${restic_bin}


### PR DESCRIPTION
Signed-off-by: Ashish Amarnath <ashisham@vmware.com>

In this release of restic v0.12.0 https://restic.net/blog/2021-02-14/restic-0.12.0-released/

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #3490 #2198 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
