### PR TITLE
internal/delete: fix dropped error

### DIFF
--- a/internal/delete/delete_item_action_handler.go
+++ b/internal/delete/delete_item_action_handler.go
@@ -68,6 +68,10 @@ func InvokeDeleteActions(ctx *Context) error {
 	ctx.Log.Debugf("Downloaded and extracted the backup file to: %s", dir)
 
 	backupResources, err := archive.NewParser(ctx.Log, ctx.Filesystem).Parse(dir)
+	if err != nil {
+		return errors.Wrapf(err, "error parsing backup %q", dir)
+	}
+
 	processdResources := sets.NewString()
 
 	ctx.Log.Debugf("Trying to reconcile resource names with Kube API server.")


### PR DESCRIPTION
Signed-off-by: Lars Lehtonen <lars.lehtonen@gmail.com>

# Please add a summary of your change

This fixes a dropped `err` variable in the `internal/delete` package.

/kind changelog-not-required

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
