### PR TITLE
Limit backup namespaces on test resource filtering cases 

### DIFF
--- a/changelogs/unreleased/4437-mqiu
+++ b/changelogs/unreleased/4437-mqiu
@@ -1,0 +1,1 @@
+Limit backup namespaces on test resource filtering cases


### PR DESCRIPTION
Signed-off-by: ming qiu <mqiu@mqiu-a01.vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Fix two problems in vsphere e2e environment.
 - Add image pull secret to avoid the image pull limit issue of Docker Hub
 - Optimal the situation that no limit namespaces when backup will make the backup procedure stuck.
# Does your change fix a particular issue?

Fixes #(issue)
#4404 
# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
