### PR TITLE
fix: remove duplicated logs introduced by adding logger in manager

### DIFF
--- a/changelogs/unreleased/4381-jxun
+++ b/changelogs/unreleased/4381-jxun
@@ -1,0 +1,1 @@
+remove duplicated logs introduced by adding logger in manager

--- a/pkg/controller/backup_storage_location_controller.go
+++ b/pkg/controller/backup_storage_location_controller.go
@@ -61,7 +61,7 @@ func (r *BackupStorageLocationReconciler) Reconcile(ctx context.Context, req ctr
 	locationList, err := storage.ListBackupStorageLocations(r.Ctx, r.Client, req.Namespace)
 	if err != nil {
 		return ctrl.Result{},
-			fmt.Errorf("error: %s, no backup storage locations found, at least one is required", err.Error())
+			fmt.Errorf("error: %s, no backup storage locations found, at least one is required", errors.WithStack(err))
 	}
 
 	pluginManager := r.NewPluginManager(log)

--- a/pkg/controller/backup_storage_location_controller.go
+++ b/pkg/controller/backup_storage_location_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -59,8 +60,8 @@ func (r *BackupStorageLocationReconciler) Reconcile(ctx context.Context, req ctr
 
 	locationList, err := storage.ListBackupStorageLocations(r.Ctx, r.Client, req.Namespace)
 	if err != nil {
-		log.WithError(err).Error("No backup storage locations found, at least one is required")
-		return ctrl.Result{}, err
+		return ctrl.Result{},
+			fmt.Errorf("error: %s, no backup storage locations found, at least one is required", err.Error())
 	}
 
 	pluginManager := r.NewPluginManager(log)

--- a/pkg/controller/download_request_controller.go
+++ b/pkg/controller/download_request_controller.go
@@ -79,7 +79,6 @@ func (r *DownloadRequestReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	defer func() {
 		// Always attempt to Patch the downloadRequest object and status after each reconciliation.
 		if err := patchHelper.Patch(ctx, downloadRequest); err != nil {
-			log.WithError(err).Error("Error updating download request")
 			reconcileResult = ctrl.Result{}
 			retErr = fmt.Errorf("error: %s, error updating download request", errors.WithStack(err))
 		}
@@ -92,7 +91,6 @@ func (r *DownloadRequestReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			// worth proceeding and trying/retrying to find it.
 			log.Debug("DownloadRequest has expired - deleting")
 			if err := r.Client.Delete(ctx, downloadRequest); err != nil {
-				log.WithError(err).Error("Error deleting an expired download request")
 				return ctrl.Result{},
 					fmt.Errorf("error :%s, error deleting an expired download request", errors.WithStack(err))
 			}

--- a/pkg/controller/server_status_request_controller.go
+++ b/pkg/controller/server_status_request_controller.go
@@ -77,7 +77,7 @@ func (r *ServerStatusRequestReconciler) Reconcile(ctx context.Context, req ctrl.
 		}
 
 		return ctrl.Result{},
-			fmt.Errorf("error: %s, error getting ServerStatusRequest, ", err.Error())
+			fmt.Errorf("error: %s, error getting ServerStatusRequest, ", errors.WithStack(err))
 	}
 
 	log = r.Log.WithFields(logrus.Fields{
@@ -94,7 +94,7 @@ func (r *ServerStatusRequestReconciler) Reconcile(ctx context.Context, req ctrl.
 		patchHelper, err := patch.NewHelper(statusRequest, r.Client)
 		if err != nil {
 			return ctrl.Result{},
-				fmt.Errorf("error: fail to get a patch helper to update this resource, %s", err.Error())
+				fmt.Errorf("error: fail to get a patch helper to update this resource, %s", errors.WithStack(err))
 		}
 
 		statusRequest.Status.ServerVersion = buildinfo.Version
@@ -104,7 +104,7 @@ func (r *ServerStatusRequestReconciler) Reconcile(ctx context.Context, req ctrl.
 
 		if err := patchHelper.Patch(r.Ctx, statusRequest); err != nil {
 			return ctrl.Result{RequeueAfter: statusRequestResyncPeriod},
-				fmt.Errorf("error: fail to update ServerStatusRequest status, %s", err.Error())
+				fmt.Errorf("error: fail to update ServerStatusRequest status, %s", errors.WithStack(err))
 		}
 	case velerov1api.ServerStatusRequestPhaseProcessed:
 		log.Debug("Checking whether ServerStatusRequest has expired")

--- a/pkg/controller/server_status_request_controller.go
+++ b/pkg/controller/server_status_request_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -75,8 +76,8 @@ func (r *ServerStatusRequestReconciler) Reconcile(ctx context.Context, req ctrl.
 			return ctrl.Result{}, nil
 		}
 
-		log.WithError(err).Error("Error getting ServerStatusRequest")
-		return ctrl.Result{}, err
+		return ctrl.Result{},
+			fmt.Errorf("error: %s, error getting ServerStatusRequest, ", err.Error())
 	}
 
 	log = r.Log.WithFields(logrus.Fields{
@@ -92,8 +93,8 @@ func (r *ServerStatusRequestReconciler) Reconcile(ctx context.Context, req ctrl.
 		// Initialize the patch helper.
 		patchHelper, err := patch.NewHelper(statusRequest, r.Client)
 		if err != nil {
-			log.WithError(err).Error("Error getting a patch helper to update this resource")
-			return ctrl.Result{}, err
+			return ctrl.Result{},
+				fmt.Errorf("error: fail to get a patch helper to update this resource, %s", err.Error())
 		}
 
 		statusRequest.Status.ServerVersion = buildinfo.Version
@@ -102,8 +103,8 @@ func (r *ServerStatusRequestReconciler) Reconcile(ctx context.Context, req ctrl.
 		statusRequest.Status.Plugins = velero.GetInstalledPluginInfo(r.PluginRegistry)
 
 		if err := patchHelper.Patch(r.Ctx, statusRequest); err != nil {
-			log.WithError(err).Error("Error updating ServerStatusRequest status")
-			return ctrl.Result{RequeueAfter: statusRequestResyncPeriod}, err
+			return ctrl.Result{RequeueAfter: statusRequestResyncPeriod},
+				fmt.Errorf("error: fail to update ServerStatusRequest status, %s", err.Error())
 		}
 	case velerov1api.ServerStatusRequestPhaseProcessed:
 		log.Debug("Checking whether ServerStatusRequest has expired")


### PR DESCRIPTION
Remove duplicated log entries, which are introduced by logger added in controller manager in pull request #4341.

Fix issue #4368 

Signed-off-by: Xun Jiang <jxun@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
