### PR TITLE
Namespace validation now allows asterisks used in namespace includes/excludes

### DIFF
--- a/pkg/util/collections/includes_excludes.go
+++ b/pkg/util/collections/includes_excludes.go
@@ -164,21 +164,13 @@ func ValidateNamespaceIncludesExcludes(includesList, excludesList []string) []er
 	excludes := sets.NewString(excludesList...)
 
 	for _, itm := range includes.List() {
-		// Although asterisks is not a valid Kubernetes namespace name, it is
-		// allowed here.
-		if itm != "*" {
-			if nsErrs := validateNamespaceName(itm); nsErrs != nil {
-				errs = append(errs, nsErrs...)
-			}
+		if nsErrs := validateNamespaceName(itm); nsErrs != nil {
+			errs = append(errs, nsErrs...)
 		}
 	}
-
 	for _, itm := range excludes.List() {
-		// Asterisks in excludes list have been checked previously.
-		if itm != "*" {
-			if nsErrs := validateNamespaceName(itm); nsErrs != nil {
-				errs = append(errs, nsErrs...)
-			}
+		if nsErrs := validateNamespaceName(itm); nsErrs != nil {
+			errs = append(errs, nsErrs...)
 		}
 	}
 
@@ -188,7 +180,12 @@ func ValidateNamespaceIncludesExcludes(includesList, excludesList []string) []er
 func validateNamespaceName(ns string) []error {
 	var errs []error
 
-	if errMsgs := validation.ValidateNamespaceName(ns, false); errMsgs != nil {
+	// Kubernetes does not allow asterisks in namespaces but Velero uses them as
+	// wildcards. Replace asterisks with an arbitrary letter to pass Kubernetes
+	// validation.
+	tmpNamespace := strings.ReplaceAll(ns, "*", "x")
+
+	if errMsgs := validation.ValidateNamespaceName(tmpNamespace, false); errMsgs != nil {
 		for _, msg := range errMsgs {
 			errs = append(errs, errors.Errorf("invalid namespace %q: %s", ns, msg))
 		}

--- a/pkg/util/collections/includes_excludes.go
+++ b/pkg/util/collections/includes_excludes.go
@@ -180,6 +180,12 @@ func ValidateNamespaceIncludesExcludes(includesList, excludesList []string) []er
 func validateNamespaceName(ns string) []error {
 	var errs []error
 
+	// Velero interprets empty string as "no namespace", so allow it even though
+	// it is not a valid Kubernetes name.
+	if ns == "" {
+		return nil
+	}
+
 	// Kubernetes does not allow asterisks in namespaces but Velero uses them as
 	// wildcards. Replace asterisks with an arbitrary letter to pass Kubernetes
 	// validation.

--- a/pkg/util/collections/includes_excludes_test.go
+++ b/pkg/util/collections/includes_excludes_test.go
@@ -232,7 +232,7 @@ func TestValidateNamespaceIncludesExcludes(t *testing.T) {
 		{
 			name:     "special characters in name is invalid",
 			includes: []string{"foo?", "foo.bar", "bar_321"},
-			excludes: []string{"$foo", "foo*bar", "bar=321"},
+			excludes: []string{"$foo", "foo>bar", "bar=321"},
 			wantErr:  true,
 		},
 		{
@@ -243,6 +243,18 @@ func TestValidateNamespaceIncludesExcludes(t *testing.T) {
 		{
 			name:     "include everything using asterisk is valid",
 			includes: []string{"*"},
+			wantErr:  false,
+		},
+		{
+			name:     "excludes can contain wildcard",
+			includes: []string{"foo", "bar"},
+			excludes: []string{"nginx-ingress-*", "*-bar", "*-ingress-*"},
+			wantErr:  false,
+		},
+		{
+			name:     "includes can contain wildcard",
+			includes: []string{"*-foo", "kube-*", "*kube*"},
+			excludes: []string{"bar"},
 			wantErr:  false,
 		},
 		{

--- a/pkg/util/collections/includes_excludes_test.go
+++ b/pkg/util/collections/includes_excludes_test.go
@@ -208,11 +208,6 @@ func TestValidateNamespaceIncludesExcludes(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name:     "empty string is invalid",
-			includes: []string{""},
-			wantErr:  true,
-		},
-		{
 			name:     "asterisk by itself is valid",
 			includes: []string{"*"},
 			wantErr:  false,
@@ -238,6 +233,16 @@ func TestValidateNamespaceIncludesExcludes(t *testing.T) {
 		{
 			name:     "empty includes (everything) is valid",
 			includes: []string{},
+			wantErr:  false,
+		},
+		{
+			name:     "empty string includes is valid (includes nothing)",
+			includes: []string{""},
+			wantErr:  false,
+		},
+		{
+			name:     "empty string excludes is valid (excludes nothing)",
+			excludes: []string{""},
 			wantErr:  false,
 		},
 		{


### PR DESCRIPTION
Signed-off-by: F. Gold <fgold@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

Updated namespace validation added in #4057 to allow for asterisks values in namespaces.

# Does your change fix a particular issue?

Fixes #4235

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
