### PR TITLE
Use velero debug command to dump the logs when case failed

### DIFF
--- a/test/e2e/enable_api_group_versions_test.go
+++ b/test/e2e/enable_api_group_versions_test.go
@@ -251,7 +251,7 @@ func runEnableAPIGroupVersionsTests(ctx context.Context, client testClient, reso
 
 		err = veleroBackupNamespace(ctx, veleroCLI, veleroNamespace, backup, namespacesStr, "", false)
 		if err != nil {
-			veleroBackupLogs(ctx, veleroCLI, veleroNamespace, backup)
+			runDebug(context.Background(), veleroCLI, veleroNamespace, backup, "")
 			return errors.Wrapf(err, "back up %s namespaces on source cluster", namespacesStr)
 		}
 
@@ -290,7 +290,7 @@ func runEnableAPIGroupVersionsTests(ctx context.Context, client testClient, reso
 
 		if tc.want != nil {
 			if err := veleroRestore(ctx, veleroCLI, veleroNamespace, restore, backup); err != nil {
-				veleroRestoreLogs(ctx, veleroCLI, veleroNamespace, restore)
+				runDebug(context.Background(), veleroCLI, veleroNamespace, "", restore)
 				return errors.Wrapf(err, "restore %s namespaces on target cluster", namespacesStr)
 			}
 

--- a/test/e2e/kibishii_utils.go
+++ b/test/e2e/kibishii_utils.go
@@ -42,7 +42,7 @@ func runKibishiiTests(client testClient, providerName, veleroCLI, veleroNamespac
 		return errors.Wrapf(err, "Failed to create namespace %s to install Kibishii workload", kibishiiNamespace)
 	}
 	defer func() {
-		if err := deleteNamespace(oneHourTimeout, client, kibishiiNamespace, true); err != nil {
+		if err := deleteNamespace(context.Background(), client, kibishiiNamespace, true); err != nil {
 			fmt.Println(errors.Wrapf(err, "failed to delete the namespace %q", kibishiiNamespace))
 		}
 	}()
@@ -51,7 +51,7 @@ func runKibishiiTests(client testClient, providerName, veleroCLI, veleroNamespac
 	}
 
 	if err := veleroBackupNamespace(oneHourTimeout, veleroCLI, veleroNamespace, backupName, kibishiiNamespace, backupLocation, useVolumeSnapshots); err != nil {
-		veleroBackupLogs(oneHourTimeout, veleroCLI, veleroNamespace, backupName)
+		runDebug(context.Background(), veleroCLI, veleroNamespace, backupName, "")
 		return errors.Wrapf(err, "Failed to backup kibishii namespace %s", kibishiiNamespace)
 	}
 
@@ -69,7 +69,7 @@ func runKibishiiTests(client testClient, providerName, veleroCLI, veleroNamespac
 	}
 
 	if err := veleroRestore(oneHourTimeout, veleroCLI, veleroNamespace, restoreName, backupName); err != nil {
-		veleroRestoreLogs(oneHourTimeout, veleroCLI, veleroNamespace, restoreName)
+		runDebug(context.Background(), veleroCLI, veleroNamespace, "", restoreName)
 		return errors.Wrapf(err, "Restore %s failed from backup %s", restoreName, backupName)
 	}
 

--- a/test/e2e/multiple_namespaces_test.go
+++ b/test/e2e/multiple_namespaces_test.go
@@ -109,7 +109,7 @@ func RunMultipleNamespaceTest(ctx context.Context, client testClient, nsBaseName
 		}
 	}
 	if err := veleroBackupExcludeNamespaces(ctx, veleroCLI, veleroNamespace, backupName, excludeNamespaces); err != nil {
-		veleroBackupLogs(ctx, veleroCLI, veleroNamespace, backupName)
+		runDebug(context.Background(), veleroCLI, veleroNamespace, backupName, "")
 		return errors.Wrapf(err, "Failed to backup backup namespaces %s-*", nsBaseName)
 	}
 
@@ -120,7 +120,7 @@ func RunMultipleNamespaceTest(ctx context.Context, client testClient, nsBaseName
 
 	err = veleroRestore(ctx, veleroCLI, veleroNamespace, restoreName, backupName)
 	if err != nil {
-		veleroRestoreLogs(ctx, veleroCLI, veleroNamespace, restoreName)
+		runDebug(context.Background(), veleroCLI, veleroNamespace, "", restoreName)
 		return errors.Wrap(err, "Restore failed")
 	}
 


### PR DESCRIPTION
Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
