### PR TITLE
Restic Backup: Add check if Pod is successful or failed for emptyDir.…

### DIFF
--- a/changelogs/unreleased/3993-mahaupt
+++ b/changelogs/unreleased/3993-mahaupt
@@ -1,0 +1,1 @@
+Fix restic error when volume is emptyDir and Pod not running

--- a/pkg/restic/backupper.go
+++ b/pkg/restic/backupper.go
@@ -157,6 +157,11 @@ func (b *backupper) BackupPodVolumes(backup *velerov1api.Backup, pod *corev1api.
 			continue
 		}
 
+		// emptyDir volumes on finished pods are not supported because the volume is already gone and would result in an error
+		if (pod.Status.Phase == corev1api.PodSucceeded || pod.Status.Phase == corev1api.PodFailed) && volume.EmptyDir != nil {
+			continue
+		}
+
 		volumeBackup := newPodVolumeBackup(backup, pod, volume, repo.Spec.ResticIdentifier, pvc)
 		if volumeBackup, err = b.repoManager.veleroClient.VeleroV1().PodVolumeBackups(volumeBackup.Namespace).Create(context.TODO(), volumeBackup, metav1.CreateOptions{}); err != nil {
 			errs = append(errs, err)


### PR DESCRIPTION
# Summary
I added a check to exclude restic backups for emptyDirs on stopped but unremoved pods (successful / failed).
Emptydirs are only guaranteed to persist on running / crashing pods.  

https://kubernetes.io/docs/concepts/storage/volumes/#emptydir

https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase

Please let me know if I shall add a changelog / documentation for this small bugfix.

# Does your change fix a particular issue?

Fixes #3812

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
