### PR TITLE
Validate namespace in velero backup create command

### DIFF
--- a/changelogs/unreleased/4057-codegold79
+++ b/changelogs/unreleased/4057-codegold79
@@ -1,0 +1,1 @@
+Validate namespace in Velero backup create command

--- a/pkg/cmd/cli/backup/create.go
+++ b/pkg/cmd/cli/backup/create.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 the Velero contributors.
+Copyright The Velero Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/cmd/cli/backup/create_test.go
+++ b/pkg/cmd/cli/backup/create_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 the Velero contributors.
+Copyright The Velero Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/cmd/cli/backup/create_test.go
+++ b/pkg/cmd/cli/backup/create_test.go
@@ -25,7 +25,6 @@ import (
 
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/builder"
-	"github.com/vmware-tanzu/velero/pkg/cmd/util/flag"
 	"github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned/fake"
 )
 
@@ -122,88 +121,4 @@ func TestCreateOptions_OrderedResources(t *testing.T) {
 	}
 	assert.Equal(t, orderedResources, expectedMixedResources)
 
-}
-
-func TestAreNamespacesValid(t *testing.T) {
-
-	tests := []struct {
-		name       string
-		namespaces []string
-		wantErr    bool
-	}{
-		{
-			name:       "empty slice doesn't return error",
-			namespaces: []string{},
-			wantErr:    false,
-		},
-		{
-			name:       "empty string is invalid",
-			namespaces: []string{""},
-			wantErr:    true,
-		},
-		{
-			name:       "asterisk is not valid",
-			namespaces: []string{"*"},
-			wantErr:    true,
-		},
-		{
-			name:       "alphanumeric names with optional dash inside are valid",
-			namespaces: []string{"foobar", "bar-321", "foo123bar"},
-			wantErr:    false,
-		},
-		{
-			name:       "not starting or ending with an alphanumeric character is invalid",
-			namespaces: []string{"-123foo", "-123foo-", "123foo-"},
-			wantErr:    true,
-		},
-		{
-			name:       "special characters in name is invalid",
-			namespaces: []string{"foo?", "foo.bar", "bar_321", "bar*321", "'321'"},
-			wantErr:    true,
-		},
-	}
-
-	for _, tc := range tests {
-		err := areNamespacesValid(tc.namespaces)
-
-		if tc.wantErr && err == nil {
-			t.Errorf("%s: wanted errors but got none", tc.name)
-		}
-
-		if !tc.wantErr && err != nil {
-			t.Errorf("%s: wanted no errors but got: %v", tc.name, err)
-		}
-	}
-}
-
-func TestFilterNamespaces(t *testing.T) {
-	tests := []struct {
-		name     string
-		includes []string
-		excludes []string
-		want     []string
-	}{
-		{
-			name:     "nothing to filter",
-			includes: []string{"foo", "bar"},
-			excludes: []string{"123foo", "bar321"},
-			want:     []string{"foo", "bar", "123foo", "bar321"},
-		},
-		{
-			name:     "filter out asterisks",
-			includes: []string{"*", "foo-bar"},
-			excludes: []string{"*", "foofoo-barbar"},
-			want:     []string{"foo-bar", "foofoo-barbar"},
-		},
-	}
-
-	for _, tc := range tests {
-		opts := CreateOptions{
-			IncludeNamespaces: flag.StringArray(tc.includes),
-			ExcludeNamespaces: flag.StringArray(tc.excludes),
-		}
-
-		got := opts.filterNamespaces()
-		assert.Equal(t, tc.want, got)
-	}
 }

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -424,7 +424,7 @@ func (c *backupController) prepareBackupRequest(backup *velerov1api.Backup) *pkg
 	}
 
 	// validate the included/excluded namespaces
