### PR TITLE
Namespace wildcard and empty string usage in Velero backup command regression cherry pick

### DIFF
--- a/pkg/util/collections/includes_excludes_test.go
+++ b/pkg/util/collections/includes_excludes_test.go
@@ -208,11 +208,6 @@ func TestValidateNamespaceIncludesExcludes(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name:     "empty string is invalid",
-			includes: []string{""},
-			wantErr:  true,
-		},
-		{
 			name:     "asterisk by itself is valid",
 			includes: []string{"*"},
 			wantErr:  false,
@@ -232,7 +227,7 @@ func TestValidateNamespaceIncludesExcludes(t *testing.T) {
 		{
 			name:     "special characters in name is invalid",
 			includes: []string{"foo?", "foo.bar", "bar_321"},
-			excludes: []string{"$foo", "foo*bar", "bar=321"},
+			excludes: []string{"$foo", "foo>bar", "bar=321"},
 			wantErr:  true,
 		},
 		{
@@ -241,8 +236,30 @@ func TestValidateNamespaceIncludesExcludes(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name:     "empty string includes is valid (includes nothing)",
+			includes: []string{""},
+			wantErr:  false,
+		},
+		{
+			name:     "empty string excludes is valid (excludes nothing)",
+			excludes: []string{""},
+			wantErr:  false,
+		},
+		{
 			name:     "include everything using asterisk is valid",
 			includes: []string{"*"},
+			wantErr:  false,
+		},
+		{
+			name:     "excludes can contain wildcard",
+			includes: []string{"foo", "bar"},
+			excludes: []string{"nginx-ingress-*", "*-bar", "*-ingress-*"},
+			wantErr:  false,
+		},
+		{
+			name:     "includes can contain wildcard",
+			includes: []string{"*-foo", "kube-*", "*kube*"},
+			excludes: []string{"bar"},
 			wantErr:  false,
 		},
 		{


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

The backup namespace validation that I introduced in #4057 caused a couple of problems: wildcard with characters and empty string namespaces were no longer permitted. These two cherry-picks from PR #4250 allow for their usage again in release 1.7.


# Does your change fix a particular issue?

Fixes #4235

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
