### PR TITLE
Skip restic backup/restore of DownwardAPI volumes

### DIFF
--- a/changelogs/unreleased/4076-zubron
+++ b/changelogs/unreleased/4076-zubron
@@ -1,0 +1,1 @@
+Skip the backup and restore of DownwardAPI volumes when using restic.


### PR DESCRIPTION
# Please add a summary of your change

Velero was including DownwardAPI volumes when backing up with restic.
When restoring these volumes, it triggered a known issue with restic (as
seen in #3863). Like projected volumes, these volumes should be skipped
as their contents are populated by the Kubernetes API server.

With this change, we are now skipping the restic backup of volumes with
a DownwardAPI source. We are also skipping the restore of any volume
that had a DownwardAPI source as there will exist backups that were
taken prior to this fix being introduced. This will allow these backups
to be restored succesfully.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

# Does your change fix a particular issue?

Fixes #4053

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
