### PR TITLE
Remove reference of restic_restore_action.go from the doc

### DIFF
--- a/site/content/docs/main/custom-plugins.md
+++ b/site/content/docs/main/custom-plugins.md
@@ -103,8 +103,7 @@ data:
   # add your configuration data here as key-value pairs
 ```
 
-Then, in your plugin's implementation, you can read this ConfigMap to fetch the necessary configuration. See the [restic restore action][3]
-for an example of this -- in particular, the `getPluginConfig(...)` function.
+Then, in your plugin's implementation, you can read this ConfigMap to fetch the necessary configuration. 
 
 ## Feature Flags
 
@@ -118,4 +117,3 @@ Velero adds the `LD_LIBRARY_PATH` into the list of environment variables to prov
 
 [1]: https://github.com/vmware-tanzu/velero-plugin-example
 [2]: https://github.com/vmware-tanzu/velero/blob/main/pkg/plugin/logger.go
-[3]: https://github.com/vmware-tanzu/velero/blob/main/pkg/restore/restic_restore_action.go


### PR DESCRIPTION
fixes #4554

Signed-off-by: Daniel Jiang <jiangd@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
