### PR TITLE
Support pulling plugins by digest

### DIFF
--- a/changelogs/unreleased/3803-2uasimojo
+++ b/changelogs/unreleased/3803-2uasimojo
@@ -1,0 +1,1 @@
+Support pulling plugin images by digest

--- a/pkg/builder/container_builder.go
+++ b/pkg/builder/container_builder.go
@@ -60,11 +60,18 @@ func getName(image string) string {
 		start = slashIndex + 1
 	}
 
-	// this removes the tag
-	colonIndex := strings.LastIndex(image, ":")
+	// If the image spec is by digest, remove the digest.
+	// If it is by tag, remove the tag.
+	// Otherwise (implicit :latest) leave it alone.
 	end := len(image)
-	if colonIndex > 0 {
-		end = colonIndex
+	atIndex := strings.LastIndex(image, "@")
+	if atIndex > 0 {
+		end = atIndex
+	} else {
+		colonIndex := strings.LastIndex(image, ":")
+		if colonIndex > 0 {
+			end = colonIndex
+		}
 	}
 
 	// https://github.com/distribution/distribution/blob/main/docs/spec/api.md#overview

--- a/pkg/builder/container_builder_test.go
+++ b/pkg/builder/container_builder_test.go
@@ -87,6 +87,11 @@ func TestGetName(t *testing.T) {
 			image:    "projects.registry.vmware.com/tanzu.migrator/route-2-httpproxy:myTag",
 			expected: "tanzu-migrator-route-2-httpproxy",
 		},
+		{
+			name:     "pull by digest",
+			image:    "quay.io/vmware-tanzu/velero@sha256:a75f9e8c3ced3943515f249597be389f8233e1258d289b11184796edceaa7dab",
+			expected: "vmware-tanzu-velero",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Previously `WithPlugins` only supported passing image URIs "by tag" -- e.g. `gcr.io/my-repo/my-image:v0.1.2`. With this commit, we add support for pulling "by digest" -- e.g. `gcr.io/my-repo/my-image@sha256:a75f9e8c3ced3943515f249597be389f8233e1258d289b11184796edceaa7dab`

Signed-off-by: Eric Fried <efried@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Previously `WithPlugins` only supported passing image URIs "by tag" -- e.g. `gcr.io/my-repo/my-image:v0.1.2`. With this commit, we add support for pulling "by digest" -- e.g. `gcr.io/my-repo/my-image@sha256:a75f9e8c3ced3943515f249597be389f8233e1258d289b11184796edceaa7dab`

# Does your change fix a particular issue?
Using velero under OpenShift with [ImageContentSourcePolicy](https://docs.openshift.com/container-platform/4.7/rest_api/operator_apis/imagecontentsourcepolicy-operator-openshift-io-v1alpha1.html) it is necessary to reference images by digest rather than by tag.

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
  (n/a, I think)
