### PR TITLE
Revert "Migrate backup sync controller from code-generator to kubebui…

### DIFF
--- a/changelogs/unreleased/4423-jxun
+++ b/changelogs/unreleased/4423-jxun
@@ -1,0 +1,1 @@
+Migrate backup sync controller from code-generator to kubebuilder.

--- a/changelogs/unreleased/4423-jxun
+++ b/changelogs/unreleased/4423-jxun
@@ -1,1 +1,0 @@
-Migrate backup sync controller from code-generator to kubebuilder.

--- a/changelogs/unreleased/4457-jxun
+++ b/changelogs/unreleased/4457-jxun
@@ -1,0 +1,1 @@
+Revert #4423 migrate backup sync controller to kubebuilder.

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -589,6 +589,28 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 
 	csiVSLister, csiVSCLister := s.getCSISnapshotListers()
 
+	backupSyncControllerRunInfo := func() controllerRunInfo {
+		backupSyncContoller := controller.NewBackupSyncController(
+			s.veleroClient.VeleroV1(),
+			s.mgr.GetClient(),
+			s.veleroClient.VeleroV1(),
+			s.sharedInformerFactory.Velero().V1().Backups().Lister(),
+			s.config.backupSyncPeriod,
+			s.namespace,
+			s.csiSnapshotClient,
+			s.kubeClient,
+			s.config.defaultBackupLocation,
+			newPluginManager,
+			backupStoreGetter,
+			s.logger,
+		)
+
+		return controllerRunInfo{
+			controller: backupSyncContoller,
+			numWorkers: defaultControllerWorkers,
+		}
+	}
+
 	backupTracker := controller.NewBackupTracker()
 
 	backupControllerRunInfo := func() controllerRunInfo {
@@ -747,6 +769,7 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 	}
 
 	enabledControllers := map[string]func() controllerRunInfo{
+		controller.BackupSync:        backupSyncControllerRunInfo,
 		controller.Backup:            backupControllerRunInfo,
 		controller.Schedule:          scheduleControllerRunInfo,
 		controller.GarbageCollection: gcControllerRunInfo,
@@ -758,7 +781,6 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 	enabledRuntimeControllers := make(map[string]struct{})
 	enabledRuntimeControllers[controller.ServerStatusRequest] = struct{}{}
 	enabledRuntimeControllers[controller.DownloadRequest] = struct{}{}
-	enabledRuntimeControllers[controller.BackupSync] = struct{}{}
 
 	if s.config.restoreOnly {
 		s.logger.Info("Restore only mode - not starting the backup, schedule, delete-backup, or GC controllers")
@@ -846,28 +868,6 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 		}
 		if err := r.SetupWithManager(s.mgr); err != nil {
 			s.logger.Fatal(err, "unable to create controller", "controller", controller.DownloadRequest)
-		}
-	}
-
-	if _, ok := enabledRuntimeControllers[controller.BackupSync]; ok {
-		syncPeriod := s.config.backupSyncPeriod
-		if syncPeriod <= 0 {
-			syncPeriod = time.Minute
-		}
-
-		r := controller.BackupSyncReconciler{
-			Client:                  s.mgr.GetClient(),
-			PodVolumeBackupClient:   s.veleroClient.VeleroV1(),
-			BackupLister:            s.sharedInformerFactory.Velero().V1().Backups().Lister(),
-			BackupClient:            s.veleroClient.VeleroV1(),
-			Namespace:               s.namespace,
-			DefaultBackupSyncPeriod: syncPeriod,
-			NewPluginManager:        newPluginManager,
-			BackupStoreGetter:       backupStoreGetter,
-			Logger:                  s.logger,
-		}
-		if err := r.SetupWithManager(s.mgr); err != nil {
-			s.logger.Fatal(err, " unable to create controller ", "controller ", controller.BackupSync)
 		}
 	}
 

--- a/pkg/controller/backup_sync_controller_test.go
+++ b/pkg/controller/backup_sync_controller_test.go
@@ -18,22 +18,16 @@ package controller
 
 import (
 	"context"
-	"fmt"
-	"reflect"
+	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	core "k8s.io/client-go/testing"
-
-	ctrl "sigs.k8s.io/controller-runtime"
-	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/builder"
@@ -113,279 +107,263 @@ func defaultLocationsListWithLongerLocationName(namespace string) []*velerov1api
 	}
 }
 
