### PR TITLE
Build for `darwin-arm64`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,11 +27,9 @@ builds:
       - arm64
       - ppc64le
     ignore:
-      # don't build arm/arm64 for darwin or windows
+      # don't build arm for darwin and arm/arm64 for windows
       - goos: darwin
         goarch: arm
-      - goos: darwin
-        goarch: arm64
       - goos: darwin
         goarch: ppc64le
       - goos: windows

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ endef
 # The version of restic binary to be downloaded
 RESTIC_VERSION ?= 0.12.1
 
-CLI_PLATFORMS ?= linux-amd64 linux-arm linux-arm64 darwin-amd64 windows-amd64 linux-ppc64le
+CLI_PLATFORMS ?= linux-amd64 linux-arm linux-arm64 darwin-amd64 darwin-arm64 windows-amd64 linux-ppc64le
 BUILDX_PLATFORMS ?= $(subst -,/,$(ARCH))
 BUILDX_OUTPUT_TYPE ?= docker
 
@@ -338,9 +338,9 @@ changelog:
 #		PUBLISH=false \
 #		make release
 #
-# To run the release, which will publish a *DRAFT* GitHub release in github.com/vmware-tanzu/velero 
+# To run the release, which will publish a *DRAFT* GitHub release in github.com/vmware-tanzu/velero
 # (you still need to review/publish the GitHub release manually):
-#		GITHUB_TOKEN=your-github-token \ 
+#		GITHUB_TOKEN=your-github-token \
 #		RELEASE_NOTES_FILE=changelogs/CHANGELOG-1.2.md \
 #		PUBLISH=true \
 #		make release
@@ -359,7 +359,7 @@ serve-docs: build-image-hugo
 	-it -p 1313:1313 \
 	$(HUGO_IMAGE) \
 	hugo server --bind=0.0.0.0 --enableGitInfo=false
-# gen-docs generates a new versioned docs directory under site/content/docs. 
+# gen-docs generates a new versioned docs directory under site/content/docs.
 # Please read the documentation in the script for instructions on how to use it.
 gen-docs:
 	@hack/release-tools/gen-docs.sh

--- a/changelogs/unreleased/4409-epk
+++ b/changelogs/unreleased/4409-epk
@@ -1,0 +1,1 @@
+Build for darwin-arm64


### PR DESCRIPTION
# Please add a summary of your change

Adds `darwin-arm64` to `CLI_PLATFORMS`

# Does your change fix a particular issue?

Closes #4408 

<details><summary>Build Logs</summary>
<p>
 ✘  ~/src/github.com/vmware-tanzu/velero   epk/darwin_arm64 ±  make all-build
building: _output/bin/linux/amd64/velero
/Applications/Xcode.app/Contents/Developer/usr/bin/make shell CMD="-c '\
		GOOS=linux \
		GOARCH=amd64 \
		VERSION=main \
		REGISTRY=velero \
		PKG=github.com/vmware-tanzu/velero \
		BIN=velero \
		GIT_SHA=02013ef3354f23041aa7a7689072889fa6491c74 \
		GIT_TREE_STATE=dirty \
		OUTPUT_DIR=/output/linux/amd64 \
		./hack/build.sh'"
