### PR TITLE
Change the base image to distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,13 +50,11 @@ RUN mkdir -p /output/usr/bin && \
     go build -o /output/${BIN} \
     -ldflags "${LDFLAGS}" ${PKG}/cmd/${BIN}
 
-FROM ubuntu:focal
+FROM gcr.io/distroless/base-debian10:nonroot
 
 LABEL maintainer="Nolan Brubaker <brubakern@vmware.com>"
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y ca-certificates tzdata && rm -rf /var/lib/apt/lists/*
-
 COPY --from=builder /output /
 
-USER nobody:nogroup
+USER nonroot:nonroot
 

--- a/changelogs/unreleased/4055-ywk253100
+++ b/changelogs/unreleased/4055-ywk253100
@@ -1,0 +1,1 @@
+Change the base image to distroless


### PR DESCRIPTION
Change the base image to distroless

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
