### PR TITLE
add solution for backups stuck InProgress to docs

### DIFF
--- a/site/content/docs/main/troubleshooting.md
+++ b/site/content/docs/main/troubleshooting.md
@@ -74,6 +74,35 @@ Here are some things to verify if you receive `SignatureDoesNotMatch` errors:
 Velero cannot resume backups that were interrupted. Backups stuck in the `InProgress` phase can be deleted with `kubectl delete backup <name> -n <velero-namespace>`.
 Backups in the `InProgress` phase have not uploaded any files to object storage.
 
+## Backup is stuck with status InProgress
+
+It may happen that the Velero backup process stucks as `InProgress` on bigger cluster setups or when a lot of cluster resources are backed up simultanously.
+This issue can lead to a restart of the Velero Pod which leads to the `InProgress` state.
+To solve this issue you can increase the memory limit of the Velero deployment:
+
+```yaml
+## Edit the Velero Kubernetes deployment
+kubectl -n velero edit deployment velero
+
+## Default values:
+        resources:
+          limits:
+            cpu: "1"
+            memory: 256Mi
+          requests:
+            cpu: 500m
+            memory: 128Mi
+
+## Double the memory limit
+        resources:
+          limits:
+            cpu: "1"
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 128Mi
+```
+
 ## Velero is not publishing prometheus metrics
 
 Steps to troubleshoot:

--- a/site/content/docs/main/troubleshooting.md
+++ b/site/content/docs/main/troubleshooting.md
@@ -74,10 +74,12 @@ Here are some things to verify if you receive `SignatureDoesNotMatch` errors:
 Velero cannot resume backups that were interrupted. Backups stuck in the `InProgress` phase can be deleted with `kubectl delete backup <name> -n <velero-namespace>`.
 Backups in the `InProgress` phase have not uploaded any files to object storage.
 
-## Backup is stuck with status InProgress
+## Avoid Velero restarts due to Memory limits
 
-It may happen that the Velero backup process stucks as `InProgress` on bigger cluster setups or when a lot of cluster resources are backed up simultanously.
-This issue can lead to a restart of the Velero Pod which leads to the `InProgress` state.
+It may happen that the Velero process hits memory limits when backing up big system with a lot of resources.
+This issue can lead to a restart of the Velero Pod which results to the `InProgress` state.
+
+You can check if you are affected by getting an overview of the Pod memory consumption on the Node via `kubectl describe nodes`.
 To solve this issue you can increase the memory limit of the Velero deployment:
 
 ```yaml


### PR DESCRIPTION
Signed-off-by: Dennis Irsigler <dennis.irsigler@metro-markets.de>

Thank you for contributing to Velero!

# Please add a summary of your change
This change adds a section to the troubleshooting guide to inform about a common problem with backups stuck InProgress for bigger cluster/backup setups.

# Does your change fix a particular issue?
No.

Fixes #(issue)
https://github.com/vmware-tanzu/velero/issues/4003

/kind changelog-not-required

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [X] Updated the corresponding documentation in `site/content/docs/main`.
