### PR TITLE
adding RBAC test to e2e tests

### DIFF
--- a/changelogs/unreleased/3982-jaidevmane
+++ b/changelogs/unreleased/3982-jaidevmane
@@ -1,0 +1,1 @@
+adding rbac test to e2e tests

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -25,9 +25,9 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	corev1api "k8s.io/api/core/v1"
+	v1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/vmware-tanzu/velero/pkg/builder"
@@ -49,26 +49,25 @@ func createNamespace(ctx context.Context, client testClient, namespace string) e
 }
 
 // createNamespaceAndRbac creates a kubernetes namespace, service account, clusterrole, and clusterrolebinding
-func createNamespaceAndRbac(ctx context.Context, client testClient, namespace string, serviceaccount string, clusterrole string, clusterrolebinding string ) error {
+func createNamespaceAndRbac(ctx context.Context, client testClient, namespace string, serviceaccount string, clusterrole string, clusterrolebinding string) error {
 	ns := builder.ForNamespace(namespace).Result()
 	_, err := client.clientGo.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 
-	if err != nil && !apierrors.IsAlreadyExists(err){
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return err
 	}
 
 	//creating service account
 	sa := &corev1api.ServiceAccount{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: serviceaccount,
-			},
-			AutomountServiceAccountToken: nil,
+		ObjectMeta: metav1.ObjectMeta{
+			Name: serviceaccount,
+		},
+		AutomountServiceAccountToken: nil,
 	}
 
-	_, err = client.clientGo.CoreV1().ServiceAccounts(namespace).Create(ctx,sa,metav1.CreateOptions{})
+	_, err = client.clientGo.CoreV1().ServiceAccounts(namespace).Create(ctx, sa, metav1.CreateOptions{})
 
-
-	if err != nil && !apierrors.IsAlreadyExists(err){
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return err
 	}
 
@@ -79,9 +78,9 @@ func createNamespaceAndRbac(ctx context.Context, client testClient, namespace st
 		},
 	}
 
-	_, err = client.clientGo.RbacV1().ClusterRoles().Create(ctx,role,metav1.CreateOptions{})
+	_, err = client.clientGo.RbacV1().ClusterRoles().Create(ctx, role, metav1.CreateOptions{})
 
-	if err != nil && !apierrors.IsAlreadyExists(err){
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return err
 	}
 
@@ -92,8 +91,8 @@ func createNamespaceAndRbac(ctx context.Context, client testClient, namespace st
 		},
 		Subjects: []v1.Subject{
 			{
-				Kind: "ServiceAccount",
-				Name: serviceaccount,
+				Kind:      "ServiceAccount",
+				Name:      serviceaccount,
 				Namespace: namespace,
 			},
 		},
@@ -103,13 +102,11 @@ func createNamespaceAndRbac(ctx context.Context, client testClient, namespace st
 		},
 	}
 
+	_, err = client.clientGo.RbacV1().ClusterRoleBindings().Create(ctx, rolebinding, metav1.CreateOptions{})
 
-	_, err = client.clientGo.RbacV1().ClusterRoleBindings().Create(ctx,rolebinding,metav1.CreateOptions{})
-
-	if err != nil && !apierrors.IsAlreadyExists(err){
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return err
 	}
-
 
 	return err
 }
@@ -118,7 +115,7 @@ func getNamespace(ctx context.Context, client testClient, namespace string) (*co
 	return client.clientGo.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 }
 
