### PR TITLE
Changed kibishii wait commands to output stdout/stderr, makes for better debugging

### DIFF
--- a/test/e2e/kibishii_tests.go
+++ b/test/e2e/kibishii_tests.go
@@ -15,6 +15,7 @@ package e2e
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strconv"
 	"time"
@@ -45,6 +46,8 @@ func installKibishii(ctx context.Context, namespace string, cloudPlatform string
 
 	kibishiiSetWaitCmd := exec.CommandContext(ctx, "kubectl", "rollout", "status", "statefulset.apps/kibishii-deployment",
 		"-n", namespace, "-w", "--timeout=30m")
+	kibishiiSetWaitCmd.Stdout = os.Stdout
+	kibishiiSetWaitCmd.Stderr = os.Stderr
 	_, _, err = veleroexec.RunCommand(kibishiiSetWaitCmd)
 
 	if err != nil {
@@ -53,6 +56,8 @@ func installKibishii(ctx context.Context, namespace string, cloudPlatform string
 
 	fmt.Printf("Waiting for kibishii jump-pad pod to be ready\n")
 	jumpPadWaitCmd := exec.CommandContext(ctx, "kubectl", "wait", "--for=condition=ready", "-n", namespace, "pod/jump-pad")
+	jumpPadWaitCmd.Stdout = os.Stdout
+	jumpPadWaitCmd.Stderr = os.Stderr
 	_, _, err = veleroexec.RunCommand(jumpPadWaitCmd)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to wait for ready status of pod %s/%s", namespace, jumpPadPod)


### PR DESCRIPTION
Changed kibishii wait commands to output stdout/stderr, makes for better debugging

Signed-off-by: Dave Smith-Uchida <dsmithuchida@vmware.com>


- [ X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
