### PR TITLE
Wait the namespace deletion completed before removing the CRDs

### DIFF
--- a/changelogs/unreleased/4007-ywk253100
+++ b/changelogs/unreleased/4007-ywk253100
@@ -1,0 +1,1 @@
+Wait for the namespace to be deleted before removing the CRDs during uninstall. This deprecates the `--wait` flag of the `uninstall` command

--- a/test/e2e/velero_utils.go
+++ b/test/e2e/velero_utils.go
@@ -342,7 +342,7 @@ func veleroInstall(ctx context.Context, veleroImage string, veleroNamespace stri
 }
 
 func veleroUninstall(ctx context.Context, client kbclient.Client, installVelero bool, veleroNamespace string) error {
-	return uninstall.Run(ctx, client, veleroNamespace, true)
+	return uninstall.Run(ctx, client, veleroNamespace)
 }
 
 func veleroBackupLogs(ctx context.Context, veleroCLI string, veleroNamespace string, backupName string) error {


### PR DESCRIPTION
Wait the namespace deletion completed before removing the CRDs when uninstalling the velero

Fixes #3974

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
