### PR TITLE
fix: modify generated from schedule's backup name timestamp to UTC ti…

### DIFF
--- a/changelogs/unreleased/4353-jxun
+++ b/changelogs/unreleased/4353-jxun
@@ -1,1 +1,1 @@
-Modify generated from schedule's backup name timestamp to UTC timestamp.
+Modify the timestamp in the name of a backup generated from schedule to use UTC.

--- a/changelogs/unreleased/4353-jxun
+++ b/changelogs/unreleased/4353-jxun
@@ -1,5 +1,1 @@
 Modify generated from schedule's backup name timestamp to UTC timestamp.
-Fix https://github.com/vmware-tanzu/velero/issues/4279
-When backup is created from schedule, and the backup name is not specified, 
-a containing-timestamp generated name will be used. 
-Due to velero client not set timezone to UTC, a local timezone will be used for the generated name.

--- a/changelogs/unreleased/4353-jxun
+++ b/changelogs/unreleased/4353-jxun
@@ -1,0 +1,5 @@
+Modify generated from schedule's backup name timestamp to UTC timestamp.
+Fix https://github.com/vmware-tanzu/velero/issues/4279
+When backup is created from schedule, and the backup name is not specified, 
+a containing-timestamp generated name will be used. 
+Due to velero client not set timezone to UTC, a local timezone will be used for the generated name.

--- a/pkg/cmd/cli/backup/create.go
+++ b/pkg/cmd/cli/backup/create.go
@@ -290,7 +290,7 @@ func (o *CreateOptions) BuildBackup(namespace string) (*velerov1api.Backup, erro
 			return nil, err
 		}
 		if o.Name == "" {
-			o.Name = schedule.TimestampedName(time.Now())
+			o.Name = schedule.TimestampedName(time.Now().UTC())
 		}
 		backupBuilder = builder.ForBackup(namespace, o.Name).
 			FromSchedule(schedule)


### PR DESCRIPTION
…mezone

fix #4279
When backup is created from schedule, and the backup name is not specified, a containing-timestamp generated name will be used. Due to velero client not set timezone to UTC, a local timezone will be used for the generated name.

Signed-off-by: Xun Jiang <jxun@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
