### PR TITLE
pkg/install: fix dropped error

### DIFF
--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -103,6 +103,9 @@ func crdsAreReady(factory client.DynamicFactory, crdKinds []string) (bool, error
 
 		return true, nil
 	})
+	if err != nil {
+		return false, errors.Wrap(err, "Error polling for CRD")
+	}
 	return areReady, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Lars Lehtonen <lars.lehtonen@gmail.com>

Thank you for contributing to Velero!

# Please add a summary of your change

This fixes a dropped `err` variable in `pkg/install`.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
