### PR TITLE
Check the failed phases either when uploading the snapshot in E2E testing

### DIFF
--- a/test/e2e/velero_utils.go
+++ b/test/e2e/velero_utils.go
@@ -449,11 +449,12 @@ func waitForVSphereUploadCompletion(ctx context.Context, timeout time.Duration, 
 			// Canceled - the operation was canceled, the snapshot ID is not valid
 			if len(comps) == 2 {
 				phase := comps[1]
-				if phase == "New" ||
-					phase == "InProgress" ||
-					phase == "Snapshotted" ||
-					phase == "Uploading" {
+				switch phase {
+				case "Uploaded":
+				case "New", "InProgress", "Snapshotted", "Uploading":
 					complete = false
+				default:
+					return false, fmt.Errorf("unexpected snapshot phase: %s", phase)
 				}
 			}
 		}


### PR DESCRIPTION
When the snapshot uploading is failed, it should not be treat as completed and continue.
This commit covers both the phases of in progress and failed when uploading snapshot with vSphere plugin

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
