### PR TITLE
Add support for volume and PV HostPath when using Restic

### DIFF
--- a/changelogs/unreleased/3794-StephenSorriaux
+++ b/changelogs/unreleased/3794-StephenSorriaux
@@ -1,0 +1,3 @@
+Add support for volume and PV HostPath when using Restic
+
+Add a new flag "EnableHostPath" to accept HostPath during backup and restore

--- a/pkg/apis/velero/v1/constants.go
+++ b/pkg/apis/velero/v1/constants.go
@@ -46,4 +46,7 @@ const (
 
 	// APIGroupVersionsFeatureFlag is the feature flag string that defines whether or not to handle multiple API Group Versions
 	APIGroupVersionsFeatureFlag = "EnableAPIGroupVersions"
+
+	// HostPathFlag is the feature flag string that defines whether or not HostPath in PV will be backuped
+	HostPathFlag = "EnableHostPath"
 )

--- a/pkg/restic/common.go
+++ b/pkg/restic/common.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/vmware-tanzu/velero/internal/credentials"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/features"
 	velerov1listers "github.com/vmware-tanzu/velero/pkg/generated/listers/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/label"
 	"github.com/vmware-tanzu/velero/pkg/util/filesystem"
@@ -170,9 +171,9 @@ func GetPodVolumesUsingRestic(pod *corev1api.Pod, defaultVolumesToRestic bool) [
 	volsToExclude := getVolumesToExclude(pod)
 	podVolumes := []string{}
 	for _, pv := range pod.Spec.Volumes {
-		// cannot backup hostpath volumes as they are not mounted into /var/lib/kubelet/pods
-		// and therefore not accessible to the restic daemon set.
-		if pv.HostPath != nil {
+		if pv.HostPath != nil && !features.IsEnabled(velerov1api.HostPathFlag) {
+			// cannot backup hostpath volumes as they are not mounted into /var/lib/kubelet/pods
+			// and therefore not accessible to the restic daemon set.
 			continue
 		}
 		// don't backup volumes mounting secrets. Secrets will be backed up separately.

--- a/pkg/util/kube/utils.go
+++ b/pkg/util/kube/utils.go
@@ -126,6 +126,10 @@ func GetVolumeDirectory(pod *corev1api.Pod, volumeName string, pvcLister corev1l
 		if volume.VolumeSource.CSI != nil {
 			return volume.Name + "/mount", nil
 		}
+		// Pod volume is actually a HostPath
+		if volume.VolumeSource.HostPath != nil {
+			return volume.VolumeSource.HostPath.Path, nil
+		}
 		return volume.Name, nil
 	}
 
@@ -143,6 +147,11 @@ func GetVolumeDirectory(pod *corev1api.Pod, volumeName string, pvcLister corev1l
 	// PV's been created with a CSI source.
 	if pv.Spec.CSI != nil {
 		return pvc.Spec.VolumeName + "/mount", nil
+	}
+
+	// PV's been created with a HostPath.
+	if pv.Spec.HostPath != nil {
+		return pv.Spec.HostPath.Path, nil
 	}
 
 	return pvc.Spec.VolumeName, nil


### PR DESCRIPTION
Add a new flag "EnableHostPath" to accept HostPath during Restic backup and restore.

Thank you for contributing to Velero!

# Please add a summary of your change
- Added a flag `EnableHostPath` in order to make Velero be OK when backuping or restoring a HostPath pod or PV volume. I don't want to create any breaking change, so I added this flag to force users to opt-in for this feature.
- Updated the `processRestore` and `processBackup` methods to fallback to a HostPath if volume is not found in `/host_pods/...` path and if the flag `EnableHostPath` is set
- Updated the `GetVolumeDirectory` to return Path when volume is a hostPath or a PV backed hostPath

This would require the user to make sure the backuped hostPath are available in the Restic DaemonSet pods.

I am personally testing it against a k3s installation (k8s 1.19) that uses [`local-path-provisioner`](https://github.com/rancher/local-path-provisioner) to create PV. Those PV are actually hostPaths, but all of them are created under the `/var/lib/rancher/k3s/storage/` directory so I am perfectly fine with mounted it inside the Restic pods.
FWIW, I successfully backuped and restored a ClickHouse instance using this (statefullset with hostPath PV). I will do some more tests.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
