### PR TITLE
Use OrderedResources in schedules

### DIFF
--- a/pkg/cmd/cli/backup/create.go
+++ b/pkg/cmd/cli/backup/create.go
@@ -295,7 +295,7 @@ func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
 // Resource names in the list are in format 'namespace/resourcename' and separated by commas.
 // Key-value pairs in the mapping are separated by semi-colon.
 // Ex: 'pods=ns1/pod1,ns1/pod2;persistentvolumeclaims=ns1/pvc4,ns1/pvc8'.
-func parseOrderedResources(orderMapStr string) (map[string]string, error) {
+func ParseOrderedResources(orderMapStr string) (map[string]string, error) {
 	entries := strings.Split(orderMapStr, ";")
 	if len(entries) == 0 {
 		return nil, fmt.Errorf("Invalid OrderedResources '%s'.", orderMapStr)
@@ -337,7 +337,7 @@ func (o *CreateOptions) BuildBackup(namespace string) (*velerov1api.Backup, erro
 			StorageLocation(o.StorageLocation).
 			VolumeSnapshotLocations(o.SnapshotLocations...)
 		if len(o.OrderedResources) > 0 {
-			orders, err := parseOrderedResources(o.OrderedResources)
+			orders, err := ParseOrderedResources(o.OrderedResources)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/cmd/cli/backup/create_test.go
+++ b/pkg/cmd/cli/backup/create_test.go
@@ -34,7 +34,7 @@ func TestCreateOptions_BuildBackup(t *testing.T) {
 	o := NewCreateOptions()
 	o.Labels.Set("velero.io/test=true")
 	o.OrderedResources = "pods=p1,p2;persistentvolumeclaims=pvc1,pvc2"
-	orders, err := parseOrderedResources(o.OrderedResources)
+	orders, err := ParseOrderedResources(o.OrderedResources)
 	assert.NoError(t, err)
 
 	backup, err := o.BuildBackup(testNamespace)
@@ -100,10 +100,10 @@ func TestCreateOptions_BuildBackupFromSchedule(t *testing.T) {
 }
 
 func TestCreateOptions_OrderedResources(t *testing.T) {
-	orderedResources, err := parseOrderedResources("pods= ns1/p1; ns1/p2; persistentvolumeclaims=ns2/pvc1, ns2/pvc2")
+	orderedResources, err := ParseOrderedResources("pods= ns1/p1; ns1/p2; persistentvolumeclaims=ns2/pvc1, ns2/pvc2")
 	assert.NotNil(t, err)
 
-	orderedResources, err = parseOrderedResources("pods= ns1/p1,ns1/p2 ; persistentvolumeclaims=ns2/pvc1,ns2/pvc2")
+	orderedResources, err = ParseOrderedResources("pods= ns1/p1,ns1/p2 ; persistentvolumeclaims=ns2/pvc1,ns2/pvc2")
 	assert.NoError(t, err)
 
 	expectedResources := map[string]string{
@@ -112,7 +112,7 @@ func TestCreateOptions_OrderedResources(t *testing.T) {
 	}
 	assert.Equal(t, orderedResources, expectedResources)
 
-	orderedResources, err = parseOrderedResources("pods= ns1/p1,ns1/p2 ; persistentvolumes=pv1,pv2")
+	orderedResources, err = ParseOrderedResources("pods= ns1/p1,ns1/p2 ; persistentvolumes=pv1,pv2")
 	assert.NoError(t, err)
 
 	expectedMixedResources := map[string]string{

--- a/pkg/cmd/cli/schedule/create.go
+++ b/pkg/cmd/cli/schedule/create.go
@@ -111,9 +111,18 @@ func (o *CreateOptions) Complete(args []string, f client.Factory) error {
 }
 
 func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
+	var orders map[string]string
+
 	veleroClient, err := f.Client()
 	if err != nil {
 		return err
+	}
+
+	if len(o.BackupOptions.OrderedResources) > 0 {
+		orders, err = backup.ParseOrderedResources(o.BackupOptions.OrderedResources)
+		if err != nil {
+			return err
+		}
 	}
 
 	schedule := &api.Schedule{
@@ -135,6 +144,7 @@ func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
 				StorageLocation:         o.BackupOptions.StorageLocation,
 				VolumeSnapshotLocations: o.BackupOptions.SnapshotLocations,
 				DefaultVolumesToRestic:  o.BackupOptions.DefaultVolumesToRestic.Value,
+				OrderedResources:        orders,
 			},
 			Schedule:                   o.Schedule,
 			UseOwnerReferencesInBackup: &o.UseOwnerReferencesInBackup,


### PR DESCRIPTION
OrderedResources at schedules have no effect.
The CRD is correct and if you edit a schedule manifest manually the backup is created correctly.
Issue here is Velero CLI. In the schedule part the orderedresources is missing, as the parameters will be used from backup part, there is no error while creating a schedule. (Parameter is known but never used)

The ParseOrderedResources function from backup is set public now, so that schedule can use it.
I have not found a central place to put this function, so it stays in backup.

Fixes #3116 

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.

No updates for documentation needed.