-func getServiceAccount(ctx context.Context, client testClient,namespace string, serviceAccount string) (*corev1api.ServiceAccount, error) {
+func getServiceAccount(ctx context.Context, client testClient, namespace string, serviceAccount string) (*corev1api.ServiceAccount, error) {
 	return client.clientGo.CoreV1().ServiceAccounts(namespace).Get(ctx, serviceAccount, metav1.GetOptions{})
 }
 

--- a/test/e2e/rbac_test.go
+++ b/test/e2e/rbac_test.go
@@ -1,0 +1,217 @@
+package e2e
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"time"
+	"strings"
+
+	"github.com/google/uuid"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("[Basic] Backup/restore of Namespaced Scoped and Cluster Scoped RBAC", func() {
+
+	client, err := newTestClient()
+	Expect(err).To(Succeed(), "Failed to instantiate cluster client for rbac test")
+
+	BeforeEach(func() {
+		var err error
+		flag.Parse()
+		uuidgen, err = uuid.NewRandom()
+		Expect(err).To(Succeed())
+		if installVelero {
+			Expect(veleroInstall(context.Background(), veleroImage, veleroNamespace, cloudProvider, objectStoreProvider, false,
+				cloudCredentialsFile, bslBucket, bslPrefix, bslConfig, vslConfig, "")).To(Succeed())
+
+		}
+	})
+
+	AfterEach(func() {
+		if installVelero {
+			timeoutCTX, _ := context.WithTimeout(context.Background(), time.Minute)
+			err := veleroUninstall(timeoutCTX, client.kubebuilder, installVelero, veleroNamespace)
+			Expect(err).To(Succeed())
+		}
+
+	})
+
+	Context("When I create Namespaced Scoped and Cluster Scoped RBAC", func() {
+		It("should be successfully backed up and restored", func() {
+			backupName := "backup-" + uuidgen.String()
+			restoreName := "restore-" + uuidgen.String()
+			tenMinTimeout, _ := context.WithTimeout(context.Background(), 10*time.Minute)
+			Expect(RunRBACTest(tenMinTimeout, client, "test-"+uuidgen.String(), 5,
+				backupName, restoreName)).To(Succeed(), "Failed to successfully backup and restore RBAC" )
+		})
+	})
+})
+
+func RunRBACTest(ctx context.Context, client testClient, nsBaseName string, numberOfNamespaces int, backupName string, restoreName string) error {
+
+	//defer does not run until the actual surrounding function returns a value, this line is meant for post test cleanup
+	defer cleanupNamespaces(ctx, client, nsBaseName) // Run at exit for final cleanup
+	var excludeNamespaces []string
+
+	// Currently it's hard to build a large list of namespaces to include and wildcards do not work so instead
+	// we will exclude all of the namespaces that existed prior to the test from the backup
+	namespaces, err := client.clientGo.CoreV1().Namespaces().List(ctx, v1.ListOptions{})
+	if err != nil {
+		return errors.Wrap(err, "Could not retrieve namespaces")
+	}
+
+	//appending current namespaces to list of excluded namespaces, and no operations will be performed on those
+	for _, excludeNamespace := range namespaces.Items {
+		excludeNamespaces = append(excludeNamespaces, excludeNamespace.Name)
+	}
+
+	//creates the test namespaces mentioned in arguments of the function, with format of test-someuuid. This loops runs up to the number mentioned in the argument
+	for nsNum := 0; nsNum < numberOfNamespaces; nsNum++ {
+		createNSName := fmt.Sprintf("%s-%00000d", nsBaseName, nsNum)
+		createServiceAccountName := fmt.Sprintf("service-account-%s-%00000d", nsBaseName, nsNum)
+		createClusterRoleName := fmt.Sprintf("clusterrole-%s-%00000d", nsBaseName, nsNum)
+		createClusterRoleBindingName := fmt.Sprintf("clusterrolebinding-%s-%00000d", nsBaseName, nsNum)
+		if err := createNamespaceAndRbac(ctx, client, createNSName, createServiceAccountName,createClusterRoleName, createClusterRoleBindingName); err != nil {
+			return errors.Wrapf(err, "Failed to create test resources")
+		}
+	}
+
+	if err := veleroBackupExcludeNamespaces(ctx, veleroCLI, veleroNamespace, backupName, excludeNamespaces); err != nil {
+		veleroBackupLogs(ctx, veleroCLI, "", backupName)
+		return errors.Wrapf(err, "Failed to backup backup namespaces %s-*", nsBaseName)
+	}
+
+	//if error in cleaning up namespaces, then throw error
+	err = cleanupNamespaces(ctx, client, nsBaseName)
+	if err != nil {
+		return errors.Wrap(err, "Could not cleanup namespaces")
+	}
+	//cleanup clusterrole
+	err = cleanupClusterRole(ctx, client, nsBaseName)
+	if err != nil {
+		return errors.Wrap(err, "Could not cleanup clusterroles")
+	}
+
+	//cleanup cluster rolebinding
+	err = cleanupClusterRoleBinding(ctx, client, nsBaseName)
+	if err != nil {
+		return errors.Wrap(err, "Could not cleanup clusterrolebindings")
+	}
+
+
+	//if error in restoring namespaces, then throw error
+	err = veleroRestore(ctx, veleroCLI, veleroNamespace, restoreName, backupName)
+	if err != nil {
+		return errors.Wrap(err, "Restore failed")
+	}
+
+	// Verify that we got back all of the namespaces, service accounts, clusterroles and clusterrolebindings we created. Also check if the clusterrolebinding mappings are correct.
+	for nsNum := 0; nsNum < numberOfNamespaces; nsNum++ {
+		checkNSName := fmt.Sprintf("%s-%00000d", nsBaseName, nsNum)
+		checkServiceAccountName := fmt.Sprintf("service-account-%s-%00000d", nsBaseName, nsNum)
+		checkClusterRoleName := fmt.Sprintf("clusterrole-%s-%00000d", nsBaseName, nsNum)
+		checkClusterRoleBindingName := fmt.Sprintf("clusterrolebinding-%s-%00000d", nsBaseName, nsNum)
+		checkNS, err := getNamespace(ctx, client, checkNSName)
+
+
+		if err != nil {
+			return errors.Wrapf(err, "Could not retrieve test namespace %s", checkNSName)
+		}
+
+		if checkNS.Name != checkNSName {
+			return errors.Errorf("Retrieved namespace for %s has name %s instead", checkNSName, checkNS.Name)
+		}
+
+		
+		//getting service account from the restore
+		checkSA, err := getServiceAccount(ctx, client, checkNSName ,checkServiceAccountName)
+
+		if err != nil {
+			return errors.Wrapf(err, "Could not retrieve test service account %s", checkSA)
+		}
+
+		if checkSA.Name != checkServiceAccountName {
+			return errors.Errorf("Retrieved service account for %s has name %s instead", checkServiceAccountName, checkSA.Name)
+		}
+
+
+		//getting cluster role from the restore
+		checkClusterRole, err := getClusterRole(ctx, client,checkClusterRoleName)
+
+		if err != nil {
+			return errors.Wrapf(err, "Could not retrieve test cluster role %s", checkClusterRole)
+		}
+
+		if checkSA.Name != checkServiceAccountName {
+			return errors.Errorf("Retrieved cluster role for %s has name %s instead", checkClusterRoleName, checkClusterRole.Name)
+		}
+
+
+		//getting cluster role binding from the restore
+		checkClusterRoleBinding, err := getClusterRoleBinding(ctx, client,checkClusterRoleBindingName)
+
+		if err != nil {
+			return errors.Wrapf(err, "Could not retrieve test cluster role binding %s", checkClusterRoleBinding)
+		}
+
+		if checkClusterRoleBinding.Name != checkClusterRoleBindingName {
+			return errors.Errorf("Retrieved cluster role binding for %s has name %s instead", checkClusterRoleBindingName, checkClusterRoleBinding.Name)
+		}
+
+
+		//check if the role binding maps to service account
+		checkSubjects := checkClusterRoleBinding.Subjects[0].Name
+
+		if checkSubjects != checkServiceAccountName {
+			return errors.Errorf("Retrieved cluster role binding for %s has name %s instead", checkServiceAccountName, checkSubjects)
+		}
+
+
+	}
+	// Cleanup is automatic on the way out
+	return nil
+}
+
+func cleanupClusterRole(ctx context.Context, client testClient, nsBaseName string) error {
+
+	clusterroles, err := client.clientGo.RbacV1().ClusterRoles().List(ctx, v1.ListOptions{})
+	if err != nil {
+		return errors.Wrap(err, "Could not retrieve clusterroles")
+	}
+
+	for _, checkClusterRole := range clusterroles.Items {
+		if strings.HasPrefix(checkClusterRole.Name, "clusterrole-"+nsBaseName) {
+			fmt.Printf("Cleaning up clusterrole %s\n", checkClusterRole.Name)
+			err = client.clientGo.RbacV1().ClusterRoles().Delete(ctx, checkClusterRole.Name, v1.DeleteOptions{})
+			if err != nil {
+				return errors.Wrapf(err, "Could not delete clusterrole %s", checkClusterRole.Name)
+			}
+		}
+	}
+	return nil
+}
+
+func cleanupClusterRoleBinding(ctx context.Context, client testClient, nsBaseName string) error {
+
+	clusterrolebindings, err := client.clientGo.RbacV1().ClusterRoleBindings().List(ctx, v1.ListOptions{})
+	if err != nil {
+		return errors.Wrap(err, "Could not retrieve clusterrolebindings")
+	}
+
+	for _, checkClusterRoleBinding := range clusterrolebindings.Items {
+		if strings.HasPrefix(checkClusterRoleBinding.Name, "clusterrolebinding-"+nsBaseName) {
+			fmt.Printf("Cleaning up clusterrolebinding %s\n", checkClusterRoleBinding.Name)
+			err = client.clientGo.RbacV1().ClusterRoleBindings().Delete(ctx, checkClusterRoleBinding.Name, v1.DeleteOptions{})
+			if err != nil {
+				return errors.Wrapf(err, "Could not delete clusterrolebinding %s", checkClusterRoleBinding.Name)
+			}
+		}
+	}
+	return nil
+}

--- a/test/e2e/rbac_test.go
+++ b/test/e2e/rbac_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"time"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -48,7 +48,7 @@ var _ = Describe("[Basic] Backup/restore of Namespaced Scoped and Cluster Scoped
 			restoreName := "restore-" + uuidgen.String()
 			tenMinTimeout, _ := context.WithTimeout(context.Background(), 10*time.Minute)
 			Expect(RunRBACTest(tenMinTimeout, client, "test-"+uuidgen.String(), 5,
-				backupName, restoreName)).To(Succeed(), "Failed to successfully backup and restore RBAC" )
+				backupName, restoreName)).To(Succeed(), "Failed to successfully backup and restore RBAC")
 		})
 	})
 })
