### PR TITLE
Restrict kubebuilder controllers to work only for objects in own Velero namespaces

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -303,7 +303,8 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 	corev1api.AddToScheme(scheme)
 
 	mgr, err := ctrl.NewManager(clientConfig, ctrl.Options{
-		Scheme: scheme,
+		Scheme:    scheme,
+		Namespace: f.Namespace(),
 	})
 	if err != nil {
 		cancelFunc()


### PR DESCRIPTION
Signed-off-by: F. Gold <fgold@vmware.com>

# Please add a summary of your change

Controllers converted to use the Kubebuilder framework now only watch for objects in their own Velero namespaces.

# Does your change fix a particular issue?

Fixes #4200 
Also fixes #4052 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
