### PR TITLE
Parse resource from backup tarball directly rather than resolving it via discovery service to avoid #4009

### DIFF
--- a/changelogs/unreleased/4398-ywk253100
+++ b/changelogs/unreleased/4398-ywk253100
@@ -1,0 +1,1 @@
+Fix the issue that the backup cannot be deleted after the application uninstalled

--- a/internal/delete/delete_item_action_handler.go
+++ b/internal/delete/delete_item_action_handler.go
@@ -74,15 +74,8 @@ func InvokeDeleteActions(ctx *Context) error {
 
 	processdResources := sets.NewString()
 
-	ctx.Log.Debugf("Trying to reconcile resource names with Kube API server.")
-	// Transform resource names based on what's canonical in the API server.
 	for resource := range backupResources {
-		gvr, _, err := ctx.DiscoveryHelper.ResourceFor(schema.ParseGroupResource(resource).WithVersion(""))
-		if err != nil {
-			return errors.Wrapf(err, "failed to resolve resource into complete group/version/resource: %v", resource)
-		}
-
-		groupResource := gvr.GroupResource()
+		groupResource := schema.ParseGroupResource(resource)
 
 		// We've already seen this group/resource, so don't process it again.
 		if processdResources.Has(groupResource.String()) {
@@ -92,8 +85,6 @@ func InvokeDeleteActions(ctx *Context) error {
 		// Get a list of all items that exist for this resource
 		resourceList := backupResources[groupResource.String()]
 		if resourceList == nil {
-			// After canonicalization from the API server, the resources may not exist in the tarball
-			// Skip them if that's the case.
 			continue
 		}
 


### PR DESCRIPTION
If the resource is a CR and the CRD is removed, the resource cannot be fully resolved via discovery and the backup cannot be deleted anymore. This commit parses the resource from backup tarball directly to avoid this

Fixes #4009

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
