### PR TITLE
Update upgrade instructions to reference v1.6.1

### DIFF
--- a/site/content/docs/main/upgrade-to-1.6.md
+++ b/site/content/docs/main/upgrade-to-1.6.md
@@ -29,7 +29,7 @@ If you're not yet running at least Velero v1.5, see the following:
 
     ```bash
     Client:
-        Version: v1.6.0
+        Version: v1.6.1
         Git commit: <git SHA>
     ```
 
@@ -45,12 +45,12 @@ If you're not yet running at least Velero v1.5, see the following:
 
     ```bash
     kubectl set image deployment/velero \
-        velero=velero/velero:v1.6.0 \
+        velero=velero/velero:v1.6.1 \
         --namespace velero
 
     # optional, if using the restic daemon set
     kubectl set image daemonset/restic \
-        restic=velero/velero:v1.6.0 \
+        restic=velero/velero:v1.6.1 \
         --namespace velero
     ```
 
@@ -64,11 +64,11 @@ If you're not yet running at least Velero v1.5, see the following:
 
     ```bash
     Client:
-        Version: v1.6.0
+        Version: v1.6.1
         Git commit: <git SHA>
 
     Server:
-        Version: v1.6.0
+        Version: v1.6.1
     ```
 
 ## Notes

--- a/site/content/docs/v1.6/upgrade-to-1.6.md
+++ b/site/content/docs/v1.6/upgrade-to-1.6.md
@@ -29,7 +29,7 @@ If you're not yet running at least Velero v1.5, see the following:
 
     ```bash
     Client:
-        Version: v1.6.0
+        Version: v1.6.1
         Git commit: <git SHA>
     ```
 
@@ -45,12 +45,12 @@ If you're not yet running at least Velero v1.5, see the following:
 
     ```bash
     kubectl set image deployment/velero \
-        velero=velero/velero:v1.6.0 \
+        velero=velero/velero:v1.6.1 \
         --namespace velero
 
     # optional, if using the restic daemon set
     kubectl set image daemonset/restic \
-        restic=velero/velero:v1.6.0 \
+        restic=velero/velero:v1.6.1 \
         --namespace velero
     ```
 
@@ -64,11 +64,11 @@ If you're not yet running at least Velero v1.5, see the following:
 
     ```bash
     Client:
-        Version: v1.6.0
+        Version: v1.6.1
         Git commit: <git SHA>
 
     Server:
-        Version: v1.6.0
+        Version: v1.6.1
     ```
 
 ## Notes


### PR DESCRIPTION
Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

# Please add a summary of your change
Now that we have released v1.6.1, we need to update our documentation to reference this new version.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
