### PR TITLE
remove all default value fields from crds

### DIFF
--- a/changelogs/unreleased/3779-foosinn
+++ b/changelogs/unreleased/3779-foosinn
@@ -1,0 +1,1 @@
+remove all default value fields from crds to prevent gitops tools from detecting diffs

--- a/config/crd/bases/velero.io_backups.yaml
+++ b/config/crd/bases/velero.io_backups.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: BackupList
     plural: backups
     singular: backup
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -45,14 +44,12 @@ spec:
                 not included in the backup.
               items:
                 type: string
-              nullable: true
               type: array
             excludedResources:
               description: ExcludedResources is a slice of resource names that are
                 not included in the backup.
               items:
                 type: string
-              nullable: true
               type: array
             hooks:
               description: Hooks represent custom behaviors that should be executed
@@ -71,14 +68,12 @@ spec:
                           which this hook spec does not apply.
                         items:
                           type: string
-                        nullable: true
                         type: array
                       excludedResources:
                         description: ExcludedResources specifies the resources to
                           which this hook spec does not apply.
                         items:
                           type: string
-                        nullable: true
                         type: array
                       includedNamespaces:
                         description: IncludedNamespaces specifies the namespaces to
@@ -86,7 +81,6 @@ spec:
                           namespaces.
                         items:
                           type: string
-                        nullable: true
                         type: array
                       includedResources:
                         description: IncludedResources specifies the resources to
@@ -94,12 +88,10 @@ spec:
                           resources.
                         items:
                           type: string
-                        nullable: true
                         type: array
                       labelSelector:
                         description: LabelSelector, if specified, filters the resources
                           to which this hook spec applies.
-                        nullable: true
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector
@@ -235,33 +227,28 @@ spec:
                     required:
                     - name
                     type: object
-                  nullable: true
                   type: array
               type: object
             includeClusterResources:
               description: IncludeClusterResources specifies whether cluster-scoped
                 resources should be included for consideration in the backup.
-              nullable: true
               type: boolean
             includedNamespaces:
               description: IncludedNamespaces is a slice of namespace names to include
                 objects from. If empty, all namespaces are included.
               items:
                 type: string
-              nullable: true
               type: array
             includedResources:
               description: IncludedResources is a slice of resource names to include
                 in the backup. If empty, all resources are included.
               items:
                 type: string
-              nullable: true
               type: array
             labelSelector:
               description: LabelSelector is a metav1.LabelSelector to filter with
                 when adding individual objects to the backup. If empty or nil, all
                 objects are included. Optional.
-              nullable: true
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.
@@ -310,12 +297,10 @@ spec:
                 of specific Kind. The map key is the Kind name and value is a list
                 of resource names separated by commas. Each resource name has format
                 "namespace/resourcename".  For cluster resources, simply use "resourcename".
-              nullable: true
               type: object
             snapshotVolumes:
               description: SnapshotVolumes specifies whether to take cloud snapshots
                 of any PV's referenced in the set of objects included in the Backup.
-              nullable: true
               type: boolean
             storageLocation:
               description: StorageLocation is a string containing the name of a BackupStorageLocation
@@ -341,7 +326,6 @@ spec:
                 is recorded before uploading the backup object. The server's time
                 is used for CompletionTimestamps
               format: date-time
-              nullable: true
               type: string
             errors:
               description: Errors is a count of all error messages that were generated
@@ -351,7 +335,6 @@ spec:
             expiration:
               description: Expiration is when this Backup is eligible for garbage-collection.
               format: date-time
-              nullable: true
               type: string
             formatVersion:
               description: FormatVersion is the backup format version, including major,
@@ -372,7 +355,6 @@ spec:
               description: Progress contains information about the backup's execution
                 progress. Note that this information is best-effort only -- if Velero
                 fails to update it during a backup for any reason, it may be inaccurate/stale.
-              nullable: true
               properties:
                 itemsBackedUp:
                   description: ItemsBackedUp is the number of items that have actually
@@ -391,14 +373,12 @@ spec:
                 from CreationTimestamp, since that value changes on restores. The
                 server's time is used for StartTimestamps
               format: date-time
