### PR TITLE
Check the existence of the expected service when ignoring the NodePort already allocated error

### DIFF
--- a/pkg/builder/service_builder.go
+++ b/pkg/builder/service_builder.go
@@ -1,0 +1,57 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	corev1api "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ServiceBuilder builds Service objects.
+type ServiceBuilder struct {
+	object *corev1api.Service
+}
+
+// ForService is the constructor for a ServiceBuilder.
+func ForService(ns, name string) *ServiceBuilder {
+	return &ServiceBuilder{
+		object: &corev1api.Service{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: corev1api.SchemeGroupVersion.String(),
+				Kind:       "Service",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      name,
+			},
+		},
+	}
+}
+
+// Result returns the built Service.
+func (s *ServiceBuilder) Result() *corev1api.Service {
+	return s.object
+}
+
+// ObjectMeta applies functional options to the Service's ObjectMeta.
+func (s *ServiceBuilder) ObjectMeta(opts ...ObjectMetaOpt) *ServiceBuilder {
+	for _, opt := range opts {
+		opt(s.object)
+	}
+
+	return s
+}

--- a/pkg/test/resources.go
+++ b/pkg/test/resources.go
@@ -162,3 +162,14 @@ func VSLs(items ...metav1.Object) *APIResource {
 		Items:      items,
 	}
 }
+
+func Services(items ...metav1.Object) *APIResource {
+	return &APIResource{
+		Group:      "",
+		Version:    "v1",
+		Name:       "services",
+		ShortName:  "svc",
+		Namespaced: true,
+		Items:      items,
+	}
+}


### PR DESCRIPTION
Check the existence of the expected service when ignoring the NodePort already allocated error

Fixes 2308

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