-func getDeleteActions(actions []core.Action) []core.Action {
-	var deleteActions []core.Action
-	for _, action := range actions {
-		if action.GetVerb() == "delete" {
-			deleteActions = append(deleteActions, action)
-		}
-	}
-	return deleteActions
-}
-
-func numBackups(c *fake.Clientset, ns string) (int, error) {
-	existingK8SBackups, err := c.VeleroV1().Backups(ns).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return 0, err
+func TestBackupSyncControllerRun(t *testing.T) {
+	type cloudBackupData struct {
+		backup           *velerov1api.Backup
+		podVolumeBackups []*velerov1api.PodVolumeBackup
 	}
 
-	return len(existingK8SBackups.Items), nil
-}
+	tests := []struct {
+		name                     string
+		namespace                string
+		locations                []*velerov1api.BackupStorageLocation
+		cloudBuckets             map[string][]*cloudBackupData
+		existingBackups          []*velerov1api.Backup
+		existingPodVolumeBackups []*velerov1api.PodVolumeBackup
+		longLocationNameEnabled  bool
+	}{
+		{
+			name: "no cloud backups",
+		},
+		{
+			name:      "normal case",
+			namespace: "ns-1",
+			locations: defaultLocationsList("ns-1"),
+			cloudBuckets: map[string][]*cloudBackupData{
+				"bucket-1": {
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-1", "backup-1").Result(),
+					},
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-1", "backup-2").Result(),
+					},
+				},
+				"bucket-2": {
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-1", "backup-3").Result(),
+					},
+				},
+			},
+		},
+		{
+			name:      "all synced backups get created in Velero server's namespace",
+			namespace: "velero",
+			locations: defaultLocationsList("velero"),
+			cloudBuckets: map[string][]*cloudBackupData{
+				"bucket-1": {
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-1", "backup-1").Result(),
+					},
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-1", "backup-2").Result(),
+					},
+				},
+				"bucket-2": {
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-2", "backup-3").Result(),
+					},
+					&cloudBackupData{
+						backup: builder.ForBackup("velero", "backup-4").Result(),
+					},
+				},
+			},
+		},
+		{
+			name:      "new backups get synced when some cloud backups already exist in the cluster",
+			namespace: "ns-1",
+			locations: defaultLocationsList("ns-1"),
+			cloudBuckets: map[string][]*cloudBackupData{
+				"bucket-1": {
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-1", "backup-1").Result(),
+					},
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-1", "backup-2").Result(),
+					},
+				},
+				"bucket-2": {
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-1", "backup-3").Result(),
+					},
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-1", "backup-4").Result(),
+					},
+				},
+			},
+			existingBackups: []*velerov1api.Backup{
+				// add a label to each existing backup so we can differentiate it from the cloud
+				// backup during verification
+				builder.ForBackup("ns-1", "backup-1").StorageLocation("location-1").ObjectMeta(builder.WithLabels("i-exist", "true")).Result(),
+				builder.ForBackup("ns-1", "backup-3").StorageLocation("location-2").ObjectMeta(builder.WithLabels("i-exist", "true")).Result(),
+			},
+		},
+		{
+			name:      "existing backups without a StorageLocation get it filled in",
+			namespace: "ns-1",
+			locations: defaultLocationsList("ns-1"),
+			cloudBuckets: map[string][]*cloudBackupData{
+				"bucket-1": {
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-1", "backup-1").Result(),
+					},
+				},
+			},
+			existingBackups: []*velerov1api.Backup{
+				// add a label to each existing backup so we can differentiate it from the cloud
+				// backup during verification
+				builder.ForBackup("ns-1", "backup-1").ObjectMeta(builder.WithLabels("i-exist", "true")).StorageLocation("location-1").Result(),
+			},
+		},
+		{
+			name:      "backup storage location names and labels get updated",
+			namespace: "ns-1",
+			locations: defaultLocationsList("ns-1"),
+			cloudBuckets: map[string][]*cloudBackupData{
+				"bucket-1": {
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-1", "backup-1").StorageLocation("foo").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "foo")).Result(),
+					},
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-1", "backup-2").Result(),
+					},
+				},
+				"bucket-2": {
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-1", "backup-3").StorageLocation("bar").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "bar")).Result(),
+					},
+				},
+			},
+		},
+		{
+			name:                    "backup storage location names and labels get updated with location name greater than 63 chars",
+			namespace:               "ns-1",
+			locations:               defaultLocationsListWithLongerLocationName("ns-1"),
+			longLocationNameEnabled: true,
+			cloudBuckets: map[string][]*cloudBackupData{
+				"bucket-1": {
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-1", "backup-1").StorageLocation("foo").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "foo")).Result(),
+					},
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-1", "backup-2").Result(),
+					},
+				},
+				"bucket-2": {
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-1", "backup-3").StorageLocation("bar").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "bar")).Result(),
+					},
+				},
+			},
+		},
+		{
+			name:      "all synced backups and pod volume backups get created in Velero server's namespace",
+			namespace: "ns-1",
+			locations: defaultLocationsList("ns-1"),
+			cloudBuckets: map[string][]*cloudBackupData{
+				"bucket-1": {
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-1", "backup-1").Result(),
+						podVolumeBackups: []*velerov1api.PodVolumeBackup{
+							builder.ForPodVolumeBackup("ns-1", "pvb-1").Result(),
+						},
+					},
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-1", "backup-2").Result(),
+						podVolumeBackups: []*velerov1api.PodVolumeBackup{
+							builder.ForPodVolumeBackup("ns-1", "pvb-2").Result(),
+						},
+					},
+				},
+				"bucket-2": {
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-1", "backup-3").Result(),
+					},
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-1", "backup-4").Result(),
+						podVolumeBackups: []*velerov1api.PodVolumeBackup{
+							builder.ForPodVolumeBackup("ns-1", "pvb-1").Result(),
+							builder.ForPodVolumeBackup("ns-1", "pvb-2").Result(),
+							builder.ForPodVolumeBackup("ns-1", "pvb-3").Result(),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:      "new pod volume backups get synched when some pod volume backups already exist in the cluster",
+			namespace: "ns-1",
+			locations: defaultLocationsList("ns-1"),
+			cloudBuckets: map[string][]*cloudBackupData{
+				"bucket-1": {
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-1", "backup-1").Result(),
+						podVolumeBackups: []*velerov1api.PodVolumeBackup{
+							builder.ForPodVolumeBackup("ns-1", "pvb-1").Result(),
+						},
+					},
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-1", "backup-2").Result(),
+						podVolumeBackups: []*velerov1api.PodVolumeBackup{
+							builder.ForPodVolumeBackup("ns-1", "pvb-3").Result(),
+						},
+					},
+				},
+				"bucket-2": {
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-1", "backup-3").Result(),
+					},
+					&cloudBackupData{
+						backup: builder.ForBackup("ns-1", "backup-4").Result(),
+						podVolumeBackups: []*velerov1api.PodVolumeBackup{
+							builder.ForPodVolumeBackup("ns-1", "pvb-1").Result(),
+							builder.ForPodVolumeBackup("ns-1", "pvb-5").Result(),
+							builder.ForPodVolumeBackup("ns-1", "pvb-6").Result(),
+						},
+					},
+				},
+			},
+			existingPodVolumeBackups: []*velerov1api.PodVolumeBackup{
+				builder.ForPodVolumeBackup("ns-1", "pvb-1").Result(),
+				builder.ForPodVolumeBackup("ns-1", "pvb-2").Result(),
+			},
+		},
+	}
 
