### PR TITLE
Ignore the provided port is already allocated error when restoring the LoadBalancer service

### DIFF
--- a/changelogs/unreleased/4462-ywk253100
+++ b/changelogs/unreleased/4462-ywk253100
@@ -1,0 +1,1 @@
+Ignore the provided port is already allocated error when restoring the LoadBalancer service

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1328,11 +1328,12 @@ func isAlreadyExistsError(ctx *restoreContext, obj *unstructured.Unstructured, e
 	if apierrors.IsAlreadyExists(err) {
 		return true
 	}
-	// the "invalid value" error rather than "already exists" error returns when restoring nodePort service
-	// that has nodePort preservation if the same nodePort service already exists.
+	// The "invalid value error" or "internal error" rather than "already exists" error returns when restoring nodePort service in the following two cases:
+	// 1. For NodePort service, the service has nodePort preservation while the same nodePort service already exists. - Get invalid value error
+	// 2. For LoadBalancer service, the "healthCheckNodePort" already exists. - Get internal error
 	// If this is the case, the function returns true to avoid reporting error.
 	// Refer to https://github.com/vmware-tanzu/velero/issues/2308 for more details
-	if obj.GetKind() != "Service" || !apierrors.IsInvalid(err) {
+	if obj.GetKind() != "Service" {
 		return false
 	}
 	statusErr, ok := err.(*apierrors.StatusError)

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -3045,16 +3045,6 @@ func TestIsAlreadyExistsError(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "The input error isn't InvalidError",
-			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"kind": "Service",
-				},
-			},
-			err:      apierrors.NewBadRequest(""),
-			expected: false,
-		},
-		{
 			name: "The StatusError contains no causes",
 			obj: &unstructured.Unstructured{
 				Object: map[string]interface{}{


### PR DESCRIPTION
Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
