### PR TITLE
PV remapClaimRefNS was being skipped when there was no snapshot

### DIFF
--- a/changelogs/unreleased/3708-sseago
+++ b/changelogs/unreleased/3708-sseago
@@ -1,0 +1,1 @@
+Handle namespace mapping for PVs without snapshots on restore

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1102,6 +1102,12 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 		default:
 			ctx.log.Infof("Restoring persistent volume as-is because it doesn't have a snapshot and its reclaim policy is not Delete.")
 
+			// Check to see if the claimRef.namespace field needs to be remapped, and do so if necessary.
+			_, err = remapClaimRefNS(ctx, obj)
+			if err != nil {
+				errs.Add(namespace, err)
+				return warnings, errs
+			}
 			obj = resetVolumeBindingInfo(obj)
 			// We call the pvRestorer here to clear out the PV's claimRef.UID,
 			// so it can be re-claimed when its PVC is restored and gets a new UID.


### PR DESCRIPTION
Signed-off-by: Scott Seago <sseago@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Previously (https://github.com/vmware-tanzu/velero/pull/3007 ) a fix was submitted which handles PV ClaimRef remapping and PV renaming when there is a snapshot, but it did not handle the default case of no snapshot, no restic, but still restoring the PV. This extends the same behavior to the default case (no snapshot, no restic, no delete reclaim policy): the ClaimRef gets its namespace remapped if necessary, and the PV gets renamed if necessary.

Tests included to confirm the fix.

# Does your change fix a particular issue?

Fixes #3707

# Please indicate you've done the following:

- [ x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