-var _ = Describe("Backup Sync Reconciler", func() {
-	It("Test Backup Sync Reconciler basic function", func() {
-		type cloudBackupData struct {
-			backup           *velerov1api.Backup
-			podVolumeBackups []*velerov1api.PodVolumeBackup
-		}
-
-		tests := []struct {
-			name                     string
-			namespace                string
-			locations                []*velerov1api.BackupStorageLocation
-			cloudBuckets             map[string][]*cloudBackupData
-			existingBackups          []*velerov1api.Backup
-			existingPodVolumeBackups []*velerov1api.PodVolumeBackup
-			longLocationNameEnabled  bool
-		}{
-			{
-				name:      "no cloud backups",
-				namespace: "ns-1",
-				locations: defaultLocationsList("ns-1"),
-			},
-			{
-				name:      "normal case",
-				namespace: "ns-1",
-				locations: defaultLocationsList("ns-1"),
-				cloudBuckets: map[string][]*cloudBackupData{
-					"bucket-1": {
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-1", "backup-1").Result(),
-						},
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-1", "backup-2").Result(),
-						},
-					},
-					"bucket-2": {
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-1", "backup-3").Result(),
-						},
-					},
-				},
-			},
-			{
-				name:      "all synced backups get created in Velero server's namespace",
-				namespace: "velero",
-				locations: defaultLocationsList("velero"),
-				cloudBuckets: map[string][]*cloudBackupData{
-					"bucket-1": {
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-1", "backup-1").Result(),
-						},
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-1", "backup-2").Result(),
-						},
-					},
-					"bucket-2": {
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-2", "backup-3").Result(),
-						},
-						&cloudBackupData{
-							backup: builder.ForBackup("velero", "backup-4").Result(),
-						},
-					},
-				},
-			},
-			{
-				name:      "new backups get synced when some cloud backups already exist in the cluster",
-				namespace: "ns-1",
-				locations: defaultLocationsList("ns-1"),
-				cloudBuckets: map[string][]*cloudBackupData{
-					"bucket-1": {
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-1", "backup-1").Result(),
-						},
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-1", "backup-2").Result(),
-						},
-					},
-					"bucket-2": {
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-1", "backup-3").Result(),
-						},
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-1", "backup-4").Result(),
-						},
-					},
-				},
-				existingBackups: []*velerov1api.Backup{
-					// add a label to each existing backup so we can differentiate it from the cloud
-					// backup during verification
-					builder.ForBackup("ns-1", "backup-1").StorageLocation("location-1").ObjectMeta(builder.WithLabels("i-exist", "true")).Result(),
-					builder.ForBackup("ns-1", "backup-3").StorageLocation("location-2").ObjectMeta(builder.WithLabels("i-exist", "true")).Result(),
-				},
-			},
-			{
-				name:      "existing backups without a StorageLocation get it filled in",
-				namespace: "ns-1",
-				locations: defaultLocationsList("ns-1"),
-				cloudBuckets: map[string][]*cloudBackupData{
-					"bucket-1": {
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-1", "backup-1").Result(),
-						},
-					},
-				},
-				existingBackups: []*velerov1api.Backup{
-					// add a label to each existing backup so we can differentiate it from the cloud
-					// backup during verification
-					builder.ForBackup("ns-1", "backup-1").ObjectMeta(builder.WithLabels("i-exist", "true")).StorageLocation("location-1").Result(),
-				},
-			},
-			{
-				name:      "backup storage location names and labels get updated",
-				namespace: "ns-1",
-				locations: defaultLocationsList("ns-1"),
-				cloudBuckets: map[string][]*cloudBackupData{
-					"bucket-1": {
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-1", "backup-1").StorageLocation("foo").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "foo")).Result(),
-						},
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-1", "backup-2").Result(),
-						},
-					},
-					"bucket-2": {
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-1", "backup-3").StorageLocation("bar").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "bar")).Result(),
-						},
-					},
-				},
-			},
-			{
-				name:                    "backup storage location names and labels get updated with location name greater than 63 chars",
-				namespace:               "ns-1",
-				locations:               defaultLocationsListWithLongerLocationName("ns-1"),
-				longLocationNameEnabled: true,
-				cloudBuckets: map[string][]*cloudBackupData{
-					"bucket-1": {
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-1", "backup-1").StorageLocation("foo").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "foo")).Result(),
-						},
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-1", "backup-2").Result(),
-						},
-					},
-					"bucket-2": {
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-1", "backup-3").StorageLocation("bar").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "bar")).Result(),
-						},
-					},
-				},
-			},
-			{
-				name:      "all synced backups and pod volume backups get created in Velero server's namespace",
-				namespace: "ns-1",
-				locations: defaultLocationsList("ns-1"),
-				cloudBuckets: map[string][]*cloudBackupData{
-					"bucket-1": {
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-1", "backup-1").Result(),
-							podVolumeBackups: []*velerov1api.PodVolumeBackup{
-								builder.ForPodVolumeBackup("ns-1", "pvb-1").Result(),
-							},
-						},
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-1", "backup-2").Result(),
-							podVolumeBackups: []*velerov1api.PodVolumeBackup{
-								builder.ForPodVolumeBackup("ns-1", "pvb-2").Result(),
-							},
-						},
-					},
-					"bucket-2": {
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-1", "backup-3").Result(),
-						},
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-1", "backup-4").Result(),
-							podVolumeBackups: []*velerov1api.PodVolumeBackup{
-								builder.ForPodVolumeBackup("ns-1", "pvb-1").Result(),
-								builder.ForPodVolumeBackup("ns-1", "pvb-2").Result(),
-								builder.ForPodVolumeBackup("ns-1", "pvb-3").Result(),
-							},
-						},
-					},
-				},
-			},
-			{
-				name:      "new pod volume backups get synched when some pod volume backups already exist in the cluster",
-				namespace: "ns-1",
-				locations: defaultLocationsList("ns-1"),
-				cloudBuckets: map[string][]*cloudBackupData{
-					"bucket-1": {
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-1", "backup-1").Result(),
-							podVolumeBackups: []*velerov1api.PodVolumeBackup{
-								builder.ForPodVolumeBackup("ns-1", "pvb-1").Result(),
-							},
-						},
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-1", "backup-2").Result(),
-							podVolumeBackups: []*velerov1api.PodVolumeBackup{
-								builder.ForPodVolumeBackup("ns-1", "pvb-3").Result(),
-							},
-						},
-					},
-					"bucket-2": {
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-1", "backup-3").Result(),
-						},
-						&cloudBackupData{
-							backup: builder.ForBackup("ns-1", "backup-4").Result(),
-							podVolumeBackups: []*velerov1api.PodVolumeBackup{
-								builder.ForPodVolumeBackup("ns-1", "pvb-1").Result(),
-								builder.ForPodVolumeBackup("ns-1", "pvb-5").Result(),
-								builder.ForPodVolumeBackup("ns-1", "pvb-6").Result(),
-							},
-						},
-					},
-				},
-				existingPodVolumeBackups: []*velerov1api.PodVolumeBackup{
-					builder.ForPodVolumeBackup("ns-1", "pvb-1").Result(),
-					builder.ForPodVolumeBackup("ns-1", "pvb-2").Result(),
-				},
-			},
-		}
-
-		for _, test := range tests {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			var (
 				client          = fake.NewSimpleClientset()
+				fakeClient      = velerotest.NewFakeControllerRuntimeClient(t)
 				sharedInformers = informers.NewSharedInformerFactory(client, 0)
 				pluginManager   = &pluginmocks.Manager{}
 				backupStores    = make(map[string]*persistencemocks.BackupStore)
 			)
 
+			c := NewBackupSyncController(
+				client.VeleroV1(),
+				fakeClient,
+				client.VeleroV1(),
+				sharedInformers.Velero().V1().Backups().Lister(),
+				time.Duration(0),
+				test.namespace,
+				nil, // csiSnapshotClient
+				nil, // kubeClient
+				"",
+				func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager },
+				NewFakeObjectBackupStoreGetter(backupStores),
+				velerotest.NewLogger(),
+			).(*backupSyncController)
+
 			pluginManager.On("CleanupClients").Return(nil)
