### PR TITLE
Ignore the `provided port is already allocated` error when restoring the `NodePort` service

### DIFF
--- a/changelogs/unreleased/4336-ywk253100
+++ b/changelogs/unreleased/4336-ywk253100
@@ -1,0 +1,1 @@
+Ignore the `provided port is already allocated` error when restoring the `NodePort` service


### PR DESCRIPTION
Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #2308

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
