### PR TITLE
Return the error when getting backup store in backup deletion controller

### DIFF
--- a/changelogs/unreleased/4465-reasonerjt
+++ b/changelogs/unreleased/4465-reasonerjt
@@ -1,0 +1,1 @@
+Return the error when getting backup store in backup deletion controller

--- a/pkg/controller/backup_deletion_controller.go
+++ b/pkg/controller/backup_deletion_controller.go
@@ -291,7 +291,7 @@ func (c *backupDeletionController) processRequest(req *velerov1api.DeleteBackupR
 
 	backupStore, err := c.backupStoreGetter.Get(location, pluginManager, log)
 	if err != nil {
-		errs = append(errs, err.Error())
+		return errors.Wrap(err, "error getting the backup store")
 	}
 
 	actions, err := pluginManager.GetDeleteItemActions()

--- a/pkg/controller/suite_test.go
+++ b/pkg/controller/suite_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -128,6 +129,13 @@ func (t *testEnvironment) startManager() error {
 func (t *testEnvironment) stop() error {
 	cancel()
 	return env.Stop()
+}
+
+type fakeErrorBackupStoreGetter struct {
+}
+
+func (f *fakeErrorBackupStoreGetter) Get(*velerov1api.BackupStorageLocation, persistence.ObjectStoreGetter, logrus.FieldLogger) (persistence.BackupStore, error) {
+	return nil, fmt.Errorf("some error")
 }
 
 type fakeSingleObjectBackupStoreGetter struct {


### PR DESCRIPTION
Per discussion in
https://github.com/vmware-tanzu/velero/issues/4260#issuecomment-947721686
https://github.com/vmware-tanzu/velero/issues/4260#issuecomment-951347384

return the error to avoid a panic when downloading the backup tarball

Signed-off-by: Daniel Jiang <jiangd@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
