### PR TITLE
Don't create a backup immediately after creating a schedule

### DIFF
--- a/changelogs/unreleased/4281-ywk253100
+++ b/changelogs/unreleased/4281-ywk253100
@@ -1,0 +1,1 @@
+Don't create a backup immediately after creating a schedule

--- a/pkg/controller/schedule_controller.go
+++ b/pkg/controller/schedule_controller.go
@@ -276,11 +276,11 @@ func (c *scheduleController) submitBackupIfDue(item *api.Schedule, cronSchedule 
 }
 
 func getNextRunTime(schedule *api.Schedule, cronSchedule cron.Schedule, asOf time.Time) (bool, time.Time) {
-	// get the latest run time (if the schedule hasn't run yet, this will be the zero value which will trigger
-	// an immediate backup)
 	var lastBackupTime time.Time
 	if schedule.Status.LastBackup != nil {
 		lastBackupTime = schedule.Status.LastBackup.Time
+	} else {
+		lastBackupTime = schedule.CreationTimestamp.Time
 	}
 
 	nextRunTime := cronSchedule.Next(lastBackupTime)

--- a/pkg/controller/schedule_controller_test.go
+++ b/pkg/controller/schedule_controller_test.go
@@ -274,7 +274,7 @@ func TestGetNextRunTime(t *testing.T) {
 		{
 			name:                      "first run",
 			schedule:                  defaultSchedule(),
-			expectedDue:               true,
+			expectedDue:               false,
 			expectedNextRunTimeOffset: "5m",
 		},
 		{
@@ -319,6 +319,9 @@ func TestGetNextRunTime(t *testing.T) {
 				require.NoError(t, err, "unable to parse test.lastRanOffset: %v", err)
 
 				test.schedule.Status.LastBackup = &metav1.Time{Time: testClock.Now().Add(-offsetDuration)}
+				test.schedule.CreationTimestamp = *test.schedule.Status.LastBackup
+			} else {
+				test.schedule.CreationTimestamp = metav1.Time{Time: testClock.Now()}
 			}
 
 			nextRunTimeOffset, err := time.ParseDuration(test.expectedNextRunTimeOffset)
@@ -326,11 +329,11 @@ func TestGetNextRunTime(t *testing.T) {
 				panic(err)
 			}
 
-			// calculate expected next run time (if the schedule hasn't run yet, this
-			// will be the zero value which will trigger an immediate backup)
 			var baseTime time.Time
 			if test.lastRanOffset != "" {
 				baseTime = test.schedule.Status.LastBackup.Time
+			} else {
+				baseTime = test.schedule.CreationTimestamp.Time
 			}
 			expectedNextRunTime := baseTime.Add(nextRunTimeOffset)
 


### PR DESCRIPTION
Don't create a backup immediately after creating a schedule
Fixes #1980

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
