### PR TITLE
Changed format of download request name to use a random UUID rather than

### DIFF
--- a/pkg/cmd/util/downloadrequest/downloadrequest.go
+++ b/pkg/cmd/util/downloadrequest/downloadrequest.go
@@ -28,6 +28,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -41,7 +42,12 @@ import (
 var ErrNotFound = errors.New("file not found")
 
 func Stream(ctx context.Context, kbClient kbclient.Client, namespace, name string, kind velerov1api.DownloadTargetKind, w io.Writer, timeout time.Duration, insecureSkipTLSVerify bool, caCertFile string) error {
-	reqName := fmt.Sprintf("%s-%s", name, time.Now().Format("20060102150405"))
+	uuid, err := uuid.NewRandom()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	reqName := fmt.Sprintf("%s-%s", name, uuid.String())
 	created := builder.ForDownloadRequest(namespace, reqName).Target(kind, name).Result()
 
 	if err := kbClient.Create(context.Background(), created, &kbclient.CreateOptions{}); err != nil {


### PR DESCRIPTION
a timestamp.  If two requests were happening very close together for the
same backup, the second would fail randomly.

Thank you for contributing to Velero!

# Please add a summary of your change
Changes the format of the download request name used by velero CLI to get logs and files from the object store

# Does your change fix a particular issue?

If two requests were happening very close together for the same backup, the second would fail randomly.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