Trying to pull build-image: velero/build-image:303d3dca
docker pull -q velero/build-image:303d3dca || /Applications/Xcode.app/Contents/Developer/usr/bin/make build-image
Error response from daemon: manifest for velero/build-image:303d3dca not found: manifest unknown: manifest unknown
[+] Building 275.0s (22/22) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                            0.6s
 => => transferring dockerfile: 3.00kB                                                                                                                                          0.0s
 => [internal] load .dockerignore                                                                                                                                               0.8s
 => => transferring context: 2B                                                                                                                                                 0.0s
 => [internal] load metadata for docker.io/library/golang:1.16                                                                                                                  2.4s
 => [ 1/18] FROM docker.io/library/golang:1.16@sha256:e2821de7346f12445962f915492c36397ce8ebc142ede2205def794c37275d33                                                         61.2s
 => => resolve docker.io/library/golang:1.16@sha256:e2821de7346f12445962f915492c36397ce8ebc142ede2205def794c37275d33                                                            0.2s
 => => sha256:e2821de7346f12445962f915492c36397ce8ebc142ede2205def794c37275d33 2.60kB / 2.60kB                                                                                  0.0s
 => => sha256:8f5be862554000ce2923edb499fed8a3ba8bc11d7fdb50f85730a48358ccf9c7 1.80kB / 1.80kB                                                                                  0.0s
 => => sha256:5b838b7289def20585ea328d486cdf41b130b88a929c691b85634a101c5777a2 6.96kB / 6.96kB                                                                                  0.0s
 => => sha256:647acf3d48c2780e00cd27bb0984367415f270d78477ef9d5b238e6ebd5290da 54.93MB / 54.93MB                                                                                3.5s
 => => sha256:b02967ef003473d9adc6e20868d9d66af85b0871919bcec92419f65c974aa8ce 5.15MB / 5.15MB                                                                                  0.8s
 => => sha256:e1ad2231829e42e6f095971b5d2dc143d97db2d0870571ba4d29ecd599db62cb 10.87MB / 10.87MB                                                                                1.2s
 => => sha256:5576ce26bf1df68da60eeb5162dccde1b69f865d2815aba8b2d29e7181aeb62b 54.57MB / 54.57MB                                                                                4.3s
 => => sha256:da9e15b4e149fbbcf4fd5211d571b25bd98c7251db9b0c53490211c6e64e4b86 85.77MB / 85.77MB                                                                                7.0s
 => => sha256:c688b2f019afb45bcf48ef45a363fdbcebb349bfbc92cf4b708fd1f96b3dfcf2 129.07MB / 129.07MB                                                                              9.1s
 => => extracting sha256:647acf3d48c2780e00cd27bb0984367415f270d78477ef9d5b238e6ebd5290da                                                                                      10.3s
 => => sha256:303de02ebdda7e124d3be497a6e5ce81745aa19b5036cd13f6890b9676691447 155B / 155B                                                                                      4.7s
 => => extracting sha256:b02967ef003473d9adc6e20868d9d66af85b0871919bcec92419f65c974aa8ce                                                                                       0.7s
 => => extracting sha256:e1ad2231829e42e6f095971b5d2dc143d97db2d0870571ba4d29ecd599db62cb                                                                                       0.9s
 => => extracting sha256:5576ce26bf1df68da60eeb5162dccde1b69f865d2815aba8b2d29e7181aeb62b                                                                                       8.5s
 => => extracting sha256:da9e15b4e149fbbcf4fd5211d571b25bd98c7251db9b0c53490211c6e64e4b86                                                                                      10.8s
 => => extracting sha256:c688b2f019afb45bcf48ef45a363fdbcebb349bfbc92cf4b708fd1f96b3dfcf2                                                                                      18.1s
 => => extracting sha256:303de02ebdda7e124d3be497a6e5ce81745aa19b5036cd13f6890b9676691447                                                                                       0.0s
 => [ 2/18] RUN mkdir -p /go/src/k8s.io                                                                                                                                         1.9s
 => [ 3/18] WORKDIR /go/src/k8s.io                                                                                                                                              0.8s
 => [ 4/18] RUN git config --global advice.detachedHead false                                                                                                                   1.9s
 => [ 5/18] RUN git clone -b v0.22.2 https://github.com/kubernetes/code-generator                                                                                               5.0s
 => [ 6/18] RUN curl -sSLo envtest-bins.tar.gz https://go.kubebuilder.io/test-tools/1.22.1/linux/amd64 &&     mkdir /usr/local/kubebuilder &&     tar -C /usr/local/kubebuilde  6.6s
 => [ 7/18] RUN wget --quiet https://github.com/kubernetes-sigs/kubebuilder/releases/download/v3.2.0/kubebuilder_linux_amd64 &&     mv kubebuilder_linux_amd64 /usr/local/kube  3.5s
 => [ 8/18] RUN go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0                                                                                                 127.2s
 => [ 9/18] RUN go get golang.org/x/tools/cmd/goimports@11e9d9cc0042e6bd10337d4d2c3e5d9295508e7d                                                                               14.8s
 => [10/18] WORKDIR /root                                                                                                                                                       0.9s
 => [11/18] RUN apt-get update && apt-get install -y unzip                                                                                                                     11.8s
 => [12/18] RUN wget --quiet https://github.com/protocolbuffers/protobuf/releases/download/v3.9.1/protoc-3.9.1-linux-x86_64.zip &&     unzip protoc-3.9.1-linux-x86_64.zip &&   2.6s
 => [13/18] RUN go get github.com/golang/protobuf/protoc-gen-go@v1.0.0                                                                                                          6.2s
 => [14/18] RUN wget --quiet https://github.com/goreleaser/goreleaser/releases/download/v0.120.8/goreleaser_Linux_x86_64.tar.gz &&     tar xvf goreleaser_Linux_x86_64.tar.gz   3.2s
 => [15/18] RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0                                4.5s
 => [16/18] RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/a  2.9s
 => [17/18] RUN chmod +x ./kubectl                                                                                                                                              1.9s
 => [18/18] RUN mv ./kubectl /usr/local/bin                                                                                                                                     1.9s
 => exporting to image                                                                                                                                                         11.2s
 => => exporting layers                                                                                                                                                        10.9s
 => => writing image sha256:e9d401af82eafa2cd4723748d3ab41c0fc4029ce1f7058c86f02c2ce9c70bd86                                                                                    0.0s
 => => naming to docker.io/velero/build-image:303d3dca                                                                                                                          0.0s
