### PR TITLE
Fix bug to make the restic prune frequency configurable

### DIFF
--- a/changelogs/unreleased/4518-ywk253100
+++ b/changelogs/unreleased/4518-ywk253100
@@ -1,0 +1,1 @@
+Fix bug to make the restic prune frequency configurable

--- a/pkg/restic/repository_ensurer.go
+++ b/pkg/restic/repository_ensurer.go
@@ -160,7 +160,6 @@ func (r *repositoryEnsurer) EnsureRepo(ctx context.Context, namespace, volumeNam
 		Spec: velerov1api.ResticRepositorySpec{
 			VolumeNamespace:       volumeNamespace,
 			BackupStorageLocation: backupLocation,
-			MaintenanceFrequency:  metav1.Duration{Duration: DefaultMaintenanceFrequency},
 		},
 	}
 


### PR DESCRIPTION
We introduces the installation option "--default-restic-prune-frequency" to make restic prune frequency configuration in the previous release, but there is a bug that make the option don't take effect. This commit fixes the bug by removing the evaluation part. The restic repository controller will take care the prune frequency for the repository

Fixes #3062

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
