### PR TITLE
Improve GH Action PR assign + labeling

### DIFF
--- a/.github/workflows/auto_assign_prs.yml
+++ b/.github/workflows/auto_assign_prs.yml
@@ -3,7 +3,7 @@ name: "Auto Assign PR Reviewers"
 # This should mean PRs from forks are supported.
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, ready_for_review]
 
 jobs:
   # Automatically assigns reviewers and owner
@@ -14,11 +14,3 @@ jobs:
         with:
           configuration-path: ".github/auto_assign.yml"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-  # Automatically labels PRs based on file globs in the change.
-  triage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/labeler@v3
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          configuration-path: .github/labels.yml

--- a/.github/workflows/auto_label_prs.yml
+++ b/.github/workflows/auto_label_prs.yml
@@ -1,0 +1,19 @@
+name: "Auto Label PRs"
+# pull_request_target means that this will run on pull requests, but in the context of the base repo.
+# This should mean PRs from forks are supported. 
+# Because it includes the `synchronize` parameter, any push of a new commit to the HEAD ref of a pull request
+# will trigger this process.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+jobs:
+  # Automatically labels PRs based on file globs in the change.
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v3
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/labels.yml


### PR DESCRIPTION
Signed-off-by: Carlisia <carlisia@vmware.com>

# Please add a summary of your change

This change removes the `synchronize` parameter from the `pull_request_target` GH action in the `Auto Assign PR Reviewers` workflow. This should avoid the workflow from being triggered on all PR events, such as additional commits, which has the effect of adding additional reviewers (with each additional commit) beyond the current limit of 2. We only want this to be triggered when the PR opens, or when the PR changes from WIP to "ready for review".

It also separates the auto labeling GH action into the `"Auto Label PRs"` workflow. This one we want to be triggered on every event, so it keeps the `synchronize` and all other parameters the same.

Thanks to @zubron for pointing these out (in https://github.com/vmware-tanzu/velero/issues/3573#issuecomment-797677976). Hopefully this will work.

# Does your change fix a particular issue?

Fixes #(https://github.com/vmware-tanzu/velero/issues/3573)

PS: It doesn't **completely** fix the entire issue. For example: if the author wants to assign 2 specific reviewers before the PR is created, the GH action will still assign additional reviewers on the "open" event. This is the known bug in the action. 

A way to get around this is to remove the originally assigned reviewers after the PR is created, and add the ones you want (assuming they don't match). This "works", but causes unnecessary notifications for the soon-to-be-removed reviewers.

A way to get around wanting to

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