go: downloading k8s.io/klog v1.0.0
go: downloading github.com/fatih/color v1.13.0
go: downloading github.com/spf13/cobra v1.2.1
go: downloading github.com/pkg/errors v0.9.1
go: downloading github.com/spf13/pflag v1.0.5
go: downloading k8s.io/apiextensions-apiserver v0.22.2
go: downloading k8s.io/apimachinery v0.22.2
go: downloading k8s.io/client-go v0.22.2
go: downloading sigs.k8s.io/controller-runtime v0.10.2
go: downloading github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0
go: downloading github.com/sirupsen/logrus v1.8.1
go: downloading github.com/vmware-tanzu/crash-diagnostics v0.3.7
go: downloading github.com/prometheus/client_golang v1.11.0
go: downloading k8s.io/api v0.22.2
go: downloading github.com/evanphx/json-patch v4.11.0+incompatible
go: downloading golang.org/x/mod v0.4.2
go: downloading github.com/bombsimon/logrusr v1.1.0
go: downloading github.com/mattn/go-colorable v0.1.9
go: downloading github.com/mattn/go-isatty v0.0.14
go: downloading github.com/gogo/protobuf v1.3.2
go: downloading k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b
go: downloading k8s.io/klog/v2 v2.9.0
go: downloading sigs.k8s.io/structured-merge-diff/v4 v4.1.2
go: downloading github.com/google/gofuzz v1.2.0
go: downloading golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f
go: downloading github.com/Azure/go-autorest v14.2.0+incompatible
go: downloading github.com/imdario/mergo v0.3.12
go: downloading github.com/Azure/go-autorest/autorest v0.11.21
go: downloading github.com/Azure/go-autorest/autorest/adal v0.9.14
go: downloading golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d
go: downloading golang.org/x/net v0.0.0-20210520170846-37e1c6afe023
go: downloading github.com/google/uuid v1.1.2
go: downloading k8s.io/cli-runtime v0.22.2
go: downloading github.com/gobwas/glob v0.2.3
go: downloading github.com/google/go-cmp v0.5.6
go: downloading golang.org/x/sys v0.0.0-20211019181941-9d821ace8654
go: downloading github.com/robfig/cron v1.1.0
go: downloading sigs.k8s.io/cluster-api v1.0.0
go: downloading github.com/prometheus/client_model v0.2.0
go: downloading github.com/prometheus/common v0.26.0
go: downloading github.com/go-logr/logr v0.4.0
go: downloading github.com/go-logr/zapr v0.4.0
go: downloading go.uber.org/zap v1.19.0
go: downloading github.com/Azure/azure-sdk-for-go v42.0.0+incompatible
go: downloading github.com/aws/aws-sdk-go v1.28.2
go: downloading github.com/Azure/go-autorest/autorest/azure/auth v0.5.8
go: downloading github.com/joho/godotenv v1.3.0
go: downloading github.com/gofrs/uuid v3.2.0+incompatible
go: downloading k8s.io/kube-aggregator v0.19.12
go: downloading github.com/golang/protobuf v1.5.2
go: downloading github.com/hashicorp/go-plugin v0.0.0-20190610192547-a1bc61569a26
go: downloading google.golang.org/grpc v1.40.0
go: downloading github.com/googleapis/gnostic v0.5.5
go: downloading github.com/hashicorp/go-hclog v0.12.0
go: downloading golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
go: downloading gopkg.in/inf.v0 v0.9.1
go: downloading github.com/json-iterator/go v1.1.11
go: downloading gopkg.in/yaml.v2 v2.4.0
go: downloading sigs.k8s.io/yaml v1.3.0
go: downloading github.com/modern-go/reflect2 v1.0.1
go: downloading github.com/Azure/go-autorest/logger v0.2.1
go: downloading github.com/Azure/go-autorest/tracing v0.6.0
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading github.com/Azure/go-autorest/autorest/date v0.3.0
go: downloading github.com/form3tech-oss/jwt-go v3.2.3+incompatible
go: downloading golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
go: downloading cloud.google.com/go v0.93.3
go: downloading github.com/beorn7/perks v1.0.1
go: downloading github.com/cespare/xxhash v1.1.0
go: downloading github.com/cespare/xxhash/v2 v2.1.1
go: downloading github.com/prometheus/procfs v0.6.0
go: downloading github.com/vladimirvivien/gexe v0.1.1
go: downloading go.starlark.net v0.0.0-20201006213952-227f4aabceb5
go: downloading github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
go: downloading github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
go: downloading github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
go: downloading k8s.io/component-base v0.22.2
go: downloading go.uber.org/atomic v1.7.0
go: downloading go.uber.org/multierr v1.6.0
go: downloading gomodules.xyz/jsonpatch/v2 v2.2.0
go: downloading k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e
go: downloading github.com/Azure/go-autorest/autorest/azure/cli v0.4.2
go: downloading github.com/dimchansky/utfbom v1.1.1
go: downloading google.golang.org/protobuf v1.27.1
go: downloading github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb
go: downloading github.com/mitchellh/go-testing-interface v1.0.0
go: downloading github.com/oklog/run v1.0.0
go: downloading google.golang.org/genproto v0.0.0-20210828152312-66f60bf46e71
go: downloading github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
go: downloading gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
go: downloading github.com/fsnotify/fsnotify v1.5.1
go: downloading github.com/mitchellh/go-homedir v1.1.0
go: downloading golang.org/x/text v0.3.7
go: downloading github.com/onsi/gomega v1.16.0
go: downloading github.com/blang/semver v3.5.1+incompatible
go: downloading github.com/gobuffalo/flect v0.2.3
go: downloading github.com/moby/spdystream v0.2.0
go: downloading github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
go: downloading github.com/Azure/go-autorest/autorest/validation v0.2.0
go: downloading github.com/Azure/go-autorest/autorest/to v0.3.0
building: _output/bin/linux/amd64/velero-restic-restore-helper
/Applications/Xcode.app/Contents/Developer/usr/bin/make shell CMD="-c '\
		GOOS=linux \
		GOARCH=amd64 \
		VERSION=main \
		REGISTRY=velero \
		PKG=github.com/vmware-tanzu/velero \
		BIN=velero-restic-restore-helper \
		GIT_SHA=02013ef3354f23041aa7a7689072889fa6491c74 \
		GIT_TREE_STATE=dirty \
		OUTPUT_DIR=/output/linux/amd64 \
		./hack/build.sh'"
