### PR TITLE
Check both the label and name when getting the velero deployment

### DIFF
--- a/pkg/cmd/cli/plugin/helpers.go
+++ b/pkg/cmd/cli/plugin/helpers.go
@@ -42,9 +42,11 @@ func veleroDeployment(ctx context.Context, kubeClient kubernetes.Interface, name
 		return nil, err
 	}
 
-	if len(deployList.Items) < 1 {
-		return nil, errors.New("Velero deployment not found")
+	for _, deployment := range deployList.Items {
+		if deployment.Name == "velero" {
+			return &deployment, nil
+		}
 	}
 
-	return &deployList.Items[0], nil
+	return nil, errors.New("Velero deployment not found")
 }


### PR DESCRIPTION
When installing velero on vSphere, more than one deployments with label '"component": "velero"' will be installed under the namespace "velero", this causes that when trying to get the velero deployment by label, the other deployment rather than velero is returned

This commit fixes it by filter the deployments with both label and name

Fixes #3961

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
