### PR TITLE
Verify group before treating resource as cohabitating

### DIFF
--- a/changelogs/unreleased/4126-sseago
+++ b/changelogs/unreleased/4126-sseago
@@ -1,0 +1,1 @@
+Verify group before treating resource as cohabitating

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -970,6 +970,30 @@ func TestBackupResourceCohabitation(t *testing.T) {
 				"resources/deployments.apps/v1-preferredversion/namespaces/zoo/raz.json",
 			},
 		},
+		{
+			name:   "when deployments exist that are not in the cohabitating groups those are backed up along with apps/deployments",
+			backup: defaultBackup().Result(),
+			apiResources: []*test.APIResource{
+				test.VeleroDeployments(
+					builder.ForTestCR("Deployment", "foo", "bar").Result(),
+					builder.ForTestCR("Deployment", "zoo", "raz").Result(),
+				),
+				test.Deployments(
+					builder.ForDeployment("foo", "bar").Result(),
+					builder.ForDeployment("zoo", "raz").Result(),
+				),
+			},
+			want: []string{
+				"resources/deployments.apps/namespaces/foo/bar.json",
+				"resources/deployments.apps/namespaces/zoo/raz.json",
+				"resources/deployments.apps/v1-preferredversion/namespaces/foo/bar.json",
+				"resources/deployments.apps/v1-preferredversion/namespaces/zoo/raz.json",
+				"resources/deployments.velero.io/namespaces/foo/bar.json",
+				"resources/deployments.velero.io/namespaces/zoo/raz.json",
+				"resources/deployments.velero.io/v1-preferredversion/namespaces/foo/bar.json",
+				"resources/deployments.velero.io/v1-preferredversion/namespaces/zoo/raz.json",
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/backup/item_collector.go
+++ b/pkg/backup/item_collector.go
@@ -209,16 +209,18 @@ func (r *itemCollector) getResourceItems(log logrus.FieldLogger, gv schema.Group
 	}
 
 	if cohabitator, found := r.cohabitatingResources[resource.Name]; found {
-		if cohabitator.seen {
-			log.WithFields(
-				logrus.Fields{
-					"cohabitatingResource1": cohabitator.groupResource1.String(),
-					"cohabitatingResource2": cohabitator.groupResource2.String(),
-				},
-			).Infof("Skipping resource because it cohabitates and we've already processed it")
-			return nil, nil
+		if gv.Group == cohabitator.groupResource1.Group || gv.Group == cohabitator.groupResource2.Group {
+			if cohabitator.seen {
+				log.WithFields(
+					logrus.Fields{
+						"cohabitatingResource1": cohabitator.groupResource1.String(),
+						"cohabitatingResource2": cohabitator.groupResource2.String(),
+					},
+				).Infof("Skipping resource because it cohabitates and we've already processed it")
+				return nil, nil
+			}
+			cohabitator.seen = true
 		}
-		cohabitator.seen = true
 	}
 
 	namespacesToList := getNamespacesToList(r.backupRequest.NamespaceIncludesExcludes)

--- a/pkg/builder/testcr_builder.go
+++ b/pkg/builder/testcr_builder.go
@@ -1,0 +1,77 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+)
+
+// CustomResourceBuilder builds objects based on velero APIVersion CRDs.
+type TestCRBuilder struct {
+	object *TestCR
+}
+
+// ForTestCR is the constructor for a TestCRBuilder.
+func ForTestCR(crdKind, ns, name string) *TestCRBuilder {
+	return &TestCRBuilder{
+		object: &TestCR{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: velerov1api.SchemeGroupVersion.String(),
+				Kind:       crdKind,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      name,
+			},
+		},
+	}
+}
+
+// Result returns the built TestCR.
+func (b *TestCRBuilder) Result() *TestCR {
+	return b.object
+}
+
+// ObjectMeta applies functional options to the TestCR's ObjectMeta.
+func (b *TestCRBuilder) ObjectMeta(opts ...ObjectMetaOpt) *TestCRBuilder {
+	for _, opt := range opts {
+		opt(b.object)
+	}
+
+	return b
+}
+
+type TestCR struct {
+	metav1.TypeMeta `json:",inline"`
+
+	// +optional
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	// +optional
+	Spec TestCRSpec `json:"spec,omitempty"`
+
+	// +optional
+	Status TestCRStatus `json:"status,omitempty"`
+}
+
+type TestCRSpec struct {
+}
+
+type TestCRStatus struct {
+}

--- a/pkg/test/api_server.go
+++ b/pkg/test/api_server.go
@@ -57,6 +57,7 @@ func NewAPIServer(t *testing.T) *APIServer {
 				{Group: "apiextensions.k8s.io", Version: "v1beta1", Resource: "customresourcedefinitions"}: "CRDList",
 				{Group: "velero.io", Version: "v1", Resource: "volumesnapshotlocations"}:                   "VSLList",
 				{Group: "extensions", Version: "v1", Resource: "deployments"}:                              "ExtDeploymentsList",
+				{Group: "velero.io", Version: "v1", Resource: "deployments"}:                               "VeleroDeploymentsList",
 			})
 		discoveryClient = &DiscoveryClient{FakeDiscovery: kubeClient.Discovery().(*discoveryfake.FakeDiscovery)}
 	)

--- a/pkg/test/resources.go
+++ b/pkg/test/resources.go
@@ -108,6 +108,18 @@ func ExtensionsDeployments(items ...metav1.Object) *APIResource {
 	}
 }
 
+// test CRD
+func VeleroDeployments(items ...metav1.Object) *APIResource {
+	return &APIResource{
+		Group:      "velero.io",
+		Version:    "v1",
+		Name:       "deployments",
+		ShortName:  "deploy",
+		Namespaced: true,
+		Items:      items,
+	}
+}
+
 func Namespaces(items ...metav1.Object) *APIResource {
 	return &APIResource{
 		Group:      "",


### PR DESCRIPTION
Signed-off-by: Scott Seago <sseago@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
This PR adds group checking to the cohabitating resource handling. Before setting cohabitator.seen or checking for cohabitator.seen, we first confirm that this resource belongs to one of the linked groups.
Also included is a unit test which confirms the fix.

# Does your change fix a particular issue?

Fixes #4125

# Please indicate you've done the following:

- [x ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
