### PR TITLE
Distinguish between different unnamed node ports when preserving

### DIFF
--- a/changelogs/unreleased/4026-sseago
+++ b/changelogs/unreleased/4026-sseago
@@ -1,0 +1,1 @@
+Distinguish between different unnamed node ports when preserving

--- a/pkg/restore/service_action_test.go
+++ b/pkg/restore/service_action_test.go
@@ -196,6 +196,9 @@ func TestServiceActionExecute(t *testing.T) {
 						{
 							NodePort: 8080,
 						},
+						{
+							NodePort: 9090,
+						},
 					},
 				},
 			},
@@ -212,6 +215,7 @@ func TestServiceActionExecute(t *testing.T) {
 						{
 							NodePort: 8080,
 						},
+						{},
 					},
 				},
 			},


### PR DESCRIPTION
Signed-off-by: Scott Seago <sseago@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Service action should delete nodeports unless specified in last-applied-configuration. The current code attempts to do this as follows:
if the port is named, then preserve it if the named port is in the configuration. Otherwise, if the port is unnamed, then preserve it if the unnamed port is in the configuration.

The previous code lumps all unnamed ports together -- it preserves all if any exist in the configuration. The updated match check compares port number when name is missing. unit test update exposes the prior bug.


# Does your change fix a particular issue?

Fixes #4025

# Please indicate you've done the following:

- [x ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
