### PR TITLE
fix on-premise `--plugins` flag documentation

### DIFF
--- a/site/content/docs/main/on-premises.md
+++ b/site/content/docs/main/on-premises.md
@@ -82,7 +82,7 @@ By default, `velero install` will use the public `velero/velero` image. When usi
 ```bash
 velero install \
  --image=$PRIVATE_REG/velero:$VELERO_VERSION \
- --plugin=$PRIVATE_REG/velero-plugin-for-aws:$PLUGIN_VERSION \
+ --plugins=$PRIVATE_REG/velero-plugin-for-aws:$PLUGIN_VERSION \
 <....>
 ```
 

--- a/site/content/docs/v1.4/on-premises.md
+++ b/site/content/docs/v1.4/on-premises.md
@@ -82,7 +82,7 @@ By default, `velero install` will use the public `velero/velero` image. When usi
 ```bash
 velero install \
  --image=$PRIVATE_REG/velero:$VELERO_VERSION \
- --plugin=$PRIVATE_REG/velero-plugin-for-aws:$PLUGIN_VERSION \
+ --plugins=$PRIVATE_REG/velero-plugin-for-aws:$PLUGIN_VERSION \
 <....>
 ```
 

--- a/site/content/docs/v1.5/on-premises.md
+++ b/site/content/docs/v1.5/on-premises.md
@@ -82,7 +82,7 @@ By default, `velero install` will use the public `velero/velero` image. When usi
 ```bash
 velero install \
  --image=$PRIVATE_REG/velero:$VELERO_VERSION \
- --plugin=$PRIVATE_REG/velero-plugin-for-aws:$PLUGIN_VERSION \
+ --plugins=$PRIVATE_REG/velero-plugin-for-aws:$PLUGIN_VERSION \
 <....>
 ```
 

--- a/site/content/docs/v1.6/on-premises.md
+++ b/site/content/docs/v1.6/on-premises.md
@@ -82,7 +82,7 @@ By default, `velero install` will use the public `velero/velero` image. When usi
 ```bash
 velero install \
  --image=$PRIVATE_REG/velero:$VELERO_VERSION \
- --plugin=$PRIVATE_REG/velero-plugin-for-aws:$PLUGIN_VERSION \
+ --plugins=$PRIVATE_REG/velero-plugin-for-aws:$PLUGIN_VERSION \
 <....>
 ```
 


### PR DESCRIPTION
--plugins instead of --plugin

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