Using Cached Image: velero/build-image:303d3dca
building: _output/bin/linux/arm/velero
/Applications/Xcode.app/Contents/Developer/usr/bin/make shell CMD="-c '\
		GOOS=linux \
		GOARCH=arm \
		VERSION=main \
		REGISTRY=velero \
		PKG=github.com/vmware-tanzu/velero \
		BIN=velero \
		GIT_SHA=02013ef3354f23041aa7a7689072889fa6491c74 \
		GIT_TREE_STATE=dirty \
		OUTPUT_DIR=/output/linux/arm \
		./hack/build.sh'"
Using Cached Image: velero/build-image:303d3dca
building: _output/bin/linux/arm/velero-restic-restore-helper
/Applications/Xcode.app/Contents/Developer/usr/bin/make shell CMD="-c '\
		GOOS=linux \
		GOARCH=arm \
		VERSION=main \
		REGISTRY=velero \
		PKG=github.com/vmware-tanzu/velero \
		BIN=velero-restic-restore-helper \
		GIT_SHA=02013ef3354f23041aa7a7689072889fa6491c74 \
		GIT_TREE_STATE=dirty \
		OUTPUT_DIR=/output/linux/arm \
		./hack/build.sh'"
Using Cached Image: velero/build-image:303d3dca
building: _output/bin/linux/arm64/velero
/Applications/Xcode.app/Contents/Developer/usr/bin/make shell CMD="-c '\
		GOOS=linux \
		GOARCH=arm64 \
		VERSION=main \
		REGISTRY=velero \
		PKG=github.com/vmware-tanzu/velero \
		BIN=velero \
		GIT_SHA=02013ef3354f23041aa7a7689072889fa6491c74 \
		GIT_TREE_STATE=dirty \
		OUTPUT_DIR=/output/linux/arm64 \
		./hack/build.sh'"
