### PR TITLE
Added BackupPhaseUploading and BackupPhaseUploadingPartialFailure backup

### DIFF
--- a/changelogs/unreleased/3805-dsmithuchida
+++ b/changelogs/unreleased/3805-dsmithuchida
@@ -1,0 +1,16 @@
+Added BackupPhaseUploading and BackupPhaseUploadingPartialFailure backup phases as part of Upload Progress Monitoring
+
+Uploading (new)
+The "Uploading" phase signifies that the main part of the backup, including 
+snapshotting has completed successfully and uploading is continuing. In 
+the event of an error during uploading, the phase will change to 
+UploadingPartialFailure. On success, the phase changes to Completed. The 
+backup cannot be restored from when it is in the Uploading state.
+
+UploadingPartialFailure (new)
+The "UploadingPartialFailure" phase signifies that the main part of the backup,
+including snapshotting has completed, but there were partial failures either 
+during the main part or during the uploading. The backup cannot be restored 
+from when it is in the UploadingPartialFailure state.
+
+

--- a/pkg/apis/velero/v1/backup.go
+++ b/pkg/apis/velero/v1/backup.go
@@ -207,6 +207,17 @@ const (
 	// BackupPhaseInProgress means the backup is currently executing.
 	BackupPhaseInProgress BackupPhase = "InProgress"
 
+	// BackupPhaseUploading means the backups of Kubernetes resources
+	// and creation of snapshots was successful and snapshot data
+	// is currently uploading.  The backup is not usable yet.
+	BackupPhaseUploading BackupPhase = "Uploading"
+
+	// BackupPhaseUploadingPartialFailure means the backup of Kubernetes
+	// resources and creation of snapshots partially failed (final phase
+	// will be PartiallyFailed) and snapshot data is currently uploading.
+	// The backup is not usable yet.
+	BackupPhaseUploadingPartialFailure BackupPhase = "UploadingPartialFailure"
+
 	// BackupPhaseCompleted means the backup has run successfully without
 	// errors.
 	BackupPhaseCompleted BackupPhase = "Completed"


### PR DESCRIPTION
Added BackupPhaseUploading and BackupPhaseUploadingPartialFailure backup phases as part of Upload Progress Monitoring, fixes #3755 Add backup phases needed for Upload Progress Monitoring

Signed-off-by: Dave Smith-Uchida <dsmithuchida@vmware.com>

# Please indicate you've done the following:

- [ C] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ C] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [C ] Updated the corresponding documentation in `site/content/docs/main`.
