### PR TITLE
Fixing multipleNamespaceTest bug - Missing expect statement in test

### DIFF
--- a/changelogs/unreleased/3983-jaidevmane
+++ b/changelogs/unreleased/3983-jaidevmane
@@ -1,0 +1,1 @@
+Fixing multipleNamespaceTest bug - Missing expect statement in test

--- a/test/e2e/multiple_namespaces_test.go
+++ b/test/e2e/multiple_namespaces_test.go
@@ -47,8 +47,8 @@ var _ = Describe("[Basic] Backup/restore of 2 namespaces", func() {
 			backupName := "backup-" + uuidgen.String()
 			restoreName := "restore-" + uuidgen.String()
 			fiveMinTimeout, _ := context.WithTimeout(context.Background(), 5*time.Minute)
-			RunMultipleNamespaceTest(fiveMinTimeout, client, "nstest-"+uuidgen.String(), 2,
-				backupName, restoreName)
+			Expect(RunMultipleNamespaceTest(fiveMinTimeout, client, "nstest-"+uuidgen.String(), 2,
+				backupName, restoreName)).To(Succeed(), "Failed to successfully backup and restore multiple namespaces")
 		})
 	})
 })
@@ -84,8 +84,8 @@ var _ = Describe("[Scale] Backup/restore of 2500 namespaces", func() {
 			backupName := "backup-" + uuidgen.String()
 			restoreName := "restore-" + uuidgen.String()
 			oneHourTimeout, _ := context.WithTimeout(context.Background(), 1*time.Hour)
-			RunMultipleNamespaceTest(oneHourTimeout, client, "nstest-"+uuidgen.String(), 2500,
-				backupName, restoreName)
+			Expect(RunMultipleNamespaceTest(oneHourTimeout, client, "nstest-"+uuidgen.String(), 2500,
+				backupName, restoreName)).To(Succeed(), "Failed to successfully backup and restore multiple namespaces")
 		})
 	})
 })


### PR DESCRIPTION
Signed-off-by: Jai Subash Devmane <jdevmane@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
- Bug Fix for multiple namespace test where Expect statement was not present
# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