Using Cached Image: velero/build-image:303d3dca
building: _output/bin/linux/arm64/velero-restic-restore-helper
/Applications/Xcode.app/Contents/Developer/usr/bin/make shell CMD="-c '\
		GOOS=linux \
		GOARCH=arm64 \
		VERSION=main \
		REGISTRY=velero \
		PKG=github.com/vmware-tanzu/velero \
		BIN=velero-restic-restore-helper \
		GIT_SHA=02013ef3354f23041aa7a7689072889fa6491c74 \
		GIT_TREE_STATE=dirty \
		OUTPUT_DIR=/output/linux/arm64 \
		./hack/build.sh'"
Using Cached Image: velero/build-image:303d3dca
building: _output/bin/darwin/amd64/velero
/Applications/Xcode.app/Contents/Developer/usr/bin/make shell CMD="-c '\
		GOOS=darwin \
		GOARCH=amd64 \
		VERSION=main \
		REGISTRY=velero \
		PKG=github.com/vmware-tanzu/velero \
		BIN=velero \
		GIT_SHA=02013ef3354f23041aa7a7689072889fa6491c74 \
		GIT_TREE_STATE=dirty \
		OUTPUT_DIR=/output/darwin/amd64 \
		./hack/build.sh'"
Using Cached Image: velero/build-image:303d3dca
building: _output/bin/darwin/amd64/velero-restic-restore-helper
/Applications/Xcode.app/Contents/Developer/usr/bin/make shell CMD="-c '\
		GOOS=darwin \
		GOARCH=amd64 \
		VERSION=main \
		REGISTRY=velero \
		PKG=github.com/vmware-tanzu/velero \
		BIN=velero-restic-restore-helper \
		GIT_SHA=02013ef3354f23041aa7a7689072889fa6491c74 \
		GIT_TREE_STATE=dirty \
		OUTPUT_DIR=/output/darwin/amd64 \
		./hack/build.sh'"
Using Cached Image: velero/build-image:303d3dca
building: _output/bin/darwin/arm64/velero
/Applications/Xcode.app/Contents/Developer/usr/bin/make shell CMD="-c '\
		GOOS=darwin \
		GOARCH=arm64 \
		VERSION=main \
		REGISTRY=velero \
		PKG=github.com/vmware-tanzu/velero \
		BIN=velero \
		GIT_SHA=02013ef3354f23041aa7a7689072889fa6491c74 \
		GIT_TREE_STATE=dirty \
		OUTPUT_DIR=/output/darwin/arm64 \
		./hack/build.sh'"
