### PR TITLE
Added UploadProgressFeature flag to enable UploadProgressMonitoring

### DIFF
--- a/changelogs/unreleased/4416-dsmithuchida
+++ b/changelogs/unreleased/4416-dsmithuchida
@@ -1,0 +1,2 @@
+Added UploadProgressFeature flag to enable Upload Progress Monitoring and Item
+Snapshotters.

--- a/pkg/apis/velero/v1/constants.go
+++ b/pkg/apis/velero/v1/constants.go
@@ -46,4 +46,8 @@ const (
 
 	// APIGroupVersionsFeatureFlag is the feature flag string that defines whether or not to handle multiple API Group Versions
 	APIGroupVersionsFeatureFlag = "EnableAPIGroupVersions"
+
+	// UploadProgressFeatureFlag is the feature flag string that defines whether or not upload progress monitoring is enabled
+	// and whether or not ItemSnapshotters should be invoked
+	UploadProgressFeatureFlag = "EnableUploadProgress"
 )


### PR DESCRIPTION
and ItemSnapshotters.  Will be required in 1.8 to use the upload progress monitoring or item snapshotters, we will plan to remove in 1.9.

Signed-off-by: Dave Smith-Uchida <dsmithuchida@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
