### PR TITLE
Assign a smaller number of reviewers to PRs

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,8 +1,9 @@
 addReviewers: true
 addAssignees: author
 
-# Set this to the length of the reviewers list because the default was not including everyone
-numberOfReviewers: 6
+# Only require 2, random reviewers.
+# TODO expand this to support using reviewGroups
+numberOfReviewers: 2
 
 reviewers:
   - nrb


### PR DESCRIPTION
# Please add a summary of your change
Updates PR assignment to only use 2 random reviewers instead of all possible maintainers. The number of reviewers required is not changing (still 2 accepting reviews), but this should help reduce noise and introduce accountability for getting assigned tasks done.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