-              nullable: true
               type: string
             validationErrors:
               description: ValidationErrors is a slice of all validation errors (if
                 applicable).
               items:
                 type: string
-              nullable: true
               type: array
             version:
               description: 'Version is the backup format major version. Deprecated:

--- a/config/crd/bases/velero.io_backupstoragelocations.yaml
+++ b/config/crd/bases/velero.io_backupstoragelocations.yaml
@@ -33,7 +33,6 @@ spec:
     shortNames:
     - bsl
     singular: backupstoragelocation
-  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -68,7 +67,6 @@ spec:
             backupSyncPeriod:
               description: BackupSyncPeriod defines how frequently to sync backup
                 API objects from object storage. A value of 0 disables sync.
-              nullable: true
               type: string
             config:
               additionalProperties:
@@ -122,7 +120,6 @@ spec:
             validationFrequency:
               description: ValidationFrequency defines how frequently to validate
                 the corresponding object storage. A value of 0 disables validation.
-              nullable: true
               type: string
           required:
           - objectStorage
@@ -150,13 +147,11 @@ spec:
               description: LastSyncedTime is the last time the contents of the location
                 were synced into the cluster.
               format: date-time
-              nullable: true
               type: string
             lastValidationTime:
               description: LastValidationTime is the last time the backup store location
                 was validated the cluster.
               format: date-time
-              nullable: true
               type: string
             phase:
               description: Phase is the current state of the BackupStorageLocation.

--- a/config/crd/bases/velero.io_deletebackuprequests.yaml
+++ b/config/crd/bases/velero.io_deletebackuprequests.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: DeleteBackupRequestList
     plural: deletebackuprequests
     singular: deletebackuprequest
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -49,7 +48,6 @@ spec:
                 the deletion process.
               items:
                 type: string
-              nullable: true
               type: array
             phase:
               description: Phase is the current state of the DeleteBackupRequest.

--- a/config/crd/bases/velero.io_downloadrequests.yaml
+++ b/config/crd/bases/velero.io_downloadrequests.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: DownloadRequestList
     plural: downloadrequests
     singular: downloadrequest
-  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -73,7 +72,6 @@ spec:
               description: Expiration is when this DownloadRequest expires and can
                 be deleted by the system.
               format: date-time
-              nullable: true
               type: string
             phase:
               description: Phase is the current state of the DownloadRequest.

--- a/config/crd/bases/velero.io_podvolumebackups.yaml
+++ b/config/crd/bases/velero.io_podvolumebackups.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: PodVolumeBackupList
     plural: podvolumebackups
     singular: podvolumebackup
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -107,7 +106,6 @@ spec:
                 is recorded before uploading the backup object. The server's time
                 is used for CompletionTimestamps
               format: date-time
-              nullable: true
               type: string
             message:
               description: Message is a message about the pod volume backup's status.
@@ -145,7 +143,6 @@ spec:
                 from CreationTimestamp, since that value changes on restores. The
                 server's time is used for StartTimestamps
               format: date-time
-              nullable: true
               type: string
           type: object
       type: object

--- a/config/crd/bases/velero.io_podvolumerestores.yaml
+++ b/config/crd/bases/velero.io_podvolumerestores.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: PodVolumeRestoreList
     plural: podvolumerestores
     singular: podvolumerestore
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -99,7 +98,6 @@ spec:
                 Completion time is recorded even on failed restores. The server's
                 time is used for CompletionTimestamps
               format: date-time
-              nullable: true
               type: string
             message:
               description: Message is a message about the pod volume restore's status.
@@ -128,7 +126,6 @@ spec:
               description: StartTimestamp records the time a restore was started.
                 The server's time is used for StartTimestamps
               format: date-time
-              nullable: true
               type: string
           type: object
       type: object

--- a/config/crd/bases/velero.io_resticrepositories.yaml
+++ b/config/crd/bases/velero.io_resticrepositories.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ResticRepositoryList
     plural: resticrepositories
     singular: resticrepository
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -62,7 +61,6 @@ spec:
             lastMaintenanceTime:
               description: LastMaintenanceTime is the last time maintenance was run.
               format: date-time
-              nullable: true
               type: string
             message:
               description: Message is a message about the current status of the ResticRepository.

