### PR TITLE
Fix gh action

### DIFF
--- a/.github/auto-assignees.yml
+++ b/.github/auto-assignees.yml
@@ -36,7 +36,4 @@ options:
     - wip
     - DO NOT MERGE
   enable_group_assignment: true
-
-# Randomly pick reviewers up to this number.
-# Do not set this option if you'd like to assign all matching reviewers.
-number_of_reviewers: 2
+  number_of_reviewers: 2

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Request a PR review based on files types/paths, and/or groups the author belongs to
-        uses: necojackarc/auto-request-review@v0.5.1
+        uses: necojackarc/auto-request-review@v0.7.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config: .github/auto-assignees.yml

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -2,7 +2,7 @@
 name: "Auto Request Review"
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review, reopened]
 
 permissions:

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -3,7 +3,7 @@ name: "Auto Request Review"
 
 on:
   pull_request:
-    types: [opened, ready_for_review, synchronize, reopened]
+    types: [opened, ready_for_review, reopened]
 
 jobs:
   auto-request-review:

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -5,9 +5,6 @@ on:
   pull_request_target:
     types: [opened, ready_for_review, reopened]
 
-permissions:
-  pull-requests: write
-
 jobs:
   auto-request-review:
     name: Auto Request Review

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     types: [opened, ready_for_review, reopened]
 
+permissions:
+  pull-requests: write
+
 jobs:
   auto-request-review:
     name: Auto Request Review


### PR DESCRIPTION
The `number_of_reviewers` option was at the wrong level. Hopefully this will be "the fix".

Signed-off-by: Carlisia <carlisia@grokkingtech.io>

# Does your change fix a particular issue?

Fixes #3723

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
