### PR TITLE
fix statefulsets volumeClaimTemplates storageClassName after use Changing PV/PVC Storage Classes

### DIFF
--- a/pkg/kuberesource/kuberesource.go
+++ b/pkg/kuberesource/kuberesource.go
@@ -34,4 +34,5 @@ var (
 	VolumeSnapshotClasses     = schema.GroupResource{Group: "snapshot.storage.k8s.io", Resource: "volumesnapshotclasses"}
 	VolumeSnapshots           = schema.GroupResource{Group: "snapshot.storage.k8s.io", Resource: "volumesnapshots"}
 	VolumeSnapshotContents    = schema.GroupResource{Group: "snapshot.storage.k8s.io", Resource: "volumesnapshotcontents"}
+	StatefulSets              = schema.GroupResource{Group: "apps", Resource: "statefulsets"}
 )


### PR DESCRIPTION

Thank you for contributing to Velero!

# Please add a summary of your change
Change STS volumeClaimTemplates storageClassName to the new storageClass when using Changing PV/PVC Storage Classes function.

# Does your change fix a particular issue?

Fixes #(issue)
#4373

# Please indicate you've done the following:

- [ ] Add StatefulSets kuberesource in pkg/kuberesource/kuberesource.go
- [ ] Added handling StatefulSets volumeClaimTemplates storageClassName updated with the new storageClass operation
