### PR TITLE
Add a built-in plugin to implement Change Image Registry

### DIFF
--- a/pkg/builder/daemonset_builder.go
+++ b/pkg/builder/daemonset_builder.go
@@ -1,12 +1,9 @@
 /*
-Copyright 2019 the Velero contributors.
-
+Copyright 2022 the Velero contributors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,18 +21,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// DeploymentBuilder builds Deployment objects.
-type DeploymentBuilder struct {
-	object *appsv1api.Deployment
+// DaemonsetBuilder builds Daemonset objects.
+type DaemonsetBuilder struct {
+	object *appsv1api.DaemonSet
 }
 
-// ForDeployment is the constructor for a DeploymentBuilder.
-func ForDeployment(ns, name string) *DeploymentBuilder {
-	return &DeploymentBuilder{
-		object: &appsv1api.Deployment{
+// ForDaemonset is the constructor for a DaemonsetBuilder.
+func ForDaemonset(ns, name string) *DaemonsetBuilder {
+	return &DaemonsetBuilder{
+		object: &appsv1api.DaemonSet{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: appsv1api.SchemeGroupVersion.String(),
-				Kind:       "Deployment",
+				Kind:       "DaemonSet",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns,
@@ -45,38 +42,29 @@ func ForDeployment(ns, name string) *DeploymentBuilder {
 	}
 }
 
-// ForDeploymentWithImage is the constructor for a DeploymentBuilder with container image.
-func ForDeploymentWithImage(ns, name string, images ...string) *DeploymentBuilder {
+// ForDaemonsetWithImage is the constructor for a DaemonsetBuilder with container image.
+func ForDaemonsetWithImage(ns, name string, images ...string) *DaemonsetBuilder {
 	containers := []corev1api.Container{}
 	for i, image := range images {
 		containers = append(containers, corev1api.Container{Name: strconv.Itoa(i), Image: image})
 	}
 	spec := corev1api.PodSpec{Containers: containers}
-	return &DeploymentBuilder{
-		object: &appsv1api.Deployment{
+	return &DaemonsetBuilder{
+		object: &appsv1api.DaemonSet{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: appsv1api.SchemeGroupVersion.String(),
-				Kind:       "Deployment",
+				Kind:       "DaemonSet",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns,
 				Name:      name,
 			},
-			Spec: appsv1api.DeploymentSpec{Template: corev1api.PodTemplateSpec{Spec: spec}},
+			Spec: appsv1api.DaemonSetSpec{Template: corev1api.PodTemplateSpec{Spec: spec}},
 		},
 	}
 }
 
-// Result returns the built Deployment.
-func (b *DeploymentBuilder) Result() *appsv1api.Deployment {
+// Result returns the built DaemonSet.
+func (b *DaemonsetBuilder) Result() *appsv1api.DaemonSet {
 	return b.object
-}
-
-// ObjectMeta applies functional options to the Deployment's ObjectMeta.
-func (b *DeploymentBuilder) ObjectMeta(opts ...ObjectMetaOpt) *DeploymentBuilder {
-	for _, opt := range opts {
-		opt(b.object)
-	}
-
-	return b
 }

--- a/pkg/builder/pod_builder.go
+++ b/pkg/builder/pod_builder.go
@@ -17,6 +17,8 @@ limitations under the License.
 package builder
 
 import (
+	"strconv"
+
 	corev1api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -38,6 +40,28 @@ func ForPod(ns, name string) *PodBuilder {
 				Namespace: ns,
 				Name:      name,
 			},
+		},
+	}
+}
+
+// ForPodWithImage is the constructor for a PodBuilder with container image.
+func ForPodWithImage(ns, name string, images ...string) *PodBuilder {
+	containers := []corev1api.Container{}
+	for i, image := range images {
+		containers = append(containers, corev1api.Container{Name: strconv.Itoa(i), Image: image})
+	}
+	spec := corev1api.PodSpec{Containers: containers}
+	return &PodBuilder{
+		object: &corev1api.Pod{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: corev1api.SchemeGroupVersion.String(),
+				Kind:       "Pod",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      name,
+			},
+			Spec: spec,
 		},
 	}
 }

--- a/pkg/builder/replicaset_builder.go
+++ b/pkg/builder/replicaset_builder.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 the Velero contributors.
+Copyright 2022 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,18 +24,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// DeploymentBuilder builds Deployment objects.
-type DeploymentBuilder struct {
-	object *appsv1api.Deployment
+// ReplicaSetBuilder builds ReplicaSet objects.
+type ReplicaSetBuilder struct {
+	object *appsv1api.ReplicaSet
 }
 
-// ForDeployment is the constructor for a DeploymentBuilder.
-func ForDeployment(ns, name string) *DeploymentBuilder {
-	return &DeploymentBuilder{
-		object: &appsv1api.Deployment{
+// ForReplicaSet is the constructor for a ReplicaSetBuilder.
+func ForReplicaSet(ns, name string) *ReplicaSetBuilder {
+	return &ReplicaSetBuilder{
+		object: &appsv1api.ReplicaSet{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: appsv1api.SchemeGroupVersion.String(),
-				Kind:       "Deployment",
+				Kind:       "ReplicaSet",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns,
@@ -45,35 +45,35 @@ func ForDeployment(ns, name string) *DeploymentBuilder {
 	}
 }
 
-// ForDeploymentWithImage is the constructor for a DeploymentBuilder with container image.
-func ForDeploymentWithImage(ns, name string, images ...string) *DeploymentBuilder {
+// ForReplicaSetWithImage is the constructor for a ReplicaSetBuilder with container image.
+func ForReplicaSetWithImage(ns, name string, images ...string) *ReplicaSetBuilder {
 	containers := []corev1api.Container{}
 	for i, image := range images {
 		containers = append(containers, corev1api.Container{Name: strconv.Itoa(i), Image: image})
 	}
 	spec := corev1api.PodSpec{Containers: containers}
-	return &DeploymentBuilder{
-		object: &appsv1api.Deployment{
+	return &ReplicaSetBuilder{
+		object: &appsv1api.ReplicaSet{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: appsv1api.SchemeGroupVersion.String(),
-				Kind:       "Deployment",
+				Kind:       "ReplicaSet",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns,
 				Name:      name,
 			},
-			Spec: appsv1api.DeploymentSpec{Template: corev1api.PodTemplateSpec{Spec: spec}},
+			Spec: appsv1api.ReplicaSetSpec{Template: corev1api.PodTemplateSpec{Spec: spec}},
 		},
 	}
 }
 
-// Result returns the built Deployment.
-func (b *DeploymentBuilder) Result() *appsv1api.Deployment {
+// Result returns the built ReplicaSet.
+func (b *ReplicaSetBuilder) Result() *appsv1api.ReplicaSet {
 	return b.object
 }
 
-// ObjectMeta applies functional options to the Deployment's ObjectMeta.
-func (b *DeploymentBuilder) ObjectMeta(opts ...ObjectMetaOpt) *DeploymentBuilder {
+// ObjectMeta applies functional options to the ReplicaSet's ObjectMeta.
+func (b *ReplicaSetBuilder) ObjectMeta(opts ...ObjectMetaOpt) *ReplicaSetBuilder {
 	for _, opt := range opts {
 		opt(b.object)
 	}

--- a/pkg/builder/statefulset_builder.go
+++ b/pkg/builder/statefulset_builder.go
@@ -17,6 +17,8 @@ limitations under the License.
 package builder
 
 import (
+	"strconv"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,6 +44,28 @@ func ForStatefulSet(ns, name string) *StatefulSetBuilder {
 			Spec: appsv1.StatefulSetSpec{
 				VolumeClaimTemplates: []corev1.PersistentVolumeClaim{},
 			},
+		},
+	}
+}
+
+// ForStatefulSetWithImage is the constructor for a StatefulSetBuilder with container image.
+func ForStatefulSetWithImage(ns, name string, images ...string) *StatefulSetBuilder {
+	containers := []corev1.Container{}
+	for i, image := range images {
+		containers = append(containers, corev1.Container{Name: strconv.Itoa(i), Image: image})
+	}
+	spec := corev1.PodSpec{Containers: containers}
+	return &StatefulSetBuilder{
+		object: &appsv1.StatefulSet{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: appsv1.SchemeGroupVersion.String(),
+				Kind:       "StatefulSet",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      name,
+			},
+			Spec: appsv1.StatefulSetSpec{Template: corev1.PodTemplateSpec{Spec: spec}},
 		},
 	}
 }

--- a/pkg/cmd/server/plugin/plugin.go
+++ b/pkg/cmd/server/plugin/plugin.go
@@ -56,6 +56,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 				RegisterRestoreItemAction("velero.io/change-pvc-node-selector", newChangePVCNodeSelectorItemAction(f)).
 				RegisterRestoreItemAction("velero.io/apiservice", newAPIServiceRestoreItemAction).
 				RegisterRestoreItemAction("velero.io/admission-webhook-configuration", newAdmissionWebhookConfigurationAction).
+				RegisterRestoreItemAction("velero.io/change-image-registry", newChangeImageRegistryRestoreItemAction(f)).
 				Serve()
 		},
 	}
@@ -206,4 +207,18 @@ func newAPIServiceRestoreItemAction(logger logrus.FieldLogger) (interface{}, err
 
 func newAdmissionWebhookConfigurationAction(logger logrus.FieldLogger) (interface{}, error) {
 	return restore.NewAdmissionWebhookConfigurationAction(logger), nil
+}
+
+func newChangeImageRegistryRestoreItemAction(f client.Factory) veleroplugin.HandlerInitializer {
+	return func(logger logrus.FieldLogger) (interface{}, error) {
+		client, err := f.KubeClient()
+		if err != nil {
+			return nil, err
+		}
+
+		return restore.NewChangeImageRegistryAction(
+			logger,
+			client.CoreV1().ConfigMaps(f.Namespace()),
+		), nil
+	}
 }

--- a/pkg/restore/change_image_registry_action.go
+++ b/pkg/restore/change_image_registry_action.go
@@ -1,0 +1,291 @@
+/*
+Copyright 2022 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restore
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	appsv1api "k8s.io/api/apps/v1"
+	corev1api "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+)
+
+// ChangeImageRegistryAction updates a pod/deploy/statefulset/daemonset/replicaset image registry
+// if a mapping is found in the plugin's config map
+type ChangeImageRegistryAction struct {
+	logger          logrus.FieldLogger
+	configMapClient corev1client.ConfigMapInterface
+}
+
+// NewChangeImageRegistryAction is the constructor for ChangeImageRegistryAction.
+func NewChangeImageRegistryAction(
+	logger logrus.FieldLogger,
+	configMapClient corev1client.ConfigMapInterface,
+) *ChangeImageRegistryAction {
+	return &ChangeImageRegistryAction{
+		logger:          logger,
+		configMapClient: configMapClient,
+	}
+}
+
+// AppliesTo returns the resources that ChangeImageRegistryAction should
+// be run for.
+func (a *ChangeImageRegistryAction) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+		IncludedResources: []string{"pods", "deployments", "statefulsets", "daemonsets", "replicasets"},
+	}, nil
+}
+
+// Execute updates the item's container's image if a mapping is found
+// in the config map for the plugin.
+func (a *ChangeImageRegistryAction) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
+	a.logger.Info("Executing ChangeImageRegistryAction")
+	defer a.logger.Info("Done executing ChangeImageRegistryAction")
+
+	a.logger.Debug("Getting plugin config")
+	config, err := getPluginConfig(framework.PluginKindRestoreItemAction, "velero.io/change-image-registry", a.configMapClient)
+	if err != nil {
+		return nil, err
+	}
+
+	if config == nil || len(config.Annotations) == 0 {
+		a.logger.Debug("No image-registry mappings found")
+		return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
+	}
+
+	obj, ok := input.Item.(*unstructured.Unstructured)
+	if !ok {
+		return nil, errors.Errorf("object was of unexpected type %T", input.Item)
+	}
+
+	log := a.logger.WithFields(map[string]interface{}{
+		"kind":      obj.GetKind(),
+		"namespace": obj.GetNamespace(),
+		"name":      obj.GetName(),
+	})
+
+	switch obj.GetKind() {
+	case "Pod":
+		if err = a.changeImageRegistryForPod(log, obj, config); err != nil {
+			return nil, err
+		}
+	case "Deployment":
+		if err = a.changeImageRegistryForDeploy(log, obj, config); err != nil {
+			return nil, err
+		}
+	case "ReplicaSet":
+		if err = a.changeImageRegistryForReplicaSet(log, obj, config); err != nil {
+			return nil, err
+		}
+	case "StatefulSet":
+		if err = a.changeImageRegistryForStatefulset(log, obj, config); err != nil {
+			return nil, err
+		}
+	case "DaemonSet":
+		if err = a.changeImageRegistryForDaemonset(log, obj, config); err != nil {
+			return nil, err
+		}
+	default:
+		notSupportedMsg := fmt.Sprintf("The kind %s image registry conversion is not supported.", obj.GetKind())
+		log.Error(notSupportedMsg)
+		return nil, errors.New(notSupportedMsg)
+	}
+
+	return velero.NewRestoreItemActionExecuteOutput(obj), nil
+}
+
+func (a *ChangeImageRegistryAction) changeImageRegistryForPod(logger *logrus.Entry, obj *unstructured.Unstructured, configmap *corev1api.ConfigMap) error {
+	pod := new(corev1api.Pod)
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), pod); err != nil {
+		return err
+	}
+
+	for k, container := range pod.Spec.Containers {
+		for inputOldImageRegistry, inputNewImageRegistry := range configmap.Annotations {
+			newImage := getNewImage(container.Image, inputOldImageRegistry, inputNewImageRegistry)
+			if newImage == "" {
+				// If empty, do nothing.
+				continue
+			} else {
+				pod.Spec.Containers[k].Image = newImage
+				logger.Infof("change pod %s container %s image to %s", pod.Name, container.Name, newImage)			}
+		}
+	}
+
+	newObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(pod)
+	if err != nil {
+		return err
+	}
+	obj.Object = newObj
+
+	return nil
+}
+
+func (a *ChangeImageRegistryAction) changeImageRegistryForDeploy(logger *logrus.Entry, obj *unstructured.Unstructured, configmap *corev1api.ConfigMap) error {
+	deploy := new(appsv1api.Deployment)
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), deploy); err != nil {
+		return err
+	}
+
+	for k, container := range deploy.Spec.Template.Spec.Containers {
+		for inputOldImageRegistry, inputNewImageRegistry := range configmap.Annotations {
+			newImage := getNewImage(container.Image, inputOldImageRegistry, inputNewImageRegistry)
+			if newImage == "" {
+				// If empty, do nothing.
+				continue
+			} else {
+				deploy.Spec.Template.Spec.Containers[k].Image = newImage
+				logger.Infof("change deployment %s container %s image to %s", deploy.Name, container.Name, newImage)
+			}
+		}
+	}
+
+	newObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(deploy)
+	if err != nil {
+		return err
+	}
+	obj.Object = newObj
+
+	return nil
+}
+
+func (a *ChangeImageRegistryAction) changeImageRegistryForReplicaSet(logger *logrus.Entry, obj *unstructured.Unstructured, configmap *corev1api.ConfigMap) error {
+	replicaset := new(appsv1api.ReplicaSet)
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), replicaset); err != nil {
+		return err
+	}
+
+	for k, container := range replicaset.Spec.Template.Spec.Containers {
+		for inputOldImageRegistry, inputNewImageRegistry := range configmap.Annotations {
+			newImage := getNewImage(container.Image, inputOldImageRegistry, inputNewImageRegistry)
+			if newImage == "" {
+				// If empty, do nothing.
+				continue
+			} else {
+				replicaset.Spec.Template.Spec.Containers[k].Image = newImage
+				logger.Infof("change replicaset %s container %s image to %s", replicaset.Name, container.Name, newImage)
+			}
+		}
+	}
+
+	newObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(replicaset)
+	if err != nil {
+		return err
+	}
+	obj.Object = newObj
+
+	return nil
+}
+
+func (a *ChangeImageRegistryAction) changeImageRegistryForStatefulset(logger *logrus.Entry, obj *unstructured.Unstructured, configmap *corev1api.ConfigMap) error {
+	sts := new(appsv1api.StatefulSet)
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), sts); err != nil {
+		return err
+	}
+
+	for k, container := range sts.Spec.Template.Spec.Containers {
+		for inputOldImageRegistry, inputNewImageRegistry := range configmap.Annotations {
+			newImage := getNewImage(container.Image, inputOldImageRegistry, inputNewImageRegistry)
+			if newImage == "" {
+				// If empty, do nothing.
+				continue
+			} else {
+				sts.Spec.Template.Spec.Containers[k].Image = newImage
+				logger.Infof("change statefulset %s container %s image to %s", sts.Name, container.Name, newImage)
+			}
+		}
+	}
+
+	newObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(sts)
+	if err != nil {
+		return err
+	}
+	obj.Object = newObj
+
+	return nil
+}
+
+func (a *ChangeImageRegistryAction) changeImageRegistryForDaemonset(logger *logrus.Entry, obj *unstructured.Unstructured, configmap *corev1api.ConfigMap) error {
+	ds := new(appsv1api.DaemonSet)
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), ds); err != nil {
+		return err
+	}
+
+	for i, container := range ds.Spec.Template.Spec.Containers {
+		for inputOldImageRegistry, inputNewImageRegistry := range configmap.Annotations {
+			newImage := getNewImage(container.Image, inputOldImageRegistry, inputNewImageRegistry)
+			if newImage == "" {
+				// If empty, do nothing.
+				continue
+			} else {
+				ds.Spec.Template.Spec.Containers[i].Image = newImage
+				logger.Infof("change daemonset %s container %s image to %s", ds.Name, container.Name, newImage)
+			}
+		}
+	}
+
+	newObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(ds)
+	if err != nil {
+		return err
+	}
+	obj.Object = newObj
+
+	return nil
+}
+
+// getNewImage returns the final expected image based on the original image passed in, combined with inputOldImageRegistry and inputNewImageRegistry.
+// If none match, an empty string is returned.
+func getNewImage(oldImage, inputOldImageRegistry, inputNewImageRegistry string) (newImage string) {
+	const slash = "/"
+	num := strings.LastIndex(oldImage, slash)
+
+	// when inputOldImageRegistry or inputNewImageRegistry last character is "/", we should move it.
+	if inputOldImageRegistry[len(inputOldImageRegistry)-1:] == slash {
+		inputOldImageRegistry = inputOldImageRegistry[:len(inputOldImageRegistry)-1]
+	}
+
+	if inputNewImageRegistry[len(inputNewImageRegistry)-1:] == slash {
+		inputNewImageRegistry = inputNewImageRegistry[:len(inputNewImageRegistry)-1]
+	}
+
+	var oldImageRegistry string
+	if num >= 0 {
+		oldImageRegistry = oldImage[0:num]
+	}
+
+	if oldImageRegistry == inputOldImageRegistry {
+		var newImageName string
+		if num < 0 {
+			newImageName = slash + oldImage
+		} else {
+			newImageName = oldImage[num:]
+		}
+		return inputNewImageRegistry + newImageName
+	} else if oldImageRegistry == "" && inputOldImageRegistry == "none" {
+		return inputNewImageRegistry + slash + oldImage
+	}
+
+	return ""
+}

--- a/pkg/restore/change_image_registry_action_test.go
+++ b/pkg/restore/change_image_registry_action_test.go
@@ -1,0 +1,321 @@
+/*
+Copyright 2022 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1api "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/vmware-tanzu/velero/pkg/builder"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+)
+
+func TestChaneImageTagActionExecute(t *testing.T) {
+	const defaultNamespace = "default"
+	tests := []struct {
+		name                 string
+		configMap            *corev1api.ConfigMap
+		podOrDeployOrStsOrDs interface{}
+		want                 interface{}
+		wantErr              error
+	}{
+		{
+			name: "a valid registry mapping for a pod is applied correctly",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/change-image-registry", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("velero.io/public", "new-registry.com/new-project")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForPodWithImage(defaultNamespace, "my-pod", "velero.io/public/nginx:stable", "velero.io/public/tomcat:stable").Result(),
+			want:                 builder.ForPodWithImage(defaultNamespace, "my-pod", "new-registry.com/new-project/nginx:stable", "new-registry.com/new-project/tomcat:stable").Result(),
+		},
+		{
+			name: "a valid registry mapping for a pod is applied correctly, but last character of Registry is entered with an ’/’ ",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/change-image-registry", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("velero.io/public/", "new-registry.com/new-project/")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForPodWithImage(defaultNamespace, "my-pod", "velero.io/public/nginx:stable").Result(),
+			want:                 builder.ForPodWithImage(defaultNamespace, "my-pod", "new-registry.com/new-project/nginx:stable").Result(),
+		},
+		{
+			name: "when pod's image registry has no mapping in the config map, the item is returned as-is",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/change-image-registry", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("none-registry.com/public", "velero.io/new-project")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForPodWithImage(defaultNamespace, "my-pod", "velero.io/public/nginx:stable").Result(),
+			want:                 builder.ForPodWithImage(defaultNamespace, "my-pod", "velero.io/public/nginx:stable").Result(),
+		},
+		{
+			name: "when no config map exists for the plugin, the pod item is returned as-is",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/some-other-plugin", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("velero.io/public", "velero.io/new-project")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForPodWithImage(defaultNamespace, "my-pod", "velero.io/public/nginx:stable").Result(),
+			want:                 builder.ForPodWithImage(defaultNamespace, "my-pod", "velero.io/public/nginx:stable").Result(),
+		},
+		{
+			name: "a valid registry mapping for a pod is applied correctly when original registry is 'none'",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/change-image-registry", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("none", "new-registry.com/new-project")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForPodWithImage(defaultNamespace, "my-pod", "nginx:stable").Result(),
+			want:                 builder.ForPodWithImage(defaultNamespace, "my-pod", "new-registry.com/new-project/nginx:stable").Result(),
+		},
+		{
+			name: "set 'none' original registry mapping for a pod, but pod's original registry not 'none', the item is returned as-is",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/change-image-registry", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("none", "new-registry.com/new-project")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForPodWithImage(defaultNamespace, "my-pod", "velero.io/public/nginx:stable").Result(),
+			want:                 builder.ForPodWithImage(defaultNamespace, "my-pod", "velero.io/public/nginx:stable").Result(),
+		},
+		{
+			name: "a valid registry mapping for a deploy is applied correctly",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/change-image-registry", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("velero.io/public", "new-registry.com/new-project", "velero.io/web", "new-registry.com/web")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForDeploymentWithImage(defaultNamespace, "my-deploy", "velero.io/public/nginx:stable", "velero.io/web/tomcat:stable").Result(),
+			want:                 builder.ForDeploymentWithImage(defaultNamespace, "my-deploy", "new-registry.com/new-project/nginx:stable", "new-registry.com/web/tomcat:stable").Result(),
+		},
+		{
+			name: "when no config map exists for the plugin, the deployment item is returned as-is",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/some-other-plugin", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("velero.io/public", "new-registry.com/new-project/")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForDeploymentWithImage(defaultNamespace, "my-deploy", "velero.io/public/nginx:stable").Result(),
+			want:                 builder.ForDeploymentWithImage(defaultNamespace, "my-deploy", "velero.io/public/nginx:stable").Result(),
+		},
+		{
+			name: "when deployment's image registry has no mapping in the config map, the item is returned as-is",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/change-image-registry", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("none-registry.com/public", "new-registry.com/new-project")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForDeploymentWithImage(defaultNamespace, "my-deploy", "velero.io/public/nginx:stable").Result(),
+			want:                 builder.ForDeploymentWithImage(defaultNamespace, "my-deploy", "velero.io/public/nginx:stable").Result(),
+		},
+		{
+			name: "a valid registry mapping for a deployment is applied correctly when original registry is 'none'",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/change-image-registry", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("none", "new-registry.com/new-project")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForDeploymentWithImage(defaultNamespace, "my-deploy", "nginx:stable").Result(),
+			want:                 builder.ForDeploymentWithImage(defaultNamespace, "my-deploy", "new-registry.com/new-project/nginx:stable").Result(),
+		},
+		{
+			name: "set 'none' original registry mapping for a deployment, but deployment's original registry not 'none', the item is returned as-is",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/change-image-registry", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("none", "new-registry.com/new-project")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForDeploymentWithImage(defaultNamespace, "my-deploy", "velero.io/public/nginx:stable").Result(),
+			want:                 builder.ForDeploymentWithImage(defaultNamespace, "my-deploy", "velero.io/public/nginx:stable").Result(),
+		},
+		{
+			name: "a valid registry mapping for a replicaset is applied correctly",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/change-image-registry", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("velero.io/public", "new-registry.com/new-project", "velero.io/web", "new-registry.com/web")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForReplicaSetWithImage(defaultNamespace, "my-replicaset", "velero.io/public/nginx:stable", "velero.io/web/tomcat:stable").Result(),
+			want:                 builder.ForReplicaSetWithImage(defaultNamespace, "my-replicaset", "new-registry.com/new-project/nginx:stable", "new-registry.com/web/tomcat:stable").Result(),
+		},
+		{
+			name: "when no config map exists for the plugin, the replicaset item is returned as-is",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/some-other-plugin", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("velero.io/public", "new-registry.com/new-project")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForReplicaSetWithImage(defaultNamespace, "my-replicaset", "velero.io/public/nginx:stable", "velero.io/web/tomcat:stable").Result(),
+			want:                 builder.ForReplicaSetWithImage(defaultNamespace, "my-replicaset", "velero.io/public/nginx:stable", "velero.io/web/tomcat:stable").Result(),
+		},
+		{
+			name: "when replicaset's image registry has no mapping in the config map, the item is returned as-is",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/change-image-registry", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("none-registry.com/public", "new-registry.com/new-project")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForReplicaSetWithImage(defaultNamespace, "my-replicaset", "velero.io/public/nginx:stable", "velero.io/web/tomcat:stable").Result(),
+			want:                 builder.ForReplicaSetWithImage(defaultNamespace, "my-replicaset", "velero.io/public/nginx:stable", "velero.io/web/tomcat:stable").Result(),
+		},
+		{
+			name: "a valid registry mapping for a replicaset is applied correctly when original registry is 'none'",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/change-image-registry", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("none", "new-registry.com/new-project")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForReplicaSetWithImage(defaultNamespace, "my-replicaset", "nginx:stable", "tomcat:stable").Result(),
+			want:                 builder.ForReplicaSetWithImage(defaultNamespace, "my-replicaset", "new-registry.com/new-project/nginx:stable", "new-registry.com/new-project/tomcat:stable").Result(),
+		},
+		{
+			name: "set 'none' original registry mapping for a replicaset, but replicaset's original registry not 'none', the item is returned as-is",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/change-image-registry", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("none", "new-registry.com/new-project")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForReplicaSetWithImage(defaultNamespace, "my-replicaset", "velero.io/public/nginx:stable", "velero.io/public/tomcat:stable").Result(),
+			want:                 builder.ForReplicaSetWithImage(defaultNamespace, "my-replicaset", "velero.io/public/nginx:stable", "velero.io/public/tomcat:stable").Result(),
+		},
+		{
+			name: "a valid registry mapping for a statefulset is applied correctly",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/change-image-registry", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("velero.io/public", "new-registry.com/new-project", "velero.io/web", "new-registry.com/web")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForStatefulSetWithImage(defaultNamespace, "my-sts", "velero.io/public/nginx:stable", "velero.io/web/tomcat:stable").Result(),
+			want:                 builder.ForStatefulSetWithImage(defaultNamespace, "my-sts", "new-registry.com/new-project/nginx:stable", "new-registry.com/web/tomcat:stable").Result(),
+		},
+		{
+			name: "when no config map exists for the plugin, the statefulset item is returned as-is",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/some-other-plugin", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("velero.io/public", "new-registry.com/new-project")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForStatefulSetWithImage(defaultNamespace, "my-sts", "velero.io/public/nginx:stable").Result(),
+			want:                 builder.ForStatefulSetWithImage(defaultNamespace, "my-sts", "velero.io/public/nginx:stable").Result(),
+		},
+		{
+			name: "when statefulset's image registry has no mapping in the config map, the item is returned as-is",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/change-image-registry", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("none-registry.com/public", "velero.io/new-project")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForStatefulSetWithImage(defaultNamespace, "my-sts", "velero.io/public/nginx:stable").Result(),
+			want:                 builder.ForStatefulSetWithImage(defaultNamespace, "my-sts", "velero.io/public/nginx:stable").Result(),
+		},
+		{
+			name: "a valid registry mapping for a statefulset is applied correctly when original registry is 'none'",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/change-image-registry", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("none", "new-registry.com/new-project")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForStatefulSetWithImage(defaultNamespace, "my-sts", "nginx:stable").Result(),
+			want:                 builder.ForStatefulSetWithImage(defaultNamespace, "my-sts", "new-registry.com/new-project/nginx:stable").Result(),
+		},
+		{
+			name: "set 'none' original registry mapping for a statefulset, but statefulset's original registry not 'none', the item is returned as-is",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/change-image-registry", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("none", "new-registry.com/new-project")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForStatefulSetWithImage(defaultNamespace, "my-sts", "velero.io/public/nginx:stable").Result(),
+			want:                 builder.ForStatefulSetWithImage(defaultNamespace, "my-sts", "velero.io/public/nginx:stable").Result(),
+		},
+		{
+			name: "a valid registry mapping for a daemonset is applied correctly",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/change-image-registry", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("velero.io/public", "new-registry.com/new-project")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForDaemonsetWithImage(defaultNamespace, "my-ds", "velero.io/public/nginx:stable").Result(),
+			want:                 builder.ForDaemonsetWithImage(defaultNamespace, "my-ds", "new-registry.com/new-project/nginx:stable").Result(),
+		},
+		{
+			name: "when no config map exists for the plugin, the daemonset item is returned as-is",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/some-other-plugin", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("velero.io/public", "new-registry.com/new-project")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForDaemonsetWithImage(defaultNamespace, "my-ds", "velero.io/public/nginx:stable").Result(),
+			want:                 builder.ForDaemonsetWithImage(defaultNamespace, "my-ds", "velero.io/public/nginx:stable").Result(),
+		},
+		{
+			name: "when daemonset's image registry has no mapping in the config map, the item is returned as-is",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/change-image-registry", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("none-registry.com/public", "velero.io/new-project")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForDaemonsetWithImage(defaultNamespace, "my-ds", "velero.io/public/nginx:stable").Result(),
+			want:                 builder.ForDaemonsetWithImage(defaultNamespace, "my-ds", "velero.io/public/nginx:stable").Result(),
+		},
+		{
+			name: "a valid registry mapping for a daemonset is applied correctly when original registry is 'none'",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/change-image-registry", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("none", "new-registry.com/new-project")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForDaemonsetWithImage(defaultNamespace, "my-ds", "nginx:stable").Result(),
+			want:                 builder.ForDaemonsetWithImage(defaultNamespace, "my-ds", "new-registry.com/new-project/nginx:stable").Result(),
+		},
+		{
+			name: "set 'none' original registry mapping for a daemonset, but daemonset's original registry not 'none', the item is returned as-is",
+			configMap: builder.ForConfigMap("velero", "change-image-registry").
+				ObjectMeta(builder.WithLabels("velero.io/plugin-config", "true", "velero.io/change-image-registry", "RestoreItemAction")).
+				ObjectMeta(builder.WithAnnotations("none", "new-registry.com/new-project")).
+				Result(),
+			podOrDeployOrStsOrDs: builder.ForDaemonsetWithImage(defaultNamespace, "my-ds", "velero.io/public/nginx:stable").Result(),
+			want:                 builder.ForDaemonsetWithImage(defaultNamespace, "my-ds", "velero.io/public/nginx:stable").Result(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset()
+			a := NewChangeImageRegistryAction(
+				logrus.StandardLogger(),
+				clientset.CoreV1().ConfigMaps("velero"),
+			)
+
+			// set up test data
+			if tc.configMap != nil {
+				_, err := clientset.CoreV1().ConfigMaps(tc.configMap.Namespace).Create(context.TODO(), tc.configMap, metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
+
+			unstructuredMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(tc.podOrDeployOrStsOrDs)
+			require.NoError(t, err)
+
+			input := &velero.RestoreItemActionExecuteInput{
+				Item: &unstructured.Unstructured{
+					Object: unstructuredMap,
+				},
+			}
+
+			// execute method under test
+			res, err := a.Execute(input)
+
+			// validate for both error and non-error cases
+			switch {
+			case tc.wantErr != nil:
+				assert.EqualError(t, err, tc.wantErr.Error())
+			default:
+				assert.NoError(t, err)
+
+				wantUnstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(tc.want)
+				require.NoError(t, err)
+
+				assert.Equal(t, &unstructured.Unstructured{Object: wantUnstructured}, res.UpdatedItem)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Box-Cube <64300761+Box-Cube@users.noreply.github.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Add a built-in plugin to implement Change Image Registry. when restoring, ChangeImageRegistryAction updates a pod/deploy/statefulset/daemonset/replicaset image registry if a mapping is found in the plugin's config map.

The valid registry mapping is configured in `annotations` of a configMap.
For example:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: change-image-registry
  namespace: velero
  annotations:
    velero.io/public: new-registry.com/new-project
    none: new-registry.com/web
  labels:
    velero.io/plugin-config: ""
    velero.io/change-image-registry: RestoreItemAction
```

# Does your change fix a particular issue?
implement #4494

# Please indicate you've done the following:

- [ ] Add a built-in plugin to implement Change Image Registry
- [ ] Add unit test for ChangeImageRegistryAction
