### PR TITLE
Fix -install-velero flag for e2e tests

### DIFF
--- a/changelogs/unreleased/3919-jaidevmane
+++ b/changelogs/unreleased/3919-jaidevmane
@@ -1,0 +1,1 @@
+Fix -install-velero flag for e2e tests

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -56,6 +56,7 @@ BSL_CONFIG ?=
 VSL_CONFIG ?=
 CLOUD_PROVIDER ?=
 OBJECT_STORE_PROVIDER ?=
+INSTALL_VELERO ?= true
 
 # Flags to create an additional BSL for multiple credentials tests
 ADDITIONAL_OBJECT_STORE_PROVIDER ?=
@@ -90,7 +91,8 @@ run: ginkgo
 		-additional-bsl-credentials-file=$(ADDITIONAL_CREDS_FILE) \
 		-additional-bsl-bucket=$(ADDITIONAL_BSL_BUCKET) \
 		-additional-bsl-prefix=$(ADDITIONAL_BSL_PREFIX) \
-		-additional-bsl-config=$(ADDITIONAL_BSL_CONFIG)
+		-additional-bsl-config=$(ADDITIONAL_BSL_CONFIG) \
+		-install-velero=$(INSTALL_VELERO)
 
 build: ginkgo
 	mkdir -p $(OUTPUT_DIR)

--- a/test/e2e/enable_api_group_versions_test.go
+++ b/test/e2e/enable_api_group_versions_test.go
@@ -84,8 +84,10 @@ var _ = Describe("[APIGroup] Velero tests with various CRD API group versions", 
 		}
 		Expect(err).NotTo(HaveOccurred())
 
-		err = veleroUninstall(ctx, client.kubebuilder, installVelero, veleroNamespace)
-		Expect(err).NotTo(HaveOccurred())
+		if installVelero {
+			err = veleroUninstall(ctx, client.kubebuilder, installVelero, veleroNamespace)
+			Expect(err).NotTo(HaveOccurred())
+		}
 
 	})
 


### PR DESCRIPTION

Thank you for contributing to Velero!

# Please add a summary of your change
1.adding install flag to test makefile 
2.fixing bug where velero was being uninstalled in the APIGroup test even though the -install-velero flag was set to false

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
