### PR TITLE
Refine tag-release.sh

### DIFF
--- a/changelogs/unreleased/4185-reasonerjt
+++ b/changelogs/unreleased/4185-reasonerjt
@@ -1,0 +1,1 @@
+Refine tag-release.sh to align with change in release process

--- a/hack/release-tools/tag-release.sh
+++ b/hack/release-tools/tag-release.sh
@@ -89,18 +89,31 @@ fi
 # Since we're past the validation of the VELERO_VERSION, parse the version's individual components.
 eval $(go run $DIR/chk_version.go)
 
-
 printf "To clarify, you've provided a version string of $VELERO_VERSION.\n"
 printf "Based on this, the following assumptions have been made: \n"
 
-[[ "$VELERO_PATCH" != 0 ]] && printf "*\t This is a patch release.\n"
+# $VELERO_PATCH gets populated by the chk_version.go scrip that parses and verifies the given version format
+# If we've got a patch release, we assume the tag is on release branch.
+if [[ "$VELERO_PATCH" != 0 ]]; then
+    printf "*\t This is a patch release.\n"
+    ON_RELEASE_BRANCH=TRUE
+fi
 
-# $VELERO_PRERELEASE gets populated by the chk_version.go script that parses and verifies the given version format 
+# $VELERO_PRERELEASE gets populated by the chk_version.go script that parses and verifies the given version format
+# If we've got a GA release, we assume the tag is on release branch.
 # -n is "string is non-empty"
 [[ -n $VELERO_PRERELEASE ]] && printf "*\t This is a pre-release.\n"
 
 # -z is "string is empty"
-[[ -z $VELERO_PRERELEASE ]] && printf "*\t This is a GA release.\n"
+if [[ -z $VELERO_PRERELEASE ]]; then
+    printf "*\t This is a GA release.\n"
+    ON_RELEASE_BRANCH=TRUE
+fi
+
+if [[ "$ON_RELEASE_BRANCH" == "TRUE" ]]; then
+   release_branch_name=release-$VELERO_MAJOR.$VELERO_MINOR
+   printf "*\t The commit to tag is on branch: %s.  Please make sure this branch has been created.\n" $release_branch_name
+fi
 
 if [[ $publish == "TRUE" ]]; then
     echo "If this is all correct, press enter/return to proceed to TAG THE RELEASE and UPLOAD THE TAG TO GITHUB."
@@ -117,55 +130,29 @@ echo "Alright, let's go."
 echo "Pulling down all git tags and branches before doing any work."
 git fetch "$remote" --tags
 
-# $VELERO_PATCH gets populated by the chk_version.go scrip that parses and verifies the given version format 
-# If we've got a patch release, we'll need to create a release branch for it.
-if [[ "$VELERO_PATCH" > 0 ]]; then
-    release_branch_name=release-$VELERO_MAJOR.$VELERO_MINOR
+if [[ -n $release_branch_name ]]; then
+    # Tag on release branch
     remote_release_branch_name="$remote/$release_branch_name"
 
     # Determine whether the local and remote release branches already exist
     local_branch=$(git branch | grep "$release_branch_name")
     remote_branch=$(git branch -r | grep "$remote_release_branch_name")
-
-    if [[ -n $remote_branch ]]; then
-      if [[ -z $local_branch ]]; then
+    if [[ -z $remote_branch ]]; then
+        echo "The branch $remote_release_branch_name must be created before you tag the release."
+        exit 1
+    fi
+    if [[ -z $local_branch ]]; then
         # Remote branch exists, but does not exist locally. Checkout and track the remote branch.
         git checkout --track "$remote_release_branch_name"
-      else
+    else
         # Checkout the local release branch and ensure it is up to date with the remote
         git checkout "$release_branch_name"
         git pull --set-upstream "$remote" "$release_branch_name"
-      fi
-    else
-      if [[ -z $local_branch ]]; then
-        # Neither the remote or local release branch exists, create it
-        git checkout -b $release_branch_name
-      else
-        # The local branch exists so check it out.
-        git checkout $release_branch_name
-      fi
     fi
-
-    echo "Now you'll need to cherry-pick any relevant git commits into this release branch."
-    echo "Either pause this script with ctrl-z, or open a new terminal window and do the cherry-picking."
-    if [[ $publish == "TRUE" ]]; then
-        read -p "Press enter when you're done cherry-picking. THIS WILL MAKE A TAG PUSH THE BRANCH TO $remote"
-    else
-        read -p "Press enter when you're done cherry-picking."
-    fi
-
-    # TODO can/should we add a way to review the cherry-picked commits before the push?
-
-    if [[ $publish == "TRUE" ]]; then
-        echo "Pushing $release_branch_name to \"$remote\" remote"
-        git push --set-upstream "$remote" $release_branch_name
-    fi
-
     tag_and_push
 else
     echo "Checking out $remote/main."
     git checkout "$remote"/main
-
     tag_and_push
 fi
 


### PR DESCRIPTION
This commit makes several changes to `tag-release.sh` according to the
change in release process:
1. It will support a "ON_RELEASE_BRANCH" param passed via env variable.
   When it's set to "TRUE". The release will be created on the commit of
   branch like `release-xxx`.  This enables us to create release branch
   before GA and tag RC release.
2. It removes the code to push a new branch to upstream.  This is
   because we decided to create branch manually.  For patch releases, we
   will not push the change to release branch, instead, we will make
   sure the release branch has all commits cherrypicked BEFORE we run
   this script to tag the release.

After the change the script will focus on only tag the release, not
making other code change to release branches.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>

Thank you for contributing to Velero!

Fixes #4174 

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