-			r := BackupSyncReconciler{
-				Client:                  ctrlfake.NewClientBuilder().Build(),
-				BackupClient:            client.VeleroV1(),
-				PodVolumeBackupClient:   client.VeleroV1(),
-				BackupLister:            sharedInformers.Velero().V1().Backups().Lister(),
-				Namespace:               test.namespace,
-				DefaultBackupSyncPeriod: time.Second * 10,
-				NewPluginManager:        func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager },
-				BackupStoreGetter:       NewFakeObjectBackupStoreGetter(backupStores),
-				Logger:                  velerotest.NewLogger(),
-			}
 
 			for _, location := range test.locations {
-				Expect(r.Client.Create(ctx, location)).ShouldNot(HaveOccurred())
+				require.NoError(t, fakeClient.Create(context.Background(), location))
 				backupStores[location.Name] = &persistencemocks.BackupStore{}
 			}
 
 			for _, location := range test.locations {
 				backupStore, ok := backupStores[location.Name]
-				Expect(ok).To(BeTrue(), "no mock backup store for location %s", location.Name)
+				require.True(t, ok, "no mock backup store for location %s", location.Name)
 
 				var backupNames []string
 				for _, bucket := range test.cloudBuckets[location.Spec.ObjectStorage.Bucket] {
@@ -397,26 +375,21 @@ var _ = Describe("Backup Sync Reconciler", func() {
 			}
 
 			for _, existingBackup := range test.existingBackups {
-				Expect(sharedInformers.Velero().V1().Backups().Informer().GetStore().Add(existingBackup)).ShouldNot(HaveOccurred())
+				require.NoError(t, sharedInformers.Velero().V1().Backups().Informer().GetStore().Add(existingBackup))
 
 				_, err := client.VeleroV1().Backups(test.namespace).Create(context.TODO(), existingBackup, metav1.CreateOptions{})
-				Expect(err).ShouldNot(HaveOccurred())
+				require.NoError(t, err)
 			}
 
 			for _, existingPodVolumeBackup := range test.existingPodVolumeBackups {
-				Expect(sharedInformers.Velero().V1().PodVolumeBackups().Informer().GetStore().Add(existingPodVolumeBackup)).ShouldNot(HaveOccurred())
+				require.NoError(t, sharedInformers.Velero().V1().PodVolumeBackups().Informer().GetStore().Add(existingPodVolumeBackup))
 
 				_, err := client.VeleroV1().PodVolumeBackups(test.namespace).Create(context.TODO(), existingPodVolumeBackup, metav1.CreateOptions{})
-				Expect(err).ShouldNot(HaveOccurred())
+				require.NoError(t, err)
 			}
 			client.ClearActions()
 
-			actualResult, err := r.Reconcile(ctx, ctrl.Request{
-				NamespacedName: types.NamespacedName{Namespace: "ns-1"},
-			})
-
-			Expect(actualResult).To(BeEquivalentTo(ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}))
-			Expect(err).To(BeNil())
+			c.run()
 
 			for bucket, backupDataSet := range test.cloudBuckets {
 				// figure out which location this bucket is for; we need this for verification
@@ -428,12 +401,12 @@ var _ = Describe("Backup Sync Reconciler", func() {
 						break
 					}
 				}
-				Expect(location).NotTo(BeNil())
+				require.NotNil(t, location)
 
 				// process the cloud backups
 				for _, cloudBackupData := range backupDataSet {
 					obj, err := client.VeleroV1().Backups(test.namespace).Get(context.TODO(), cloudBackupData.backup.Name, metav1.GetOptions{})
-					Expect(err).To(BeNil())
+					require.NoError(t, err)
 
 					// did this cloud backup already exist in the cluster?
 					var existing *velerov1api.Backup
@@ -452,23 +425,23 @@ var _ = Describe("Backup Sync Reconciler", func() {
 						expected := existing.DeepCopy()
 						expected.Spec.StorageLocation = location.Name
 
-						Expect(expected).To(BeEquivalentTo(obj))
+						assert.Equal(t, expected, obj)
 					} else {
 						// verify that the storage location field and label are set properly
-						Expect(location.Name).To(BeEquivalentTo(obj.Spec.StorageLocation))
+						assert.Equal(t, location.Name, obj.Spec.StorageLocation)
 
 						locationName := location.Name
 						if test.longLocationNameEnabled {
 							locationName = label.GetValidName(locationName)
 						}
-						Expect(locationName).To(BeEquivalentTo(obj.Labels[velerov1api.StorageLocationLabel]))
-						Expect(len(obj.Labels[velerov1api.StorageLocationLabel]) <= validation.DNS1035LabelMaxLength).To(BeTrue())
+						assert.Equal(t, locationName, obj.Labels[velerov1api.StorageLocationLabel])
+						assert.Equal(t, true, len(obj.Labels[velerov1api.StorageLocationLabel]) <= validation.DNS1035LabelMaxLength)
 					}
 
 					// process the cloud pod volume backups for this backup, if any
 					for _, podVolumeBackup := range cloudBackupData.podVolumeBackups {
 						objPodVolumeBackup, err := client.VeleroV1().PodVolumeBackups(test.namespace).Get(context.TODO(), podVolumeBackup.Name, metav1.GetOptions{})
-						Expect(err).ShouldNot(HaveOccurred())
+						require.NoError(t, err)
 
 						// did this cloud pod volume backup already exist in the cluster?
 						var existingPodVolumeBackup *velerov1api.PodVolumeBackup
@@ -483,160 +456,134 @@ var _ = Describe("Backup Sync Reconciler", func() {
 							// if this cloud pod volume backup already exists in the cluster, make sure that what we get from the
 							// client is the existing backup, not the cloud one.
 							expected := existingPodVolumeBackup.DeepCopy()
-							Expect(expected).To(BeEquivalentTo(objPodVolumeBackup))
+							assert.Equal(t, expected, objPodVolumeBackup)
 						}
 					}
 				}
 			}
-		}
-	})
+		})
+	}
+}
 