@@ -77,7 +77,7 @@ func RunRBACTest(ctx context.Context, client testClient, nsBaseName string, numb
 		createServiceAccountName := fmt.Sprintf("service-account-%s-%00000d", nsBaseName, nsNum)
 		createClusterRoleName := fmt.Sprintf("clusterrole-%s-%00000d", nsBaseName, nsNum)
 		createClusterRoleBindingName := fmt.Sprintf("clusterrolebinding-%s-%00000d", nsBaseName, nsNum)
-		if err := createNamespaceAndRbac(ctx, client, createNSName, createServiceAccountName,createClusterRoleName, createClusterRoleBindingName); err != nil {
+		if err := createNamespaceAndRbac(ctx, client, createNSName, createServiceAccountName, createClusterRoleName, createClusterRoleBindingName); err != nil {
 			return errors.Wrapf(err, "Failed to create test resources")
 		}
 	}
@@ -104,7 +104,6 @@ func RunRBACTest(ctx context.Context, client testClient, nsBaseName string, numb
 		return errors.Wrap(err, "Could not cleanup clusterrolebindings")
 	}
 
-
 	//if error in restoring namespaces, then throw error
 	err = veleroRestore(ctx, veleroCLI, veleroNamespace, restoreName, backupName)
 	if err != nil {
@@ -119,7 +118,6 @@ func RunRBACTest(ctx context.Context, client testClient, nsBaseName string, numb
 		checkClusterRoleBindingName := fmt.Sprintf("clusterrolebinding-%s-%00000d", nsBaseName, nsNum)
 		checkNS, err := getNamespace(ctx, client, checkNSName)
 
-
 		if err != nil {
 			return errors.Wrapf(err, "Could not retrieve test namespace %s", checkNSName)
 		}
@@ -128,9 +126,8 @@ func RunRBACTest(ctx context.Context, client testClient, nsBaseName string, numb
 			return errors.Errorf("Retrieved namespace for %s has name %s instead", checkNSName, checkNS.Name)
 		}
 
-		
 		//getting service account from the restore
-		checkSA, err := getServiceAccount(ctx, client, checkNSName ,checkServiceAccountName)
+		checkSA, err := getServiceAccount(ctx, client, checkNSName, checkServiceAccountName)
 
 		if err != nil {
 			return errors.Wrapf(err, "Could not retrieve test service account %s", checkSA)
@@ -140,9 +137,8 @@ func RunRBACTest(ctx context.Context, client testClient, nsBaseName string, numb
 			return errors.Errorf("Retrieved service account for %s has name %s instead", checkServiceAccountName, checkSA.Name)
 		}
 
-
 		//getting cluster role from the restore
-		checkClusterRole, err := getClusterRole(ctx, client,checkClusterRoleName)
+		checkClusterRole, err := getClusterRole(ctx, client, checkClusterRoleName)
 
 		if err != nil {
 			return errors.Wrapf(err, "Could not retrieve test cluster role %s", checkClusterRole)
@@ -152,9 +148,8 @@ func RunRBACTest(ctx context.Context, client testClient, nsBaseName string, numb
 			return errors.Errorf("Retrieved cluster role for %s has name %s instead", checkClusterRoleName, checkClusterRole.Name)
 		}
 
-
 		//getting cluster role binding from the restore
-		checkClusterRoleBinding, err := getClusterRoleBinding(ctx, client,checkClusterRoleBindingName)
+		checkClusterRoleBinding, err := getClusterRoleBinding(ctx, client, checkClusterRoleBindingName)
 
 		if err != nil {
 			return errors.Wrapf(err, "Could not retrieve test cluster role binding %s", checkClusterRoleBinding)
@@ -164,14 +159,12 @@ func RunRBACTest(ctx context.Context, client testClient, nsBaseName string, numb
 			return errors.Errorf("Retrieved cluster role binding for %s has name %s instead", checkClusterRoleBindingName, checkClusterRoleBinding.Name)
 		}
 
-
 		//check if the role binding maps to service account
 		checkSubjects := checkClusterRoleBinding.Subjects[0].Name
 
 		if checkSubjects != checkServiceAccountName {
 			return errors.Errorf("Retrieved cluster role binding for %s has name %s instead", checkServiceAccountName, checkSubjects)
 		}
-
 
 	}
 	// Cleanup is automatic on the way out


### PR DESCRIPTION
Signed-off-by: Jai Subash Devmane <jdevmane@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
- Added an E2E test that verifies service accounts, cluster roles, and cluster rolebindings are backed up and restored correctly.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
