### PR TITLE
Consolidated code for resolving actions and plugins into ActionResolver

### DIFF
--- a/changelogs/unreleased/4410-dsu
+++ b/changelogs/unreleased/4410-dsu
@@ -1,0 +1,2 @@
+Added BackupWithResolvers and RestoreWithResolvers calls.  Will eventually replace Backup and Restore methods.
+Adds ItemSnapshotters to Backup and Restore workflows.

--- a/internal/delete/delete_item_action_handler.go
+++ b/internal/delete/delete_item_action_handler.go
@@ -19,6 +19,8 @@ package delete
 import (
 	"io"
 
+	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/labels"
@@ -28,7 +30,6 @@ import (
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/archive"
 	"github.com/vmware-tanzu/velero/pkg/discovery"
-	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	"github.com/vmware-tanzu/velero/pkg/util/filesystem"
 )
@@ -41,7 +42,6 @@ type Context struct {
 	Filesystem      filesystem.Interface
 	Log             logrus.FieldLogger
 	DiscoveryHelper discovery.Helper
-
 	resolvedActions []framework.DeleteItemResolvedAction
 }
 
@@ -119,10 +119,10 @@ func InvokeDeleteActions(ctx *Context) error {
 				itemLog.Infof("invoking DeleteItemAction plugins")
 
 				for _, action := range actions {
-					if !action.GetSelector().Matches(labels.Set(obj.GetLabels())) {
+					if !action.Selector.Matches(labels.Set(obj.GetLabels())) {
 						continue
 					}
-					err = action.Execute(&velero.DeleteItemActionExecuteInput{
+					err = action.DeleteItemAction.Execute(&velero.DeleteItemActionExecuteInput{
 						Item:   obj,
 						Backup: ctx.Backup,
 					})

--- a/internal/delete/delete_item_action_handler.go
+++ b/internal/delete/delete_item_action_handler.go
@@ -28,8 +28,8 @@ import (
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/archive"
 	"github.com/vmware-tanzu/velero/pkg/discovery"
+	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
-	"github.com/vmware-tanzu/velero/pkg/util/collections"
 	"github.com/vmware-tanzu/velero/pkg/util/filesystem"
 )
 
@@ -42,13 +42,13 @@ type Context struct {
 	Log             logrus.FieldLogger
 	DiscoveryHelper discovery.Helper
 
-	resolvedActions []resolvedAction
+	resolvedActions []framework.DeleteItemResolvedAction
 }
 
 func InvokeDeleteActions(ctx *Context) error {
 	var err error
-	ctx.resolvedActions, err = resolveActions(ctx.Actions, ctx.DiscoveryHelper)
-
+	resolver := framework.NewDeleteItemActionResolver(ctx.Actions)
+	ctx.resolvedActions, err = resolver.ResolveActions(ctx.DiscoveryHelper)
 	// No actions installed and no error means we don't have to continue;
 	// just do the backup deletion without worrying about plugins.
 	if len(ctx.resolvedActions) == 0 && err == nil {
@@ -119,7 +119,7 @@ func InvokeDeleteActions(ctx *Context) error {
 				itemLog.Infof("invoking DeleteItemAction plugins")
 
 				for _, action := range actions {
-					if !action.selector.Matches(labels.Set(obj.GetLabels())) {
+					if !action.GetSelector().Matches(labels.Set(obj.GetLabels())) {
 						continue
 					}
 					err = action.Execute(&velero.DeleteItemActionExecuteInput{
@@ -139,65 +139,12 @@ func InvokeDeleteActions(ctx *Context) error {
 }
 
 // getApplicableActions takes resolved DeleteItemActions and filters them for a given group/resource and namespace.
-func (ctx *Context) getApplicableActions(groupResource schema.GroupResource, namespace string) []resolvedAction {
-	var actions []resolvedAction
-
+func (ctx *Context) getApplicableActions(groupResource schema.GroupResource, namespace string) []framework.DeleteItemResolvedAction {
+	var actions []framework.DeleteItemResolvedAction
 	for _, action := range ctx.resolvedActions {
-		if !action.resourceIncludesExcludes.ShouldInclude(groupResource.String()) {
-			continue
+		if action.ShouldUse(groupResource, namespace, nil, ctx.Log) {
+			actions = append(actions, action)
 		}
-
-		if namespace != "" && !action.namespaceIncludesExcludes.ShouldInclude(namespace) {
-			continue
-		}
-
-		if namespace == "" && !action.namespaceIncludesExcludes.IncludeEverything() {
-			continue
-		}
-
-		actions = append(actions, action)
 	}
-
 	return actions
-}
-
-// resolvedActions are DeleteItemActions decorated with resource/namespace include/exclude collections, as well as label selectors for easy comparison.
-type resolvedAction struct {
-	velero.DeleteItemAction
-
-	resourceIncludesExcludes  *collections.IncludesExcludes
-	namespaceIncludesExcludes *collections.IncludesExcludes
-	selector                  labels.Selector
-}
-
-// resolveActions resolves the AppliesTo ResourceSelectors of DeleteItemActions plugins against the Kubernetes discovery API for fully-qualified names.
-func resolveActions(actions []velero.DeleteItemAction, helper discovery.Helper) ([]resolvedAction, error) {
-	var resolved []resolvedAction
-
-	for _, action := range actions {
-		resourceSelector, err := action.AppliesTo()
-		if err != nil {
-			return nil, err
-		}
-
-		resources := collections.GetResourceIncludesExcludes(helper, resourceSelector.IncludedResources, resourceSelector.ExcludedResources)
-		namespaces := collections.NewIncludesExcludes().Includes(resourceSelector.IncludedNamespaces...).Excludes(resourceSelector.ExcludedNamespaces...)
-
-		selector := labels.Everything()
-		if resourceSelector.LabelSelector != "" {
-			if selector, err = labels.Parse(resourceSelector.LabelSelector); err != nil {
-				return nil, err
-			}
-		}
-
-		res := resolvedAction{
-			DeleteItemAction:          action,
-			resourceIncludesExcludes:  resources,
-			namespaceIncludesExcludes: namespaces,
-			selector:                  selector,
-		}
-		resolved = append(resolved, res)
-	}
-
-	return resolved, nil
 }

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -63,7 +63,7 @@ type Backupper interface {
 	// to the given writers.
 	Backup(logger logrus.FieldLogger, backup *Request, backupFile io.Writer, actions []velero.BackupItemAction, volumeSnapshotterGetter VolumeSnapshotterGetter) error
 	BackupWithResolvers(log logrus.FieldLogger, backupRequest *Request, backupFile io.Writer,
-		backupItemActions framework.BackupItemActionResolver, itemSnapshotters framework.ItemSnapshotterResolver,
+		backupItemActionResolver framework.BackupItemActionResolver, itemSnapshotterResolver framework.ItemSnapshotterResolver,
 		volumeSnapshotterGetter VolumeSnapshotterGetter) error
 }
 
@@ -176,8 +176,11 @@ func (kb *kubernetesBackupper) Backup(log logrus.FieldLogger, backupRequest *Req
 		volumeSnapshotterGetter)
 }
 
-func (kb *kubernetesBackupper) BackupWithResolvers(log logrus.FieldLogger, backupRequest *Request, backupFile io.Writer,
-	backupItemActions framework.BackupItemActionResolver, itemSnapshotters framework.ItemSnapshotterResolver,
+func (kb *kubernetesBackupper) BackupWithResolvers(log logrus.FieldLogger,
+	backupRequest *Request,
+	backupFile io.Writer,
+	backupItemActionResolver framework.BackupItemActionResolver,
+	itemSnapshotterResolver framework.ItemSnapshotterResolver,
 	volumeSnapshotterGetter VolumeSnapshotterGetter) error {
 	gzippedData := gzip.NewWriter(backupFile)
 	defer gzippedData.Close()
@@ -205,12 +208,12 @@ func (kb *kubernetesBackupper) BackupWithResolvers(log logrus.FieldLogger, backu
 		return err
 	}
 
-	backupRequest.ResolvedActions, err = backupItemActions.ResolveActions(kb.discoveryHelper)
+	backupRequest.ResolvedActions, err = backupItemActionResolver.ResolveActions(kb.discoveryHelper)
 	if err != nil {
 		return err
 	}
 
-	backupRequest.ResolvedItemSnapshotters, err = itemSnapshotters.ResolveActions(kb.discoveryHelper)
+	backupRequest.ResolvedItemSnapshotters, err = itemSnapshotterResolver.ResolveActions(kb.discoveryHelper)
 	if err != nil {
 		return err
 	}

--- a/pkg/backup/request.go
+++ b/pkg/backup/request.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/vmware-tanzu/velero/internal/hook"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
 	"github.com/vmware-tanzu/velero/pkg/util/collections"
 	"github.com/vmware-tanzu/velero/pkg/volume"
 )
@@ -42,11 +43,11 @@ type Request struct {
 	NamespaceIncludesExcludes *collections.IncludesExcludes
 	ResourceIncludesExcludes  *collections.IncludesExcludes
 	ResourceHooks             []hook.ResourceHook
-	ResolvedActions           []resolvedAction
-
-	VolumeSnapshots  []*volume.Snapshot
-	PodVolumeBackups []*velerov1api.PodVolumeBackup
-	BackedUpItems    map[itemKey]struct{}
+	ResolvedActions           []framework.BackupItemResolvedAction
+	ResolvedItemSnapshotters  []framework.ItemSnapshotterResolvedAction
+	VolumeSnapshots           []*volume.Snapshot
+	PodVolumeBackups          []*velerov1api.PodVolumeBackup
+	BackedUpItems             map[itemKey]struct{}
 }
 
 // BackupResourceList returns the list of backed up resources grouped by the API

--- a/pkg/plugin/framework/action_resolver.go
+++ b/pkg/plugin/framework/action_resolver.go
@@ -1,0 +1,278 @@
+/*
+Copyright the Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	isv1 "github.com/vmware-tanzu/velero/pkg/plugin/velero/item_snapshotter/v1"
+
+	"github.com/vmware-tanzu/velero/pkg/discovery"
+	"github.com/vmware-tanzu/velero/pkg/util/collections"
+)
+
+/*
+Velero has a variety of Actions that can be executed on Kubernetes resources.  The Actions (BackupItemAction, RestoreItemAction
+and others) implement the Applicable interface which returns a ResourceSelector for the Action.  The ResourceSelector
+can specify namespaces, resource names and labels to include or exclude.  The ResourceSelector is resolved into lists
+of namespaces and resources present in the backup to be matched against.  These lists and the label selector are then used to
+decide whether or not the ResolvedAction should be used for a particular resource.
+*/
+
+type ResolvedAction interface {
+	GetApplicable() velero.Applicable
+	GetSelector() labels.Selector
+	ShouldUse(groupResource schema.GroupResource, namespace string, metadata metav1.Object,
+		log logrus.FieldLogger) bool
+}
+
+type resolvedAction struct {
+	ResourceIncludesExcludes  *collections.IncludesExcludes
+	NamespaceIncludesExcludes *collections.IncludesExcludes
+	Selector                  labels.Selector
+}
+
+func (recv resolvedAction) ShouldUse(groupResource schema.GroupResource, namespace string, metadata metav1.Object,
+	log logrus.FieldLogger) bool {
+	if !recv.ResourceIncludesExcludes.ShouldInclude(groupResource.String()) {
+		log.Debug("Skipping action because it does not apply to this resource")
+		return false
+	}
+
+	if namespace != "" && !recv.NamespaceIncludesExcludes.ShouldInclude(namespace) {
+		log.Debug("Skipping action because it does not apply to this namespace")
+		return false
+	}
+
+	if namespace == "" && !recv.NamespaceIncludesExcludes.IncludeEverything() {
+		log.Debug("Skipping action because resource is cluster-scoped and action only applies to specific namespaces")
+		return false
+	}
+
+	if metadata != nil && !recv.Selector.Matches(labels.Set(metadata.GetLabels())) {
+		log.Debug("Skipping action because label selector does not match")
+		return false
+	}
+	return true
+}
+
+/*
+Resolves the resources, namespaces and selector into fully-qualified versions
+*/
+func resolveAction(helper discovery.Helper, action velero.Applicable) (resources *collections.IncludesExcludes,
+	namespaces *collections.IncludesExcludes, selector labels.Selector, err error) {
+	resourceSelector, err := action.AppliesTo()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	resources = collections.GetResourceIncludesExcludes(helper, resourceSelector.IncludedResources, resourceSelector.ExcludedResources)
+	namespaces = collections.NewIncludesExcludes().Includes(resourceSelector.IncludedNamespaces...).Excludes(resourceSelector.ExcludedNamespaces...)
+
+	selector = labels.Everything()
+	if resourceSelector.LabelSelector != "" {
+		if selector, err = labels.Parse(resourceSelector.LabelSelector); err != nil {
+			return nil, nil, nil, err
+		}
+	}
+
+	return
+}
+
+func (recv resolvedAction) GetSelector() labels.Selector {
+	return recv.Selector
+}
+
+type BackupItemResolvedAction struct {
+	velero.BackupItemAction
+	resolvedAction
+}
+
+func (recv BackupItemResolvedAction) GetApplicable() velero.Applicable {
+	return recv.BackupItemAction
+}
+
+func (recv BackupItemResolvedAction) GetBackupItemAction() velero.BackupItemAction {
+	return recv.BackupItemAction
+}
+
+func NewBackupItemActionResolver(actions []velero.BackupItemAction) BackupItemActionResolver {
+	return BackupItemActionResolver{
+		actions: actions,
+	}
+}
+
+func NewRestoreItemActionResolver(actions []velero.RestoreItemAction) RestoreItemActionResolver {
+	return RestoreItemActionResolver{
+		actions: actions,
+	}
+}
+
+func NewDeleteItemActionResolver(actions []velero.DeleteItemAction) DeleteItemActionResolver {
+	return DeleteItemActionResolver{
+		actions: actions,
+	}
+}
+
+func NewItemSnapshotterResolver(actions []isv1.ItemSnapshotter) ItemSnapshotterResolver {
+	return ItemSnapshotterResolver{
+		actions: actions,
+	}
+}
+
+type ActionResolver interface {
+	ResolveAction(helper discovery.Helper, action velero.Applicable) (ResolvedAction, error)
+}
+
+type BackupItemActionResolver struct {
+	actions []velero.BackupItemAction
+}
+
+func (recv BackupItemActionResolver) ResolveActions(helper discovery.Helper) ([]BackupItemResolvedAction, error) {
+	var resolved []BackupItemResolvedAction
+	for _, action := range recv.actions {
+		resources, namespaces, selector, err := resolveAction(helper, action)
+		if err != nil {
+			return nil, err
+		}
+		res := BackupItemResolvedAction{
+			BackupItemAction: action,
+			resolvedAction: resolvedAction{
+				ResourceIncludesExcludes:  resources,
+				NamespaceIncludesExcludes: namespaces,
+				Selector:                  selector,
+			},
+		}
+		resolved = append(resolved, res)
+	}
+	return resolved, nil
+}
+
+type RestoreItemResolvedAction struct {
+	velero.RestoreItemAction
+	resolvedAction
+}
+
+func (recv RestoreItemResolvedAction) GetApplicable() velero.Applicable {
+	return recv.RestoreItemAction
+}
+
+func (recv RestoreItemResolvedAction) GetRestoreItemAction() velero.RestoreItemAction {
+	return recv.RestoreItemAction
+}
+
+type RestoreItemActionResolver struct {
+	actions []velero.RestoreItemAction
+}
+
+func (recv RestoreItemActionResolver) ResolveActions(helper discovery.Helper) ([]RestoreItemResolvedAction, error) {
+	var resolved []RestoreItemResolvedAction
+	for _, action := range recv.actions {
+		resources, namespaces, selector, err := resolveAction(helper, action)
+		if err != nil {
+			return nil, err
+		}
+		res := RestoreItemResolvedAction{
+			RestoreItemAction: action,
+			resolvedAction: resolvedAction{
+				ResourceIncludesExcludes:  resources,
+				NamespaceIncludesExcludes: namespaces,
+				Selector:                  selector,
+			},
+		}
+		resolved = append(resolved, res)
+	}
+	return resolved, nil
+}
+
+type DeleteItemResolvedAction struct {
+	velero.DeleteItemAction
+	resolvedAction
+}
+
+func (recv DeleteItemResolvedAction) GetApplicable() velero.Applicable {
+	return recv.DeleteItemAction
+}
+
+func (recv DeleteItemResolvedAction) GetRestoreItemAction() velero.DeleteItemAction {
+	return recv.DeleteItemAction
+}
+
+type DeleteItemActionResolver struct {
+	actions []velero.DeleteItemAction
+}
+
+func (recv DeleteItemActionResolver) ResolveActions(helper discovery.Helper) ([]DeleteItemResolvedAction, error) {
+	var resolved []DeleteItemResolvedAction
+	for _, action := range recv.actions {
+		resources, namespaces, selector, err := resolveAction(helper, action)
+		if err != nil {
+			return nil, err
+		}
+		res := DeleteItemResolvedAction{
+			DeleteItemAction: action,
+			resolvedAction: resolvedAction{
+				ResourceIncludesExcludes:  resources,
+				NamespaceIncludesExcludes: namespaces,
+				Selector:                  selector,
+			},
+		}
+		resolved = append(resolved, res)
+	}
+	return resolved, nil
+}
+
+type ItemSnapshotterResolvedAction struct {
+	isv1.ItemSnapshotter
+	resolvedAction
+}
+
+func (recv ItemSnapshotterResolvedAction) GetApplicable() velero.Applicable {
+	return recv.ItemSnapshotter
+}
+
+func (recv ItemSnapshotterResolvedAction) GetRestoreItemAction() isv1.ItemSnapshotter {
+	return recv.ItemSnapshotter
+}
+
+type ItemSnapshotterResolver struct {
+	actions []isv1.ItemSnapshotter
+}
+
+func (recv ItemSnapshotterResolver) ResolveActions(helper discovery.Helper) ([]ItemSnapshotterResolvedAction, error) {
+	var resolved []ItemSnapshotterResolvedAction
+	for _, action := range recv.actions {
+		resources, namespaces, selector, err := resolveAction(helper, action)
+		if err != nil {
+			return nil, err
+		}
+		res := ItemSnapshotterResolvedAction{
+			ItemSnapshotter: action,
+			resolvedAction: resolvedAction{
+				ResourceIncludesExcludes:  resources,
+				NamespaceIncludesExcludes: namespaces,
+				Selector:                  selector,
+			},
+		}
+		resolved = append(resolved, res)
+	}
+	return resolved, nil
+}

--- a/pkg/plugin/framework/action_resolver.go
+++ b/pkg/plugin/framework/action_resolver.go
@@ -37,13 +37,15 @@ of namespaces and resources present in the backup to be matched against.  These 
 decide whether or not the ResolvedAction should be used for a particular resource.
 */
 
+// ResolvedAction is an action that has had the namespaces, resources names and labels to include or exclude resolved
 type ResolvedAction interface {
-	GetApplicable() velero.Applicable
-	GetSelector() labels.Selector
+	// ShouldUse returns true if the resolved namespaces, resource names and labels match those passed in the parameters.
+	// metadata is optional and may be nil
 	ShouldUse(groupResource schema.GroupResource, namespace string, metadata metav1.Object,
 		log logrus.FieldLogger) bool
 }
 
+// resolvedAction is a core struct that holds the resolved namespaces, resource names and labels
 type resolvedAction struct {
 	ResourceIncludesExcludes  *collections.IncludesExcludes
 	NamespaceIncludesExcludes *collections.IncludesExcludes
@@ -74,9 +76,7 @@ func (recv resolvedAction) ShouldUse(groupResource schema.GroupResource, namespa
 	return true
 }
 
-/*
-Resolves the resources, namespaces and selector into fully-qualified versions
-*/
+// resolveAction resolves the resources, namespaces and selector into fully-qualified versions
 func resolveAction(helper discovery.Helper, action velero.Applicable) (resources *collections.IncludesExcludes,
 	namespaces *collections.IncludesExcludes, selector labels.Selector, err error) {
 	resourceSelector, err := action.AppliesTo()
@@ -97,21 +97,9 @@ func resolveAction(helper discovery.Helper, action velero.Applicable) (resources
 	return
 }
 
-func (recv resolvedAction) GetSelector() labels.Selector {
-	return recv.Selector
-}
-
 type BackupItemResolvedAction struct {
 	velero.BackupItemAction
 	resolvedAction
-}
-
-func (recv BackupItemResolvedAction) GetApplicable() velero.Applicable {
-	return recv.BackupItemAction
-}
-
-func (recv BackupItemResolvedAction) GetBackupItemAction() velero.BackupItemAction {
-	return recv.BackupItemAction
 }
 
 func NewBackupItemActionResolver(actions []velero.BackupItemAction) BackupItemActionResolver {
@@ -171,14 +159,6 @@ type RestoreItemResolvedAction struct {
 	resolvedAction
 }
 
-func (recv RestoreItemResolvedAction) GetApplicable() velero.Applicable {
-	return recv.RestoreItemAction
-}
-
-func (recv RestoreItemResolvedAction) GetRestoreItemAction() velero.RestoreItemAction {
-	return recv.RestoreItemAction
-}
-
 type RestoreItemActionResolver struct {
 	actions []velero.RestoreItemAction
 }
@@ -208,14 +188,6 @@ type DeleteItemResolvedAction struct {
 	resolvedAction
 }
 
-func (recv DeleteItemResolvedAction) GetApplicable() velero.Applicable {
-	return recv.DeleteItemAction
-}
-
-func (recv DeleteItemResolvedAction) GetRestoreItemAction() velero.DeleteItemAction {
-	return recv.DeleteItemAction
-}
-
 type DeleteItemActionResolver struct {
 	actions []velero.DeleteItemAction
 }
@@ -243,14 +215,6 @@ func (recv DeleteItemActionResolver) ResolveActions(helper discovery.Helper) ([]
 type ItemSnapshotterResolvedAction struct {
 	isv1.ItemSnapshotter
 	resolvedAction
-}
-
-func (recv ItemSnapshotterResolvedAction) GetApplicable() velero.Applicable {
-	return recv.ItemSnapshotter
-}
-
-func (recv ItemSnapshotterResolvedAction) GetRestoreItemAction() isv1.ItemSnapshotter {
-	return recv.ItemSnapshotter
 }
 
 type ItemSnapshotterResolver struct {

--- a/pkg/plugin/framework/action_resolver_test.go
+++ b/pkg/plugin/framework/action_resolver_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright the Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	velerotest "github.com/vmware-tanzu/velero/pkg/test"
+)
+
+type mockApplicable struct {
+	selector velero.ResourceSelector
+}
+
+func (recv mockApplicable) AppliesTo() (velero.ResourceSelector, error) {
+	return recv.selector, nil
+}
+
+func TestActionResolverNamespace(t *testing.T) {
+	discoveryHelper := velerotest.NewFakeDiscoveryHelper(false, map[schema.GroupVersionResource]schema.GroupVersionResource{})
+	namespaceMatchApplicable := mockApplicable{
+		selector: velero.ResourceSelector{
+			IncludedNamespaces: []string{"default"},
+		},
+	}
+	resources, namespaces, selector, err := resolveAction(discoveryHelper, namespaceMatchApplicable)
+	require.NoError(t, err)
+	require.Equal(t, []string{"default"}, namespaces.GetIncludes())
+	require.Empty(t, namespaces.GetExcludes())
+	require.Empty(t, resources.GetIncludes())
+	require.Empty(t, resources.GetExcludes())
+	require.True(t, selector.Empty())
+}
+
+func TestActionResolverResource(t *testing.T) {
+	pvGVR := schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "persistentvolumes",
+	}
+	discoveryHelper := velerotest.NewFakeDiscoveryHelper(false, map[schema.GroupVersionResource]schema.GroupVersionResource{pvGVR: pvGVR})
+	namespaceMatchApplicable := mockApplicable{
+		selector: velero.ResourceSelector{
+			IncludedResources: []string{"persistentvolumes"},
+		},
+	}
+	resources, namespaces, selector, err := resolveAction(discoveryHelper, namespaceMatchApplicable)
+	require.NoError(t, err)
+	require.Empty(t, namespaces.GetIncludes())
+	require.Empty(t, namespaces.GetExcludes())
+	require.True(t, resources.ShouldInclude("persistentvolumes"))
+	require.Empty(t, resources.GetExcludes())
+	require.True(t, selector.Empty())
+}
+
+func TestActionResolverLabel(t *testing.T) {
+	discoveryHelper := velerotest.NewFakeDiscoveryHelper(false, map[schema.GroupVersionResource]schema.GroupVersionResource{})
+	namespaceMatchApplicable := mockApplicable{
+		selector: velero.ResourceSelector{
+			LabelSelector: "myLabel=true",
+		},
+	}
+	checkLabel, err := labels.ConvertSelectorToLabelsMap("myLabel=true")
+	require.NoError(t, err)
+
+	resources, namespaces, selector, err := resolveAction(discoveryHelper, namespaceMatchApplicable)
+	require.NoError(t, err)
+	require.Empty(t, namespaces.GetIncludes())
+	require.Empty(t, namespaces.GetExcludes())
+	require.Empty(t, resources.GetIncludes())
+	require.Empty(t, resources.GetExcludes())
+	require.True(t, selector.Matches(checkLabel))
+}

--- a/pkg/plugin/velero/shared.go
+++ b/pkg/plugin/velero/shared.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 the Velero contributors.
+Copyright the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -47,4 +47,10 @@ type ResourceSelector struct {
 	// when matching resources. See "k8s.io/apimachinery/pkg/labels".Parse()
 	// for details on syntax.
 	LabelSelector string
+}
+
+// Applicable allows actions and plugins to specify which resources they should be invoked for
+type Applicable interface {
+	// AppliesTo returns information about which resources this Responder should be invoked for.
+	AppliesTo() (ResourceSelector, error)
 }

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -545,7 +545,7 @@ func TestRestoreResourceFiltering(t *testing.T) {
 			}
 			warnings, errs := h.restorer.Restore(
 				data,
-				nil, // actions
+				nil, // restoreItemActions
 				nil, // snapshot location lister
 				nil, // volume snapshotter getter
 			)
@@ -626,7 +626,7 @@ func TestRestoreNamespaceMapping(t *testing.T) {
 			}
 			warnings, errs := h.restorer.Restore(
 				data,
-				nil, // actions
+				nil, // restoreItemActions
 				nil, // snapshot location lister
 				nil, // volume snapshotter getter
 			)
@@ -708,7 +708,7 @@ func TestRestoreResourcePriorities(t *testing.T) {
 		}
 		warnings, errs := h.restorer.Restore(
 			data,
-			nil, // actions
+			nil, // restoreItemActions
 			nil, // snapshot location lister
 			nil, // volume snapshotter getter
 		)
@@ -785,7 +785,7 @@ func TestInvalidTarballContents(t *testing.T) {
 			}
 			warnings, errs := h.restorer.Restore(
 				data,
-				nil, // actions
+				nil, // restoreItemActions
 				nil, // snapshot location lister
 				nil, // volume snapshotter getter
 			)
@@ -1000,7 +1000,7 @@ func TestRestoreItems(t *testing.T) {
 			}
 			warnings, errs := h.restorer.Restore(
 				data,
-				nil, // actions
+				nil, // restoreItemActions
 				nil, // snapshot location lister
 				nil, // volume snapshotter getter
 			)
@@ -2510,7 +2510,7 @@ func TestRestorePersistentVolumes(t *testing.T) {
 			}
 			warnings, errs := h.restorer.Restore(
 				data,
-				nil, // actions
+				nil, // restoreItemActions
 				vslInformer.Lister(),
 				tc.volumeSnapshotterGetter,
 			)
@@ -2646,7 +2646,7 @@ func TestRestoreWithRestic(t *testing.T) {
 
 			warnings, errs := h.restorer.Restore(
 				data,
-				nil, // actions
+				nil, // restoreItemActions
 				nil, // snapshot location lister
 				nil, // volume snapshotter getter
 			)

--- a/pkg/test/fake_mapper.go
+++ b/pkg/test/fake_mapper.go
@@ -43,6 +43,16 @@ func (m *FakeMapper) ResourceFor(input schema.GroupVersionResource) (schema.Grou
 	if gr, found := m.Resources[input]; found {
 		return gr, nil
 	}
+	if input.Version == "" {
+		input.Version = "v1"
+		if gr, found := m.Resources[input]; found {
+			return gr, nil
+		}
+		input.Version = "v1beta1"
+		if gr, found := m.Resources[input]; found {
+			return gr, nil
+		}
+	}
 
 	return schema.GroupVersionResource{}, errors.Errorf("invalid resource %q", input.String())
 }


### PR DESCRIPTION
Consolidated code for resolving actions and plugins into ActionResolver.  Added BackupWithResolvers and
RestoreWithResolvers.  Introduces ItemSnapshooterResolver to bring ItemSnapshotter plugins into backup and
restore.  ItemSnapshotters are not used yet.

Signed-off-by: Dave Smith-Uchida <dsmithuchida@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
