### PR TITLE
Fix bug of E2E test case

### DIFF
--- a/test/e2e/kibishii_tests.go
+++ b/test/e2e/kibishii_tests.go
@@ -18,7 +18,6 @@ package e2e
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"strconv"
 	"time"
@@ -40,28 +39,28 @@ func installKibishii(ctx context.Context, namespace string, cloudPlatform string
 	// We use kustomize to generate YAML for Kibishii from the checked-in yaml directories
 	kibishiiInstallCmd := exec.CommandContext(ctx, "kubectl", "apply", "-n", namespace, "-k",
 		"github.com/vmware-tanzu-experiments/distributed-data-generator/kubernetes/yaml/"+cloudPlatform)
-
-	_, _, err := veleroexec.RunCommand(kibishiiInstallCmd)
+	stdout, stderr, err := veleroexec.RunCommand(kibishiiInstallCmd)
 	if err != nil {
+		fmt.Println(stdout)
+		fmt.Println(stderr)
 		return errors.Wrap(err, "failed to install kibishii")
 	}
 
 	kibishiiSetWaitCmd := exec.CommandContext(ctx, "kubectl", "rollout", "status", "statefulset.apps/kibishii-deployment",
 		"-n", namespace, "-w", "--timeout=30m")
-	kibishiiSetWaitCmd.Stdout = os.Stdout
-	kibishiiSetWaitCmd.Stderr = os.Stderr
-	_, _, err = veleroexec.RunCommand(kibishiiSetWaitCmd)
-
+	stdout, stderr, err = veleroexec.RunCommand(kibishiiSetWaitCmd)
 	if err != nil {
+		fmt.Println(stdout)
+		fmt.Println(stderr)
 		return err
 	}
 
 	fmt.Printf("Waiting for kibishii jump-pad pod to be ready\n")
 	jumpPadWaitCmd := exec.CommandContext(ctx, "kubectl", "wait", "--for=condition=ready", "-n", namespace, "pod/jump-pad")
-	jumpPadWaitCmd.Stdout = os.Stdout
-	jumpPadWaitCmd.Stderr = os.Stderr
-	_, _, err = veleroexec.RunCommand(jumpPadWaitCmd)
+	stdout, stderr, err = veleroexec.RunCommand(jumpPadWaitCmd)
 	if err != nil {
+		fmt.Println(stdout)
+		fmt.Println(stderr)
 		return errors.Wrapf(err, "Failed to wait for ready status of pod %s/%s", namespace, jumpPadPod)
 	}
 
@@ -75,8 +74,10 @@ func generateData(ctx context.Context, namespace string, levels int, filesPerLev
 		strconv.Itoa(blockSize), strconv.Itoa(passNum), strconv.Itoa(expectedNodes))
 	fmt.Printf("kibishiiGenerateCmd cmd =%v\n", kibishiiGenerateCmd)
 
-	_, _, err := veleroexec.RunCommand(kibishiiGenerateCmd)
+	stdout, stderr, err := veleroexec.RunCommand(kibishiiGenerateCmd)
 	if err != nil {
+		fmt.Println(stdout)
+		fmt.Println(stderr)
 		return errors.Wrap(err, "failed to generate")
 	}
 
@@ -90,8 +91,10 @@ func verifyData(ctx context.Context, namespace string, levels int, filesPerLevel
 		strconv.Itoa(blockSize), strconv.Itoa(passNum), strconv.Itoa(expectedNodes))
 	fmt.Printf("kibishiiVerifyCmd cmd =%v\n", kibishiiVerifyCmd)
 
-	_, _, err := veleroexec.RunCommand(kibishiiVerifyCmd)
+	stdout, stderr, err := veleroexec.RunCommand(kibishiiVerifyCmd)
 	if err != nil {
+		fmt.Println(stdout)
+		fmt.Println(stderr)
 		return errors.Wrap(err, "failed to verify")
 	}
 	return nil

--- a/test/e2e/velero_utils.go
+++ b/test/e2e/velero_utils.go
@@ -426,7 +426,7 @@ func veleroAddPluginsForProvider(ctx context.Context, veleroCLI string, veleroNa
 
 		installPluginCmd := exec.CommandContext(ctx, veleroCLI, "--namespace", veleroNamespace, "plugin", "add", plugin)
 		installPluginCmd.Stdout = stdoutBuf
-		installPluginCmd.Stderr = stdoutBuf
+		installPluginCmd.Stderr = stderrBuf
 
 		err := installPluginCmd.Run()
 


### PR DESCRIPTION
1. The variable "stdoutBuf" is assigned to both "installPluginCmd.Stdout" and "installPluginCmd.Stderr", this causes 'if !strings.Contains(stderrBuf.String(), "Duplicate value")' takes no effect as the "stderrBuf.String()" is always empty
2. Print the stdout and stderr for easy debugging

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
