### PR TITLE
Enhance e2e test

### DIFF
--- a/test/e2e/install.go
+++ b/test/e2e/install.go
@@ -280,7 +280,7 @@ func waitVeleroReady(ctx context.Context, namespace string, useRestic bool) erro
 
 	if useRestic {
 		fmt.Println("Waiting for Velero restic daemonset to be ready.")
-		wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+		err := wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
 			stdout, stderr, err := velerexec.RunCommand(exec.CommandContext(ctx, "kubectl", "get", "daemonset/restic",
 				"-o", "json", "-n", namespace))
 			if err != nil {
@@ -295,6 +295,9 @@ func waitVeleroReady(ctx context.Context, namespace string, useRestic bool) erro
 			}
 			return false, nil
 		})
+		if err != nil {
+			return errors.Wrap(err, "fail to wait for the velero restic ready")
+		}
 	}
 
 	fmt.Printf("Velero is installed and ready to be tested in the %s namespace! ⛵ \n", namespace)

--- a/test/e2e/velero_utils.go
+++ b/test/e2e/velero_utils.go
@@ -46,8 +46,10 @@ func getProviderPlugins(providerName string) []string {
 		return []string{"velero/velero-plugin-for-microsoft-azure:v1.2.0"}
 	case "vsphere":
 		return []string{"velero/velero-plugin-for-aws:v1.2.1", "vsphereveleroplugin/velero-plugin-for-vsphere:v1.1.1"}
+	case "gcp":
+		return []string{"velero/velero-plugin-for-gcp:v1.2.1"}
 	default:
-		return []string{""}
+		panic(fmt.Errorf("unknown provider name: %s", providerName))
 	}
 }
 


### PR DESCRIPTION


Thank you for contributing to Velero!

# Please add a summary of your change
1. Check the error when waiting for restice daemonset to be ready, so
   the timeout will be reported
2. Add support for gcp provider and fail early if the provider is
   unknown

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
