### PR TITLE
Fix:rss link blindly appends /blog/index.html

### DIFF
--- a/site/config.yaml
+++ b/site/config.yaml
@@ -55,7 +55,7 @@ params:
       url: https://groups.google.com/forum/#!forum/projectvelero
     - title: RSS
       fa_icon: fa fa-rss
-      url: blog/index.xml
+      url: /blog/index.xml
     - title: GitHub
       fa_icon: fab fa-github
       url: https://github.com/vmware-tanzu/velero


### PR DESCRIPTION
Fixes #3882