Using Cached Image: velero/build-image:303d3dca
building: _output/bin/darwin/arm64/velero-restic-restore-helper
/Applications/Xcode.app/Contents/Developer/usr/bin/make shell CMD="-c '\
		GOOS=darwin \
		GOARCH=arm64 \
		VERSION=main \
		REGISTRY=velero \
		PKG=github.com/vmware-tanzu/velero \
		BIN=velero-restic-restore-helper \
		GIT_SHA=02013ef3354f23041aa7a7689072889fa6491c74 \
		GIT_TREE_STATE=dirty \
		OUTPUT_DIR=/output/darwin/arm64 \
		./hack/build.sh'"
Using Cached Image: velero/build-image:303d3dca
building: _output/bin/windows/amd64/velero
/Applications/Xcode.app/Contents/Developer/usr/bin/make shell CMD="-c '\
		GOOS=windows \
		GOARCH=amd64 \
		VERSION=main \
		REGISTRY=velero \
		PKG=github.com/vmware-tanzu/velero \
		BIN=velero \
		GIT_SHA=02013ef3354f23041aa7a7689072889fa6491c74 \
		GIT_TREE_STATE=dirty \
		OUTPUT_DIR=/output/windows/amd64 \
		./hack/build.sh'"
Using Cached Image: velero/build-image:303d3dca
go: downloading github.com/inconshreveable/mousetrap v1.0.0
building: _output/bin/windows/amd64/velero-restic-restore-helper
/Applications/Xcode.app/Contents/Developer/usr/bin/make shell CMD="-c '\
		GOOS=windows \
		GOARCH=amd64 \
		VERSION=main \
		REGISTRY=velero \
		PKG=github.com/vmware-tanzu/velero \
		BIN=velero-restic-restore-helper \
		GIT_SHA=02013ef3354f23041aa7a7689072889fa6491c74 \
		GIT_TREE_STATE=dirty \
		OUTPUT_DIR=/output/windows/amd64 \
		./hack/build.sh'"
Using Cached Image: velero/build-image:303d3dca
building: _output/bin/linux/ppc64le/velero
/Applications/Xcode.app/Contents/Developer/usr/bin/make shell CMD="-c '\
		GOOS=linux \
		GOARCH=ppc64le \
		VERSION=main \
		REGISTRY=velero \
		PKG=github.com/vmware-tanzu/velero \
		BIN=velero \
		GIT_SHA=02013ef3354f23041aa7a7689072889fa6491c74 \
		GIT_TREE_STATE=dirty \
		OUTPUT_DIR=/output/linux/ppc64le \
		./hack/build.sh'"
Using Cached Image: velero/build-image:303d3dca
building: _output/bin/linux/ppc64le/velero-restic-restore-helper
/Applications/Xcode.app/Contents/Developer/usr/bin/make shell CMD="-c '\
		GOOS=linux \
		GOARCH=ppc64le \
		VERSION=main \
		REGISTRY=velero \
		PKG=github.com/vmware-tanzu/velero \
		BIN=velero-restic-restore-helper \
		GIT_SHA=02013ef3354f23041aa7a7689072889fa6491c74 \
		GIT_TREE_STATE=dirty \
		OUTPUT_DIR=/output/linux/ppc64le \
		./hack/build.sh'"
Using Cached Image: velero/build-image:303d3dca
```
</p>
</details>


```
 ~/src/github.com/vmware-tanzu/velero   epk/darwin_arm64  lipo -info _output/bin/darwin/arm64/velero
Non-fat file: _output/bin/darwin/arm64/velero is architecture: arm64
 ~/src/github.com/vmware-tanzu/velero   epk/darwin_arm64  lipo -info _output/bin/darwin/arm64/velero-restic-restore-helper
Non-fat file: _output/bin/darwin/arm64/velero-restic-restore-helper is architecture: arm64
```

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
