### PR TITLE
Add documentation for TLS error 116

### DIFF
--- a/site/content/docs/main/self-signed-certificates.md
+++ b/site/content/docs/main/self-signed-certificates.md
@@ -32,3 +32,17 @@ the `--cacert` flag to provide a path to the certificate to be trusted.
 ```bash
 velero backup describe my-backup --cacert <PATH_TO_CA_BUNDLE>
 ```
+
+## Error with client certificate with custom S3 server
+
+In case you are using a custom S3-compatible server, you may encounter that the backup fails with an error similar to one below.
+
+```
+rpc error: code = Unknown desc = RequestError: send request failed caused by:
+Get https://minio.com:3000/k8s-backup-bucket?delimiter=%2F&list-type=2&prefix=: remote error: tls: alert(116)
+```
+
+Error 116 represents certificate required as seen here in [error codes](https://datatracker.ietf.org/doc/html/rfc8446#appendix-B.2).
+Velero as a client does not include its certificate while performing SSL handshake with the server.
+From [TLS 1.3 spec](https://tools.ietf.org/html/rfc8446), verifying client certificate is optional on the server.
+You will need to change this setting on the server to make it work.

--- a/site/content/docs/v1.4/self-signed-certificates.md
+++ b/site/content/docs/v1.4/self-signed-certificates.md
@@ -32,3 +32,17 @@ the `--cacert` flag to provide a path to the certificate to be trusted.
 ```bash
 velero backup describe my-backup --cacert <PATH_TO_CA_BUNDLE>
 ```
+
+## Error with client certificate with custom S3 server
+
+In case you are using a custom S3-compatible server, you may encounter that the backup fails with error similar to one below -
+
+```
+rpc error: code = Unknown desc = RequestError: send request failed caused by:
+Get https://sv4-dell87-c3-ve02.com:3000/k8s-backup-bucket?delimiter=%2F&list-type=2&prefix=: remote error: tls: alert(116)
+```
+
+Error 116 represents certificate required as seen here in [error codes](https://datatracker.ietf.org/doc/html/rfc8446#appendix-B.2)
+Velero as a client does not include its certificate while performing SSL handshake with the server.
+From [TLS 1.3 spec](https://tools.ietf.org/html/rfc8446), verifying client certificate is optional on the server.
+You will beed to change this setting on the server to make it work.

--- a/site/content/docs/v1.4/self-signed-certificates.md
+++ b/site/content/docs/v1.4/self-signed-certificates.md
@@ -39,10 +39,10 @@ In case you are using a custom S3-compatible server, you may encounter that the 
 
 ```
 rpc error: code = Unknown desc = RequestError: send request failed caused by:
-Get https://sv4-dell87-c3-ve02.com:3000/k8s-backup-bucket?delimiter=%2F&list-type=2&prefix=: remote error: tls: alert(116)
+Get https://minio.com:3000/k8s-backup-bucket?delimiter=%2F&list-type=2&prefix=: remote error: tls: alert(116)
 ```
 
-Error 116 represents certificate required as seen here in [error codes](https://datatracker.ietf.org/doc/html/rfc8446#appendix-B.2)
+Error 116 represents certificate required as seen here in [error codes](https://datatracker.ietf.org/doc/html/rfc8446#appendix-B.2).
 Velero as a client does not include its certificate while performing SSL handshake with the server.
 From [TLS 1.3 spec](https://tools.ietf.org/html/rfc8446), verifying client certificate is optional on the server.
-You will beed to change this setting on the server to make it work.
+You will need to change this setting on the server to make it work.

--- a/site/content/docs/v1.4/self-signed-certificates.md
+++ b/site/content/docs/v1.4/self-signed-certificates.md
@@ -35,7 +35,7 @@ velero backup describe my-backup --cacert <PATH_TO_CA_BUNDLE>
 
 ## Error with client certificate with custom S3 server
 
-In case you are using a custom S3-compatible server, you may encounter that the backup fails with error similar to one below -
+In case you are using a custom S3-compatible server, you may encounter that the backup fails with an error similar to one below.
 
 ```
 rpc error: code = Unknown desc = RequestError: send request failed caused by:

--- a/site/content/docs/v1.5/self-signed-certificates.md
+++ b/site/content/docs/v1.5/self-signed-certificates.md
@@ -32,3 +32,17 @@ the `--cacert` flag to provide a path to the certificate to be trusted.
 ```bash
 velero backup describe my-backup --cacert <PATH_TO_CA_BUNDLE>
 ```
+
+## Error with client certificate with custom S3 server
+
+In case you are using a custom S3-compatible server, you may encounter that the backup fails with error similar to one below -
+
+```
+rpc error: code = Unknown desc = RequestError: send request failed caused by:
+Get https://sv4-dell87-c3-ve02.com:3000/k8s-backup-bucket?delimiter=%2F&list-type=2&prefix=: remote error: tls: alert(116)
+```
+
+Error 116 represents certificate required as seen here in [error codes](https://datatracker.ietf.org/doc/html/rfc8446#appendix-B.2)
+Velero as a client does not include its certificate while performing SSL handshake with the server.
+From [TLS 1.3 spec](https://tools.ietf.org/html/rfc8446), verifying client certificate is optional on the server.
+You will beed to change this setting on the server to make it work.

--- a/site/content/docs/v1.5/self-signed-certificates.md
+++ b/site/content/docs/v1.5/self-signed-certificates.md
@@ -39,10 +39,10 @@ In case you are using a custom S3-compatible server, you may encounter that the 
 
 ```
 rpc error: code = Unknown desc = RequestError: send request failed caused by:
-Get https://sv4-dell87-c3-ve02.com:3000/k8s-backup-bucket?delimiter=%2F&list-type=2&prefix=: remote error: tls: alert(116)
+Get https://minio.com:3000/k8s-backup-bucket?delimiter=%2F&list-type=2&prefix=: remote error: tls: alert(116)
 ```
 
-Error 116 represents certificate required as seen here in [error codes](https://datatracker.ietf.org/doc/html/rfc8446#appendix-B.2)
+Error 116 represents certificate required as seen here in [error codes](https://datatracker.ietf.org/doc/html/rfc8446#appendix-B.2).
 Velero as a client does not include its certificate while performing SSL handshake with the server.
 From [TLS 1.3 spec](https://tools.ietf.org/html/rfc8446), verifying client certificate is optional on the server.
-You will beed to change this setting on the server to make it work.
+You will need to change this setting on the server to make it work.

--- a/site/content/docs/v1.5/self-signed-certificates.md
+++ b/site/content/docs/v1.5/self-signed-certificates.md
@@ -35,7 +35,7 @@ velero backup describe my-backup --cacert <PATH_TO_CA_BUNDLE>
 
 ## Error with client certificate with custom S3 server
 
-In case you are using a custom S3-compatible server, you may encounter that the backup fails with error similar to one below -
+In case you are using a custom S3-compatible server, you may encounter that the backup fails with an error similar to one below.
 
 ```
 rpc error: code = Unknown desc = RequestError: send request failed caused by:

--- a/site/content/docs/v1.6/self-signed-certificates.md
+++ b/site/content/docs/v1.6/self-signed-certificates.md
@@ -32,3 +32,17 @@ the `--cacert` flag to provide a path to the certificate to be trusted.
 ```bash
 velero backup describe my-backup --cacert <PATH_TO_CA_BUNDLE>
 ```
+
+## Error with client certificate with custom S3 server
+
+In case you are using a custom S3-compatible server, you may encounter that the backup fails with error similar to one below -
+
+```
+rpc error: code = Unknown desc = RequestError: send request failed caused by:
+Get https://sv4-dell87-c3-ve02.com:3000/k8s-backup-bucket?delimiter=%2F&list-type=2&prefix=: remote error: tls: alert(116)
+```
+
+Error 116 represents certificate required as seen here in [error codes](https://datatracker.ietf.org/doc/html/rfc8446#appendix-B.2)
+Velero as a client does not include its certificate while performing SSL handshake with the server.
+From [TLS 1.3 spec](https://tools.ietf.org/html/rfc8446), verifying client certificate is optional on the server.
+You will beed to change this setting on the server to make it work.

--- a/site/content/docs/v1.6/self-signed-certificates.md
+++ b/site/content/docs/v1.6/self-signed-certificates.md
@@ -39,10 +39,10 @@ In case you are using a custom S3-compatible server, you may encounter that the 
 
 ```
 rpc error: code = Unknown desc = RequestError: send request failed caused by:
-Get https://sv4-dell87-c3-ve02.com:3000/k8s-backup-bucket?delimiter=%2F&list-type=2&prefix=: remote error: tls: alert(116)
+Get https://minio.com:3000/k8s-backup-bucket?delimiter=%2F&list-type=2&prefix=: remote error: tls: alert(116)
 ```
 
-Error 116 represents certificate required as seen here in [error codes](https://datatracker.ietf.org/doc/html/rfc8446#appendix-B.2)
+Error 116 represents certificate required as seen here in [error codes](https://datatracker.ietf.org/doc/html/rfc8446#appendix-B.2).
 Velero as a client does not include its certificate while performing SSL handshake with the server.
 From [TLS 1.3 spec](https://tools.ietf.org/html/rfc8446), verifying client certificate is optional on the server.
-You will beed to change this setting on the server to make it work.
+You will need to change this setting on the server to make it work.

--- a/site/content/docs/v1.6/self-signed-certificates.md
+++ b/site/content/docs/v1.6/self-signed-certificates.md
@@ -35,7 +35,7 @@ velero backup describe my-backup --cacert <PATH_TO_CA_BUNDLE>
 
 ## Error with client certificate with custom S3 server
 
-In case you are using a custom S3-compatible server, you may encounter that the backup fails with error similar to one below -
+In case you are using a custom S3-compatible server, you may encounter that the backup fails with an error similar to one below.
 
 ```
 rpc error: code = Unknown desc = RequestError: send request failed caused by:


### PR DESCRIPTION
Update docs for custom certificates seeing TLS error 116

Signed-off-by: Himanshu Mehra <himanshu.mehra91@gmail.com>

Thank you for contributing to Velero!

# Please add a summary of your change
When using a custom S3 compatible server, backups/restore may fail with
TLS error 116. This happens because the S3 server expects Velero to
send client certificate during SSL TLS v1.3 handshake.
You will need to modify your S3 server settings to turn off client
certificate authentication.

# Does your change fix a particular issue?
Yes

Fixes #2825 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
