### PR TITLE
run backup/restore describe in debug subcommand

### DIFF
--- a/pkg/cmd/cli/debug/cshd-scripts/velero.cshd
+++ b/pkg/cmd/cli/debug/cshd-scripts/velero.cshd
@@ -1,11 +1,15 @@
 def capture_backup_logs(cmd, namespace):
     if args.backup:
-        log("Collecting log for backup: {}".format(args.backup))
+        log("Collecting log and information for backup: {}".format(args.backup))
+        backupDescCmd = "{} --namespace={} backup describe {} --details".format(cmd, namespace, args.backup)
+        capture_local(cmd=backupDescCmd, file_name="backup_describe_{}.txt".format(args.backup))
         backupLogsCmd = "{} --namespace={} backup logs {}".format(cmd, namespace, args.backup)
         capture_local(cmd=backupLogsCmd, file_name="backup_{}.log".format(args.backup))
 def capture_restore_logs(cmd, namespace):
     if args.restore:
-        log("Collecting log for restore: {}".format(args.restore))
+        log("Collecting log and information for restore: {}".format(args.restore))
+        restoreDescCmd = "{} --namespace={} restore describe {} --details".format(cmd, namespace, args.restore)
+        capture_local(cmd=restoreDescCmd, file_name="restore_describe_{}.txt".format(args.restore))
         restoreLogsCmd = "{} --namespace={} restore logs {}".format(cmd, namespace, args.restore)
         capture_local(cmd=restoreLogsCmd, file_name="restore_{}.log".format(args.restore))
 


### PR DESCRIPTION
The errors of restore/backup may be stored in object storage
The well formatted output of describe is also helpful for debugging.
This commit add the command to the crashd script so the output of
"velero backup/restore describe xxx" can be collected

Signed-off-by: Daniel Jiang <jiangd@vmware.com>

More details see https://github.com/vmware-tanzu/velero/issues/4159#issuecomment-922281196


- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
