### PR TITLE
pkg/controller: fix dropped test error

### DIFF
--- a/pkg/controller/restore_controller_test.go
+++ b/pkg/controller/restore_controller_test.go
@@ -487,7 +487,7 @@ func TestProcessQueueItem(t *testing.T) {
 						res.Spec.BackupName = backupName
 					}
 
-					return true, res, nil
+					return true, res, err
 				})
 			}
 


### PR DESCRIPTION
Signed-off-by: Lars Lehtonen <lars.lehtonen@gmail.com>

# Please add a summary of your change

This fixes a dropped test `err` variable in `pkg/controller`.
/kind changelog-not-required

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
