### PR TITLE
Add defaultVolumesToRestic to schedule api docs

### DIFF
--- a/site/content/docs/main/api-types/schedule.md
+++ b/site/content/docs/main/api-types/schedule.md
@@ -78,6 +78,8 @@ spec:
     # a default value of 30 days will be used. The default can be configured on the velero server
     # by passing the flag --default-backup-ttl.
     ttl: 24h0m0s
+    # Whether restic should be used to take a backup of all pod volumes by default.
+    defaultVolumesToRestic: true
     # The labels you want on backup objects, created from this schedule (instead of copying the labels you have on schedule object itself).
     # When this field is set, the labels from the Schedule resource are not copied to the Backup resource.
     metadata:


### PR DESCRIPTION
Signed-off-by: Abigail McCarthy <mabigail@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Updates docs to include the defaultVolumesToRestic as an available setting in the Schedule api spec

# Does your change fix a particular issue?

Fixes #4352 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