--- a/config/crd/bases/velero.io_restores.yaml
+++ b/config/crd/bases/velero.io_restores.yaml
@@ -12,7 +12,6 @@ spec:
     listKind: RestoreList
     plural: restores
     singular: restore
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -43,14 +42,12 @@ spec:
                 not included in the restore.
               items:
                 type: string
-              nullable: true
               type: array
             excludedResources:
               description: ExcludedResources is a slice of resource names that are
                 not included in the restore.
               items:
                 type: string
-              nullable: true
               type: array
             hooks:
               description: Hooks represent custom behaviors that should be executed
@@ -67,14 +64,12 @@ spec:
                           which this hook spec does not apply.
                         items:
                           type: string
-                        nullable: true
                         type: array
                       excludedResources:
                         description: ExcludedResources specifies the resources to
                           which this hook spec does not apply.
                         items:
                           type: string
-                        nullable: true
                         type: array
                       includedNamespaces:
                         description: IncludedNamespaces specifies the namespaces to
@@ -82,7 +77,6 @@ spec:
                           namespaces.
                         items:
                           type: string
-                        nullable: true
                         type: array
                       includedResources:
                         description: IncludedResources specifies the resources to
@@ -90,12 +84,10 @@ spec:
                           resources.
                         items:
                           type: string
-                        nullable: true
                         type: array
                       labelSelector:
                         description: LabelSelector, if specified, filters the resources
                           to which this hook spec applies.
-                        nullable: true
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector
@@ -1506,27 +1498,23 @@ spec:
               description: IncludeClusterResources specifies whether cluster-scoped
                 resources should be included for consideration in the restore. If
                 null, defaults to true.
-              nullable: true
               type: boolean
             includedNamespaces:
               description: IncludedNamespaces is a slice of namespace names to include
                 objects from. If empty, all namespaces are included.
               items:
                 type: string
-              nullable: true
               type: array
             includedResources:
               description: IncludedResources is a slice of resource names to include
                 in the restore. If empty, all resources in the backup are included.
               items:
                 type: string
-              nullable: true
               type: array
             labelSelector:
               description: LabelSelector is a metav1.LabelSelector to filter with
                 when restoring individual objects from the backup. If empty or nil,
                 all objects are included. Optional.
-              nullable: true
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.
@@ -1578,12 +1566,10 @@ spec:
             preserveNodePorts:
               description: PreserveNodePorts specifies whether to restore old nodePorts
                 from backup.
-              nullable: true
               type: boolean
             restorePVs:
               description: RestorePVs specifies whether to restore all included PVs
                 from snapshot (via the cloudprovider).
-              nullable: true
               type: boolean
             scheduleName:
               description: ScheduleName is the unique name of the Velero schedule
@@ -1601,7 +1587,6 @@ spec:
                 was completed. Completion time is recorded even on failed restore.
                 The server's time is used for StartTimestamps
               format: date-time
-              nullable: true
               type: string
             errors:
               description: Errors is a count of all error messages that were generated
@@ -1626,7 +1611,6 @@ spec:
               description: Progress contains information about the restore's execution
                 progress. Note that this information is best-effort only -- if Velero
                 fails to update it during a restore for any reason, it may be inaccurate/stale.
-              nullable: true
               properties:
                 itemsRestored:
                   description: ItemsRestored is the number of items that have actually
@@ -1642,14 +1626,12 @@ spec:
               description: StartTimestamp records the time the restore operation was
                 started. The server's time is used for StartTimestamps
               format: date-time
-              nullable: true
               type: string
             validationErrors:
               description: ValidationErrors is a slice of all validation errors (if
                 applicable)
               items:
                 type: string
-              nullable: true
               type: array
             warnings:
               description: Warnings is a count of all warning messages that were generated

--- a/config/crd/bases/velero.io_schedules.yaml
+++ b/config/crd/bases/velero.io_schedules.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ScheduleList
     plural: schedules
     singular: schedule
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -53,14 +52,12 @@ spec:
                     are not included in the backup.
                   items:
                     type: string
-                  nullable: true
                   type: array
                 excludedResources:
                   description: ExcludedResources is a slice of resource names that
                     are not included in the backup.
                   items:
                     type: string