-	It("Test deleting orphaned backups.", func() {
-		longLabelName := "the-really-long-location-name-that-is-much-more-than-63-characters"
+func TestDeleteOrphanedBackups(t *testing.T) {
+	baseBuilder := func(name string) *builder.BackupBuilder {
+		return builder.ForBackup("ns-1", name).ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "default"))
+	}
 
-		baseBuilder := func(name string) *builder.BackupBuilder {
-			return builder.ForBackup("ns-1", name).ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "default"))
-		}
+	tests := []struct {
+		name            string
+		cloudBackups    sets.String
+		k8sBackups      []*velerov1api.Backup
+		namespace       string
+		expectedDeletes sets.String
+	}{
+		{
+			name:         "no overlapping backups",
+			namespace:    "ns-1",
+			cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
+			k8sBackups: []*velerov1api.Backup{
+				baseBuilder("backupA").Phase(velerov1api.BackupPhaseCompleted).Result(),
+				baseBuilder("backupB").Phase(velerov1api.BackupPhaseCompleted).Result(),
+				baseBuilder("backupC").Phase(velerov1api.BackupPhaseCompleted).Result(),
+			},
+			expectedDeletes: sets.NewString("backupA", "backupB", "backupC"),
+		},
+		{
+			name:         "some overlapping backups",
+			namespace:    "ns-1",
+			cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
+			k8sBackups: []*velerov1api.Backup{
+				baseBuilder("backup-1").Phase(velerov1api.BackupPhaseCompleted).Result(),
+				baseBuilder("backup-2").Phase(velerov1api.BackupPhaseCompleted).Result(),
+				baseBuilder("backup-C").Phase(velerov1api.BackupPhaseCompleted).Result(),
+			},
+			expectedDeletes: sets.NewString("backup-C"),
+		},
+		{
+			name:         "all overlapping backups",
+			namespace:    "ns-1",
+			cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
+			k8sBackups: []*velerov1api.Backup{
+				baseBuilder("backup-1").Phase(velerov1api.BackupPhaseCompleted).Result(),
+				baseBuilder("backup-2").Phase(velerov1api.BackupPhaseCompleted).Result(),
+				baseBuilder("backup-3").Phase(velerov1api.BackupPhaseCompleted).Result(),
+			},
+			expectedDeletes: sets.NewString(),
+		},
+		{
+			name:         "no overlapping backups but including backups that are not complete",
+			namespace:    "ns-1",
+			cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
+			k8sBackups: []*velerov1api.Backup{
+				baseBuilder("backupA").Phase(velerov1api.BackupPhaseCompleted).Result(),
+				baseBuilder("Deleting").Phase(velerov1api.BackupPhaseDeleting).Result(),
+				baseBuilder("Failed").Phase(velerov1api.BackupPhaseFailed).Result(),
+				baseBuilder("FailedValidation").Phase(velerov1api.BackupPhaseFailedValidation).Result(),
+				baseBuilder("InProgress").Phase(velerov1api.BackupPhaseInProgress).Result(),
+				baseBuilder("New").Phase(velerov1api.BackupPhaseNew).Result(),
+			},
+			expectedDeletes: sets.NewString("backupA"),
+		},
+		{
+			name:         "all overlapping backups and all backups that are not complete",
+			namespace:    "ns-1",
+			cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
+			k8sBackups: []*velerov1api.Backup{
+				baseBuilder("backup-1").Phase(velerov1api.BackupPhaseFailed).Result(),
+				baseBuilder("backup-2").Phase(velerov1api.BackupPhaseFailedValidation).Result(),
+				baseBuilder("backup-3").Phase(velerov1api.BackupPhaseInProgress).Result(),
+			},
+			expectedDeletes: sets.NewString(),
+		},
+		{
+			name:         "no completed backups in other locations are deleted",
+			namespace:    "ns-1",
+			cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
+			k8sBackups: []*velerov1api.Backup{
+				baseBuilder("backup-1").Phase(velerov1api.BackupPhaseCompleted).Result(),
+				baseBuilder("backup-2").Phase(velerov1api.BackupPhaseCompleted).Result(),
+				baseBuilder("backup-C").Phase(velerov1api.BackupPhaseCompleted).Result(),
 
-		tests := []struct {
-			name            string
-			cloudBackups    sets.String
-			k8sBackups      []*velerov1api.Backup
-			namespace       string
-			expectedDeletes sets.String
-			useLongBSLName  bool
-		}{
-			{
-				name:         "no overlapping backups",
-				namespace:    "ns-1",
-				cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
-				k8sBackups: []*velerov1api.Backup{
-					baseBuilder("backupA").Phase(velerov1api.BackupPhaseCompleted).Result(),
-					baseBuilder("backupB").Phase(velerov1api.BackupPhaseCompleted).Result(),
-					baseBuilder("backupC").Phase(velerov1api.BackupPhaseCompleted).Result(),
-				},
-				expectedDeletes: sets.NewString("backupA", "backupB", "backupC"),
+				baseBuilder("backup-4").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "alternate")).Phase(velerov1api.BackupPhaseCompleted).Result(),
+				baseBuilder("backup-5").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "alternate")).Phase(velerov1api.BackupPhaseCompleted).Result(),
+				baseBuilder("backup-6").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "alternate")).Phase(velerov1api.BackupPhaseCompleted).Result(),
 			},
