### PR TITLE
Fix e2e 2500 namespaces scale test timeout problem

### DIFF
--- a/changelogs/unreleased/4480-mqiu
+++ b/changelogs/unreleased/4480-mqiu
@@ -1,0 +1,1 @@
+Fix e2e 2500 namespaces scale test timeout problem


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Fix e2e 2500 namespaces scale test timeout problem
# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
