### PR TITLE
pass velero cli executable to crashd

### DIFF
--- a/pkg/cmd/cli/debug/cshd-scripts/velero.cshd
+++ b/pkg/cmd/cli/debug/cshd-scripts/velero.cshd
@@ -1,26 +1,27 @@
-def capture_backup_logs(namespace):
+def capture_backup_logs(cmd, namespace):
     if args.backup:
         log("Collecting log for backup: {}".format(args.backup))
-        backupLogsCmd = "velero --namespace={} backup logs {}".format(namespace, args.backup)
+        backupLogsCmd = "{} --namespace={} backup logs {}".format(cmd, namespace, args.backup)
         capture_local(cmd=backupLogsCmd, file_name="backup_{}.log".format(args.backup))
-def capture_restore_logs(namespace):
+def capture_restore_logs(cmd, namespace):
     if args.restore:
         log("Collecting log for restore: {}".format(args.restore))
-        restoreLogsCmd = "velero --namespace={} restore logs {}".format(namespace, args.restore)
+        restoreLogsCmd = "{} --namespace={} restore logs {}".format(cmd, namespace, args.restore)
         capture_local(cmd=restoreLogsCmd, file_name="restore_{}.log".format(args.restore))
 
 ns = args.namespace if args.namespace else "velero"
 output = args.output if args.output else "bundle.tar.gz"
+cmd = args.cmd if args.cmd else "velero"
 # Working dir for writing during script execution
 crshd = crashd_config(workdir="./velero-bundle")
 set_defaults(kube_config(path=args.kubeconfig, cluster_context=args.kubecontext))
 log("Collecting velero resources in namespace: {}". format(ns))
 kube_capture(what="objects", namespaces=[ns], groups=['velero.io'])
-capture_local(cmd="velero version -n {}".format(ns), file_name="version.txt")
+capture_local(cmd="{} version -n {}".format(cmd, ns), file_name="version.txt")
 log("Collecting velero deployment logs in namespace: {}". format(ns))
 kube_capture(what="logs", namespaces=[ns])
-capture_backup_logs(ns)
-capture_restore_logs(ns)
+capture_backup_logs(cmd, ns)
+capture_restore_logs(cmd, ns)
 archive(output_file=output, source_paths=[crshd.workdir])
 log("Generated debug information bundle: {}".format(output))
 

--- a/pkg/cmd/cli/debug/debug.go
+++ b/pkg/cmd/cli/debug/debug.go
@@ -42,6 +42,8 @@ import (
 var scriptBytes []byte
 
 type option struct {
+	// currCmd the velero command
+	currCmd string
 	// workdir for crashd will be $baseDir/velero-debug
 	baseDir string
 	// the namespace where velero server is installed
@@ -74,6 +76,7 @@ func (o *option) asCrashdArgs() string {
 
 func (o *option) asCrashdArgMap() exec.ArgMap {
 	return exec.ArgMap{
+		"cmd":         o.currCmd,
 		"output":      o.outputPath,
 		"namespace":   o.namespace,
 		"basedir":     o.baseDir,
@@ -100,6 +103,10 @@ func (o *option) complete(f client.Factory, fs *pflag.FlagSet) error {
 	o.baseDir = tmpDir
 	o.namespace = f.Namespace()
 	kp, kc := kubeconfigAndContext(fs)
+	o.currCmd, err = os.Executable()
+	if err != nil {
+		return err
+	}
 	o.kubeconfigPath, err = filepath.Abs(kp)
 	if err != nil {
 		return fmt.Errorf("invalid kubeconfig path: %s, %v", kp, err)


### PR DESCRIPTION
# Please add a summary of your change

This commit fixes the issue when velero CLI is not in `PATH` or compiled
to other file names.

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
