### PR TITLE
Return the error if velero failed to detect S3 region for restic repo

### DIFF
--- a/changelogs/unreleased/4343-reasonerjt
+++ b/changelogs/unreleased/4343-reasonerjt
@@ -1,0 +1,1 @@
+Return the error if velero failed to detect S3 region for restic repo

--- a/pkg/restic/config.go
+++ b/pkg/restic/config.go
@@ -74,10 +74,9 @@ func getRepoPrefix(location *velerov1api.BackupStorageLocation) (string, error) 
 				region, err = getAWSBucketRegion(bucket)
 			}
 			if err != nil {
-				url = "s3.amazonaws.com"
-			} else {
-				url = fmt.Sprintf("s3-%s.amazonaws.com", region)
+				return "", errors.Wrapf(err, "failed to detect the region via bucket: %s", bucket)
 			}
+			url = fmt.Sprintf("s3-%s.amazonaws.com", region)
 		}
 
 		return fmt.Sprintf("s3:%s/%s", url, path.Join(bucket, prefix)), nil

--- a/pkg/restic/config_test.go
+++ b/pkg/restic/config_test.go
@@ -85,7 +85,8 @@ func TestGetRepoIdentifier(t *testing.T) {
 			getAWSBucketRegion: func(string) (string, error) {
 				return "", errors.New("no region found")
 			},
-			expected: "s3:s3.amazonaws.com/bucket/restic/repo-1",
+			expected:    "",
+			expectedErr: "failed to detect the region via bucket: bucket: no region found",
 		},
 		{
 			name: "s3.s3-<region>.amazonaws.com URL format is used if region can be determined for AWS BSL",


### PR DESCRIPTION
The error should be returned explicitly, because when the default URL is
used S3 will return a 301 and the response can't be handled by restic.

Fixes #4178

Signed-off-by: Daniel Jiang <jiangd@vmware.com>

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
