### PR TITLE
Define a Velero release schedule

### DIFF
--- a/site/content/docs/main/release-schedule.md
+++ b/site/content/docs/main/release-schedule.md
@@ -1,0 +1,14 @@
+---
+title: "Release Schedule"
+layout: docs
+toc: "true"
+---
+
+Definitons borrowed from [the Kubernetes release process document](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#definitions)
+
+General phases for a Velero release
+- Enhancement/Design freeze
+- Implementation phase
+- Feature freeze & pruning
+- Code freeze & prerelease
+- Release

--- a/site/content/docs/main/release-schedule.md
+++ b/site/content/docs/main/release-schedule.md
@@ -4,7 +4,7 @@ layout: docs
 toc: "true"
 ---
 
-Definitons borrowed from [the Kubernetes release process document](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#definitions)
+Definitions borrowed from [the Kubernetes release process document](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#definitions)
 
 General phases for a Velero release
 - Enhancement/Design freeze
@@ -12,3 +12,4 @@ General phases for a Velero release
 - Feature freeze & pruning
 - Code freeze & prerelease
 - Release
+


### PR DESCRIPTION
# Please add a summary of your change
Defines a release schedule for Velero, modeled somewhat after the Kubernetes release schedule.

Initial draft doesn't define dates yet, pending discussions.


# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
