### PR TITLE
Nominate Xun Jiang and Ming Qiu to become maintainers

### DIFF
--- a/.github/auto-assignees.yml
+++ b/.github/auto-assignees.yml
@@ -15,6 +15,8 @@ reviewers:
       - sseago
       - reasonerjt
       - ywk253100
+      - blackpiglet
+      - qiuming-best
 
     tech-writer:
       - a-mccarthy

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,6 +12,8 @@
 | Scott Seago | [sseago](https://github.com/sseago) | [OpenShift](https://github.com/openshift)
 | Daniel Jiang | [reasonerjt](https://github.com/reasonerjt) | [VMware](https://www.github.com/vmware/)
 | Wenkai Yin | [ywk253100](https://github.com/ywk253100) | [VMware](https://www.github.com/vmware/) |
+| Xun Jiang | [blackpiglet](https://github.com/blackpiglet) | [VMware](https://www.github.com/vmware/) |
+| Ming Qiu | [qiuming-best](https://github.com/qiuming-best) | [VMware](https://www.github.com/vmware/) |
 
 ## Emeritus Maintainers
 * Adnan Abdulhussein ([prydonius](https://github.com/prydonius))


### PR DESCRIPTION
Xun joined Velero team within VMware since October 2021 within VMware.
He has been contributing to the refactor work to use kubebuilder,
general bug fix.  He will continue the work and cover more areas.

Ming joined Velero team within VMware since October 2021 within VMware.
He has been contributing to E2E test cases and framework.  He will
continue the work and cover more areas such as Restic support, etc.

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
