### PR TITLE
Updated Azure plugin in e2e tests to 1.1.2 (latest)

### DIFF
--- a/test/e2e/velero_utils.go
+++ b/test/e2e/velero_utils.go
@@ -28,9 +28,9 @@ func getProviderPlugins(providerName string) []string {
 	case "aws":
 		return []string{"velero/velero-plugin-for-aws:v1.1.0"}
 	case "azure":
-		return []string{"velero/velero-plugin-for-microsoft-azure:v1.1.1"}
+		return []string{"velero/velero-plugin-for-microsoft-azure:v1.1.2"}
 	case "vsphere":
-		return []string{"velero/velero-plugin-for-aws:v1.1.0", "velero/velero-plugin-for-vsphere:v1.0.2"}
+		return []string{"velero/velero-plugin-for-aws:v1.1.0", "velero/velero-plugin-for-vsphere:v1.1.0"}
 	default:
 		return []string{""}
 	}


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

Tests were using previous release for install/test.  Now uses 1.1.2 for Azure and 1.1.0 for vSphere plugin
