### PR TITLE
Nominate Daniel Jiang to become a maintainer

### DIFF
--- a/.github/auto-assignees.yml
+++ b/.github/auto-assignees.yml
@@ -13,6 +13,7 @@ reviewers:
       - dsu-igeek
       - jenting
       - sseago
+      - reasonerjt
 
     tech-writer:
       - a-mccarthy

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,6 +10,7 @@
 | Dave Smith-Uchida | [dsu-igeek](https://github.com/dsu-igeek) | [VMware](https://www.github.com/vmware/) |
 | JenTing Hsiao | [jenting](https://github.com/jenting) | [SUSE](https://github.com/SUSE/)
 | Scott Seago | [sseago](https://github.com/sseago) | [OpenShift](https://github.com/openshift)
+| Daniel Jiang | [reasonerjt](https://github.com/reasonerjt) | [VMware](https://www.github.com/vmware/)
 
 ## Emeritus Maintainers
 * Adnan Abdulhussein ([prydonius](https://github.com/prydonius))


### PR DESCRIPTION
[Daniel Jiang](https://github.com/reasonerjt) recently joined the Velero team within VMware and will be
taking on a technical leadership role. He has been contributing to the
project through community engagement including issue triage and
community support, and is taking on more significant feature development
within Velero such as the design and development of the `velero debug`
feature.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
