### PR TITLE
chore(build-image): change the way of installing goreleaser

### DIFF
--- a/hack/build-image/Dockerfile
+++ b/hack/build-image/Dockerfile
@@ -51,11 +51,25 @@ RUN wget --quiet https://github.com/protocolbuffers/protobuf/releases/download/v
     chmod +x /usr/bin/protoc
 RUN go get github.com/golang/protobuf/protoc-gen-go@v1.0.0
 
-# get goreleaser
-RUN wget --quiet https://github.com/goreleaser/goreleaser/releases/download/v0.120.8/goreleaser_Linux_x86_64.tar.gz && \
-    tar xvf goreleaser_Linux_x86_64.tar.gz && \
-    mv goreleaser /usr/bin/goreleaser && \
-    chmod +x /usr/bin/goreleaser
+# install cosign
+COPY --from=gcr.io/projectsigstore/cosign:v1.4.1@sha256:502d5130431e45f28c51d2c24a05ef5ccd3fd916bcc91db0c8bee3a81e09a0bb /ko-app/cosign /usr/local/bin/cosign
+
+# install goreleaser
+ARG GORELEASER_VERSION=1.5.0
+ARG GORELEASER_SHA=a7bd4f76a495ed91f087dbf86fdbfa5f1bb594e86c1ec953e6b2dd46f596563b
+RUN  \
+	wget https://github.com/goreleaser/goreleaser/releases/download/v$GORELEASER_VERSION/checksums.txt.pem && \
+	GORELEASER_DOWNLOAD_FILE=goreleaser_Linux_x86_64.tar.gz && \
+	GORELEASER_DOWNLOAD_URL=https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VERSION}/${GORELEASER_DOWNLOAD_FILE} && \
+	cosign verify-blob --cert checksums.txt.pem \
+	--signature https://github.com/goreleaser/goreleaser/releases/download/v$GORELEASER_VERSION/checksums.txt.sig \
+	https://github.com/goreleaser/goreleaser/releases/download/v$GORELEASER_VERSION/checksums.txt && \
+	wget ${GORELEASER_DOWNLOAD_URL} && \
+	echo "$GORELEASER_SHA $GORELEASER_DOWNLOAD_FILE" | sha256sum -c - || exit 1 && \
+	tar -xzf $GORELEASER_DOWNLOAD_FILE -C /usr/bin/ goreleaser && \
+	rm $GORELEASER_DOWNLOAD_FILE && \
+	rm checksums.txt.pem && \
+	goreleaser -v
 
 # get golangci-lint
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0


### PR DESCRIPTION
- [x] upgrade GoReleaser to 1.5.0
- [x] verify GoReleaser signature whether it has been tampered with

Thank you for contributing to Velero!

# Please add a summary of your change

I noticed that the velero project uses an older version of GoReleaser, so, I've updated that.

# Does your change fix a particular issue?

Nope

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
