### PR TITLE
Add support for RestoreItemAction plugin for namespaces

### DIFF
--- a/changelogs/unreleased/4479-mouellet
+++ b/changelogs/unreleased/4479-mouellet
@@ -1,0 +1,1 @@
+Add support for RestoreItemAction plugin for namespaces

--- a/pkg/cmd/server/plugin/plugin.go
+++ b/pkg/cmd/server/plugin/plugin.go
@@ -56,6 +56,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 				RegisterRestoreItemAction("velero.io/change-pvc-node-selector", newChangePVCNodeSelectorItemAction(f)).
 				RegisterRestoreItemAction("velero.io/apiservice", newAPIServiceRestoreItemAction).
 				RegisterRestoreItemAction("velero.io/admission-webhook-configuration", newAdmissionWebhookConfigurationAction).
+				RegisterRestoreItemAction("velero.io/namespaces", newNamespaceItemAction).
 				Serve()
 		},
 	}
@@ -215,4 +216,8 @@ func newAPIServiceRestoreItemAction(logger logrus.FieldLogger) (interface{}, err
 
 func newAdmissionWebhookConfigurationAction(logger logrus.FieldLogger) (interface{}, error) {
 	return restore.NewAdmissionWebhookConfigurationAction(logger), nil
+}
+
+func newNamespaceItemAction(logger logrus.FieldLogger) (interface{}, error) {
+	return restore.NewNamespaceAction(logger), nil
 }

--- a/pkg/restore/namespace_action.go
+++ b/pkg/restore/namespace_action.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2022 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restore
+
+import (
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	corev1api "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+)
+
+// NamespaceAction handle namespace mapping
+type NamespaceAction struct {
+	logger logrus.FieldLogger
+}
+
+func NewNamespaceAction(logger logrus.FieldLogger) *NamespaceAction {
+	return &NamespaceAction{logger: logger}
+}
+
+func (a *NamespaceAction) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+		IncludedResources: []string{"namespaces"},
+	}, nil
+}
+
+func (a *NamespaceAction) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
+	namespaceMapping := input.Restore.Spec.NamespaceMapping
+	if len(namespaceMapping) == 0 {
+		return velero.NewRestoreItemActionExecuteOutput(&unstructured.Unstructured{Object: input.Item.UnstructuredContent()}), nil
+	}
+
+	namespace := new(corev1api.Namespace)
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(input.Item.UnstructuredContent(), namespace); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	if newNamespace, ok := namespaceMapping[namespace.Name]; ok {
+		namespace.SetName(newNamespace)
+	}
+
+	res, err := runtime.DefaultUnstructuredConverter.ToUnstructured(namespace)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return velero.NewRestoreItemActionExecuteOutput(&unstructured.Unstructured{Object: res}), nil
+}

