### PR TITLE
Initialize the labels field of `velero backup-location create` option

### DIFF
--- a/changelogs/unreleased/4491-ywk253100
+++ b/changelogs/unreleased/4491-ywk253100
@@ -1,0 +1,1 @@
+Initialize the labels field of `velero backup-location create` option to avoid #4484

--- a/pkg/cmd/cli/backuplocation/create.go
+++ b/pkg/cmd/cli/backuplocation/create.go
@@ -78,6 +78,7 @@ func NewCreateOptions() *CreateOptions {
 	return &CreateOptions{
 		Credential: flag.NewMap(),
 		Config:     flag.NewMap(),
+		Labels:     flag.NewMap(),
 		AccessMode: flag.NewEnum(
 			string(velerov1api.BackupStorageLocationAccessModeReadWrite),
 			string(velerov1api.BackupStorageLocationAccessModeReadWrite),

--- a/pkg/cmd/cli/backuplocation/create_test.go
+++ b/pkg/cmd/cli/backuplocation/create_test.go
@@ -76,3 +76,14 @@ func TestBuildBackupStorageLocationSetsCredential(t *testing.T) {
 		Key:                  "key-from-secret",
 	}, bsl.Spec.Credential)
 }
+
+func TestBuildBackupStorageLocationSetsLabels(t *testing.T) {
+	o := NewCreateOptions()
+
+	err := o.Labels.Set("key=value")
+	assert.NoError(t, err)
+
+	bsl, err := o.BuildBackupStorageLocation("velero-test-ns", false, false)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"key": "value"}, bsl.Labels)
+}


### PR DESCRIPTION
Initialize the labels field of `velero backup-location create` option to avoid #4484

Fixes #4484

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