-			{
-				name:         "some overlapping backups",
-				namespace:    "ns-1",
-				cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
-				k8sBackups: []*velerov1api.Backup{
-					baseBuilder("backup-1").Phase(velerov1api.BackupPhaseCompleted).Result(),
-					baseBuilder("backup-2").Phase(velerov1api.BackupPhaseCompleted).Result(),
-					baseBuilder("backup-C").Phase(velerov1api.BackupPhaseCompleted).Result(),
-				},
-				expectedDeletes: sets.NewString("backup-C"),
-			},
-			{
-				name:         "all overlapping backups",
-				namespace:    "ns-1",
-				cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
-				k8sBackups: []*velerov1api.Backup{
-					baseBuilder("backup-1").Phase(velerov1api.BackupPhaseCompleted).Result(),
-					baseBuilder("backup-2").Phase(velerov1api.BackupPhaseCompleted).Result(),
-					baseBuilder("backup-3").Phase(velerov1api.BackupPhaseCompleted).Result(),
-				},
-				expectedDeletes: sets.NewString(),
-			},
-			{
-				name:         "no overlapping backups but including backups that are not complete",
-				namespace:    "ns-1",
-				cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
-				k8sBackups: []*velerov1api.Backup{
-					baseBuilder("backupA").Phase(velerov1api.BackupPhaseCompleted).Result(),
-					baseBuilder("Deleting").Phase(velerov1api.BackupPhaseDeleting).Result(),
-					baseBuilder("Failed").Phase(velerov1api.BackupPhaseFailed).Result(),
-					baseBuilder("FailedValidation").Phase(velerov1api.BackupPhaseFailedValidation).Result(),
-					baseBuilder("InProgress").Phase(velerov1api.BackupPhaseInProgress).Result(),
-					baseBuilder("New").Phase(velerov1api.BackupPhaseNew).Result(),
-				},
-				expectedDeletes: sets.NewString("backupA"),
-			},
-			{
-				name:         "all overlapping backups and all backups that are not complete",
-				namespace:    "ns-1",
-				cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
-				k8sBackups: []*velerov1api.Backup{
-					baseBuilder("backup-1").Phase(velerov1api.BackupPhaseFailed).Result(),
-					baseBuilder("backup-2").Phase(velerov1api.BackupPhaseFailedValidation).Result(),
-					baseBuilder("backup-3").Phase(velerov1api.BackupPhaseInProgress).Result(),
-				},
-				expectedDeletes: sets.NewString(),
-			},
-			{
-				name:         "no completed backups in other locations are deleted",
-				namespace:    "ns-1",
-				cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
-				k8sBackups: []*velerov1api.Backup{
-					baseBuilder("backup-1").Phase(velerov1api.BackupPhaseCompleted).Result(),
-					baseBuilder("backup-2").Phase(velerov1api.BackupPhaseCompleted).Result(),
-					baseBuilder("backup-C").Phase(velerov1api.BackupPhaseCompleted).Result(),
+			expectedDeletes: sets.NewString("backup-C"),
+		},
+	}
 
