### PR TITLE
Updated uninstall to remove both v1beta1 and v1 CRDs if present

### DIFF
--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -19,6 +19,7 @@ package client
 import (
 	"os"
 
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	k8scheme "k8s.io/client-go/kubernetes/scheme"
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -156,6 +157,7 @@ func (f *factory) KubebuilderClient() (kbclient.Client, error) {
 	velerov1api.AddToScheme(scheme)
 	k8scheme.AddToScheme(scheme)
 	apiextv1beta1.AddToScheme(scheme)
+	apiextv1.AddToScheme(scheme)
 	kubebuilderClient, err := kbclient.New(clientConfig, kbclient.Options{
 		Scheme: scheme,
 	})


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Uninstall now removes the new and old CRDs if present

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [X] Updated the corresponding documentation in `site/content/docs/main`.
