### PR TITLE
Keep the annotation "pv.kubernetes.io/provisioned-by" when restoring PVs

### DIFF
--- a/changelogs/unreleased/4391-ywk253100
+++ b/changelogs/unreleased/4391-ywk253100
@@ -1,0 +1,1 @@
+Keep the annotation "pv.kubernetes.io/provisioned-by" when restoring PVs

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1562,10 +1562,6 @@ func resetVolumeBindingInfo(obj *unstructured.Unstructured) *unstructured.Unstru
 	// the PV(C) controller to take the two objects and bind them again.
 	delete(annotations, KubeAnnBoundByController)
 
-	// Remove the provisioned-by annotation which signals that the persistent
-	// volume was dynamically provisioned; it is now statically provisioned.
-	delete(annotations, KubeAnnDynamicallyProvisioned)
-
 	// GetAnnotations returns a copy, so we have to set them again.
 	obj.SetAnnotations(annotations)
 

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -2997,7 +2997,7 @@ func Test_resetVolumeBindingInfo(t *testing.T) {
 				"resourceVersion": "1"}).Unstructured,
 			expected: NewTestUnstructured().WithMetadataField("kind", "persistentVolume").
 				WithName("pv-1").
-				WithAnnotations().
+				WithAnnotations(KubeAnnDynamicallyProvisioned).
 				WithSpecField("claimRef", map[string]interface{}{
 					"namespace": "ns-1", "name": "pvc-1"}).Unstructured,
 		},
@@ -3007,7 +3007,6 @@ func Test_resetVolumeBindingInfo(t *testing.T) {
 				WithName("pvc-1").WithAnnotations(
 				KubeAnnBindCompleted,
 				KubeAnnBoundByController,
-				KubeAnnDynamicallyProvisioned,
 			).WithSpecField("volumeName", "pv-1").Unstructured,
 			expected: NewTestUnstructured().WithMetadataField("kind", "persistentVolumeClaim").
 				WithName("pvc-1").WithAnnotations().


### PR DESCRIPTION
More details please refer to https://github.com/vmware-tanzu/velero/issues/3470#issuecomment-976279606

Fixes #3470

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
