### PR TITLE
🐛  Fix plugin name derivation from image name

### DIFF
--- a/changelogs/unreleased/3711-ashish-amarnath
+++ b/changelogs/unreleased/3711-ashish-amarnath
@@ -1,0 +1,1 @@
+🐛 Fix plugin name derivation from image name

--- a/pkg/builder/container_builder.go
+++ b/pkg/builder/container_builder.go
@@ -45,7 +45,7 @@ func ForPluginContainer(image string, pullPolicy corev1api.PullPolicy) *Containe
 
 // getName returns the 'name' component of a docker
 // image that includes the entire string except the registry name, and transforms the combined
-// string into a DNS-1123 compatible name.
+// string into a RFC-1123 compatible name.
 func getName(image string) string {
 	slashIndex := strings.Index(image, "/")
 	slashCount := 0
@@ -67,7 +67,14 @@ func getName(image string) string {
 		end = colonIndex
 	}
 
-	return strings.Replace(image[start:end], "/", "-", -1) // this makes it DNS-1123 compatible
+	// https://github.com/distribution/distribution/blob/main/docs/spec/api.md#overview
+	// valid repository names match the regex [a-z0-9]+(?:[._-][a-z0-9]+)*
+	// image repository names can container [._] but [._] are not allowed in RFC-1123 labels.
+	// replace '/', '_' and '.' with '-'
+	re := strings.NewReplacer("/", "-",
+		"_", "-",
+		".", "-")
+	return re.Replace(image[start:end])
 }
 
 // Result returns the built Container.

--- a/pkg/builder/container_builder_test.go
+++ b/pkg/builder/container_builder_test.go
@@ -75,7 +75,17 @@ func TestGetName(t *testing.T) {
 		{
 			name:     "image name with registry hostname starting with a / will include the registry name ¯\\_(ツ)_/¯",
 			image:    "/gcr.io/my-repo/mystery/another/my-image",
-			expected: "gcr.io-my-repo-mystery-another-my-image",
+			expected: "gcr-io-my-repo-mystery-another-my-image",
+		},
+		{
+			name:     "image repository names containing _ ",
+			image:    "projects.registry.vmware.com/tanzu_migrator/route-2-httpproxy:myTag",
+			expected: "tanzu-migrator-route-2-httpproxy",
+		},
+		{
+			name:     "image repository names containing . ",
+			image:    "projects.registry.vmware.com/tanzu.migrator/route-2-httpproxy:myTag",
+			expected: "tanzu-migrator-route-2-httpproxy",
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Ashish Amarnath <ashisham@vmware.com>

Thank you for contributing to Velero!

Plugin's init container name is derived from the plugin's image that is supplied in the `velero plugin add` command.
This derivation is a concatenation of image's repository name, and the image name. Further replacing characters that are allowed in container images repository name but not in a valid RFC-1123 label. Specifically, the container image repository name matches the regex `[a-z0-9]+(?:[._-][a-z0-9]+)*`. However, valid RFC-1123 labels should not have `_` or `.`.
This PR replaces `_` and `.`with `-` making the derived name RFC-1123 compliant.

# Does your change fix a particular issue?

Fixes #3715 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
