### PR TITLE
Update MinIO docs for correct AWS plugin version

### DIFF
--- a/site/content/docs/main/contributions/minio.md
+++ b/site/content/docs/main/contributions/minio.md
@@ -19,7 +19,7 @@ If you encounter issues with installing or configuring, see [Debugging Installat
 * Access to a Kubernetes cluster, version 1.7 or later.  **Note:** restic support requires Kubernetes version 1.10 or later, or an earlier version with the mount propagation feature enabled. Restic support is not required for this example, but may be of interest later. See [Restic Integration][17].
 * A DNS server on the cluster
 * `kubectl` installed
-* Sufficient disk space to store backups in Minio.  You will need sufficient disk space available to handle any 
+* Sufficient disk space to store backups in Minio.  You will need sufficient disk space available to handle any
 backups plus at least 1GB additional.  Minio will not operate if less than 1GB of free disk space is available.
 
 ## Download Velero
@@ -65,21 +65,21 @@ These instructions start the Velero server and a Minio instance that is accessib
     ```
     kubectl apply -f examples/minio/00-minio-deployment.yaml
     ```
-_Note_: The example Minio yaml provided uses "empty dir".  Your node needs to have enough space available to store the
-data being backed up plus 1GB of free space.  If the node does not have enough space, you can modify the example yaml to
-use a Persistent Volume instead of "empty dir"
+    _Note_: The example Minio yaml provided uses "empty dir".  Your node needs to have enough space available to store the
+    data being backed up plus 1GB of free space.  If the node does not have enough space, you can modify the example yaml to
+    use a Persistent Volume instead of "empty dir"
 
     ```
     velero install \
         --provider aws \
-        --plugins velero/velero-plugin-for-aws:v1.0.0 \
+        --plugins velero/velero-plugin-for-aws:v1.2.0 \
         --bucket velero \
         --secret-file ./credentials-velero \
         --use-volume-snapshots=false \
         --backup-location-config region=minio,s3ForcePathStyle="true",s3Url=http://minio.velero.svc:9000
     ```
 
-    This example assumes that it is running within a local cluster without a volume provider capable of snapshots, so no `VolumeSnapshotLocation` is created (`--use-volume-snapshots=false`).
+    This example assumes that it is running within a local cluster without a volume provider capable of snapshots, so no `VolumeSnapshotLocation` is created (`--use-volume-snapshots=false`). You may need to update AWS plugin version to one that is [compatible](https://github.com/vmware-tanzu/velero-plugin-for-aws#compatibility) with the version of Velero you are installing.
 
     Additionally, you can specify `--use-restic` to enable restic support, and `--wait` to wait for the deployment to be ready.
 

--- a/site/content/docs/v1.4/contributions/minio.md
+++ b/site/content/docs/v1.4/contributions/minio.md
@@ -66,7 +66,7 @@ These instructions start the Velero server and a Minio instance that is accessib
     ```
     velero install \
         --provider aws \
-        --plugins velero/velero-plugin-for-aws:v1.0.0 \
+        --plugins velero/velero-plugin-for-aws:v1.1.0 \
         --bucket velero \
         --secret-file ./credentials-velero \
         --use-volume-snapshots=false \

--- a/site/content/docs/v1.5/contributions/minio.md
+++ b/site/content/docs/v1.5/contributions/minio.md
@@ -66,11 +66,11 @@ These instructions start the Velero server and a Minio instance that is accessib
     ```
     velero install \
         --provider aws \
-        --plugins velero/velero-plugin-for-aws:v1.0.0 \
+        --plugins velero/velero-plugin-for-aws:v1.1.0 \
         --bucket velero \
         --secret-file ./credentials-velero \
         --use-volume-snapshots=false \
-        --backup-location-config region=minio,s3ForcePathStyle="true",s3Url=http://minio.velero.svc:9000 
+        --backup-location-config region=minio,s3ForcePathStyle="true",s3Url=http://minio.velero.svc:9000
     ```
 
     This example assumes that it is running within a local cluster without a volume provider capable of snapshots, so no `VolumeSnapshotLocation` is created (`--use-volume-snapshots=false`).

--- a/site/content/docs/v1.6/contributions/minio.md
+++ b/site/content/docs/v1.6/contributions/minio.md
@@ -19,7 +19,7 @@ If you encounter issues with installing or configuring, see [Debugging Installat
 * Access to a Kubernetes cluster, version 1.7 or later.  **Note:** restic support requires Kubernetes version 1.10 or later, or an earlier version with the mount propagation feature enabled. Restic support is not required for this example, but may be of interest later. See [Restic Integration][17].
 * A DNS server on the cluster
 * `kubectl` installed
-* Sufficient disk space to store backups in Minio.  You will need sufficient disk space available to handle any 
+* Sufficient disk space to store backups in Minio.  You will need sufficient disk space available to handle any
 backups plus at least 1GB additional.  Minio will not operate if less than 1GB of free disk space is available.
 
 ## Download Velero
@@ -65,14 +65,14 @@ These instructions start the Velero server and a Minio instance that is accessib
     ```
     kubectl apply -f examples/minio/00-minio-deployment.yaml
     ```
-_Note_: The example Minio yaml provided uses "empty dir".  Your node needs to have enough space available to store the
-data being backed up plus 1GB of free space.  If the node does not have enough space, you can modify the example yaml to
-use a Persistent Volume instead of "empty dir"
+    _Note_: The example Minio yaml provided uses "empty dir".  Your node needs to have enough space available to store the
+    data being backed up plus 1GB of free space.  If the node does not have enough space, you can modify the example yaml to
+    use a Persistent Volume instead of "empty dir"
 
     ```
     velero install \
         --provider aws \
-        --plugins velero/velero-plugin-for-aws:v1.0.0 \
+        --plugins velero/velero-plugin-for-aws:v1.2.0 \
         --bucket velero \
         --secret-file ./credentials-velero \
         --use-volume-snapshots=false \


### PR DESCRIPTION
Signed-off-by: Abigail McCarthy <mabigail@vmware.com>

Thank you for contributing to Velero!

This updates the MinIO docs to point to the compatible AWS plugin versions. It also adds a note to the /main docs to point folks to the AWS plugin and Velero version compatibility chart, so that all future versions point users to where to find this info, in case the plugin version gets out of sync again.

# Does your change fix a particular issue?

Fixes #3736 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
