### PR TITLE
fix: remove --crds-version in velero install command

### DIFF
--- a/changelogs/unreleased/4446-jxun
+++ b/changelogs/unreleased/4446-jxun
@@ -1,0 +1,1 @@
+remove --crds-version in velero install command.

--- a/pkg/cmd/cli/install/install.go
+++ b/pkg/cmd/cli/install/install.go
@@ -25,11 +25,9 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/vmware-tanzu/velero/internal/velero"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -37,7 +35,6 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/cmd"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/flag"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/output"
-	velerodiscovery "github.com/vmware-tanzu/velero/pkg/discovery"
 	"github.com/vmware-tanzu/velero/pkg/install"
 	kubeutil "github.com/vmware-tanzu/velero/pkg/util/kube"
 )
@@ -72,7 +69,6 @@ type InstallOptions struct {
 	Plugins                           flag.StringArray
 	NoDefaultBackupLocation           bool
 	CRDsOnly                          bool
-	CRDsVersion                       string
 	CACertFile                        string
 	Features                          string
 	DefaultVolumesToRestic            bool
@@ -107,7 +103,6 @@ func (o *InstallOptions) BindFlags(flags *pflag.FlagSet) {
 	flags.DurationVar(&o.DefaultResticMaintenanceFrequency, "default-restic-prune-frequency", o.DefaultResticMaintenanceFrequency, "How often 'restic prune' is run for restic repositories by default. Optional.")
 	flags.Var(&o.Plugins, "plugins", "Plugin container images to install into the Velero Deployment")
 	flags.BoolVar(&o.CRDsOnly, "crds-only", o.CRDsOnly, "Only generate CustomResourceDefinition resources. Useful for updating CRDs for an existing Velero install.")
-	flags.StringVar(&o.CRDsVersion, "crds-version", o.CRDsVersion, "The version to generate CustomResourceDefinition resources if Velero can't discover the Kubernetes preferred CRD API version. Optional.")
 	flags.StringVar(&o.CACertFile, "cacert", o.CACertFile, "File containing a certificate bundle to use when verifying TLS connections to the object store. Optional.")
 	flags.StringVar(&o.Features, "features", o.Features, "Comma separated list of Velero feature flags to be set on the Velero deployment and the restic daemonset, if restic is enabled")
 	flags.BoolVar(&o.DefaultVolumesToRestic, "default-volumes-to-restic", o.DefaultVolumesToRestic, "Bool flag to configure Velero server to use restic by default to backup all pod volumes on all backups. Optional.")
@@ -134,7 +129,6 @@ func NewInstallOptions() *InstallOptions {
 		UseVolumeSnapshots:      true,
 		NoDefaultBackupLocation: false,
 		CRDsOnly:                false,
-		CRDsVersion:             "v1",
 		DefaultVolumesToRestic:  false,
 	}
 }
@@ -193,7 +187,6 @@ func (o *InstallOptions) AsVeleroOptions() (*install.VeleroOptions, error) {
 		NoDefaultBackupLocation:           o.NoDefaultBackupLocation,
 		CACertData:                        caCertData,
 		Features:                          strings.Split(o.Features, ","),
-		CRDsVersion:                       o.CRDsVersion,
 		DefaultVolumesToRestic:            o.DefaultVolumesToRestic,
 	}, nil
 }
