### PR TITLE
Remove the [insert current year] in the code standards doc

### DIFF
--- a/site/content/docs/main/code-standards.md
+++ b/site/content/docs/main/code-standards.md
@@ -24,7 +24,7 @@ If a PR does not warrant a changelog, the CI check for a changelog can be skippe
 
 ## Copyright header 
 
-Whenever a source code file is being modified, the copyright notice should be updated to our standard copyright notice. That is, it should read “Copyright [insert current year] the Velero contributors.” 
+Whenever a source code file is being modified, the copyright notice should be updated to our standard copyright notice. That is, it should read “Copyright the Velero contributors.” 
 
 For new files, the entire copyright and license header must be added.
 

--- a/site/content/docs/v1.4/code-standards.md
+++ b/site/content/docs/v1.4/code-standards.md
@@ -17,7 +17,7 @@ Add that to the PR.
 
 ## Copyright header 
 
-Whenever a source code file is being modified, the copyright notice should be updated to our standard copyright notice. That is, it should read “Copyright [insert current year] the Velero contributors.” 
+Whenever a source code file is being modified, the copyright notice should be updated to our standard copyright notice. That is, it should read “Copyright the Velero contributors.” 
 
 For new files, the entire copyright and license header must be added.
 

--- a/site/content/docs/v1.5/code-standards.md
+++ b/site/content/docs/v1.5/code-standards.md
@@ -24,7 +24,7 @@ If a PR does not warrant a changelog, the CI check for a changelog can be skippe
 
 ## Copyright header 
 
-Whenever a source code file is being modified, the copyright notice should be updated to our standard copyright notice. That is, it should read “Copyright [insert current year] the Velero contributors.” 
+Whenever a source code file is being modified, the copyright notice should be updated to our standard copyright notice. That is, it should read “Copyright the Velero contributors.” 
 
 For new files, the entire copyright and license header must be added.
 

--- a/site/content/docs/v1.6/code-standards.md
+++ b/site/content/docs/v1.6/code-standards.md
@@ -24,7 +24,7 @@ If a PR does not warrant a changelog, the CI check for a changelog can be skippe
 
 ## Copyright header 
 
-Whenever a source code file is being modified, the copyright notice should be updated to our standard copyright notice. That is, it should read “Copyright [insert current year] the Velero contributors.” 
+Whenever a source code file is being modified, the copyright notice should be updated to our standard copyright notice. That is, it should read “Copyright the Velero contributors.” 
 
 For new files, the entire copyright and license header must be added.
 


### PR DESCRIPTION
# Please add a summary of your change

Update the code standards documentation, remove the ` [insert current year]`.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
