### PR TITLE
Wait for velero deployment to be ready

### DIFF
--- a/changelogs/unreleased/3879-divya063
+++ b/changelogs/unreleased/3879-divya063
@@ -1,0 +1,1 @@
+Wait for velero deployment and restic DaemonSet to be ready.

--- a/pkg/cmd/cli/install/install.go
+++ b/pkg/cmd/cli/install/install.go
@@ -278,19 +278,18 @@ func (o *InstallOptions) Run(c *cobra.Command, f client.Factory) error {
 		return errors.Wrap(err, errorMsg)
 	}
 
-	if o.Wait {
-		fmt.Println("Waiting for Velero deployment to be ready.")
-		if _, err = install.DeploymentIsReady(factory, o.Namespace); err != nil {
+	fmt.Println("Waiting for Velero deployment to be ready.")
+	if _, err = install.DeploymentIsReady(factory, o.Namespace); err != nil {
+		return errors.Wrap(err, errorMsg)
+	}
+
+	if o.UseRestic {
+		fmt.Println("Waiting for Velero restic daemonset to be ready.")
+		if _, err = install.DaemonSetIsReady(factory, o.Namespace); err != nil {
 			return errors.Wrap(err, errorMsg)
 		}
-
-		if o.UseRestic {
-			fmt.Println("Waiting for Velero restic daemonset to be ready.")
-			if _, err = install.DaemonSetIsReady(factory, o.Namespace); err != nil {
-				return errors.Wrap(err, errorMsg)
-			}
-		}
 	}
+
 	if o.SecretFile == "" {
 		fmt.Printf("\nNo secret file was specified, no Secret created.\n\n")
 	}

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -307,6 +307,10 @@ func Install(factory client.DynamicFactory, resources *unstructured.Unstructured
 			return err
 		}
 	}
+	fmt.Fprint(w, "Waiting for deployment to be ready in cluster...\n")
+	if _, err = DeploymentIsReady(factory, "velero"); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -307,10 +307,6 @@ func Install(factory client.DynamicFactory, resources *unstructured.Unstructured
 			return err
 		}
 	}
-	fmt.Fprint(w, "Waiting for deployment to be ready in cluster...\n")
-	if _, err = DeploymentIsReady(factory, "velero"); err != nil {
-		return err
-	}
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Divya Rani <drani@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

Running `velero install` does not wait for velero to be healthy and does not report errors. The changes fix this issue. 

# Does your change fix a particular issue?
Yes

Fixes #3861 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
