### PR TITLE
Workaround the velero uninstallation doesn't cleanup issue(#3974) in E2E test code

### DIFF
--- a/test/e2e/velero_utils.go
+++ b/test/e2e/velero_utils.go
@@ -341,6 +341,14 @@ func veleroInstall(ctx context.Context, veleroImage string, veleroNamespace stri
 }
 
 func veleroUninstall(ctx context.Context, client kbclient.Client, installVelero bool, veleroNamespace string) error {
+	// TODO remove the workaround logic after the issue fixed
+	// this is a workaround for issue https://github.com/vmware-tanzu/velero/issues/3974
+	cmd := exec.CommandContext(ctx, "bash", "-c", fmt.Sprintf(`kubectl delete "$(kubectl api-resources --api-group=velero.io -o name | tr "\n" "," | sed -e 's/,$//')" --all -n %s`, veleroNamespace))
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
 	return uninstall.Run(ctx, client, veleroNamespace, true)
 }
 


### PR DESCRIPTION
We delete all the resources under the "velero" namespace before uninstalling the velero to  workaround the issue https://github.com/vmware-tanzu/velero/issues/3974

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
