### PR TITLE
Check the test result for the "Basic" and "Scale"

### DIFF
--- a/test/e2e/multiple_namespaces_test.go
+++ b/test/e2e/multiple_namespaces_test.go
@@ -47,8 +47,8 @@ var _ = Describe("[Basic] Backup/restore of 2 namespaces", func() {
 			backupName := "backup-" + uuidgen.String()
 			restoreName := "restore-" + uuidgen.String()
 			fiveMinTimeout, _ := context.WithTimeout(context.Background(), 5*time.Minute)
-			RunMultipleNamespaceTest(fiveMinTimeout, client, "nstest-"+uuidgen.String(), 2,
-				backupName, restoreName)
+			Expect(RunMultipleNamespaceTest(fiveMinTimeout, client, "nstest-"+uuidgen.String(), 2,
+				backupName, restoreName)).To(Succeed())
 		})
 	})
 })
@@ -84,8 +84,8 @@ var _ = Describe("[Scale] Backup/restore of 2500 namespaces", func() {
 			backupName := "backup-" + uuidgen.String()
 			restoreName := "restore-" + uuidgen.String()
 			oneHourTimeout, _ := context.WithTimeout(context.Background(), 1*time.Hour)
-			RunMultipleNamespaceTest(oneHourTimeout, client, "nstest-"+uuidgen.String(), 2500,
-				backupName, restoreName)
+			Expect(RunMultipleNamespaceTest(oneHourTimeout, client, "nstest-"+uuidgen.String(), 2500,
+				backupName, restoreName)).To(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
Fix bug of "Basic" and "Scale" test cases: we don't check the result status for both of them

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