@@ -254,30 +247,9 @@ This is useful as a starting point for more customized installations.
 
 // Run executes a command in the context of the provided arguments.
 func (o *InstallOptions) Run(c *cobra.Command, f client.Factory) error {
-	// Find the kube-apiserver group apiextensions.k8s.io preferred API version
-	clientset, err := f.KubeClient()
-	if err == nil {
-		// kubeconfig available
-		discoveryHelper, err := velerodiscovery.NewHelper(clientset.Discovery(), &logrus.Logger{})
-		if err == nil {
-			// kubernetes apiserver available
-			gvr, _, err := discoveryHelper.ResourceFor(
-				schema.GroupVersionResource{
-					Group:    "apiextensions.k8s.io",
-					Resource: "customresourcedefinitions",
-				})
-			if err != nil {
-				return err
-			}
-
-			// Update the group apiextensions.k8s.io preferred API version
-			o.CRDsVersion = gvr.Version
-		}
-	}
-
 	var resources *unstructured.UnstructuredList
 	if o.CRDsOnly {
-		resources = install.AllCRDs(o.CRDsVersion)
+		resources = install.AllCRDs()
 	} else {
 		vo, err := o.AsVeleroOptions()
 		if err != nil {
@@ -346,11 +318,6 @@ func (o *InstallOptions) Complete(args []string, f client.Factory) error {
 func (o *InstallOptions) Validate(c *cobra.Command, args []string, f client.Factory) error {
 	if err := output.ValidateFlags(c); err != nil {
 		return err
-	}
-
-	// Check the CRD version is valid.
-	if o.CRDsVersion != "v1beta1" && o.CRDsVersion != "v1" {
-		return errors.Errorf("CRD version must be v1beta1 or v1")
 	}
 
 	// If we're only installing CRDs, we can skip the rest of the validation.

--- a/pkg/install/resources.go
+++ b/pkg/install/resources.go
@@ -215,21 +215,17 @@ type VeleroOptions struct {
 	NoDefaultBackupLocation           bool
 	CACertData                        []byte
 	Features                          []string
-	CRDsVersion                       string
 	DefaultVolumesToRestic            bool
 }
 
-func AllCRDs(perferredAPIVersion string) *unstructured.UnstructuredList {
+func AllCRDs() *unstructured.UnstructuredList {
 	resources := new(unstructured.UnstructuredList)
 	// Set the GVK so that the serialization framework outputs the list properly
 	resources.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "List"})
 
-	switch perferredAPIVersion {
-	case "v1":
-		for _, crd := range v1crds.CRDs {
-			crd.SetLabels(Labels())
-			appendUnstructured(resources, crd)
-		}
+	for _, crd := range v1crds.CRDs {
+		crd.SetLabels(Labels())
+		appendUnstructured(resources, crd)
 	}
 
 	return resources
@@ -238,7 +234,7 @@ func AllCRDs(perferredAPIVersion string) *unstructured.UnstructuredList {
 // AllResources returns a list of all resources necessary to install Velero, in the appropriate order, into a Kubernetes cluster.
 // Items are unstructured, since there are different data types returned.
 func AllResources(o *VeleroOptions) *unstructured.UnstructuredList {
-	resources := AllCRDs(o.CRDsVersion)
+	resources := AllCRDs()
 
 	ns := Namespace(o.Namespace)
 	appendUnstructured(resources, ns)

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -54,7 +54,6 @@ RESTIC_HELPER_IMAGE ?=
 #Released version only
 UPGRADE_FROM_VELERO_CLI ?=
 UPGRADE_FROM_VELERO_VERSION ?= v1.6.3
-CRDS_VERSION ?= v1
 VELERO_NAMESPACE ?= velero
 CREDS_FILE ?=
 BSL_BUCKET ?=
@@ -94,7 +93,6 @@ run: ginkgo
 		-upgrade-from-velero-cli=$(UPGRADE_FROM_VELERO_CLI) \
 		-upgrade-from-velero-version=$(UPGRADE_FROM_VELERO_VERSION) \
 		-velero-namespace=$(VELERO_NAMESPACE) \
-		-crds-version=$(CRDS_VERSION) \
 		-credentials-file=$(CREDS_FILE) \
 		-bucket=$(BSL_BUCKET) \
 		-prefix=$(BSL_PREFIX) \

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -58,7 +58,6 @@ func init() {
 	flag.StringVar(&VeleroCfg.AdditionalBSLPrefix, "additional-bsl-prefix", "", "prefix under which all Velero data should be stored within the bucket for additional backup storage location. Optional.")
 	flag.StringVar(&VeleroCfg.AdditionalBSLConfig, "additional-bsl-config", "", "configuration to use for the additional backup storage location. Format is key1=value1,key2=value2")
 	flag.StringVar(&VeleroCfg.AdditionalBSLCredentials, "additional-bsl-credentials-file", "", "file containing credentials for additional backup storage location provider. Required if testing multiple credentials support.")
-	flag.StringVar(&VeleroCfg.CRDsVersion, "crds-version", "v1", "CRD apiVersion for velero CRD creation.")
 }
 
 var _ = Describe("[APIGroup] Velero tests with various CRD API group versions", APIGropuVersionsTest)

--- a/test/e2e/types.go
+++ b/test/e2e/types.go
@@ -36,7 +36,6 @@ type VerleroConfig struct {
 	CloudProvider            string
 	ObjectStoreProvider      string
 	VeleroNamespace          string
-	CRDsVersion              string
 	AdditionalBSLProvider    string
 	AdditionalBSLBucket      string
 	AdditionalBSLPrefix      string

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -78,7 +78,6 @@ func BackupUpgradeRestoreTest(useVolumeSnapshots bool) {
 			tmpCfg.VeleroImage = ""
 			tmpCfg.ResticHelperImage = ""
 			tmpCfg.Plugins = ""
-			tmpCfg.CRDsVersion = ""
 			Expect(VeleroInstall(context.Background(), &tmpCfg, "", useVolumeSnapshots)).To(Succeed())
 			Expect(CheckVeleroVersion(context.Background(), upgradeFromVeleroCLI, tmpCfg.UpgradeFromVeleroVersion)).To(Succeed())
 		} else {

--- a/test/e2e/util/velero/install.go
+++ b/test/e2e/util/velero/install.go
@@ -82,7 +82,6 @@ func VeleroInstall(ctx context.Context, veleroCfg *VerleroConfig, features strin
 	veleroInstallOptions.UseVolumeSnapshots = useVolumeSnapshots
 	veleroInstallOptions.UseRestic = !useVolumeSnapshots
 	veleroInstallOptions.Image = veleroCfg.VeleroImage
-	veleroInstallOptions.CRDsVersion = veleroCfg.CRDsVersion
 	veleroInstallOptions.Namespace = veleroCfg.VeleroNamespace
 
 	err = installVeleroServer(ctx, veleroCfg.VeleroCLI, &installOptions{
@@ -103,9 +102,6 @@ func installVeleroServer(ctx context.Context, cli string, options *installOption
 	if len(options.Namespace) > 0 {
 		args = append(args, "--namespace", options.Namespace)
 		namespace = options.Namespace
-	}
-	if len(options.CRDsVersion) > 0 {
-		args = append(args, "--crds-version", options.CRDsVersion)
 	}
 	if len(options.Image) > 0 {
 		args = append(args, "--image", options.Image)


### PR DESCRIPTION
Fix: 4389

Due to only v1 CRD is supported in velero version 1.8, remove CRDs version choosing option.

Signed-off-by: Xun Jiang <jxun@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
