### PR TITLE
E2E test on ssr object with controller namespace mix-ups

### DIFF
--- a/changelogs/unreleased/4521-mqiu
+++ b/changelogs/unreleased/4521-mqiu
@@ -1,0 +1,1 @@
+E2E test on ssr object with controller namespace mix-ups

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -29,6 +29,7 @@ import (
 	. "github.com/vmware-tanzu/velero/test/e2e/backups"
 	. "github.com/vmware-tanzu/velero/test/e2e/basic"
 	. "github.com/vmware-tanzu/velero/test/e2e/basic/resources-check"
+	. "github.com/vmware-tanzu/velero/test/e2e/privilegesmgmt"
 	. "github.com/vmware-tanzu/velero/test/e2e/resource-filtering"
 	. "github.com/vmware-tanzu/velero/test/e2e/scale"
 	. "github.com/vmware-tanzu/velero/test/e2e/upgrade"
@@ -89,6 +90,7 @@ var _ = Describe("[ResourceFiltering][IncludeResources][Backup] Velero test on i
 var _ = Describe("[ResourceFiltering][IncludeResources][Restore] Velero test on include resources from the cluster restore", RestoreWithIncludeResources)
 var _ = Describe("[ResourceFiltering][LabelSelector] Velero test on backup include resources matching the label selector", BackupWithLabelSelector)
 var _ = Describe("[Backups][Deletion] Velero tests on cluster using the plugin provider for object storage and Restic for volume backups", Backup_deletion_with_restic)
+var _ = Describe("[PrivilegesMgmt][SSR] Velero test on ssr object when controller namespace mix-ups", SSRTest)
 
 func TestE2e(t *testing.T) {
 	// Skip running E2E tests when running only "short" tests because:

--- a/test/e2e/privilegesmgmt/ssr.go
+++ b/test/e2e/privilegesmgmt/ssr.go
@@ -1,0 +1,114 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package privilegesmgmt
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	waitutil "k8s.io/apimachinery/pkg/util/wait"
+	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	. "github.com/vmware-tanzu/velero/test/e2e"
+	. "github.com/vmware-tanzu/velero/test/e2e/util/k8s"
+	. "github.com/vmware-tanzu/velero/test/e2e/util/velero"
+)
+
+func SSRTest() {
+	testNS := "ssr-test"
+	client, err := NewTestClient()
+	if err != nil {
+		println(err.Error())
+	}
+	Expect(err).To(Succeed(), "Failed to instantiate cluster client for backup tests")
+
+	BeforeEach(func() {
+		flag.Parse()
+		if VeleroCfg.InstallVelero {
+			Expect(VeleroInstall(context.Background(), &VeleroCfg, "", false)).To(Succeed())
+		}
+	})
+
+	AfterEach(func() {
+		if VeleroCfg.InstallVelero {
+			Expect(VeleroUninstall(context.Background(), VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace)).To(Succeed())
+		}
+	})
+
+	It(fmt.Sprintf("Should create an ssr object in the %s namespace and later removed by controller", VeleroCfg.VeleroNamespace), func() {
+		defer DeleteNamespace(context.TODO(), client, testNS, false)
+		ctx, _ := context.WithTimeout(context.Background(), time.Duration(time.Minute*10))
+		By(fmt.Sprintf("Create %s namespace", testNS))
+		Expect(CreateNamespace(ctx, client, testNS)).To(Succeed(),
+			fmt.Sprintf("Failed to create %s namespace", testNS))
+
+		By(fmt.Sprintf("Get version in %s namespace", testNS))
+		cmd := []string{"version", "-n", testNS}
+		Expect(VeleroCmdExec(context.Background(), VeleroCfg.VeleroCLI, cmd)).To(Succeed(),
+			fmt.Sprintf("Failed to create an ssr object in the %s namespace", testNS))
+
+		By(fmt.Sprintf("Get version in %s namespace", VeleroCfg.VeleroNamespace))
+		cmd = []string{"version", "-n", VeleroCfg.VeleroNamespace}
+		Expect(VeleroCmdExec(context.Background(), VeleroCfg.VeleroCLI, cmd)).To(Succeed(),
+			fmt.Sprintf("Failed to create an ssr object in %s namespace", VeleroCfg.VeleroNamespace))
+
+		ssrListResp := new(v1.ServerStatusRequestList)
+
+		By(fmt.Sprintf("Check ssr object in %s namespace", VeleroCfg.VeleroNamespace))
+		Expect(client.Kubebuilder.List(ctx, ssrListResp, &kbclient.ListOptions{Namespace: VeleroCfg.VeleroNamespace})).To(Succeed(),
+			fmt.Sprintf("Failed to list ssr object in %s namespace", VeleroCfg.VeleroNamespace))
+		Expect(len(ssrListResp.Items)).To(BeNumerically("==", 1),
+			fmt.Sprintf("Count of ssr object in %s namespace is not 1", VeleroCfg.VeleroNamespace))
+		Expect(ssrListResp.Items[0].Status.ServerVersion).NotTo(BeEmpty(),
+			fmt.Sprintf("ServerVersion of ssr object in %s namespace should not empty", VeleroCfg.VeleroNamespace))
+		Expect(ssrListResp.Items[0].Status.Phase == "Processed").To(BeTrue(),
+			fmt.Sprintf("Phase of ssr object in %s namespace should be Processed", VeleroCfg.VeleroNamespace))
+
+		By(fmt.Sprintf("Check ssr object in %s namespace", testNS))
+		Expect(client.Kubebuilder.List(ctx, ssrListResp, &kbclient.ListOptions{Namespace: testNS})).To(Succeed(),
+			fmt.Sprintf("Failed to list ssr object in %s namespace", testNS))
+		Expect(len(ssrListResp.Items)).To(BeNumerically("==", 1),
+			fmt.Sprintf("Count of ssr object in %s namespace is not 1", testNS))
+		Expect(ssrListResp.Items[0].Status.Phase).To(BeEmpty(),
+			fmt.Sprintf("Status of ssr object in %s namespace should be empty", testNS))
+		Expect(ssrListResp.Items[0].Status.ServerVersion).To(BeEmpty(),
+			fmt.Sprintf("ServerVersion of ssr object in %s namespace should be empty", testNS))
+
+		By(fmt.Sprintf("Waiting ssr object in %s namespace deleted", VeleroCfg.VeleroNamespace))
+		err = waitutil.PollImmediateInfinite(5*time.Second,
+			func() (bool, error) {
+				if err = client.Kubebuilder.List(ctx, ssrListResp, &kbclient.ListOptions{Namespace: VeleroCfg.VeleroNamespace}); err != nil {
+					if apierrors.IsNotFound(err) {
+						return true, nil
+					}
+					return false, err
+				}
+				if len(ssrListResp.Items) != 0 {
+					return false, nil
+				}
+				return true, nil
+			})
+
+		Expect(err).To(Succeed(), fmt.Sprintf("ssr object in %s namespace is not been deleted by controller", VeleroCfg.VeleroNamespace))
+	})
+}

--- a/test/e2e/util/k8s/client.go
+++ b/test/e2e/util/k8s/client.go
@@ -29,7 +29,7 @@ import (
 // the e2e tests.
 
 type TestClient struct {
-	kubebuilder kbclient.Client
+	Kubebuilder kbclient.Client
 
 	// clientGo returns a client-go API client.
 	//
@@ -87,7 +87,7 @@ func InitTestClient() (TestClient, error) {
 	factory := client.NewDynamicFactory(dynamicClient)
 
 	return TestClient{
-		kubebuilder:    kb,
+		Kubebuilder:    kb,
 		ClientGo:       clientGo,
 		dynamicFactory: factory,
 	}, nil


### PR DESCRIPTION
Signed-off-by: Ming <mqiu@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change
It reference to #4522, it's test on ssr object.
# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
