### PR TITLE
skip backuping projected volume when using restic

### DIFF
--- a/changelogs/unreleased/3866-alaypatel07
+++ b/changelogs/unreleased/3866-alaypatel07
@@ -1,0 +1,1 @@
+skip backuping projected volume when using restic

--- a/pkg/restic/common.go
+++ b/pkg/restic/common.go
@@ -183,6 +183,10 @@ func GetPodVolumesUsingRestic(pod *corev1api.Pod, defaultVolumesToRestic bool) [
 		if pv.ConfigMap != nil {
 			continue
 		}
+		// don't backup volumes mounted as projected volumes, all data in those come from kube state.
+		if pv.Projected != nil {
+			continue
+		}
 		// don't backup volumes that are included in the exclude list.
 		if contains(volsToExclude, pv.Name) {
 			continue

--- a/pkg/restic/common_test.go
+++ b/pkg/restic/common_test.go
@@ -507,6 +507,41 @@ func TestGetPodVolumesUsingRestic(t *testing.T) {
 			},
 			expected: []string{"resticPV1", "resticPV2", "resticPV3"},
 		},
+		{
+			name:                   "should exclude projected volumes",
+			defaultVolumesToRestic: true,
+			pod: &corev1api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						VolumesToExcludeAnnotation: "nonResticPV1,nonResticPV2,nonResticPV3",
+					},
+				},
+				Spec: corev1api.PodSpec{
+					Volumes: []corev1api.Volume{
+						{Name: "resticPV1"}, {Name: "resticPV2"}, {Name: "resticPV3"},
+						{
+							Name: "projected",
+							VolumeSource: corev1api.VolumeSource{
+								Projected: &corev1api.ProjectedVolumeSource{
+									Sources: []corev1api.VolumeProjection{{
+										Secret: &corev1api.SecretProjection{
+											LocalObjectReference: corev1api.LocalObjectReference{},
+											Items:                nil,
+											Optional:             nil,
+										},
+										DownwardAPI:         nil,
+										ConfigMap:           nil,
+										ServiceAccountToken: nil,
+									}},
+									DefaultMode: nil,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []string{"resticPV1", "resticPV2", "resticPV3"},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/site/content/posts/2019-10-10-Velero-v1-1-Stateful-Backup-vSphere.md
+++ b/site/content/posts/2019-10-10-Velero-v1-1-Stateful-Backup-vSphere.md
@@ -459,7 +459,7 @@ cqlsh:demodb> select * from emp;
 cqlsh:demodb>
 ```
 
-It looks like the restore has been successful. Velero v1.1 has successfully restored the Kubenetes objects for the Cassandra application, as well as restored the database and table contents.
+It looks like the restore has been successful. Velero v1.1 has successfully restored the Kubernetes objects for the Cassandra application, as well as restored the database and table contents.
 
 ## Feedback and Participation
 

--- a/test/e2e/kibishii_tests.go
+++ b/test/e2e/kibishii_tests.go
@@ -166,7 +166,7 @@ func runKibishiiTests(client testClient, providerName, veleroCLI, veleroNamespac
 	}
 
 	if err := client.clientGo.CoreV1().Namespaces().Delete(oneHourTimeout, kibishiiNamespace, metav1.DeleteOptions{}); err != nil {
-		return errors.Wrapf(err, "Failed to cleanup %s wrokload namespace", kibishiiNamespace)
+		return errors.Wrapf(err, "Failed to cleanup %s workload namespace", kibishiiNamespace)
 	}
 	// wait for ns delete
 	if err = waitForNamespaceDeletion(interval, timeout, client, kibishiiNamespace); err != nil {


### PR DESCRIPTION
Signed-off-by: Alay Patel <alay1431@gmail.com>

Thank you for contributing to Velero!

# Please add a summary of your change

This skips adding projected volumes to PVB spec for restic backup

# Does your change fix a particular issue?

Fixes #3863

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
