### PR TITLE
Specify the "--snapshot-volumes=false" option explicitly when running backup with Restic

### DIFF
--- a/test/e2e/velero_utils.go
+++ b/test/e2e/velero_utils.go
@@ -236,6 +236,11 @@ func veleroBackupNamespace(ctx context.Context, veleroCLI string, veleroNamespac
 		args = append(args, "--snapshot-volumes")
 	} else {
 		args = append(args, "--default-volumes-to-restic")
+		// To workaround https://github.com/vmware-tanzu/velero-plugin-for-vsphere/issues/347 for vsphere plugin v1.1.1
+		// if the "--snapshot-volumes=false" isn't specified explicitly, the vSphere plugin will always take snapshots
+		// for the volumes even though the "--default-volumes-to-restic" is specified
+		// TODO This can be removed if the logic of vSphere plugin bump up to 1.3
+		args = append(args, "--snapshot-volumes=false")
 	}
 	if backupLocation != "" {
 		args = append(args, "--storage-location", backupLocation)


### PR DESCRIPTION
If the "--snapshot-volumes=false" isn't specified explicitly, the vSphere plugin will always take snapshots for the volumes even though the "--default-volumes-to-restic" is specified
This can be removed if the logic of vSphere plugin changes

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
