### PR TITLE
Update stale bot setting

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -14,6 +14,7 @@ exemptLabels:
   - Area/Design
   - Area/Documentation
   - Area/Plugins
+  - Enhancement/User
   - kind/tech-debt
   - Needs investigation
   - P0 - Hair on fire


### PR DESCRIPTION
This commit add `Enhancement/User` as an exempt label such that issues
like #3772 won't be closed by the stale bot.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