-	for _, err := range collections.ValidateIncludesExcludes(request.Spec.IncludedNamespaces, request.Spec.ExcludedNamespaces) {
+	for _, err := range collections.ValidateNamespaceIncludesExcludes(request.Spec.IncludedNamespaces, request.Spec.ExcludedNamespaces) {
 		request.Status.ValidationErrors = append(request.Status.ValidationErrors, fmt.Sprintf("Invalid included/excluded namespace lists: %v", err))
 	}
 

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright the Velero contributors.
+Copyright The Velero Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controller/backup_deletion_controller_test.go
+++ b/pkg/controller/backup_deletion_controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright the Velero contributors.
+Copyright The Velero Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/util/collections/includes_excludes.go
+++ b/pkg/util/collections/includes_excludes.go
@@ -167,8 +167,8 @@ func ValidateNamespaceIncludesExcludes(includesList, excludesList []string) []er
 		// Although asterisks is not a valid Kubernetes namespace name, it is
 		// allowed here.
 		if itm != "*" {
-			if err := validateNamespaceName(itm); err != nil {
-				errs = append(errs, err)
+			if nsErrs := validateNamespaceName(itm); nsErrs != nil {
+				errs = append(errs, nsErrs...)
 			}
 		}
 	}
@@ -176,8 +176,8 @@ func ValidateNamespaceIncludesExcludes(includesList, excludesList []string) []er
 	for _, itm := range excludes.List() {
 		// Asterisks in excludes list have been checked previously.
 		if itm != "*" {
-			if err := validateNamespaceName(itm); err != nil {
-				errs = append(errs, err)
+			if nsErrs := validateNamespaceName(itm); nsErrs != nil {
+				errs = append(errs, nsErrs...)
 			}
 		}
 	}
@@ -185,14 +185,16 @@ func ValidateNamespaceIncludesExcludes(includesList, excludesList []string) []er
 	return errs
 }
 
-func validateNamespaceName(ns string) error {
-	if errs := validation.ValidateNamespaceName(ns, false); errs != nil {
-		for _, e := range errs {
-			return errors.Errorf("namespace name, %q: %v", ns, e)
+func validateNamespaceName(ns string) []error {
+	var errs []error
+
+	if errMsgs := validation.ValidateNamespaceName(ns, false); errMsgs != nil {
+		for _, msg := range errMsgs {
+			errs = append(errs, errors.Errorf("namespace, %q: %s", ns, msg))
 		}
 	}
 
-	return nil
+	return errs
 }
 
 // GenerateIncludesExcludes constructs an IncludesExcludes struct by taking the provided

--- a/pkg/util/collections/includes_excludes.go
+++ b/pkg/util/collections/includes_excludes.go
@@ -190,7 +190,7 @@ func validateNamespaceName(ns string) []error {
 
 	if errMsgs := validation.ValidateNamespaceName(ns, false); errMsgs != nil {
 		for _, msg := range errMsgs {
-			errs = append(errs, errors.Errorf("namespace, %q: %s", ns, msg))
+			errs = append(errs, errors.Errorf("invalid namespace %q: %s", ns, msg))
 		}
 	}
 

--- a/pkg/util/collections/includes_excludes.go
+++ b/pkg/util/collections/includes_excludes.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 the Velero contributors.
+Copyright The Velero Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/util/collections/includes_excludes_test.go
+++ b/pkg/util/collections/includes_excludes_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 the Velero contributors.
+Copyright The Velero Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/util/collections/includes_excludes_test.go
+++ b/pkg/util/collections/includes_excludes_test.go
@@ -235,6 +235,33 @@ func TestValidateNamespaceIncludesExcludes(t *testing.T) {
 			excludes: []string{"$foo", "foo*bar", "bar=321"},
 			wantErr:  true,
 		},
+		{
+			name:     "empty includes (everything) is valid",
+			includes: []string{},
+			wantErr:  false,
+		},
+		{
+			name:     "include everything using asterisk is valid",
+			includes: []string{"*"},
+			wantErr:  false,
+		},
+		{
+			name:     "include everything not allowed with other includes",
+			includes: []string{"*", "foo"},
+			wantErr:  true,
+		},
+		{
+			name:     "exclude everything not allowed",
+			includes: []string{"foo"},
+			excludes: []string{"*"},
+			wantErr:  true,
+		},
+		{
+			name:     "excludes cannot contain items in includes",
+			includes: []string{"foo", "bar"},
+			excludes: []string{"bar"},
+			wantErr:  true,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
# Please add a summary of your change

Added validation of namespaces included and excluded when creating Velero backups. The validatation was added both in the client and the server (the backup controller).

# Does your change fix a particular issue?

Fixes #2690. In this issue, it was reported that when a forward slash was used in an included namespace for a backup, the backup proceeded instead of gracefully failing with useful information to the user. 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