-					baseBuilder("backup-4").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "alternate")).Phase(velerov1api.BackupPhaseCompleted).Result(),
-					baseBuilder("backup-5").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "alternate")).Phase(velerov1api.BackupPhaseCompleted).Result(),
-					baseBuilder("backup-6").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "alternate")).Phase(velerov1api.BackupPhaseCompleted).Result(),
-				},
-				expectedDeletes: sets.NewString("backup-C"),
-			},
-			{
-				name:         "some overlapping backups",
-				namespace:    "ns-1",
-				cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
-				k8sBackups: []*velerov1api.Backup{
-					builder.ForBackup("ns-1", "backup-1").
-						ObjectMeta(
-							builder.WithLabels(velerov1api.StorageLocationLabel, "the-really-long-location-name-that-is-much-more-than-63-c69e779"),
-						).
-						Phase(velerov1api.BackupPhaseCompleted).
-						Result(),
-					builder.ForBackup("ns-1", "backup-2").
-						ObjectMeta(
-							builder.WithLabels(velerov1api.StorageLocationLabel, "the-really-long-location-name-that-is-much-more-than-63-c69e779"),
-						).
-						Phase(velerov1api.BackupPhaseCompleted).
-						Result(),
-					builder.ForBackup("ns-1", "backup-C").
-						ObjectMeta(
-							builder.WithLabels(velerov1api.StorageLocationLabel, "the-really-long-location-name-that-is-much-more-than-63-c69e779"),
-						).
-						Phase(velerov1api.BackupPhaseCompleted).
-						Result(),
-				},
-				expectedDeletes: sets.NewString("backup-C"),
-				useLongBSLName:  true,
-			},
-		}
-
-		for _, test := range tests {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			var (
 				client          = fake.NewSimpleClientset()
+				fakeClient      = velerotest.NewFakeControllerRuntimeClient(t)
 				sharedInformers = informers.NewSharedInformerFactory(client, 0)
-				pluginManager   = &pluginmocks.Manager{}
-				backupStores    = make(map[string]*persistencemocks.BackupStore)
 			)
 
-			r := BackupSyncReconciler{
-				Client:                  ctrlfake.NewClientBuilder().Build(),
-				BackupClient:            client.VeleroV1(),
-				PodVolumeBackupClient:   client.VeleroV1(),
-				BackupLister:            sharedInformers.Velero().V1().Backups().Lister(),
-				Namespace:               test.namespace,
-				DefaultBackupSyncPeriod: time.Second * 10,
-				NewPluginManager:        func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager },
-				BackupStoreGetter:       NewFakeObjectBackupStoreGetter(backupStores),
-				Logger:                  velerotest.NewLogger(),
-			}
+			c := NewBackupSyncController(
+				client.VeleroV1(),
+				fakeClient,
+				client.VeleroV1(),
+				sharedInformers.Velero().V1().Backups().Lister(),
+				time.Duration(0),
+				test.namespace,
+				nil, // csiSnapshotClient
+				nil, // kubeClient
+				"",
+				nil, // new plugin manager func
+				nil, // backupStoreGetter
+				velerotest.NewLogger(),
+			).(*backupSyncController)
 
 			expectedDeleteActions := make([]core.Action, 0)
 
 			for _, backup := range test.k8sBackups {
 				// add test backup to informer
-				Expect(sharedInformers.Velero().V1().Backups().Informer().GetStore().Add(backup)).ShouldNot(HaveOccurred())
+				require.NoError(t, sharedInformers.Velero().V1().Backups().Informer().GetStore().Add(backup), "Error adding backup to informer")
 
 				// add test backup to client
 				_, err := client.VeleroV1().Backups(test.namespace).Create(context.TODO(), backup, metav1.CreateOptions{})
-				Expect(err).ShouldNot(HaveOccurred())
+				require.NoError(t, err, "Error adding backup to clientset")
 
 				// if we expect this backup to be deleted, set up the expected DeleteAction
 				if test.expectedDeletes.Has(backup.Name) {
@@ -649,49 +596,139 @@ var _ = Describe("Backup Sync Reconciler", func() {
 				}
 			}
 
-			bslName := "default"
-			if test.useLongBSLName {
-				bslName = longLabelName
-			}
-			r.deleteOrphanedBackups(ctx, bslName, test.cloudBackups, velerotest.NewLogger())
+			c.deleteOrphanedBackups("default", test.cloudBackups, velerotest.NewLogger())
 
-			numBackups, err := numBackups(client, r.Namespace)
-			Expect(err).ShouldNot(HaveOccurred())
+			numBackups, err := numBackups(t, client, c.namespace)
+			assert.NoError(t, err)
 
 			expected := len(test.k8sBackups) - len(test.expectedDeletes)
-			Expect(expected).To(BeEquivalentTo(numBackups))
+			assert.Equal(t, expected, numBackups)
 
-			compareActions(expectedDeleteActions, getDeleteActions(client.Actions()))
-		}
-	})
-})
+			velerotest.CompareActions(t, expectedDeleteActions, getDeleteActions(client.Actions()))
+		})
+	}
+}
 
