### PR TITLE
Nominate Wenkai Yin to become a maintainer

### DIFF
--- a/.github/auto-assignees.yml
+++ b/.github/auto-assignees.yml
@@ -14,6 +14,7 @@ reviewers:
       - jenting
       - sseago
       - reasonerjt
+      - ywk253100
 
     tech-writer:
       - a-mccarthy

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,6 +11,7 @@
 | JenTing Hsiao | [jenting](https://github.com/jenting) | [SUSE](https://github.com/SUSE/)
 | Scott Seago | [sseago](https://github.com/sseago) | [OpenShift](https://github.com/openshift)
 | Daniel Jiang | [reasonerjt](https://github.com/reasonerjt) | [VMware](https://www.github.com/vmware/)
+| Wenkai Yin | [ywk253100](https://github.com/ywk253100) | [VMware](https://www.github.com/vmware/) |
 
 ## Emeritus Maintainers
 * Adnan Abdulhussein ([prydonius](https://github.com/prydonius))


### PR DESCRIPTION
[Wenkai Yin](https://github.com/ywk253100) recently joined the Velero team within VMware. He has been
contributing to the technical health of Velero, introducing important
changes such as running our E2E tests as part of our PR checks and will
continue to focus in this area.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
