### PR TITLE
Add Kubernetes v1.22 CI test

### DIFF
--- a/.github/workflows/crds-verify-kind.yaml
+++ b/.github/workflows/crds-verify-kind.yaml
@@ -59,6 +59,7 @@ jobs:
           - 1.19.7
           - 1.20.2
           - 1.21.1
+          - 1.22.0
     # All steps run in parallel unless otherwise specified.
     # See https://docs.github.com/en/actions/learn-github-actions/managing-complex-workflows#creating-dependent-jobs
     steps:

--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -63,6 +63,7 @@ jobs:
           - 1.19.7
           - 1.20.2
           - 1.21.1
+          - 1.22.0
       fail-fast: false
     steps:
       - name: Check out the code


### PR DESCRIPTION
# Please add a summary of your change

Kubernetes v1.22 released https://github.com/kubernetes/kubernetes/releases/tag/v1.22.0

Add Kubernetes v1.22 CI test for testing CRD verify and E2E test on v1.22.0.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
