### PR TITLE
Use factory.Namespace() to replace hardcoded velero namespace

### DIFF
--- a/changelogs/unreleased/4346-half-life666
+++ b/changelogs/unreleased/4346-half-life666
@@ -1,0 +1,1 @@
+Use factory.Namespace() to replace hardcoded velero namespace

--- a/pkg/restore/prioritize_group_version.go
+++ b/pkg/restore/prioritize_group_version.go
@@ -221,7 +221,7 @@ func userPriorityConfigMap() (*corev1.ConfigMap, error) {
 		return nil, errors.Wrap(err, "getting Kube client")
 	}
 
-	cm, err := kc.CoreV1().ConfigMaps("velero").Get(
+	cm, err := kc.CoreV1().ConfigMaps(fc.Namespace()).Get(
 		context.Background(),
 		"enableapigroupversions",
 		metav1.GetOptions{},


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Replace the hardcoded namespace value by using factory.Namespace()

# Does your change fix a particular issue?
yes
Fixes #4345

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
