### PR TITLE
Fix log print error using a wrong var name

### DIFF
--- a/internal/storage/storagelocation.go
+++ b/internal/storage/storagelocation.go
@@ -53,7 +53,7 @@ func IsReadyToValidate(bslValidationFrequency *metav1.Duration, lastValidationTi
 	}
 
 	if validationFrequency < 0 {
-		log.Debugf("Validation period must be non-negative, changing from %d to %d", validationFrequency, validationFrequency)
+		log.Debugf("Validation period must be non-negative, changing from %d to %d", validationFrequency, serverValidationFrequency)
 		validationFrequency = serverValidationFrequency
 	}
 

--- a/internal/storage/storagelocation.go
+++ b/internal/storage/storagelocation.go
@@ -53,7 +53,7 @@ func IsReadyToValidate(bslValidationFrequency *metav1.Duration, lastValidationTi
 	}
 
 	if validationFrequency < 0 {
-		log.Debugf("Validation period must be non-negative, changing from %d to %d", validationFrequency, serverValidationFrequency)
+		log.Debugf("Validation period must be non-negative, changing from %d to %d", validationFrequency, validationFrequency)
 		validationFrequency = serverValidationFrequency
 	}
 


### PR DESCRIPTION
Signed-off-by: jacklu1024 <jacklu1024@outlook.com>

/kind changelog-not-required

Fix log print error using a wrong var name, it is easy to see and fix.