-                  nullable: true
                   type: array
                 hooks:
                   description: Hooks represent custom behaviors that should be executed
@@ -79,14 +76,12 @@ spec:
                               to which this hook spec does not apply.
                             items:
                               type: string
-                            nullable: true
                             type: array
                           excludedResources:
                             description: ExcludedResources specifies the resources
                               to which this hook spec does not apply.
                             items:
                               type: string
-                            nullable: true
                             type: array
                           includedNamespaces:
                             description: IncludedNamespaces specifies the namespaces
@@ -94,7 +89,6 @@ spec:
                               to all namespaces.
                             items:
                               type: string
-                            nullable: true
                             type: array
                           includedResources:
                             description: IncludedResources specifies the resources
@@ -102,12 +96,10 @@ spec:
                               to all resources.
                             items:
                               type: string
-                            nullable: true
                             type: array
                           labelSelector:
                             description: LabelSelector, if specified, filters the
                               resources to which this hook spec applies.
-                            nullable: true
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
@@ -249,33 +241,28 @@ spec:
                         required:
                         - name
                         type: object
-                      nullable: true
                       type: array
                   type: object
                 includeClusterResources:
                   description: IncludeClusterResources specifies whether cluster-scoped
                     resources should be included for consideration in the backup.
-                  nullable: true
                   type: boolean
                 includedNamespaces:
                   description: IncludedNamespaces is a slice of namespace names to
                     include objects from. If empty, all namespaces are included.
                   items:
                     type: string
-                  nullable: true
                   type: array
                 includedResources:
                   description: IncludedResources is a slice of resource names to include
                     in the backup. If empty, all resources are included.
                   items:
                     type: string
-                  nullable: true
                   type: array
                 labelSelector:
                   description: LabelSelector is a metav1.LabelSelector to filter with
                     when adding individual objects to the backup. If empty or nil,
                     all objects are included. Optional.
-                  nullable: true
                   properties:
                     matchExpressions:
                       description: matchExpressions is a list of label selector requirements.
@@ -326,12 +313,10 @@ spec:
                     list of resource names separated by commas. Each resource name
                     has format "namespace/resourcename".  For cluster resources, simply
                     use "resourcename".
-                  nullable: true
                   type: object
                 snapshotVolumes:
                   description: SnapshotVolumes specifies whether to take cloud snapshots
                     of any PV's referenced in the set of objects included in the Backup.
-                  nullable: true
                   type: boolean
                 storageLocation:
                   description: StorageLocation is a string containing the name of
@@ -351,7 +336,6 @@ spec:
             useOwnerReferencesInBackup:
               description: UseOwnerReferencesBackup specifies whether to use OwnerReferences
                 on backups created by this Schedule.
-              nullable: true
               type: boolean
           required:
           - schedule
@@ -364,7 +348,6 @@ spec:
               description: LastBackup is the last time a Backup was run for this Schedule
                 schedule
               format: date-time
-              nullable: true
               type: string
             phase:
               description: Phase is the current phase of the Schedule

--- a/config/crd/bases/velero.io_serverstatusrequests.yaml
+++ b/config/crd/bases/velero.io_serverstatusrequests.yaml
@@ -16,7 +16,6 @@ spec:
     shortNames:
     - ssr
     singular: serverstatusrequest
-  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -63,13 +62,11 @@ spec:
                 - kind
                 - name
                 type: object
-              nullable: true
               type: array
             processedTimestamp:
               description: ProcessedTimestamp is when the ServerStatusRequest was
                 processed by the ServerStatusRequestController.
               format: date-time
-              nullable: true
               type: string
             serverVersion:
               description: ServerVersion is the Velero server version.

--- a/config/crd/bases/velero.io_volumesnapshotlocations.yaml
+++ b/config/crd/bases/velero.io_volumesnapshotlocations.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: VolumeSnapshotLocationList
     plural: volumesnapshotlocations
     singular: volumesnapshotlocation
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:


### PR DESCRIPTION
# Please add a summary of your change

this commit removes all `nullable: true` and `preserveUnknownFields: false` mentions. 

# Does your change fix a particular issue?

These are default and not visible when dumping the resource from the Kubernetes API. That causes ArgoCD to always detect a diff.

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.

