### PR TITLE
Correctly render links with fragments on docs pages

### DIFF
--- a/site/layouts/_default/_markup/render-link.html
+++ b/site/layouts/_default/_markup/render-link.html
@@ -1,5 +1,10 @@
 {{ $link := .Destination }}
 {{ if not (strings.HasPrefix $link "http") }}
-    {{ $link = (.Page.GetPage .Destination).RelPermalink }}
+    {{ $url := urls.Parse .Destination }}
+    {{- if $url.Path -}}
+        {{ $fragment := "" }}
+        {{- with $url.Fragment }}{{ $fragment = printf "#%s" . }}{{ end -}}
+        {{- with .Page.GetPage $url.Path }}{{ $link = printf "%s%s" .RelPermalink $fragment }}{{ end }}
+    {{ end }}
 {{ end }}
 <a href="{{ $link | safeURL }}">{{ .Text | safeHTML }}</a>


### PR DESCRIPTION
# Please add a summary of your change
Our previous render hook to create links would drop the fragment when
linking to headings within the current page or within other markdown
pages on the site.

This change parses the URL and formats the link correctly if it includes
a fragment. If the link is a header on the current page, it is rendered
as `http://<current-url>/#header`. If the link is a header on a
different page (e.g. page.md#header), it is rendered as
`http://<page-url>/#header`.

This change is taken from the following Hugo community support post:
https://discourse.gohugo.io/t/markdown-render-hooks-github-and-hugo-compatible-links/22543/14

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

# Does your change fix a particular issue?

Fixes #3566

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
