### PR TITLE
Fix incorrect links in BSL docs

### DIFF
--- a/site/content/docs/main/locations.md
+++ b/site/content/docs/main/locations.md
@@ -191,7 +191,7 @@ Please see the [earlier example][9] for details on how to create multiple `Backu
 - The [plugin for the object storage provider][5] you wish to use must be [installed][6].
 - You must create a file with the object storage credentials. Follow the instructions provided by your object storage provider plugin to create this file.
 
-Once you have installed the necessary plugin and created the credentials file, create a [Kubernetes Secret][6] in the Velero namespace that contains these credentials:
+Once you have installed the necessary plugin and created the credentials file, create a [Kubernetes Secret][7] in the Velero namespace that contains these credentials:
 
 ```shell
 kubectl create secret generic -n velero credentials --from-file=bsl=</path/to/credentialsfile>

--- a/site/content/docs/v1.6/locations.md
+++ b/site/content/docs/v1.6/locations.md
@@ -191,7 +191,7 @@ Please see the [earlier example][9] for details on how to create multiple `Backu
 - The [plugin for the object storage provider][5] you wish to use must be [installed][6].
 - You must create a file with the object storage credentials. Follow the instructions provided by your object storage provider plugin to create this file.
 
-Once you have installed the necessary plugin and created the credentials file, create a [Kubernetes Secret][6] in the Velero namespace that contains these credentials:
+Once you have installed the necessary plugin and created the credentials file, create a [Kubernetes Secret][7] in the Velero namespace that contains these credentials:
 
 ```shell
 kubectl create secret generic -n velero credentials --from-file=bsl=</path/to/credentialsfile>


### PR DESCRIPTION
# Please add a summary of your change
The link for Kubernetes Secrets was incorrectly pointing at the plugins
documentation. This fixes the incorrect link.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