--- a/pkg/restore/namespace_action_test.go
+++ b/pkg/restore/namespace_action_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2022 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1api "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	velerotest "github.com/vmware-tanzu/velero/pkg/test"
+)
+
+func TestNamespaceActionAppliesTo(t *testing.T) {
+	action := NewNamespaceAction(velerotest.NewLogger())
+	actual, err := action.AppliesTo()
+	require.NoError(t, err)
+	assert.Equal(t, velero.ResourceSelector{IncludedResources: []string{"namespaces"}}, actual)
+}
+
+func TestNamespaceActionExecute(t *testing.T) {
+	tests := []struct {
+		name             string
+		namespace        string
+		namespaceMapping map[string]string
+		expected         string
+	}{
+		{
+			name:             "namespace mapping disabled",
+			namespace:        "foo",
+			namespaceMapping: map[string]string{},
+			expected:         "foo",
+		},
+		{
+			name:             "namespace mapping enabled",
+			namespace:        "foo",
+			namespaceMapping: map[string]string{"foo": "bar", "fizz": "buzz"},
+			expected:         "bar",
+		},
+		{
+			name:             "namespace mapping enabled, not included namespace remains unchanged",
+			namespace:        "xyz",
+			namespaceMapping: map[string]string{"foo": "bar", "fizz": "buzz"},
+			expected:         "xyz",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			namespace := corev1api.Namespace{}
+			namespace.SetName(tc.namespace)
+
+			namespaceUnstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&namespace)
+			require.NoError(t, err)
+
+			action := NewNamespaceAction(velerotest.NewLogger())
+			res, err := action.Execute(&velero.RestoreItemActionExecuteInput{
+				Item:           &unstructured.Unstructured{Object: namespaceUnstructured},
+				ItemFromBackup: &unstructured.Unstructured{Object: namespaceUnstructured},
+				Restore: &velerov1api.Restore{
+					Spec: velerov1api.RestoreSpec{
+						NamespaceMapping: tc.namespaceMapping,
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			var actual *corev1api.Namespace
+			err = runtime.DefaultUnstructuredConverter.FromUnstructured(res.UpdatedItem.UnstructuredContent(), &actual)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, actual.GetName())
+		})
+	}
+}

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -77,6 +77,10 @@ func TestRestoreResourceFiltering(t *testing.T) {
 			restore: defaultRestore().Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
 				AddItems("pods",
 					builder.ForPod("ns-1", "pod-1").Result(),
 					builder.ForPod("ns-2", "pod-2").Result(),
@@ -87,12 +91,14 @@ func TestRestoreResourceFiltering(t *testing.T) {
 				).
 				Done(),
 			apiResources: []*test.APIResource{
+				test.Namespaces(),
 				test.Pods(),
 				test.PVs(),
 			},
 			want: map[*test.APIResource][]string{
-				test.Pods(): {"ns-1/pod-1", "ns-2/pod-2"},
-				test.PVs():  {"/pv-1", "/pv-2"},
+				test.Namespaces(): {"/ns-1", "/ns-2"},
+				test.Pods():       {"ns-1/pod-1", "ns-2/pod-2"},
+				test.PVs():        {"/pv-1", "/pv-2"},
 			},
 		},
 		{
@@ -100,6 +106,10 @@ func TestRestoreResourceFiltering(t *testing.T) {
 			restore: defaultRestore().IncludedResources("pods").Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
 				AddItems("pods",
 					builder.ForPod("ns-1", "pod-1").Result(),
 					builder.ForPod("ns-2", "pod-2").Result(),
@@ -110,11 +120,13 @@ func TestRestoreResourceFiltering(t *testing.T) {
 				).
 				Done(),
 			apiResources: []*test.APIResource{
+				test.Namespaces(),
 				test.Pods(),
 				test.PVs(),
 			},
 			want: map[*test.APIResource][]string{
-				test.Pods(): {"ns-1/pod-1", "ns-2/pod-2"},
+				test.Namespaces(): {"/ns-1", "/ns-2"},
+				test.Pods():       {"ns-1/pod-1", "ns-2/pod-2"},
 			},
 		},
 		{
@@ -122,6 +134,10 @@ func TestRestoreResourceFiltering(t *testing.T) {
 			restore: defaultRestore().ExcludedResources("pvs").Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
 				AddItems("pods",
 					builder.ForPod("ns-1", "pod-1").Result(),
 					builder.ForPod("ns-2", "pod-2").Result(),
@@ -132,11 +148,13 @@ func TestRestoreResourceFiltering(t *testing.T) {
 				).
 				Done(),
 			apiResources: []*test.APIResource{
+				test.Namespaces(),
 				test.Pods(),
 				test.PVs(),
 			},
 			want: map[*test.APIResource][]string{
-				test.Pods(): {"ns-1/pod-1", "ns-2/pod-2"},
+				test.Namespaces(): {"/ns-1", "/ns-2"},
+				test.Pods():       {"ns-1/pod-1", "ns-2/pod-2"},
 			},
 		},
 		{
@@ -144,6 +162,10 @@ func TestRestoreResourceFiltering(t *testing.T) {
 			restore: defaultRestore().IncludedNamespaces("ns-1").Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
 				AddItems("pods",
 					builder.ForPod("ns-1", "pod-1").Result(),
 					builder.ForPod("ns-2", "pod-2").Result(),
@@ -158,11 +180,13 @@ func TestRestoreResourceFiltering(t *testing.T) {
 				).
 				Done(),
 			apiResources: []*test.APIResource{
+				test.Namespaces(),
 				test.Pods(),
 				test.Deployments(),
 				test.PVs(),
 			},
 			want: map[*test.APIResource][]string{
+				test.Namespaces():  {"/ns-1"},
 				test.Pods():        {"ns-1/pod-1"},
 				test.Deployments(): {"ns-1/deploy-1"},
 			},
@@ -172,6 +196,10 @@ func TestRestoreResourceFiltering(t *testing.T) {
 			restore: defaultRestore().ExcludedNamespaces("ns-2").Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
 				AddItems("pods",
 					builder.ForPod("ns-1", "pod-1").Result(),
 					builder.ForPod("ns-2", "pod-2").Result(),
@@ -186,11 +214,13 @@ func TestRestoreResourceFiltering(t *testing.T) {
 				).
 				Done(),
 			apiResources: []*test.APIResource{
+				test.Namespaces(),
 				test.Pods(),
 				test.Deployments(),
 				test.PVs(),
 			},
 			want: map[*test.APIResource][]string{
+				test.Namespaces():  {"/ns-1"},
 				test.Pods():        {"ns-1/pod-1"},
 				test.Deployments(): {"ns-1/deploy-1"},
 			},
@@ -200,6 +230,10 @@ func TestRestoreResourceFiltering(t *testing.T) {
 			restore: defaultRestore().IncludeClusterResources(false).Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
 				AddItems("pods",
 					builder.ForPod("ns-1", "pod-1").Result(),
 					builder.ForPod("ns-2", "pod-2").Result(),
@@ -214,11 +248,13 @@ func TestRestoreResourceFiltering(t *testing.T) {
 				).
 				Done(),
 			apiResources: []*test.APIResource{
+				test.Namespaces(),
 				test.Pods(),
 				test.Deployments(),
 				test.PVs(),
 			},
 			want: map[*test.APIResource][]string{
+				test.Namespaces():  {"/ns-1", "/ns-2"},
 				test.Pods():        {"ns-1/pod-1", "ns-2/pod-2"},
 				test.Deployments(): {"ns-1/deploy-1", "ns-2/deploy-2"},
 			},
@@ -228,6 +264,10 @@ func TestRestoreResourceFiltering(t *testing.T) {
 			restore: defaultRestore().LabelSelector(&metav1.LabelSelector{MatchLabels: map[string]string{"a": "b"}}).Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
 				AddItems("pods",
 					builder.ForPod("ns-1", "pod-1").ObjectMeta(builder.WithLabels("a", "b")).Result(),
 					builder.ForPod("ns-2", "pod-2").Result(),
@@ -242,11 +282,13 @@ func TestRestoreResourceFiltering(t *testing.T) {
 				).
 				Done(),
 			apiResources: []*test.APIResource{
+				test.Namespaces(),
 				test.Pods(),
 				test.Deployments(),
 				test.PVs(),
 			},
 			want: map[*test.APIResource][]string{
+				test.Namespaces():  {"/ns-1", "/ns-2"},
 				test.Pods():        {"ns-1/pod-1"},
 				test.Deployments(): {"ns-2/deploy-2"},
 				test.PVs():         {"/pv-1"},
@@ -257,6 +299,10 @@ func TestRestoreResourceFiltering(t *testing.T) {
 			restore: defaultRestore().IncludedNamespaces("ns-1").IncludeClusterResources(true).Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
 				AddItems("pods",
 					builder.ForPod("ns-1", "pod-1").Result(),
 					builder.ForPod("ns-2", "pod-2").Result(),
@@ -271,11 +317,13 @@ func TestRestoreResourceFiltering(t *testing.T) {
 				).
 				Done(),
 			apiResources: []*test.APIResource{
+				test.Namespaces(),
 				test.Pods(),
 				test.Deployments(),
 				test.PVs(),
 			},
 			want: map[*test.APIResource][]string{
+				test.Namespaces():  {"/ns-1"},
 				test.Pods():        {"ns-1/pod-1"},
 				test.Deployments(): {"ns-1/deploy-1"},
 				test.PVs():         {"/pv-1", "/pv-2"},
@@ -286,6 +334,10 @@ func TestRestoreResourceFiltering(t *testing.T) {
 			restore: defaultRestore().IncludedNamespaces("ns-1").IncludeClusterResources(false).Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
 				AddItems("pods",
 					builder.ForPod("ns-1", "pod-1").Result(),
 					builder.ForPod("ns-2", "pod-2").Result(),
@@ -300,11 +352,13 @@ func TestRestoreResourceFiltering(t *testing.T) {
 				).
 				Done(),
 			apiResources: []*test.APIResource{
+				test.Namespaces(),
 				test.Pods(),
 				test.Deployments(),
 				test.PVs(),
 			},
 			want: map[*test.APIResource][]string{
+				test.Namespaces():  {"/ns-1"},
 				test.Pods():        {"ns-1/pod-1"},
 				test.Deployments(): {"ns-1/deploy-1"},
 				test.PVs():         {},
@@ -315,6 +369,10 @@ func TestRestoreResourceFiltering(t *testing.T) {
 			restore: defaultRestore().IncludedNamespaces("ns-1").Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
 				AddItems("pods",
 					builder.ForPod("ns-1", "pod-1").Result(),
 					builder.ForPod("ns-2", "pod-2").Result(),
@@ -329,11 +387,13 @@ func TestRestoreResourceFiltering(t *testing.T) {
 				).
 				Done(),
 			apiResources: []*test.APIResource{
+				test.Namespaces(),
 				test.Pods(),
 				test.Deployments(),
 				test.PVs(),
 			},
 			want: map[*test.APIResource][]string{
+				test.Namespaces():  {"/ns-1"},
 				test.Pods():        {"ns-1/pod-1"},
 				test.Deployments(): {"ns-1/deploy-1"},
 				test.PVs():         {},
@@ -344,6 +404,10 @@ func TestRestoreResourceFiltering(t *testing.T) {
 			restore: defaultRestore().IncludeClusterResources(true).Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
 				AddItems("pods",
 					builder.ForPod("ns-1", "pod-1").Result(),
 					builder.ForPod("ns-2", "pod-2").Result(),
@@ -358,11 +422,13 @@ func TestRestoreResourceFiltering(t *testing.T) {
 				).
 				Done(),
 			apiResources: []*test.APIResource{
+				test.Namespaces(),
 				test.Pods(),
 				test.Deployments(),
 				test.PVs(),
 			},
 			want: map[*test.APIResource][]string{
+				test.Namespaces():  {"/ns-1", "/ns-2"},
 				test.Pods():        {"ns-1/pod-1", "ns-2/pod-2"},
 				test.Deployments(): {"ns-1/deploy-1", "ns-2/deploy-2"},
 				test.PVs():         {"/pv-1", "/pv-2"},
@@ -373,6 +439,10 @@ func TestRestoreResourceFiltering(t *testing.T) {
 			restore: defaultRestore().IncludeClusterResources(false).Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
 				AddItems("pods",
 					builder.ForPod("ns-1", "pod-1").Result(),
 					builder.ForPod("ns-2", "pod-2").Result(),
@@ -387,11 +457,13 @@ func TestRestoreResourceFiltering(t *testing.T) {
 				).
 				Done(),
 			apiResources: []*test.APIResource{
+				test.Namespaces(),
 				test.Pods(),
 				test.Deployments(),
 				test.PVs(),
 			},
 			want: map[*test.APIResource][]string{
+				test.Namespaces():  {"/ns-1", "/ns-2"},
 				test.Pods():        {"ns-1/pod-1", "ns-2/pod-2"},
 				test.Deployments(): {"ns-1/deploy-1", "ns-2/deploy-2"},
 			},
@@ -401,6 +473,10 @@ func TestRestoreResourceFiltering(t *testing.T) {
 			restore: defaultRestore().IncludedResources("*", "pods").Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
 				AddItems("pods",
 					builder.ForPod("ns-1", "pod-1").Result(),
 					builder.ForPod("ns-2", "pod-2").Result(),
@@ -415,11 +491,13 @@ func TestRestoreResourceFiltering(t *testing.T) {
 				).
 				Done(),
 			apiResources: []*test.APIResource{
+				test.Namespaces(),
 				test.Pods(),
 				test.Deployments(),
 				test.PVs(),
 			},
 			want: map[*test.APIResource][]string{
+				test.Namespaces():  {"/ns-1", "/ns-2"},
 				test.Pods():        {"ns-1/pod-1", "ns-2/pod-2"},
 				test.Deployments(): {"ns-1/deploy-1", "ns-2/deploy-2"},
 				test.PVs():         {"/pv-1", "/pv-2"},
@@ -430,6 +508,10 @@ func TestRestoreResourceFiltering(t *testing.T) {
 			restore: defaultRestore().ExcludedResources("*").Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
 				AddItems("pods",
 					builder.ForPod("ns-1", "pod-1").Result(),
 					builder.ForPod("ns-2", "pod-2").Result(),
@@ -444,11 +526,13 @@ func TestRestoreResourceFiltering(t *testing.T) {
 				).
 				Done(),
 			apiResources: []*test.APIResource{
+				test.Namespaces(),
 				test.Pods(),
 				test.Deployments(),
 				test.PVs(),
 			},
 			want: map[*test.APIResource][]string{
+				test.Namespaces():  {"/ns-1", "/ns-2"},
 				test.Pods():        {"ns-1/pod-1", "ns-2/pod-2"},
 				test.Deployments(): {"ns-1/deploy-1", "ns-2/deploy-2"},
 				test.PVs():         {"/pv-1", "/pv-2"},
@@ -459,6 +543,10 @@ func TestRestoreResourceFiltering(t *testing.T) {
 			restore: defaultRestore().IncludedResources("pods", "unresolvable").Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
 				AddItems("pods",
 					builder.ForPod("ns-1", "pod-1").Result(),
 					builder.ForPod("ns-2", "pod-2").Result(),
@@ -473,12 +561,14 @@ func TestRestoreResourceFiltering(t *testing.T) {
 				).
 				Done(),
 			apiResources: []*test.APIResource{
+				test.Namespaces(),
 				test.Pods(),
 				test.Deployments(),
 				test.PVs(),
 			},
 			want: map[*test.APIResource][]string{
-				test.Pods(): {"ns-1/pod-1", "ns-2/pod-2"},
+				test.Namespaces(): {"/ns-1", "/ns-2"},
+				test.Pods():       {"ns-1/pod-1", "ns-2/pod-2"},
 			},
 		},
 		{
@@ -486,6 +576,10 @@ func TestRestoreResourceFiltering(t *testing.T) {
 			restore: defaultRestore().ExcludedResources("deployments", "unresolvable").Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
 				AddItems("pods",
 					builder.ForPod("ns-1", "pod-1").Result(),
 					builder.ForPod("ns-2", "pod-2").Result(),
@@ -500,13 +594,15 @@ func TestRestoreResourceFiltering(t *testing.T) {
 				).
 				Done(),
 			apiResources: []*test.APIResource{
+				test.Namespaces(),
 				test.Pods(),
 				test.Deployments(),
 				test.PVs(),
 			},
 			want: map[*test.APIResource][]string{
-				test.Pods(): {"ns-1/pod-1", "ns-2/pod-2"},
-				test.PVs():  {"/pv-1", "/pv-2"},
+				test.Namespaces(): {"/ns-1", "/ns-2"},
+				test.Pods():       {"ns-1/pod-1", "ns-2/pod-2"},
+				test.PVs():        {"/pv-1", "/pv-2"},
 			},
 		},
 		{
@@ -575,9 +671,15 @@ func TestRestoreNamespaceMapping(t *testing.T) {
 			restore: defaultRestore().NamespaceMappings("ns-1", "mapped-ns-1", "ns-2", "mapped-ns-2").Result(),
 			backup:  defaultBackup().Result(),
 			apiResources: []*test.APIResource{
+				test.Namespaces(),
 				test.Pods(),
 			},
 			tarball: test.NewTarWriter(t).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+					builder.ForNamespace("ns-3").Result(),
+				).
 				AddItems("pods",
 					builder.ForPod("ns-1", "pod-1").Result(),
 					builder.ForPod("ns-2", "pod-2").Result(),
@@ -585,7 +687,8 @@ func TestRestoreNamespaceMapping(t *testing.T) {
 				).
 				Done(),
 			want: map[*test.APIResource][]string{
-				test.Pods(): {"mapped-ns-1/pod-1", "mapped-ns-2/pod-2", "ns-3/pod-3"},
+				test.Namespaces(): {"/mapped-ns-1", "/mapped-ns-2", "/ns-3"},
+				test.Pods():       {"mapped-ns-1/pod-1", "mapped-ns-2/pod-2", "ns-3/pod-3"},
 			},
 		},
 		{
@@ -593,9 +696,15 @@ func TestRestoreNamespaceMapping(t *testing.T) {
 			restore: defaultRestore().IncludedNamespaces("ns-1", "ns-2").NamespaceMappings("ns-1", "mapped-ns-1", "ns-2", "mapped-ns-2").Result(),
 			backup:  defaultBackup().Result(),
 			apiResources: []*test.APIResource{
+				test.Namespaces(),
 				test.Pods(),
 			},
 			tarball: test.NewTarWriter(t).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+					builder.ForNamespace("ns-3").Result(),
+				).
 				AddItems("pods",
 					builder.ForPod("ns-1", "pod-1").Result(),
 					builder.ForPod("ns-2", "pod-2").Result(),
@@ -603,7 +712,8 @@ func TestRestoreNamespaceMapping(t *testing.T) {
 				).
 				Done(),
 			want: map[*test.APIResource][]string{
-				test.Pods(): {"mapped-ns-1/pod-1", "mapped-ns-2/pod-2"},
+				test.Namespaces(): {"/mapped-ns-1", "/mapped-ns-2"},
+				test.Pods():       {"mapped-ns-1/pod-1", "mapped-ns-2/pod-2"},
 			},
 		},
 	}
@@ -627,7 +737,7 @@ func TestRestoreNamespaceMapping(t *testing.T) {
 			}
 			warnings, errs := h.restorer.Restore(
 				data,
-				nil, // restoreItemActions
+				[]velero.RestoreItemAction{NewNamespaceAction(h.log)}, // restoreItemActions
 				nil, // snapshot location lister
 				nil, // volume snapshotter getter
 			)
@@ -814,6 +924,9 @@ func TestRestoreItems(t *testing.T) {
 			restore: defaultRestore().Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+				).
 				AddItems("pods",
 					builder.ForPod("ns-1", "pod-1").
 						ObjectMeta(
@@ -826,9 +939,17 @@ func TestRestoreItems(t *testing.T) {
 				).
 				Done(),
 			apiResources: []*test.APIResource{
+				test.Namespaces(),
 				test.Pods(),
 			},
 			want: []*test.APIResource{
+				test.Namespaces(
+					builder.ForNamespace("ns-1").
+						ObjectMeta(
+							builder.WithLabels("velero.io/backup-name", "backup-1", "velero.io/restore-name", "restore-1"),
+						).
+						Result(),
+				),
 				test.Pods(
 					builder.ForPod("ns-1", "pod-1").
 						ObjectMeta(
@@ -1079,12 +1200,26 @@ func TestRestoreActionsRunForCorrectItems(t *testing.T) {
 			restore: defaultRestore().Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
-				AddItems("pods", builder.ForPod("ns-1", "pod-1").Result(), builder.ForPod("ns-2", "pod-2").Result()).
-				AddItems("persistentvolumes", builder.ForPersistentVolume("pv-1").Result(), builder.ForPersistentVolume("pv-2").Result()).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
+				AddItems("pods",
+					builder.ForPod("ns-1", "pod-1").Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+				).
+				AddItems("persistentvolumes",
+					builder.ForPersistentVolume("pv-1").Result(),
+					builder.ForPersistentVolume("pv-2").Result(),
+				).
 				Done(),
-			apiResources: []*test.APIResource{test.Pods(), test.PVs()},
+			apiResources: []*test.APIResource{
+				test.Namespaces(),
+				test.Pods(),
+				test.PVs(),
+			},
 			actions: map[*recordResourcesAction][]string{
-				new(recordResourcesAction): {"ns-1/pod-1", "ns-2/pod-2", "pv-1", "pv-2"},
+				new(recordResourcesAction): {"ns-1", "ns-1/pod-1", "ns-2", "ns-2/pod-2", "pv-1", "pv-2"},
 			},
 		},
 		{
@@ -1092,10 +1227,24 @@ func TestRestoreActionsRunForCorrectItems(t *testing.T) {
 			restore: defaultRestore().Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
-				AddItems("pods", builder.ForPod("ns-1", "pod-1").Result(), builder.ForPod("ns-2", "pod-2").Result()).
-				AddItems("persistentvolumes", builder.ForPersistentVolume("pv-1").Result(), builder.ForPersistentVolume("pv-2").Result()).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
+				AddItems("pods",
+					builder.ForPod("ns-1", "pod-1").Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+				).
+				AddItems("persistentvolumes",
+					builder.ForPersistentVolume("pv-1").Result(),
+					builder.ForPersistentVolume("pv-2").Result(),
+				).
 				Done(),
-			apiResources: []*test.APIResource{test.Pods(), test.PVs()},
+			apiResources: []*test.APIResource{
+				test.Namespaces(),
+				test.Pods(),
+				test.PVs(),
+			},
 			actions: map[*recordResourcesAction][]string{
 				new(recordResourcesAction).ForResource("pods"): {"ns-1/pod-1", "ns-2/pod-2"},
 			},
@@ -1105,10 +1254,24 @@ func TestRestoreActionsRunForCorrectItems(t *testing.T) {
 			restore: defaultRestore().Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
-				AddItems("pods", builder.ForPod("ns-1", "pod-1").Result(), builder.ForPod("ns-2", "pod-2").Result()).
-				AddItems("persistentvolumes", builder.ForPersistentVolume("pv-1").Result(), builder.ForPersistentVolume("pv-2").Result()).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
+				AddItems("pods",
+					builder.ForPod("ns-1", "pod-1").Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+				).
+				AddItems("persistentvolumes",
+					builder.ForPersistentVolume("pv-1").Result(),
+					builder.ForPersistentVolume("pv-2").Result(),
+				).
 				Done(),
-			apiResources: []*test.APIResource{test.Pods(), test.PVs()},
+			apiResources: []*test.APIResource{
+				test.Namespaces(),
+				test.Pods(),
+				test.PVs(),
+			},
 			actions: map[*recordResourcesAction][]string{
 				new(recordResourcesAction).ForResource("persistentvolumes"): {"pv-1", "pv-2"},
 			},
@@ -1118,11 +1281,29 @@ func TestRestoreActionsRunForCorrectItems(t *testing.T) {
 			restore: defaultRestore().Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
-				AddItems("pods", builder.ForPod("ns-1", "pod-1").Result(), builder.ForPod("ns-2", "pod-2").Result()).
-				AddItems("persistentvolumeclaims", builder.ForPersistentVolumeClaim("ns-1", "pvc-1").Result(), builder.ForPersistentVolumeClaim("ns-2", "pvc-2").Result()).
-				AddItems("persistentvolumes", builder.ForPersistentVolume("pv-1").Result(), builder.ForPersistentVolume("pv-2").Result()).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
+				AddItems("pods",
+					builder.ForPod("ns-1", "pod-1").Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+				).
+				AddItems("persistentvolumeclaims",
+					builder.ForPersistentVolumeClaim("ns-1", "pvc-1").Result(),
+					builder.ForPersistentVolumeClaim("ns-2", "pvc-2").Result(),
+				).
+				AddItems("persistentvolumes",
+					builder.ForPersistentVolume("pv-1").Result(),
+					builder.ForPersistentVolume("pv-2").Result(),
+				).
 				Done(),
-			apiResources: []*test.APIResource{test.Pods(), test.PVCs(), test.PVs()},
+			apiResources: []*test.APIResource{
+				test.Namespaces(),
+				test.Pods(),
+				test.PVCs(),
+				test.PVs(),
+			},
 			actions: map[*recordResourcesAction][]string{
 				new(recordResourcesAction).ForNamespace("ns-1"): {"ns-1/pod-1", "ns-1/pvc-1"},
 			},
@@ -1132,11 +1313,29 @@ func TestRestoreActionsRunForCorrectItems(t *testing.T) {
 			restore: defaultRestore().Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
-				AddItems("pods", builder.ForPod("ns-1", "pod-1").Result(), builder.ForPod("ns-2", "pod-2").Result()).
-				AddItems("persistentvolumeclaims", builder.ForPersistentVolumeClaim("ns-1", "pvc-1").Result(), builder.ForPersistentVolumeClaim("ns-2", "pvc-2").Result()).
-				AddItems("persistentvolumes", builder.ForPersistentVolume("pv-1").Result(), builder.ForPersistentVolume("pv-2").Result()).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
+				AddItems("pods",
+					builder.ForPod("ns-1", "pod-1").Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+				).
+				AddItems("persistentvolumeclaims",
+					builder.ForPersistentVolumeClaim("ns-1", "pvc-1").Result(),
+					builder.ForPersistentVolumeClaim("ns-2", "pvc-2").Result(),
+				).
+				AddItems("persistentvolumes",
+					builder.ForPersistentVolume("pv-1").Result(),
+					builder.ForPersistentVolume("pv-2").Result(),
+				).
 				Done(),
-			apiResources: []*test.APIResource{test.Pods(), test.PVCs(), test.PVs()},
+			apiResources: []*test.APIResource{
+				test.Namespaces(),
+				test.Pods(),
+				test.PVCs(),
+				test.PVs(),
+			},
 			actions: map[*recordResourcesAction][]string{
 				new(recordResourcesAction).ForNamespace("ns-1").ForResource("pods"): {"ns-1/pod-1"},
 			},
@@ -1146,13 +1345,20 @@ func TestRestoreActionsRunForCorrectItems(t *testing.T) {
 			restore: defaultRestore().Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
 				AddItems("pods",
 					builder.ForPod("ns-1", "pod-1").ObjectMeta(builder.WithLabels("restore-resource", "true")).Result(),
 					builder.ForPod("ns-1", "pod-2").ObjectMeta(builder.WithLabels("do-not-restore-resource", "true")).Result(),
 					builder.ForPod("ns-2", "pod-1").Result(),
 					builder.ForPod("ns-2", "pod-2").ObjectMeta(builder.WithLabels("restore-resource")).Result(),
 				).Done(),
-			apiResources: []*test.APIResource{test.Pods()},
+			apiResources: []*test.APIResource{
+				test.Namespaces(),
+				test.Pods(),
+			},
 			actions: map[*recordResourcesAction][]string{
 				new(recordResourcesAction).ForResource("pods").ForLabelSelector("restore-resource"): {"ns-1/pod-1", "ns-2/pod-2"},
 			},
@@ -1162,12 +1368,31 @@ func TestRestoreActionsRunForCorrectItems(t *testing.T) {
 			restore: defaultRestore().Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
-				AddItems("pods", builder.ForPod("ns-1", "pod-1").Result(), builder.ForPod("ns-2", "pod-2").Result()).
-				AddItems("persistentvolumeclaims", builder.ForPersistentVolumeClaim("ns-1", "pvc-1").Result(), builder.ForPersistentVolumeClaim("ns-2", "pvc-2").Result()).
-				AddItems("persistentvolumes", builder.ForPersistentVolume("pv-1").Result(), builder.ForPersistentVolume("pv-2").Result()).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
+				AddItems("pods",
+					builder.ForPod("ns-1", "pod-1").Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+				).
+				AddItems("persistentvolumeclaims",
+					builder.ForPersistentVolumeClaim("ns-1", "pvc-1").Result(),
+					builder.ForPersistentVolumeClaim("ns-2", "pvc-2").Result(),
+				).
+				AddItems("persistentvolumes",
+					builder.ForPersistentVolume("pv-1").Result(),
+					builder.ForPersistentVolume("pv-2").Result(),
+				).
 				Done(),
-			apiResources: []*test.APIResource{test.Pods(), test.PVCs(), test.PVs()},
+			apiResources: []*test.APIResource{
+				test.Namespaces(),
+				test.Pods(),
+				test.PVCs(),
+				test.PVs(),
+			},
 			actions: map[*recordResourcesAction][]string{
+				new(recordResourcesAction).ForResource("ns"): {"ns-1", "ns-2"},
 				new(recordResourcesAction).ForResource("po"): {"ns-1/pod-1", "ns-2/pod-2"},
 				new(recordResourcesAction).ForResource("pv"): {"pv-1", "pv-2"},
 			},
@@ -1177,10 +1402,19 @@ func TestRestoreActionsRunForCorrectItems(t *testing.T) {
 			restore: defaultRestore().Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
 				AddItems("pods", builder.ForPod("ns-1", "pod-1").Result()).
 				AddItems("persistentvolumeclaims", builder.ForPersistentVolumeClaim("ns-2", "pvc-2").Result()).
 				Done(),
-			apiResources: []*test.APIResource{test.Pods(), test.PVCs(), test.PVs()},
+			apiResources: []*test.APIResource{
+				test.Namespaces(),
+				test.Pods(),
+				test.PVCs(),
+				test.PVs(),
+			},
 			actions: map[*recordResourcesAction][]string{
 				new(recordResourcesAction).ForNamespace("ns-1").ForResource("persistentvolumeclaims"): nil,
 				new(recordResourcesAction).ForNamespace("ns-2").ForResource("pods"):                   nil,
@@ -1282,11 +1516,17 @@ func TestRestoreActionModifications(t *testing.T) {
 		want         []*test.APIResource
 	}{
 		{
-			name:         "action that adds a label to item gets restored",
-			restore:      defaultRestore().Result(),
-			backup:       defaultBackup().Result(),
-			tarball:      test.NewTarWriter(t).AddItems("pods", builder.ForPod("ns-1", "pod-1").Result()).Done(),
-			apiResources: []*test.APIResource{test.Pods()},
+			name:    "action that adds a label to item gets restored",
+			restore: defaultRestore().Result(),
+			backup:  defaultBackup().Result(),
+			tarball: test.NewTarWriter(t).
+				AddItems("namespaces", builder.ForNamespace("ns-1").Result()).
+				AddItems("pods", builder.ForPod("ns-1", "pod-1").Result()).
+				Done(),
+			apiResources: []*test.APIResource{
+				test.Namespaces(),
+				test.Pods(),
+			},
 			actions: []velero.RestoreItemAction{
 				modifyingActionGetter(func(item *unstructured.Unstructured) {
 					item.SetLabels(map[string]string{"updated": "true"})
@@ -1299,11 +1539,20 @@ func TestRestoreActionModifications(t *testing.T) {
 			},
 		},
 		{
-			name:         "action that removes a label to item gets restored",
-			restore:      defaultRestore().Result(),
-			backup:       defaultBackup().Result(),
-			tarball:      test.NewTarWriter(t).AddItems("pods", builder.ForPod("ns-1", "pod-1").ObjectMeta(builder.WithLabels("should-be-removed", "true")).Result()).Done(),
-			apiResources: []*test.APIResource{test.Pods()},
+			name:    "action that removes a label to item gets restored",
+			restore: defaultRestore().Result(),
+			backup:  defaultBackup().Result(),
+			tarball: test.NewTarWriter(t).
+				AddItems("namespaces", builder.ForNamespace("ns-1").Result()).
+				AddItems("pods",
+					builder.ForPod("ns-1", "pod-1").
+						ObjectMeta(builder.WithLabels("should-be-removed", "true")).Result(),
+				).
+				Done(),
+			apiResources: []*test.APIResource{
+				test.Namespaces(),
+				test.Pods(),
+			},
 			actions: []velero.RestoreItemAction{
 				modifyingActionGetter(func(item *unstructured.Unstructured) {
 					item.SetLabels(nil)
@@ -1375,11 +1624,23 @@ func TestRestoreActionAdditionalItems(t *testing.T) {
 		want         map[*test.APIResource][]string
 	}{
 		{
-			name:         "additional items that are already being restored are not restored twice",
-			restore:      defaultRestore().Result(),
-			backup:       defaultBackup().Result(),
-			tarball:      test.NewTarWriter(t).AddItems("pods", builder.ForPod("ns-1", "pod-1").Result(), builder.ForPod("ns-2", "pod-2").Result()).Done(),
-			apiResources: []*test.APIResource{test.Pods()},
+			name:    "additional items that are already being restored are not restored twice",
+			restore: defaultRestore().Result(),
+			backup:  defaultBackup().Result(),
+			tarball: test.NewTarWriter(t).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
+				AddItems("pods",
+					builder.ForPod("ns-1", "pod-1").Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+				).
+				Done(),
+			apiResources: []*test.APIResource{
+				test.Namespaces(),
+				test.Pods(),
+			},
 			actions: []velero.RestoreItemAction{
 				&pluggableAction{
 					selector: velero.ResourceSelector{IncludedNamespaces: []string{"ns-1"}},
@@ -1394,15 +1655,28 @@ func TestRestoreActionAdditionalItems(t *testing.T) {
 				},
 			},
 			want: map[*test.APIResource][]string{
-				test.Pods(): {"ns-1/pod-1", "ns-2/pod-2"},
+				test.Namespaces(): {"/ns-1", "/ns-2"},
+				test.Pods():       {"ns-1/pod-1", "ns-2/pod-2"},
 			},
 		},
 		{
-			name:         "when using a restore namespace filter, additional items that are in a non-included namespace are not restored",
-			restore:      defaultRestore().IncludedNamespaces("ns-1").Result(),
-			backup:       defaultBackup().Result(),
-			tarball:      test.NewTarWriter(t).AddItems("pods", builder.ForPod("ns-1", "pod-1").Result(), builder.ForPod("ns-2", "pod-2").Result()).Done(),
-			apiResources: []*test.APIResource{test.Pods()},
+			name:    "when using a restore namespace filter, additional items that are in a non-included namespace are not restored",
+			restore: defaultRestore().IncludedNamespaces("ns-1").Result(),
+			backup:  defaultBackup().Result(),
+			tarball: test.NewTarWriter(t).
+				AddItems("namespaces",
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				).
+				AddItems("pods",
+					builder.ForPod("ns-1", "pod-1").Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+				).
+				Done(),
+			apiResources: []*test.APIResource{
+				test.Namespaces(),
+				test.Pods(),
+			},
 			actions: []velero.RestoreItemAction{
 				&pluggableAction{
 					executeFunc: func(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
@@ -1416,7 +1690,8 @@ func TestRestoreActionAdditionalItems(t *testing.T) {
 				},
 			},
 			want: map[*test.APIResource][]string{
-				test.Pods(): {"ns-1/pod-1"},
+				test.Namespaces(): {"/ns-1"},
+				test.Pods():       {"ns-1/pod-1"},
 			},
 		},
 		{
@@ -1424,10 +1699,15 @@ func TestRestoreActionAdditionalItems(t *testing.T) {
 			restore: defaultRestore().IncludedNamespaces("ns-1").Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
+				AddItems("namespaces", builder.ForNamespace("ns-1").Result()).
 				AddItems("pods", builder.ForPod("ns-1", "pod-1").Result()).
 				AddItems("persistentvolumes", builder.ForPersistentVolume("pv-1").Result()).
 				Done(),
-			apiResources: []*test.APIResource{test.Pods(), test.PVs()},
+			apiResources: []*test.APIResource{
+				test.Namespaces(),
+				test.Pods(),
+				test.PVs(),
+			},
 			actions: []velero.RestoreItemAction{
 				&pluggableAction{
 					executeFunc: func(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
@@ -1441,8 +1721,9 @@ func TestRestoreActionAdditionalItems(t *testing.T) {
 				},
 			},
 			want: map[*test.APIResource][]string{
-				test.Pods(): {"ns-1/pod-1"},
-				test.PVs():  {"/pv-1"},
+				test.Namespaces(): {"/ns-1"},
+				test.Pods():       {"ns-1/pod-1"},
+				test.PVs():        {"/pv-1"},
 			},
 		},
 		{
@@ -1450,10 +1731,15 @@ func TestRestoreActionAdditionalItems(t *testing.T) {
 			restore: defaultRestore().IncludeClusterResources(false).Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
+				AddItems("namespaces", builder.ForNamespace("ns-1").Result()).
 				AddItems("pods", builder.ForPod("ns-1", "pod-1").Result()).
 				AddItems("persistentvolumes", builder.ForPersistentVolume("pv-1").Result()).
 				Done(),
-			apiResources: []*test.APIResource{test.Pods(), test.PVs()},
+			apiResources: []*test.APIResource{
+				test.Namespaces(),
+				test.Pods(),
+				test.PVs(),
+			},
 			actions: []velero.RestoreItemAction{
 				&pluggableAction{
 					executeFunc: func(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
@@ -1467,8 +1753,9 @@ func TestRestoreActionAdditionalItems(t *testing.T) {
 				},
 			},
 			want: map[*test.APIResource][]string{
-				test.Pods(): {"ns-1/pod-1"},
-				test.PVs():  nil,
+				test.Namespaces(): {"/ns-1"},
+				test.Pods():       {"ns-1/pod-1"},
+				test.PVs():        nil,
 			},
 		},
 		{
@@ -1476,10 +1763,15 @@ func TestRestoreActionAdditionalItems(t *testing.T) {
 			restore: defaultRestore().IncludedResources("pods").Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
+				AddItems("namespaces", builder.ForNamespace("ns-1").Result()).
 				AddItems("pods", builder.ForPod("ns-1", "pod-1").Result()).
 				AddItems("persistentvolumes", builder.ForPersistentVolume("pv-1").Result()).
 				Done(),
-			apiResources: []*test.APIResource{test.Pods(), test.PVs()},
+			apiResources: []*test.APIResource{
+				test.Namespaces(),
+				test.Pods(),
+				test.PVs(),
+			},
 			actions: []velero.RestoreItemAction{
 				&pluggableAction{
 					executeFunc: func(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
@@ -1493,8 +1785,9 @@ func TestRestoreActionAdditionalItems(t *testing.T) {
 				},
 			},
 			want: map[*test.APIResource][]string{
-				test.Pods(): {"ns-1/pod-1"},
-				test.PVs():  nil,
+				test.Namespaces(): {"/ns-1"},
+				test.Pods():       {"ns-1/pod-1"},
+				test.PVs():        nil,
 			},
 		},
 	}
@@ -2121,7 +2414,7 @@ func TestRestorePersistentVolumes(t *testing.T) {
 						ObjectMeta(
 							builder.WithAnnotations("velero.io/original-pv-name", "source-pv"),
 							builder.WithLabels("velero.io/backup-name", "backup-1", "velero.io/restore-name", "restore-1"),
-						// the namespace for this PV's claimRef should be the one that the PVC was remapped into.
+							// the namespace for this PV's claimRef should be the one that the PVC was remapped into.
 						).ClaimRef("target-ns", "pvc-1").
 						AWSEBSVolumeID("new-volume").
 						Result(),
@@ -2815,6 +3108,13 @@ func assertResourceCreationOrder(t *testing.T, resourcePriorities []string, crea
 	// we saw created. Once we've seen a resource in 'resourcePriorities', we should
 	// never see another instance of a prior resource.
 	lastSeen := 0
+
+	// Remove namespaces from 'createdResources' as those are restored lazily.
+	for i, resource := range createdResources {
+		if resource.groupResource == "namespaces" {
+			createdResources = append(createdResources[:i], createdResources[i+1:]...)
+		}
+	}
 
 	// Find the index in 'resourcePriorities' of the resource type for
 	// the current item, if it exists. This index ('current') *must*


### PR DESCRIPTION
# Please add a summary of your change
Namespaces are still lazily restored but using the normal restore process instead of directly from backup.

# Does your change fix a particular issue?

Fixes #4478

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
