### PR TITLE
service_action: use unstructured to marshal selective fields 

### DIFF
--- a/changelogs/unreleased/3789-alaypatel07
+++ b/changelogs/unreleased/3789-alaypatel07
@@ -1,0 +1,1 @@
+use unstructured to marshal selective fields for service restore action


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

Instead of unmarshaling into service object, this attempts to pick select fields from the json in last applied config annotation and checks the types for it, explicitely converting it to int before comparing and processing

# Does your change fix a particular issue?

Fixes: #3788 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
