### PR TITLE
Add PVC UID label to PVR (as we already have for PVB)

### DIFF
--- a/changelogs/unreleased/3792-sseago
+++ b/changelogs/unreleased/3792-sseago
@@ -1,0 +1,1 @@
+Add PVC UID label to PodVolumeRestore

--- a/pkg/restic/repository_manager.go
+++ b/pkg/restic/repository_manager.go
@@ -160,7 +160,7 @@ func (rm *repositoryManager) NewRestorer(ctx context.Context, restore *velerov1a
 		},
 	)
 
-	r := newRestorer(ctx, rm, rm.repoEnsurer, informer, rm.log)
+	r := newRestorer(ctx, rm, rm.repoEnsurer, informer, rm.pvcClient, rm.log)
 
 	go informer.Run(ctx.Done())
 	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced, rm.repoInformerSynced) {


### PR DESCRIPTION
Signed-off-by: Scott Seago <sseago@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
This adds a PVC UID label to the PodVolumeRestore similar to what is already added to the PodVolumeBackup. While Velero doesn't need this, it provides a way for users or external tools to identify which PVCs were restored by the PodVolumeRestore. We were already using the PVB label in our konveyor/crane migration tool for a UI debug view which showed users which PVCs (and PVs) were associated with a given PVB. This change will allow us to do the same on the restore side.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
