### PR TITLE
Update release instruction

### DIFF
--- a/site/content/docs/main/release-instructions.md
+++ b/site/content/docs/main/release-instructions.md
@@ -82,6 +82,12 @@ For each major or minor release, create and publish a blog post to let folks kno
 	- Do a review of the diffs, and/or run `make serve-docs` and review the site.
 	- Submit a PR containing the changelog and the version-tagged docs.
 
+### Pin the base image 
+The image of velero is built based on [Distroless docker image](https://github.com/GoogleContainerTools/distroless).  
+For the reproducibility of the release, before the release candidate is tagged, we need to make sure the in the Dockerfile 
+on the release branch, the base image is referenced by digest, such as
+https://github.com/vmware-tanzu/velero/blob/release-1.7/Dockerfile#L53-L54
+
 ## Velero release
 ### Notes
 - Pre-requisite: PR with the changelog and docs is merged, so that it's included in the release tag.


### PR DESCRIPTION
Add one step to pin the base image of velero

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [X] Updated the corresponding documentation in `site/content/docs/main`.