-func compareActions(expected, actual []core.Action) {
-	Expect(len(expected)).To(BeEquivalentTo(len(actual)))
-
-	for _, e := range expected {
-		found := false
-		for _, a := range actual {
-			if reflect.DeepEqual(e, a) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			fmt.Printf("missing expected action %#v\n", e)
-		}
+func TestStorageLabelsInDeleteOrphanedBackups(t *testing.T) {
+	longLabelName := "the-really-long-location-name-that-is-much-more-than-63-characters"
+	tests := []struct {
+		name            string
+		cloudBackups    sets.String
+		k8sBackups      []*velerov1api.Backup
+		namespace       string
+		expectedDeletes sets.String
+	}{
+		{
+			name:         "some overlapping backups",
+			namespace:    "ns-1",
+			cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
+			k8sBackups: []*velerov1api.Backup{
+				builder.ForBackup("ns-1", "backup-1").
+					ObjectMeta(
+						builder.WithLabels(velerov1api.StorageLocationLabel, "the-really-long-location-name-that-is-much-more-than-63-c69e779"),
+					).
+					Phase(velerov1api.BackupPhaseCompleted).
+					Result(),
+				builder.ForBackup("ns-1", "backup-2").
+					ObjectMeta(
+						builder.WithLabels(velerov1api.StorageLocationLabel, "the-really-long-location-name-that-is-much-more-than-63-c69e779"),
+					).
+					Phase(velerov1api.BackupPhaseCompleted).
+					Result(),
+				builder.ForBackup("ns-1", "backup-C").
+					ObjectMeta(
+						builder.WithLabels(velerov1api.StorageLocationLabel, "the-really-long-location-name-that-is-much-more-than-63-c69e779"),
+					).
+					Phase(velerov1api.BackupPhaseCompleted).
+					Result(),
+			},
+			expectedDeletes: sets.NewString("backup-C"),
+		},
 	}
 
-	for _, a := range actual {
-		found := false
-		for _, e := range expected {
-			if reflect.DeepEqual(e, a) {
-				found = true
-				break
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var (
+				client          = fake.NewSimpleClientset()
+				fakeClient      = velerotest.NewFakeControllerRuntimeClient(t)
+				sharedInformers = informers.NewSharedInformerFactory(client, 0)
+			)
+
+			c := NewBackupSyncController(
+				client.VeleroV1(),
+				fakeClient,
+				client.VeleroV1(),
+				sharedInformers.Velero().V1().Backups().Lister(),
+				time.Duration(0),
+				test.namespace,
+				nil, // csiSnapshotClient
+				nil, // kubeClient
+				"",
+				nil, // new plugin manager func
+				nil, // backupStoreGetter
+				velerotest.NewLogger(),
+			).(*backupSyncController)
+
+			expectedDeleteActions := make([]core.Action, 0)
+
+			for _, backup := range test.k8sBackups {
+				// add test backup to informer
+				require.NoError(t, sharedInformers.Velero().V1().Backups().Informer().GetStore().Add(backup), "Error adding backup to informer")
+
+				// add test backup to client
+				_, err := client.VeleroV1().Backups(test.namespace).Create(context.TODO(), backup, metav1.CreateOptions{})
+				require.NoError(t, err, "Error adding backup to clientset")
+
+				// if we expect this backup to be deleted, set up the expected DeleteAction
+				if test.expectedDeletes.Has(backup.Name) {
+					actionDelete := core.NewDeleteAction(
+						velerov1api.SchemeGroupVersion.WithResource("backups"),
+						test.namespace,
+						backup.Name,
+					)
+					expectedDeleteActions = append(expectedDeleteActions, actionDelete)
+				}
 			}
-		}
-		if !found {
-			fmt.Printf("unexpected action %#v\n", a)
+
+			c.deleteOrphanedBackups(longLabelName, test.cloudBackups, velerotest.NewLogger())
+
+			numBackups, err := numBackups(t, client, c.namespace)
+			assert.NoError(t, err)
+
+			expected := len(test.k8sBackups) - len(test.expectedDeletes)
+			assert.Equal(t, expected, numBackups)
+
+			velerotest.CompareActions(t, expectedDeleteActions, getDeleteActions(client.Actions()))
+		})
+	}
+}
+
+func getDeleteActions(actions []core.Action) []core.Action {
+	var deleteActions []core.Action
+	for _, action := range actions {
+		if action.GetVerb() == "delete" {
+			deleteActions = append(deleteActions, action)
 		}
 	}
+	return deleteActions
+}
+
+func numBackups(t *testing.T, c *fake.Clientset, ns string) (int, error) {
+	t.Helper()
+	existingK8SBackups, err := c.VeleroV1().Backups(ns).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return 0, err
+	}
+
+	return len(existingK8SBackups.Items), nil
+}
+
+func numPodVolumeBackups(t *testing.T, c *fake.Clientset, ns string) (int, error) {
+	t.Helper()
+	existingK8SPodvolumeBackups, err := c.VeleroV1().PodVolumeBackups(ns).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return 0, err
+	}
+
+	return len(existingK8SPodvolumeBackups.Items), nil
 }


### PR DESCRIPTION
…lder (#4423)"

This reverts commit 5aaeb3ebbee05d461957dcb80c3c4d146aa82f92.

Thank you for contributing to Velero!

# Please add a summary of your change
This commit is used to revert #4423. 
After #4423 is merged, we found backup sync controller is not expected to work as a list-watch way. Before refactor, backup sync controller actually works as an time-routine job, which is implemented by velero generic controller as an goroutine sleeps  by the resyncPeriod then runs the resyncFunc. 
The refactor code uses Reconcile to watch Backup CR as event trigger to backup sync. 
Actually, the backup sync task should work, but the sync process will be trigger every time a backup has some change. So there is behavior difference. 

In the future, I think the time-base sync process can be replaced by Reconcile way. The controller can sync just the changed backup in the Reconcile function, instead of whole backups in cluster. This is a more Kubernetes or event-driven way. 

The advantages are: 
* break down the batch sync task into small ones. If there is a lot of backups in cluster, this way has better performance.
* More timely backup sync. After the backup change event occurs, the sync is triggered, rather than to wait for 30s sync period.

But due to the coming FC date, revert first, then doing the job in future release is more reasonable.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
