### PR TITLE
pkg/restore: fix dropped error

### DIFF
--- a/pkg/restore/init_restorehook_pod_action.go
+++ b/pkg/restore/init_restorehook_pod_action.go
@@ -54,6 +54,9 @@ func (a *InitRestoreHookPodAction) Execute(input *velero.RestoreItemActionExecut
 	}
 	hookHandler := hook.InitContainerRestoreHookHandler{}
 	postHooksItem, err := hookHandler.HandleRestoreHooks(a.logger, kuberesource.Pods, input.Item, restoreHooks)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
 	a.logger.Infof("Returning from InitRestoreHookPodAction")
 
 	return velero.NewRestoreItemActionExecuteOutput(&unstructured.Unstructured{Object: postHooksItem.UnstructuredContent()}), nil


### PR DESCRIPTION
Signed-off-by: Lars Lehtonen <lars.lehtonen@gmail.com>

# Please add a summary of your change
This fixes a dropped `err` variable in `pkg/restore`.
# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.

/kind changelog-not-required