### PR TITLE
use relative path in links

### DIFF
--- a/site/config.yaml
+++ b/site/config.yaml
@@ -1,4 +1,4 @@
-#baseURL: "https://velero.io/"
+#baseURL: "/"
 disablePathToLower: true
 languageCode: en-us
 DefaultContentLanguage: "en"

--- a/site/content/community/_index.md
+++ b/site/content/community/_index.md
@@ -7,7 +7,7 @@ id: community
 
 If you’re a newcomer, check out the “[Good first issue](https://github.com/vmware-tanzu/velero/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+first+issue%22)” and “[Help wanted](https://github.com/vmware-tanzu/velero/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22Help+wanted%22+)” labels in the Velero repository.
 
-If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](https://velero.io/docs/main/start-contributing/) documentation for guidance on how to setup Velero for development.
+If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](/docs/main/start-contributing/) documentation for guidance on how to setup Velero for development.
 
 You can follow the work we do, see our milestones, and our backlog on our [GitHub project boards](https://github.com/vmware-tanzu/velero/projects).
 

--- a/site/content/docs/main/_index.md
+++ b/site/content/docs/main/_index.md
@@ -33,7 +33,7 @@ If you encounter issues, review the [troubleshooting docs][30], [file an issue][
 
 ## Contributing
 
-If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](https://velero.io/docs/main/start-contributing/) documentation for guidance on how to setup Velero for development.
+If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](/docs/main/start-contributing/) documentation for guidance on how to setup Velero for development.
 
 ## Changelog
 

--- a/site/content/docs/main/contributions/oracle-config.md
+++ b/site/content/docs/main/contributions/oracle-config.md
@@ -5,7 +5,7 @@ layout: docs
 
 ## Introduction
 
-[Velero](https://velero.io/) is a tool used to backup and migrate Kubernetes applications. Here are the steps to use [Oracle Cloud Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a destination for Velero backups.
+[Velero](/) is a tool used to backup and migrate Kubernetes applications. Here are the steps to use [Oracle Cloud Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a destination for Velero backups.
 
 1. [Download Velero](#download-velero)
 2. [Create A Customer Secret Key](#create-a-customer-secret-key)
@@ -244,5 +244,5 @@ After creating the Velero server in your cluster, try this example:
 
 ## Additional Reading
 
-* [Official Velero Documentation](https://velero.io/docs/main/)
+* [Official Velero Documentation](/docs/main/)
 * [Oracle Cloud Infrastructure Documentation](https://docs.cloud.oracle.com/)

--- a/site/content/docs/main/contributions/tencent-config.md
+++ b/site/content/docs/main/contributions/tencent-config.md
@@ -37,7 +37,7 @@ aws_secret_access_key=<SecretKey>
 
 ## Install Velero Resources
 
-You need to install the Velero CLI first, see [Install the CLI](https://velero.io/docs/v1.5/basic-install/#install-the-cli)  for how to install.
+You need to install the Velero CLI first, see [Install the CLI](/docs/v1.5/basic-install/#install-the-cli)  for how to install.
 
 Follow the Velero installation command below to create velero and restic workloads and other necessary resource objects.
 
@@ -60,7 +60,7 @@ Description of the parameters:
 
 - `--secret-file`: Access tencent cloud COS access credential file for the "credentials-velero" credential file created above.
 
-- `--use-restic`: Back up and restore persistent volume data using the open source free backup tool [restic](https://github.com/restic/restic).  However, 'hostPath' volumes are not supported, see the [restic limit](https://velero.io/docs/v1.5/restic/#limitations) for details), an integration 		that complements Velero's backup capabilities and is recommended to be turned on.
+- `--use-restic`: Back up and restore persistent volume data using the open source free backup tool [restic](https://github.com/restic/restic).  However, 'hostPath' volumes are not supported, see the [restic limit](/docs/v1.5/restic/#limitations) for details), an integration 		that complements Velero's backup capabilities and is recommended to be turned on.
 
 - `--default-volumes-to-restic`: Enable the use of Restic to back up all Pod volumes, provided that the `--use-restic`parameter needs to be turned on.
 
@@ -84,7 +84,7 @@ Executing the 'velero backup-location get' command to view the storage location 
 
 {{< figure src="/docs/main/contributions/img-for-tencent/69194157ccd5e377d1e7d914fd8c0336.png" width="100%">}}
 
-At this point, The installation using Tencent Cloud COS as Velero storage location is complete, If you need more installation information about Velero, You can see the official website [Velero documentation](https://velero.io/docs/) .
+At this point, The installation using Tencent Cloud COS as Velero storage location is complete, If you need more installation information about Velero, You can see the official website [Velero documentation](/docs/) .
 
 ## Velero backup and restore example
 
@@ -164,5 +164,5 @@ kubectl delete crds -l component=velero
 
 ## Additional Reading
 
-- [Official Velero Documentation](https://velero.io/docs/)
+- [Official Velero Documentation](/docs/)
 - [Tencent Cloud Documentation](https://cloud.tencent.com/document/product)

--- a/site/content/docs/main/maintainers.md
+++ b/site/content/docs/main/maintainers.md
@@ -17,8 +17,8 @@ Please be sure to also go through the guidance under the entire [Contribute](sta
 - Be familiar with the [lazy consensus](https://github.com/vmware-tanzu/velero/blob/main/GOVERNANCE.md#lazy-consensus) policy for the project.
 
 Some tips for doing reviews:
-- There are some [code standards and general guidelines](https://velero.io/docs/main/code-standards) we aim for
-- We have [guidelines for writing and reviewing documentation](https://velero.io/docs/main/style-guide/)
+- There are some [code standards and general guidelines](/docs/main/code-standards) we aim for
+- We have [guidelines for writing and reviewing documentation](/docs/main/style-guide/)
 - When reviewing a design document, ensure it follows [our format and guidelines]( https://github.com/vmware-tanzu/velero/blob/main/design/_template.md). Also, when reviewing a PR that implements a previously accepted design, ensure the associated design doc is moved to the [design/implemented](https://github.com/vmware-tanzu/velero/tree/main/design/implemented) folder.
 
 

--- a/site/content/docs/main/release-instructions.md
+++ b/site/content/docs/main/release-instructions.md
@@ -74,7 +74,7 @@ For each major or minor release, create and publish a blog post to let folks kno
     - Delete the pre-release docs table of contents file, i.e. `site/data/docs/<pre-release-version>-toc.yml`.
     - Remove the pre-release docs table of contents mapping entry from `site/data/toc-mapping.yml`.
     - Remove all references to the pre-release docs from `site/config.yml`.
-1. Create the "Upgrade to $major.minor" page if it does not already exist ([example](https://velero.io/docs/v1.5/upgrade-to-1.5/)).
+1. Create the "Upgrade to $major.minor" page if it does not already exist ([example](/docs/v1.5/upgrade-to-1.5/)).
    If it already exists, update any usage of the previous version string within this file to use the new version string instead ([example](https://github.com/vmware-tanzu/velero/pull/2941/files#diff-d594f8fd0901fed79c39aab4b348193d)).
    This needs to be done in both the versioned and the `main` folders.
 1. Review and submit PR
@@ -162,6 +162,6 @@ What to include:
 * A brief list of highlights in the release
 * Link to the release blog post, release notes, and/or github release page
 
-[1]: https://velero.io/blog
+[1]: /blog
 [2]: website-guidelines.md
 [3]: https://github.com/vmware-tanzu/velero/tree/main/test/e2e

--- a/site/content/docs/main/start-contributing.md
+++ b/site/content/docs/main/start-contributing.md
@@ -20,9 +20,9 @@ You may join the Velero community and contribute in many different ways, includi
 
 You can also vote on issues using :+1: and :-1:, as explained in our [Feature enhancement request][3] and [Bug issue][4] templates. This will help us quantify importance and prioritize issues.
 
-For information on how to connect with our maintainers and community, join our online meetings, or find good first issues, start on our [Velero community](https://velero.io/community/) page.
+For information on how to connect with our maintainers and community, join our online meetings, or find good first issues, start on our [Velero community](/community/) page.
 
-Please browse our list of resources, including a playlist of past online community meetings, blog posts, and other resources to help you get familiar with our project: [Velero resources](https://velero.io/resources/).
+Please browse our list of resources, including a playlist of past online community meetings, blog posts, and other resources to help you get familiar with our project: [Velero resources](/resources/).
 
 ## Contributing
 

--- a/site/content/docs/main/tilt.md
+++ b/site/content/docs/main/tilt.md
@@ -24,7 +24,7 @@ files in this directory are gitignored so you may configure your setup according
 1. Clone the [Velero project](https://github.com/vmware-tanzu/velero) repository
    locally
 1. Access to an S3 object storage
-1. Clone any [provider plugin(s)](https://velero.io/plugins/) you want to make changes to and deploy (optional, must be configured to be deployed by the Velero Tilt's setup, [more info below](#provider-plugins))
+1. Clone any [provider plugin(s)](/plugins/) you want to make changes to and deploy (optional, must be configured to be deployed by the Velero Tilt's setup, [more info below](#provider-plugins))
 
 Note: To properly configure any plugin you use, please follow the plugin's documentation.
 
@@ -107,7 +107,7 @@ storage location. A sample file is provided that needs to be modified with the s
 configuration for your object storage. See the next sub-section for more details on this.
 
 ### Configure a backup storage location
-You will have to configure the `velero/tilt-resources/velero_v1_backupstoragelocation.yaml` with the proper values according to your storage provider. Read the [plugin documentation](https://velero.io/plugins/)
+You will have to configure the `velero/tilt-resources/velero_v1_backupstoragelocation.yaml` with the proper values according to your storage provider. Read the [plugin documentation](/plugins/)
 to learn what field/value pairs are required for your particular provider's backup storage location configuration.
 
 Below are some ways to configure a backup storage location for Velero.
@@ -146,7 +146,7 @@ necessary to expose MinIO outside the cluster.
 Please see our [locations documentation](locations/) to learn more how backup locations work.
 
 ### Configure the provider credentials (secret)
-Whatever object storage provider you use, configure the credentials for in the `velero/tilt-resources/cloud` file. Read the [plugin documentation](https://velero.io/plugins/)
+Whatever object storage provider you use, configure the credentials for in the `velero/tilt-resources/cloud` file. Read the [plugin documentation](/plugins/)
 to learn what field/value pairs are required for your provider's credentials. The Tilt file will invoke Kustomize to create the secret under the hard-coded key `secret.cloud-credentials.data.cloud` in the Velero namespace.
 
 There is a sample credentials file properly formatted for a MinIO storage credentials in `velero/tilt-resources/examples/cloud`.

--- a/site/content/docs/main/upgrade-to-1.8.md
+++ b/site/content/docs/main/upgrade-to-1.8.md
@@ -82,11 +82,11 @@ We have deprecated the way to indicate the default backup storage location. Prev
 After upgrading, if there is a previously created backup storage location with the name that matches what was defined on the server side as the default, it will be automatically set as the `default`.
 
 [0]: basic-install.md#install-the-cli
-[1]: https://velero.io/docs/v1.1.0/upgrade-to-1.1/
-[2]: https://velero.io/docs/v1.2.0/upgrade-to-1.2/
-[3]: https://velero.io/docs/v1.3.2/upgrade-to-1.3/
-[4]: https://velero.io/docs/v1.4/upgrade-to-1.4/
-[5]: https://velero.io/docs/v1.5/upgrade-to-1.5
-[6]: https://velero.io/docs/v1.6/upgrade-to-1.6
-[7]: https://velero.io/docs/v1.7/upgrade-to-1.7
-[9]: https://velero.io/docs/v1.8/locations
+[1]: /docs/v1.1.0/upgrade-to-1.1/
+[2]: /docs/v1.2.0/upgrade-to-1.2/
+[3]: /docs/v1.3.2/upgrade-to-1.3/
+[4]: /docs/v1.4/upgrade-to-1.4/
+[5]: /docs/v1.5/upgrade-to-1.5
+[6]: /docs/v1.6/upgrade-to-1.6
+[7]: /docs/v1.7/upgrade-to-1.7
+[9]: /docs/v1.8/locations

--- a/site/content/docs/main/website-guidelines.md
+++ b/site/content/docs/main/website-guidelines.md
@@ -40,6 +40,6 @@ image: /img/posts/example-image.jpg
 tags: ['Velero Team', 'Nolan Brubaker']
 ```
 
-Include the `author_name` value in tags field so the page that lists the author's posts will work properly, for example https://velero.io/tags/carlisia-thompson/.
+Include the `author_name` value in tags field so the page that lists the author's posts will work properly, for example /tags/carlisia-thompson/.
 
 Ideally each blog will have a unique image to use on the blog home page, but if you do not include an image, the default Velero logo will be used instead. Use an image that is less than 70KB and add it to the `/site/static/img/posts` folder.

--- a/site/content/docs/v0.10.0/_index.md
+++ b/site/content/docs/v0.10.0/_index.md
@@ -75,7 +75,7 @@ See [the list of releases][6] to find out about feature changes.
 [26]: https://github.com/heptio/ark/blob/main/docs/zenhub.md
 
 
-[29]: https://velero.io/docs/v0.10.0/
+[29]: /docs/v0.10.0/
 [30]: /troubleshooting.md
 
 [99]: /support-matrix.md

--- a/site/content/docs/v0.11.0/_index.md
+++ b/site/content/docs/v0.11.0/_index.md
@@ -77,7 +77,7 @@ See [the list of releases][6] to find out about feature changes.
 [26]: https://github.com/heptio/velero/blob/main/docs/zenhub.md
 
 
-[29]: https://velero.io/docs/v0.11.0/install-overview
+[29]: /docs/v0.11.0/install-overview
 [30]: /troubleshooting.md
 
 [99]: /support-matrix.md

--- a/site/content/docs/v0.11.0/migrating-to-velero.md
+++ b/site/content/docs/v0.11.0/migrating-to-velero.md
@@ -82,4 +82,4 @@ kubectl delete crds -l component=ark
 kubectl delete clusterrolebindings -l component=ark
 ```
 
-[1]: https://velero.io/docs/v0.10.0/upgrading-to-v0.10
+[1]: /docs/v0.10.0/upgrading-to-v0.10

--- a/site/content/docs/v0.11.0/versions.md
+++ b/site/content/docs/v0.11.0/versions.md
@@ -25,5 +25,5 @@ Not all Velero versions support all versions of Kubernetes. You should be aware 
 - Restic support requires Kubernetes version 1.10 or later, or an earlier version with the mount propagation feature enabled. See [Restic Integration][3].
 
 [1]: https://github.com/heptio/velero/releases
-[2]: https://velero.io/docs/v0.10.0/upgrading-to-v0.10
+[2]: /docs/v0.10.0/upgrading-to-v0.10
 [3]: restic.md

--- a/site/content/docs/v0.7.0/_index.md
+++ b/site/content/docs/v0.7.0/_index.md
@@ -199,4 +199,4 @@ See [the list of releases][6] to find out about feature changes.
 [26]: https://github.com/heptio/ark/releases
 [27]: /hooks.md
 [28]: /plugins.md
-[29]: https://velero.io/docs/v0.7.0/
+[29]: /docs/v0.7.0/

--- a/site/content/docs/v0.7.1/_index.md
+++ b/site/content/docs/v0.7.1/_index.md
@@ -211,5 +211,5 @@ See [the list of releases][6] to find out about feature changes.
 [26]: https://github.com/heptio/ark/releases
 [27]: /hooks.md
 [28]: /plugins.md
-[29]: https://velero.io/docs/v0.7.1/
+[29]: /docs/v0.7.1/
 [30]: /troubleshooting.md

--- a/site/content/docs/v0.8.0/_index.md
+++ b/site/content/docs/v0.8.0/_index.md
@@ -217,5 +217,5 @@ See [the list of releases][6] to find out about feature changes.
 [26]: https://github.com/heptio/ark/releases
 [27]: /hooks.md
 [28]: /plugins.md
-[29]: https://velero.io/docs/v0.8.0/
+[29]: /docs/v0.8.0/
 [30]: /troubleshooting.md

--- a/site/content/docs/v0.8.1/_index.md
+++ b/site/content/docs/v0.8.1/_index.md
@@ -217,5 +217,5 @@ See [the list of releases][6] to find out about feature changes.
 [26]: https://github.com/heptio/ark/releases
 [27]: /hooks.md
 [28]: /plugins.md
-[29]: https://velero.io/docs/v0.8.1/
+[29]: /docs/v0.8.1/
 [30]: /troubleshooting.md

--- a/site/content/docs/v0.9.0/_index.md
+++ b/site/content/docs/v0.9.0/_index.md
@@ -67,5 +67,5 @@ See [the list of releases][6] to find out about feature changes.
 [25]: https://kubernetes.slack.com/messages/ark-dr
 
 
-[29]: https://velero.io/docs/v0.9.0/
+[29]: /docs/v0.9.0/
 [30]: /troubleshooting.md

--- a/site/content/docs/v1.0.0/_index.md
+++ b/site/content/docs/v1.0.0/_index.md
@@ -77,7 +77,7 @@ See [the list of releases][6] to find out about feature changes.
 
 
 [28]: install-overview.md
-[29]: https://velero.io/docs/v1.0.0/
+[29]: /docs/v1.0.0/
 [30]: troubleshooting.md
 
 [99]: support-matrix.md

--- a/site/content/docs/v1.0.0/migrating-to-velero.md
+++ b/site/content/docs/v1.0.0/migrating-to-velero.md
@@ -82,4 +82,4 @@ kubectl delete crds -l component=ark
 kubectl delete clusterrolebindings -l component=ark
 ```
 
-[1]: https://velero.io/docs/v0.10.0/upgrading-to-v0.10
+[1]: /docs/v0.10.0/upgrading-to-v0.10

--- a/site/content/docs/v1.0.0/oracle-config.md
+++ b/site/content/docs/v1.0.0/oracle-config.md
@@ -5,7 +5,7 @@ layout: docs
 
 ## Introduction
 
-[Velero](https://velero.io/) is a tool used to backup and migrate Kubernetes applications. Here are the steps to use [Oracle Cloud Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a destination for Velero backups. 
+[Velero](/) is a tool used to backup and migrate Kubernetes applications. Here are the steps to use [Oracle Cloud Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a destination for Velero backups. 
 
 1. [Download Velero](#download-velero)
 2. [Create A Customer Secret Key](#create-a-customer-secret-key)
@@ -244,5 +244,5 @@ After creating the Velero server in your cluster, try this example:
 
 ## Additional Reading 
 
-* [Official Velero Documentation](https://velero.io/docs/main/)
+* [Official Velero Documentation](/docs/main/)
 * [Oracle Cloud Infrastructure Documentation](https://docs.cloud.oracle.com/)

--- a/site/content/docs/v1.0.0/upgrade-to-1.0.md
+++ b/site/content/docs/v1.0.0/upgrade-to-1.0.md
@@ -142,6 +142,6 @@ _*backups created prior to v0.10 stored snapshot metadata in the `status.volumeB
     kubectl -n velero set image daemonset/restic  restic=gcr.io/heptio-images/velero:v1.0.0
     ```
 
-[0]: https://velero.io/docs/v0.11.0/migrating-to-velero
+[0]: /docs/v0.11.0/migrating-to-velero
 [1]: https://github.com/vmware-tanzu/velero/releases/tag/v0.11.1
 [2]: https://github.com/vmware-tanzu/velero/releases/tag/v1.0.0

--- a/site/content/docs/v1.1.0/_index.md
+++ b/site/content/docs/v1.1.0/_index.md
@@ -39,7 +39,7 @@ If you encounter issues, review the [troubleshooting docs][30], [file an issue][
 
 ## Contributing
 
-If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](https://velero.io/docs/main/start-contributing/) documentation for guidance on how to setup Velero for development.
+If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](/docs/main/start-contributing/) documentation for guidance on how to setup Velero for development.
 
 ## Changelog
 
@@ -61,7 +61,7 @@ See [the list of releases][6] to find out about feature changes.
 [25]: https://kubernetes.slack.com/messages/velero
 
 [28]: install-overview.md
-[29]: https://velero.io/docs/main/
+[29]: /docs/main/
 [30]: troubleshooting.md
 
 [99]: support-matrix.md

--- a/site/content/docs/v1.1.0/migrating-to-velero.md
+++ b/site/content/docs/v1.1.0/migrating-to-velero.md
@@ -82,4 +82,4 @@ kubectl delete crds -l component=ark
 kubectl delete clusterrolebindings -l component=ark
 ```
 
-[1]: https://velero.io/docs/v0.10.0/upgrading-to-v0.10
+[1]: /docs/v0.10.0/upgrading-to-v0.10

--- a/site/content/docs/v1.1.0/oracle-config.md
+++ b/site/content/docs/v1.1.0/oracle-config.md
@@ -5,7 +5,7 @@ layout: docs
 
 ## Introduction
 
-[Velero](https://velero.io/) is a tool used to backup and migrate Kubernetes applications. Here are the steps to use [Oracle Cloud Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a destination for Velero backups. 
+[Velero](/) is a tool used to backup and migrate Kubernetes applications. Here are the steps to use [Oracle Cloud Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a destination for Velero backups. 
 
 1. [Download Velero](#download-velero)
 2. [Create A Customer Secret Key](#create-a-customer-secret-key)
@@ -244,5 +244,5 @@ After creating the Velero server in your cluster, try this example:
 
 ## Additional Reading 
 
-* [Official Velero Documentation](https://velero.io/docs/v1.1.0/)
+* [Official Velero Documentation](/docs/v1.1.0/)
 * [Oracle Cloud Infrastructure Documentation](https://docs.cloud.oracle.com/)

--- a/site/content/docs/v1.1.0/start-contributing.md
+++ b/site/content/docs/v1.1.0/start-contributing.md
@@ -12,9 +12,9 @@ layout: docs
 
 You may join the Velero community and contribute in many different ways, including helping us design or test new features. For any significant feature we consider adding, we start with a design document. You may find a list of currently in progress new designs here: https://github.com/vmware-tanzu/velero/pulls?q=is%3Aopen+is%3Apr+label%3ADesign. Feel free to review and help us with your input.
 
-For information on how to connect with our maintainers and community, join our online meetings, or find good first issues, start on our [Velero community](https://velero.io/community/) page.
+For information on how to connect with our maintainers and community, join our online meetings, or find good first issues, start on our [Velero community](/community/) page.
 
-Please browse our list of resources, including a playlist of past online community meetings, blog posts, and other resources to help you get familiar with our project: [Velero resources](https://velero.io/resources/).
+Please browse our list of resources, including a playlist of past online community meetings, blog posts, and other resources to help you get familiar with our project: [Velero resources](/resources/).
 
 ### Contributing
 

--- a/site/content/docs/v1.2.0/_index.md
+++ b/site/content/docs/v1.2.0/_index.md
@@ -30,7 +30,7 @@ If you encounter issues, review the [troubleshooting docs][30], [file an issue][
 
 ## Contributing
 
-If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](https://velero.io/docs/v1.2.0/start-contributing/) documentation for guidance on how to setup Velero for development.
+If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](/docs/v1.2.0/start-contributing/) documentation for guidance on how to setup Velero for development.
 
 ## Changelog
 

--- a/site/content/docs/v1.2.0/contributions/oracle-config.md
+++ b/site/content/docs/v1.2.0/contributions/oracle-config.md
@@ -5,7 +5,7 @@ layout: docs
 
 ## Introduction
 
-[Velero](https://velero.io/) is a tool used to backup and migrate Kubernetes applications. Here are the steps to use [Oracle Cloud Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a destination for Velero backups. 
+[Velero](/) is a tool used to backup and migrate Kubernetes applications. Here are the steps to use [Oracle Cloud Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a destination for Velero backups. 
 
 1. [Download Velero](#download-velero)
 2. [Create A Customer Secret Key](#create-a-customer-secret-key)
@@ -244,5 +244,5 @@ After creating the Velero server in your cluster, try this example:
 
 ## Additional Reading 
 
-* [Official Velero Documentation](https://velero.io/docs/v1.2.0/)
+* [Official Velero Documentation](/docs/v1.2.0/)
 * [Oracle Cloud Infrastructure Documentation](https://docs.cloud.oracle.com/)

--- a/site/content/docs/v1.2.0/start-contributing.md
+++ b/site/content/docs/v1.2.0/start-contributing.md
@@ -12,9 +12,9 @@ layout: docs
 
 You may join the Velero community and contribute in many different ways, including helping us design or test new features. For any significant feature we consider adding, we start with a design document. You may find a list of currently in progress new designs here: https://github.com/vmware-tanzu/velero/pulls?q=is%3Aopen+is%3Apr+label%3ADesign. Feel free to review and help us with your input.
 
-For information on how to connect with our maintainers and community, join our online meetings, or find good first issues, start on our [Velero community](https://velero.io/community/) page.
+For information on how to connect with our maintainers and community, join our online meetings, or find good first issues, start on our [Velero community](/community/) page.
 
-Please browse our list of resources, including a playlist of past online community meetings, blog posts, and other resources to help you get familiar with our project: [Velero resources](https://velero.io/resources/).
+Please browse our list of resources, including a playlist of past online community meetings, blog posts, and other resources to help you get familiar with our project: [Velero resources](/resources/).
 
 ### Contributing
 

--- a/site/content/docs/v1.2.0/upgrade-to-1.2.md
+++ b/site/content/docs/v1.2.0/upgrade-to-1.2.md
@@ -101,5 +101,5 @@ _Note: if you're upgrading from v1.0, follow the [upgrading to v1.1][2] instruct
 
 [0]: https://github.com/vmware-tanzu/velero/releases/tag/v1.1.0
 [1]: https://github.com/vmware-tanzu/velero/releases/tag/v1.0.0
-[2]: https://velero.io/docs/v1.1.0/upgrade-to-1.1/
+[2]: /docs/v1.1.0/upgrade-to-1.1/
 [3]: basic-install.md#install-the-cli

--- a/site/content/docs/v1.2.0/website-guidelines.md
+++ b/site/content/docs/v1.2.0/website-guidelines.md
@@ -25,7 +25,7 @@ For more information on how to run the website locally, please see our [jekyll d
 
 ## Adding a blog post
 
-The `author_name` value must also be included in the tags field so the page that lists the author's posts will work properly (Ex: https://velero.io/tags/carlisia%20campos/). 
+The `author_name` value must also be included in the tags field so the page that lists the author's posts will work properly (Ex: /tags/carlisia%20campos/). 
 
 Note that the tags field can have multiple values. 
 

--- a/site/content/docs/v1.3.0/_index.md
+++ b/site/content/docs/v1.3.0/_index.md
@@ -30,7 +30,7 @@ If you encounter issues, review the [troubleshooting docs][30], [file an issue][
 
 ## Contributing
 
-If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](https://velero.io/docs/v1.3.0/start-contributing/) documentation for guidance on how to setup Velero for development.
+If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](/docs/v1.3.0/start-contributing/) documentation for guidance on how to setup Velero for development.
 
 ## Changelog
 

--- a/site/content/docs/v1.3.0/contributions/oracle-config.md
+++ b/site/content/docs/v1.3.0/contributions/oracle-config.md
@@ -5,7 +5,7 @@ layout: docs
 
 ## Introduction
 
-[Velero](https://velero.io/) is a tool used to backup and migrate Kubernetes applications. Here are the steps to use [Oracle Cloud Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a destination for Velero backups. 
+[Velero](/) is a tool used to backup and migrate Kubernetes applications. Here are the steps to use [Oracle Cloud Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a destination for Velero backups. 
 
 1. [Download Velero](#download-velero)
 2. [Create A Customer Secret Key](#create-a-customer-secret-key)
@@ -244,5 +244,5 @@ After creating the Velero server in your cluster, try this example:
 
 ## Additional Reading 
 
-* [Official Velero Documentation](https://velero.io/docs/v1.3.0/)
+* [Official Velero Documentation](/docs/v1.3.0/)
 * [Oracle Cloud Infrastructure Documentation](https://docs.cloud.oracle.com/)

--- a/site/content/docs/v1.3.0/start-contributing.md
+++ b/site/content/docs/v1.3.0/start-contributing.md
@@ -12,9 +12,9 @@ layout: docs
 
 You may join the Velero community and contribute in many different ways, including helping us design or test new features. For any significant feature we consider adding, we start with a design document. You may find a list of currently in progress new designs here: https://github.com/vmware-tanzu/velero/pulls?q=is%3Aopen+is%3Apr+label%3ADesign. Feel free to review and help us with your input.
 
-For information on how to connect with our maintainers and community, join our online meetings, or find good first issues, start on our [Velero community](https://velero.io/community/) page.
+For information on how to connect with our maintainers and community, join our online meetings, or find good first issues, start on our [Velero community](/community/) page.
 
-Please browse our list of resources, including a playlist of past online community meetings, blog posts, and other resources to help you get familiar with our project: [Velero resources](https://velero.io/resources/).
+Please browse our list of resources, including a playlist of past online community meetings, blog posts, and other resources to help you get familiar with our project: [Velero resources](/resources/).
 
 ### Contributing
 

--- a/site/content/docs/v1.3.0/upgrade-to-1.3.md
+++ b/site/content/docs/v1.3.0/upgrade-to-1.3.md
@@ -61,6 +61,6 @@ If you're not yet running Velero v1.2, see the following:
     ```
 
 [0]: basic-install.md#install-the-cli
-[1]: https://velero.io/docs/v1.1.0/upgrade-to-1.1/
-[2]: https://velero.io/docs/v1.2.0/upgrade-to-1.2/
+[1]: /docs/v1.1.0/upgrade-to-1.1/
+[2]: /docs/v1.2.0/upgrade-to-1.2/
 [3]: https://github.com/vmware-tanzu/velero/releases/tag/v1.2.0

--- a/site/content/docs/v1.3.0/website-guidelines.md
+++ b/site/content/docs/v1.3.0/website-guidelines.md
@@ -25,7 +25,7 @@ For more information on how to run the website locally, please see our [jekyll d
 
 ## Adding a blog post
 
-The `author_name` value must also be included in the tags field so the page that lists the author's posts will work properly (Ex: https://velero.io/tags/carlisia%20campos/). 
+The `author_name` value must also be included in the tags field so the page that lists the author's posts will work properly (Ex: /tags/carlisia%20campos/). 
 
 Note that the tags field can have multiple values. 
 

--- a/site/content/docs/v1.3.1/_index.md
+++ b/site/content/docs/v1.3.1/_index.md
@@ -30,7 +30,7 @@ If you encounter issues, review the [troubleshooting docs][30], [file an issue][
 
 ## Contributing
 
-If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](https://velero.io/docs/v1.3.1/start-contributing/) documentation for guidance on how to setup Velero for development.
+If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](/docs/v1.3.1/start-contributing/) documentation for guidance on how to setup Velero for development.
 
 ## Changelog
 

--- a/site/content/docs/v1.3.1/contributions/oracle-config.md
+++ b/site/content/docs/v1.3.1/contributions/oracle-config.md
@@ -5,7 +5,7 @@ layout: docs
 
 ## Introduction
 
-[Velero](https://velero.io/) is a tool used to backup and migrate Kubernetes applications. Here are the steps to use [Oracle Cloud Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a destination for Velero backups. 
+[Velero](/) is a tool used to backup and migrate Kubernetes applications. Here are the steps to use [Oracle Cloud Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a destination for Velero backups. 
 
 1. [Download Velero](#download-velero)
 2. [Create A Customer Secret Key](#create-a-customer-secret-key)
@@ -244,5 +244,5 @@ After creating the Velero server in your cluster, try this example:
 
 ## Additional Reading 
 
-* [Official Velero Documentation](https://velero.io/docs/v1.3.1/)
+* [Official Velero Documentation](/docs/v1.3.1/)
 * [Oracle Cloud Infrastructure Documentation](https://docs.cloud.oracle.com/)

--- a/site/content/docs/v1.3.1/start-contributing.md
+++ b/site/content/docs/v1.3.1/start-contributing.md
@@ -12,9 +12,9 @@ layout: docs
 
 You may join the Velero community and contribute in many different ways, including helping us design or test new features. For any significant feature we consider adding, we start with a design document. You may find a list of currently in progress new designs here: https://github.com/vmware-tanzu/velero/pulls?q=is%3Aopen+is%3Apr+label%3ADesign. Feel free to review and help us with your input.
 
-For information on how to connect with our maintainers and community, join our online meetings, or find good first issues, start on our [Velero community](https://velero.io/community/) page.
+For information on how to connect with our maintainers and community, join our online meetings, or find good first issues, start on our [Velero community](/community/) page.
 
-Please browse our list of resources, including a playlist of past online community meetings, blog posts, and other resources to help you get familiar with our project: [Velero resources](https://velero.io/resources/).
+Please browse our list of resources, including a playlist of past online community meetings, blog posts, and other resources to help you get familiar with our project: [Velero resources](/resources/).
 
 ### Contributing
 

--- a/site/content/docs/v1.3.1/upgrade-to-1.3.md
+++ b/site/content/docs/v1.3.1/upgrade-to-1.3.md
@@ -61,7 +61,7 @@ If you're not yet running at least Velero v1.2, see the following:
     ```
 
 [0]: basic-install.md#install-the-cli
-[1]: https://velero.io/docs/v1.1.0/upgrade-to-1.1/
-[2]: https://velero.io/docs/v1.2.0/upgrade-to-1.2/
+[1]: /docs/v1.1.0/upgrade-to-1.1/
+[2]: /docs/v1.2.0/upgrade-to-1.2/
 [3]: https://github.com/vmware-tanzu/velero/releases/tag/v1.2.0
 [4]: https://github.com/vmware-tanzu/velero/releases/tag/v1.3.0

--- a/site/content/docs/v1.3.1/website-guidelines.md
+++ b/site/content/docs/v1.3.1/website-guidelines.md
@@ -25,7 +25,7 @@ For more information on how to run the website locally, please see our [jekyll d
 
 ## Adding a blog post
 
-The `author_name` value must also be included in the tags field so the page that lists the author's posts will work properly (Ex: https://velero.io/tags/carlisia%20campos/). 
+The `author_name` value must also be included in the tags field so the page that lists the author's posts will work properly (Ex: /tags/carlisia%20campos/). 
 
 Note that the tags field can have multiple values. 
 

--- a/site/content/docs/v1.3.2/_index.md
+++ b/site/content/docs/v1.3.2/_index.md
@@ -31,7 +31,7 @@ If you encounter issues, review the [troubleshooting docs][30], [file an issue][
 
 ## Contributing
 
-If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](https://velero.io/docs/v1.3.2/start-contributing/) documentation for guidance on how to setup Velero for development.
+If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](/docs/v1.3.2/start-contributing/) documentation for guidance on how to setup Velero for development.
 
 ## Changelog
 

--- a/site/content/docs/v1.3.2/contributions/oracle-config.md
+++ b/site/content/docs/v1.3.2/contributions/oracle-config.md
@@ -5,7 +5,7 @@ layout: docs
 
 ## Introduction
 
-[Velero](https://velero.io/) is a tool used to backup and migrate Kubernetes applications. Here are the steps to use [Oracle Cloud Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a destination for Velero backups. 
+[Velero](/) is a tool used to backup and migrate Kubernetes applications. Here are the steps to use [Oracle Cloud Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a destination for Velero backups. 
 
 1. [Download Velero](#download-velero)
 2. [Create A Customer Secret Key](#create-a-customer-secret-key)
@@ -244,5 +244,5 @@ After creating the Velero server in your cluster, try this example:
 
 ## Additional Reading 
 
-* [Official Velero Documentation](https://velero.io/docs/v1.3.2/)
+* [Official Velero Documentation](/docs/v1.3.2/)
 * [Oracle Cloud Infrastructure Documentation](https://docs.cloud.oracle.com/)

--- a/site/content/docs/v1.3.2/start-contributing.md
+++ b/site/content/docs/v1.3.2/start-contributing.md
@@ -12,9 +12,9 @@ layout: docs
 
 You may join the Velero community and contribute in many different ways, including helping us design or test new features. For any significant feature we consider adding, we start with a design document. You may find a list of currently in progress new designs here: https://github.com/vmware-tanzu/velero/pulls?q=is%3Aopen+is%3Apr+label%3ADesign. Feel free to review and help us with your input.
 
-For information on how to connect with our maintainers and community, join our online meetings, or find good first issues, start on our [Velero community](https://velero.io/community/) page.
+For information on how to connect with our maintainers and community, join our online meetings, or find good first issues, start on our [Velero community](/community/) page.
 
-Please browse our list of resources, including a playlist of past online community meetings, blog posts, and other resources to help you get familiar with our project: [Velero resources](https://velero.io/resources/).
+Please browse our list of resources, including a playlist of past online community meetings, blog posts, and other resources to help you get familiar with our project: [Velero resources](/resources/).
 
 ### Contributing
 

--- a/site/content/docs/v1.3.2/upgrade-to-1.3.md
+++ b/site/content/docs/v1.3.2/upgrade-to-1.3.md
@@ -61,8 +61,8 @@ If you're not yet running at least Velero v1.2, see the following:
     ```
 
 [0]: basic-install.md#install-the-cli
-[1]: https://velero.io/docs/v1.1.0/upgrade-to-1.1/
-[2]: https://velero.io/docs/v1.2.0/upgrade-to-1.2/
+[1]: /docs/v1.1.0/upgrade-to-1.1/
+[2]: /docs/v1.2.0/upgrade-to-1.2/
 [3]: https://github.com/vmware-tanzu/velero/releases/tag/v1.2.0
 [4]: https://github.com/vmware-tanzu/velero/releases/tag/v1.3.0
 [5]: https://github.com/vmware-tanzu/velero/releases/tag/v1.3.1

--- a/site/content/docs/v1.3.2/website-guidelines.md
+++ b/site/content/docs/v1.3.2/website-guidelines.md
@@ -25,7 +25,7 @@ For more information on how to run the website locally, please see our [jekyll d
 
 ## Adding a blog post
 
-The `author_name` value must also be included in the tags field so the page that lists the author's posts will work properly (Ex: https://velero.io/tags/carlisia%20campos/). 
+The `author_name` value must also be included in the tags field so the page that lists the author's posts will work properly (Ex: /tags/carlisia%20campos/). 
 
 Note that the tags field can have multiple values. 
 

--- a/site/content/docs/v1.4/_index.md
+++ b/site/content/docs/v1.4/_index.md
@@ -33,7 +33,7 @@ If you encounter issues, review the [troubleshooting docs][30], [file an issue][
 
 ## Contributing
 
-If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](https://velero.io/docs/v1.4/start-contributing/) documentation for guidance on how to setup Velero for development.
+If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](/docs/v1.4/start-contributing/) documentation for guidance on how to setup Velero for development.
 
 ## Changelog
 

--- a/site/content/docs/v1.4/contributions/oracle-config.md
+++ b/site/content/docs/v1.4/contributions/oracle-config.md
@@ -5,7 +5,7 @@ layout: docs
 
 ## Introduction
 
-[Velero](https://velero.io/) is a tool used to backup and migrate Kubernetes applications. Here are the steps to use [Oracle Cloud Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a destination for Velero backups. 
+[Velero](/) is a tool used to backup and migrate Kubernetes applications. Here are the steps to use [Oracle Cloud Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a destination for Velero backups. 
 
 1. [Download Velero](#download-velero)
 2. [Create A Customer Secret Key](#create-a-customer-secret-key)
@@ -244,5 +244,5 @@ After creating the Velero server in your cluster, try this example:
 
 ## Additional Reading 
 
-* [Official Velero Documentation](https://velero.io/docs/v1.4/)
+* [Official Velero Documentation](/docs/v1.4/)
 * [Oracle Cloud Infrastructure Documentation](https://docs.cloud.oracle.com/)

--- a/site/content/docs/v1.4/start-contributing.md
+++ b/site/content/docs/v1.4/start-contributing.md
@@ -14,9 +14,9 @@ You may join the Velero community and contribute in many different ways, includi
 
 You can also vote on issues using :+1: and :-1:, as explained in our [Feature enhancement request][3] and [Bug issue][4] templates. This will help us quantify importance and prioritize issues.
 
-For information on how to connect with our maintainers and community, join our online meetings, or find good first issues, start on our [Velero community](https://velero.io/community/) page.
+For information on how to connect with our maintainers and community, join our online meetings, or find good first issues, start on our [Velero community](/community/) page.
 
-Please browse our list of resources, including a playlist of past online community meetings, blog posts, and other resources to help you get familiar with our project: [Velero resources](https://velero.io/resources/).
+Please browse our list of resources, including a playlist of past online community meetings, blog posts, and other resources to help you get familiar with our project: [Velero resources](/resources/).
 
 ## Contributing
 

--- a/site/content/docs/v1.4/upgrade-to-1.4.md
+++ b/site/content/docs/v1.4/upgrade-to-1.4.md
@@ -74,9 +74,9 @@ Before upgrading, check the [Velero compatibility matrix](https://github.com/vmw
     ```
 
 [0]: basic-install.md#install-the-cli
-[1]: https://velero.io/docs/v1.1.0/upgrade-to-1.1/
-[2]: https://velero.io/docs/v1.2.0/upgrade-to-1.2/
-[3]: https://velero.io/docs/v1.3.2/upgrade-to-1.3/
+[1]: /docs/v1.1.0/upgrade-to-1.1/
+[2]: /docs/v1.2.0/upgrade-to-1.2/
+[3]: /docs/v1.3.2/upgrade-to-1.3/
 [4]: https://github.com/vmware-tanzu/velero/releases/tag/v1.3.2
 [5]: https://github.com/vmware-tanzu/velero/issues/2077
 [6]: https://github.com/vmware-tanzu/velero/issues/2311

--- a/site/content/docs/v1.4/website-guidelines.md
+++ b/site/content/docs/v1.4/website-guidelines.md
@@ -25,7 +25,7 @@ For more information on how to run the website locally, please see our [jekyll d
 
 ## Adding a blog post
 
-The `author_name` value must also be included in the tags field so the page that lists the author's posts will work properly (Ex: https://velero.io/tags/carlisia%20campos/). 
+The `author_name` value must also be included in the tags field so the page that lists the author's posts will work properly (Ex: /tags/carlisia%20campos/). 
 
 Note that the tags field can have multiple values. 
 

--- a/site/content/docs/v1.5/_index.md
+++ b/site/content/docs/v1.5/_index.md
@@ -33,7 +33,7 @@ If you encounter issues, review the [troubleshooting docs][30], [file an issue][
 
 ## Contributing
 
-If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](https://velero.io/docs/v1.5/start-contributing/) documentation for guidance on how to setup Velero for development.
+If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](/docs/v1.5/start-contributing/) documentation for guidance on how to setup Velero for development.
 
 ## Changelog
 

--- a/site/content/docs/v1.5/contributions/oracle-config.md
+++ b/site/content/docs/v1.5/contributions/oracle-config.md
@@ -5,7 +5,7 @@ layout: docs
 
 ## Introduction
 
-[Velero](https://velero.io/) is a tool used to backup and migrate Kubernetes applications. Here are the steps to use [Oracle Cloud Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a destination for Velero backups.
+[Velero](/) is a tool used to backup and migrate Kubernetes applications. Here are the steps to use [Oracle Cloud Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a destination for Velero backups.
 
 1. [Download Velero](#download-velero)
 2. [Create A Customer Secret Key](#create-a-customer-secret-key)
@@ -244,5 +244,5 @@ After creating the Velero server in your cluster, try this example:
 
 ## Additional Reading
 
-* [Official Velero Documentation](https://velero.io/docs/v1.5/)
+* [Official Velero Documentation](/docs/v1.5/)
 * [Oracle Cloud Infrastructure Documentation](https://docs.cloud.oracle.com/)

--- a/site/content/docs/v1.5/contributions/tencent-config.md
+++ b/site/content/docs/v1.5/contributions/tencent-config.md
@@ -37,7 +37,7 @@ aws_secret_access_key=<SecretKey>
 
 ## Install Velero Resources
 
-You need to install the Velero CLI first, see [Install the CLI](https://velero.io/docs/v1.5/basic-install/#install-the-cli)  for how to install.
+You need to install the Velero CLI first, see [Install the CLI](/docs/v1.5/basic-install/#install-the-cli)  for how to install.
 
 Follow the Velero installation command below to create velero and restic workloads and other necessary resource objects.
 
@@ -60,7 +60,7 @@ Description of the parameters:
 
 - `--secret-file`: Access tencent cloud COS access credential file for the "credentials-velero" credential file created above.
 
-- `--use-restic`: Back up and restore persistent volume data using the open source free backup tool [restic](https://github.com/restic/restic).  However, 'hostPath' volumes are not supported, see the [restic limit](https://velero.io/docs/v1.5/restic/#limitations) for details), an integration 		that complements Velero's backup capabilities and is recommended to be turned on.
+- `--use-restic`: Back up and restore persistent volume data using the open source free backup tool [restic](https://github.com/restic/restic).  However, 'hostPath' volumes are not supported, see the [restic limit](/docs/v1.5/restic/#limitations) for details), an integration 		that complements Velero's backup capabilities and is recommended to be turned on.
 
 - `--default-volumes-to-restic`: Enable the use of Restic to back up all Pod volumes, provided that the `--use-restic`parameter needs to be turned on.
 
@@ -84,7 +84,7 @@ Executing the 'velero backup-location get' command to view the storage location 
 
 {{< figure src="/docs/v1.5/contributions/img-for-tencent/69194157ccd5e377d1e7d914fd8c0336.png" width="100%">}}
 
-At this point, The installation using Tencent Cloud COS as Velero storage location is complete, If you need more installation information about Velero, You can see the official website [Velero documentation](https://velero.io/docs/) .
+At this point, The installation using Tencent Cloud COS as Velero storage location is complete, If you need more installation information about Velero, You can see the official website [Velero documentation](/docs/) .
 
 ## Velero backup and restore example
 
@@ -164,5 +164,5 @@ kubectl delete crds -l component=velero
 
 ## Additional Reading
 
-- [Official Velero Documentation](https://velero.io/docs/)
+- [Official Velero Documentation](/docs/)
 - [Tencent Cloud Documentation](https://cloud.tencent.com/document/product)

--- a/site/content/docs/v1.5/maintainers.md
+++ b/site/content/docs/v1.5/maintainers.md
@@ -17,8 +17,8 @@ Please be sure to also go through the guidance under the entire [Contribute](sta
 - Be familiar with the [lazy consensus](https://github.com/vmware-tanzu/velero/blob/v1.5.1/GOVERNANCE.md#lazy-consensus) policy for the project.
 
 Some tips for doing reviews:
-- There are some [code standards and general guidelines](https://velero.io/docs/main/code-standards) we aim for
-- We have [guidelines for writing and reviewing documentation](https://velero.io/docs/main/style-guide/)
+- There are some [code standards and general guidelines](/docs/main/code-standards) we aim for
+- We have [guidelines for writing and reviewing documentation](/docs/main/style-guide/)
 - When reviewing a design document, ensure it follows [our format and guidelines]( https://github.com/vmware-tanzu/velero/blob/main/design/_template.md). Also, when reviewing a PR that implements a previously accepted design, ensure the associated design doc is moved to the [design/implemented](https://github.com/vmware-tanzu/velero/tree/main/design/implemented) folder.
 
 ## Creating a release

--- a/site/content/docs/v1.5/release-instructions.md
+++ b/site/content/docs/v1.5/release-instructions.md
@@ -46,7 +46,7 @@ For each major or minor release, create and publish a blog post to let folks kno
     - Delete the pre-release docs table of contents file, i.e. `site/data/docs/<pre-release-version>-toc.yml`.
     - Remove the pre-release docs table of contents mapping entry from `site/data/toc-mapping.yml`.
     - Remove all references to the pre-release docs from `site/config.yml`.
-1. Create the "Upgrade to $major.minor" page if it does not already exist ([example](https://velero.io/docs/v1.5/upgrade-to-1.5/)).
+1. Create the "Upgrade to $major.minor" page if it does not already exist ([example](/docs/v1.5/upgrade-to-1.5/)).
    If it already exists, update any usage of the previous version string within this file to use the new version string instead ([example](https://github.com/vmware-tanzu/velero/pull/2941/files#diff-d594f8fd0901fed79c39aab4b348193d)).
    This needs to be done in both the versioned and the `main` folders.
 1. Review and submit PR
@@ -122,5 +122,5 @@ What to include:
 * A brief list of highlights in the release
 * Link to the release blog post, release notes, and/or github release page
 
-[1]: https://velero.io/blog
+[1]: /blog
 [2]: website-guidelines.md

--- a/site/content/docs/v1.5/start-contributing.md
+++ b/site/content/docs/v1.5/start-contributing.md
@@ -20,9 +20,9 @@ You may join the Velero community and contribute in many different ways, includi
 
 You can also vote on issues using :+1: and :-1:, as explained in our [Feature enhancement request][3] and [Bug issue][4] templates. This will help us quantify importance and prioritize issues.
 
-For information on how to connect with our maintainers and community, join our online meetings, or find good first issues, start on our [Velero community](https://velero.io/community/) page.
+For information on how to connect with our maintainers and community, join our online meetings, or find good first issues, start on our [Velero community](/community/) page.
 
-Please browse our list of resources, including a playlist of past online community meetings, blog posts, and other resources to help you get familiar with our project: [Velero resources](https://velero.io/resources/).
+Please browse our list of resources, including a playlist of past online community meetings, blog posts, and other resources to help you get familiar with our project: [Velero resources](/resources/).
 
 ## Contributing
 

--- a/site/content/docs/v1.5/tilt.md
+++ b/site/content/docs/v1.5/tilt.md
@@ -24,7 +24,7 @@ files in this directory are gitignored so you may configure your setup according
 1. Clone the [Velero project](https://github.com/vmware-tanzu/velero) repository
    locally
 1. Access to an S3 object storage
-1. Clone any [provider plugin(s)](https://velero.io/plugins/) you want to make changes to and deploy (optional, must be configured to be deployed by the Velero Tilt's setup, [more info below](#provider-plugins))
+1. Clone any [provider plugin(s)](/plugins/) you want to make changes to and deploy (optional, must be configured to be deployed by the Velero Tilt's setup, [more info below](#provider-plugins))
 
 Note: To properly configure any plugin you use, please follow the plugin's documentation.
 
@@ -107,7 +107,7 @@ storage location. A sample file is provided that needs to be modified with the s
 configuration for your object storage. See the next sub-section for more details on this.
 
 ### Configure a backup storage location
-You will have to configure the `velero/tilt-resources/velero_v1_backupstoragelocation.yaml` with the proper values according to your storage provider. Read the [plugin documentation](https://velero.io/plugins/)
+You will have to configure the `velero/tilt-resources/velero_v1_backupstoragelocation.yaml` with the proper values according to your storage provider. Read the [plugin documentation](/plugins/)
 to learn what field/value pairs are required for your particular provider's backup storage location configuration.
 
 Below are some ways to configure a backup storage location for Velero.
@@ -146,7 +146,7 @@ necessary to expose MinIO outside the cluster.
 Please see our [locations documentation](locations/) to learn more how backup locations work.
 
 ### Configure the provider credentials (secret)
-Whatever object storage provider you use, configure the credentials for in the `velero/tilt-resources/cloud` file. Read the [plugin documentation](https://velero.io/plugins/)
+Whatever object storage provider you use, configure the credentials for in the `velero/tilt-resources/cloud` file. Read the [plugin documentation](/plugins/)
 to learn what field/value pairs are required for your provider's credentials. The Tilt file will invoke Kustomize to create the secret under the hard-coded key `secret.cloud-credentials.data.cloud` in the Velero namespace.
 
 There is a sample credentials file properly formatted for a MinIO storage credentials in `velero/tilt-resources/examples/cloud`.

--- a/site/content/docs/v1.5/upgrade-to-1.5.md
+++ b/site/content/docs/v1.5/upgrade-to-1.5.md
@@ -73,10 +73,10 @@ Before upgrading, check the [Velero compatibility matrix](https://github.com/vmw
     ```
 
 [0]: basic-install.md#install-the-cli
-[1]: https://velero.io/docs/v1.1.0/upgrade-to-1.1/
-[2]: https://velero.io/docs/v1.2.0/upgrade-to-1.2/
-[3]: https://velero.io/docs/v1.3.2/upgrade-to-1.3/
-[4]: https://velero.io/docs/v1.4/upgrade-to-1.4/
+[1]: /docs/v1.1.0/upgrade-to-1.1/
+[2]: /docs/v1.2.0/upgrade-to-1.2/
+[3]: /docs/v1.3.2/upgrade-to-1.3/
+[4]: /docs/v1.4/upgrade-to-1.4/
 [5]: https://github.com/vmware-tanzu/velero/releases/tag/v1.4.2
 [6]: https://github.com/vmware-tanzu/velero/issues/2077
 [7]: https://github.com/vmware-tanzu/velero/issues/2311

--- a/site/content/docs/v1.5/website-guidelines.md
+++ b/site/content/docs/v1.5/website-guidelines.md
@@ -40,6 +40,6 @@ image: /img/posts/example-image.jpg
 tags: ['Velero Team', 'Nolan Brubaker']
 ```
 
-Include the `author_name` value in tags field so the page that lists the author's posts will work properly, for example https://velero.io/tags/carlisia-campos/.
+Include the `author_name` value in tags field so the page that lists the author's posts will work properly, for example /tags/carlisia-campos/.
 
 Ideally each blog will have a unique image to use on the blog home page, but if you do not include an image, the default Velero logo will be used instead. Use an image that is less than 70KB and add it to the `/site/static/img/posts` folder.

--- a/site/content/docs/v1.6/_index.md
+++ b/site/content/docs/v1.6/_index.md
@@ -33,7 +33,7 @@ If you encounter issues, review the [troubleshooting docs][30], [file an issue][
 
 ## Contributing
 
-If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](https://velero.io/docs/v1.6/start-contributing/) documentation for guidance on how to setup Velero for development.
+If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](/docs/v1.6/start-contributing/) documentation for guidance on how to setup Velero for development.
 
 ## Changelog
 

--- a/site/content/docs/v1.6/contributions/oracle-config.md
+++ b/site/content/docs/v1.6/contributions/oracle-config.md
@@ -5,7 +5,7 @@ layout: docs
 
 ## Introduction
 
-[Velero](https://velero.io/) is a tool used to backup and migrate Kubernetes applications. Here are the steps to use [Oracle Cloud Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a destination for Velero backups.
+[Velero](/) is a tool used to backup and migrate Kubernetes applications. Here are the steps to use [Oracle Cloud Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a destination for Velero backups.
 
 1. [Download Velero](#download-velero)
 2. [Create A Customer Secret Key](#create-a-customer-secret-key)
@@ -244,5 +244,5 @@ After creating the Velero server in your cluster, try this example:
 
 ## Additional Reading
 
-* [Official Velero Documentation](https://velero.io/docs/v1.6/)
+* [Official Velero Documentation](/docs/v1.6/)
 * [Oracle Cloud Infrastructure Documentation](https://docs.cloud.oracle.com/)

--- a/site/content/docs/v1.6/contributions/tencent-config.md
+++ b/site/content/docs/v1.6/contributions/tencent-config.md
@@ -37,7 +37,7 @@ aws_secret_access_key=<SecretKey>
 
 ## Install Velero Resources
 
-You need to install the Velero CLI first, see [Install the CLI](https://velero.io/docs/v1.5/basic-install/#install-the-cli)  for how to install.
+You need to install the Velero CLI first, see [Install the CLI](/docs/v1.5/basic-install/#install-the-cli)  for how to install.
 
 Follow the Velero installation command below to create velero and restic workloads and other necessary resource objects.
 
@@ -60,7 +60,7 @@ Description of the parameters:
 
 - `--secret-file`: Access tencent cloud COS access credential file for the "credentials-velero" credential file created above.
 
-- `--use-restic`: Back up and restore persistent volume data using the open source free backup tool [restic](https://github.com/restic/restic).  However, 'hostPath' volumes are not supported, see the [restic limit](https://velero.io/docs/v1.5/restic/#limitations) for details), an integration 		that complements Velero's backup capabilities and is recommended to be turned on.
+- `--use-restic`: Back up and restore persistent volume data using the open source free backup tool [restic](https://github.com/restic/restic).  However, 'hostPath' volumes are not supported, see the [restic limit](/docs/v1.5/restic/#limitations) for details), an integration 		that complements Velero's backup capabilities and is recommended to be turned on.
 
 - `--default-volumes-to-restic`: Enable the use of Restic to back up all Pod volumes, provided that the `--use-restic`parameter needs to be turned on.
 
@@ -84,7 +84,7 @@ Executing the 'velero backup-location get' command to view the storage location 
 
 {{< figure src="/docs/main/contributions/img-for-tencent/69194157ccd5e377d1e7d914fd8c0336.png" width="100%">}}
 
-At this point, The installation using Tencent Cloud COS as Velero storage location is complete, If you need more installation information about Velero, You can see the official website [Velero documentation](https://velero.io/docs/) .
+At this point, The installation using Tencent Cloud COS as Velero storage location is complete, If you need more installation information about Velero, You can see the official website [Velero documentation](/docs/) .
 
 ## Velero backup and restore example
 
@@ -164,5 +164,5 @@ kubectl delete crds -l component=velero
 
 ## Additional Reading
 
-- [Official Velero Documentation](https://velero.io/docs/)
+- [Official Velero Documentation](/docs/)
 - [Tencent Cloud Documentation](https://cloud.tencent.com/document/product)

--- a/site/content/docs/v1.6/maintainers.md
+++ b/site/content/docs/v1.6/maintainers.md
@@ -17,8 +17,8 @@ Please be sure to also go through the guidance under the entire [Contribute](sta
 - Be familiar with the [lazy consensus](https://github.com/vmware-tanzu/velero/blob/v1.6.0/GOVERNANCE.md#lazy-consensus) policy for the project.
 
 Some tips for doing reviews:
-- There are some [code standards and general guidelines](https://velero.io/docs/v1.6/code-standards) we aim for
-- We have [guidelines for writing and reviewing documentation](https://velero.io/docs/v1.6/style-guide/)
+- There are some [code standards and general guidelines](/docs/v1.6/code-standards) we aim for
+- We have [guidelines for writing and reviewing documentation](/docs/v1.6/style-guide/)
 - When reviewing a design document, ensure it follows [our format and guidelines]( https://github.com/vmware-tanzu/velero/blob/v1.6.0/design/_template.md). Also, when reviewing a PR that implements a previously accepted design, ensure the associated design doc is moved to the [design/implemented](https://github.com/vmware-tanzu/velero/tree/main/design/implemented) folder.
 
 

--- a/site/content/docs/v1.6/release-instructions.md
+++ b/site/content/docs/v1.6/release-instructions.md
@@ -48,7 +48,7 @@ For each major or minor release, create and publish a blog post to let folks kno
     - Delete the pre-release docs table of contents file, i.e. `site/data/docs/<pre-release-version>-toc.yml`.
     - Remove the pre-release docs table of contents mapping entry from `site/data/toc-mapping.yml`.
     - Remove all references to the pre-release docs from `site/config.yml`.
-1. Create the "Upgrade to $major.minor" page if it does not already exist ([example](https://velero.io/docs/v1.5/upgrade-to-1.5/)).
+1. Create the "Upgrade to $major.minor" page if it does not already exist ([example](/docs/v1.5/upgrade-to-1.5/)).
    If it already exists, update any usage of the previous version string within this file to use the new version string instead ([example](https://github.com/vmware-tanzu/velero/pull/2941/files#diff-d594f8fd0901fed79c39aab4b348193d)).
    This needs to be done in both the versioned and the `main` folders.
 1. Review and submit PR
@@ -130,6 +130,6 @@ What to include:
 * A brief list of highlights in the release
 * Link to the release blog post, release notes, and/or github release page
 
-[1]: https://velero.io/blog
+[1]: /blog
 [2]: website-guidelines.md
 [3]: https://github.com/vmware-tanzu/velero/tree/main/test/e2e

--- a/site/content/docs/v1.6/start-contributing.md
+++ b/site/content/docs/v1.6/start-contributing.md
@@ -20,9 +20,9 @@ You may join the Velero community and contribute in many different ways, includi
 
 You can also vote on issues using :+1: and :-1:, as explained in our [Feature enhancement request][3] and [Bug issue][4] templates. This will help us quantify importance and prioritize issues.
 
-For information on how to connect with our maintainers and community, join our online meetings, or find good first issues, start on our [Velero community](https://velero.io/community/) page.
+For information on how to connect with our maintainers and community, join our online meetings, or find good first issues, start on our [Velero community](/community/) page.
 
-Please browse our list of resources, including a playlist of past online community meetings, blog posts, and other resources to help you get familiar with our project: [Velero resources](https://velero.io/resources/).
+Please browse our list of resources, including a playlist of past online community meetings, blog posts, and other resources to help you get familiar with our project: [Velero resources](/resources/).
 
 ## Contributing
 

--- a/site/content/docs/v1.6/tilt.md
+++ b/site/content/docs/v1.6/tilt.md
@@ -24,7 +24,7 @@ files in this directory are gitignored so you may configure your setup according
 1. Clone the [Velero project](https://github.com/vmware-tanzu/velero) repository
    locally
 1. Access to an S3 object storage
-1. Clone any [provider plugin(s)](https://velero.io/plugins/) you want to make changes to and deploy (optional, must be configured to be deployed by the Velero Tilt's setup, [more info below](#provider-plugins))
+1. Clone any [provider plugin(s)](/plugins/) you want to make changes to and deploy (optional, must be configured to be deployed by the Velero Tilt's setup, [more info below](#provider-plugins))
 
 Note: To properly configure any plugin you use, please follow the plugin's documentation.
 
@@ -107,7 +107,7 @@ storage location. A sample file is provided that needs to be modified with the s
 configuration for your object storage. See the next sub-section for more details on this.
 
 ### Configure a backup storage location
-You will have to configure the `velero/tilt-resources/velero_v1_backupstoragelocation.yaml` with the proper values according to your storage provider. Read the [plugin documentation](https://velero.io/plugins/)
+You will have to configure the `velero/tilt-resources/velero_v1_backupstoragelocation.yaml` with the proper values according to your storage provider. Read the [plugin documentation](/plugins/)
 to learn what field/value pairs are required for your particular provider's backup storage location configuration.
 
 Below are some ways to configure a backup storage location for Velero.
@@ -146,7 +146,7 @@ necessary to expose MinIO outside the cluster.
 Please see our [locations documentation](locations/) to learn more how backup locations work.
 
 ### Configure the provider credentials (secret)
-Whatever object storage provider you use, configure the credentials for in the `velero/tilt-resources/cloud` file. Read the [plugin documentation](https://velero.io/plugins/)
+Whatever object storage provider you use, configure the credentials for in the `velero/tilt-resources/cloud` file. Read the [plugin documentation](/plugins/)
 to learn what field/value pairs are required for your provider's credentials. The Tilt file will invoke Kustomize to create the secret under the hard-coded key `secret.cloud-credentials.data.cloud` in the Velero namespace.
 
 There is a sample credentials file properly formatted for a MinIO storage credentials in `velero/tilt-resources/examples/cloud`.

--- a/site/content/docs/v1.6/upgrade-to-1.6.md
+++ b/site/content/docs/v1.6/upgrade-to-1.6.md
@@ -80,12 +80,12 @@ We have deprecated the way to indicate the default backup storage location. Prev
 After upgrading, if there is a previously created backup storage location with the name that matches what was defined on the server side as the default, it will be automatically set as the `default`.
 
 [0]: basic-install.md#install-the-cli
-[1]: https://velero.io/docs/v1.1.0/upgrade-to-1.1/
-[2]: https://velero.io/docs/v1.2.0/upgrade-to-1.2/
-[3]: https://velero.io/docs/v1.3.2/upgrade-to-1.3/
-[4]: https://velero.io/docs/v1.4/upgrade-to-1.4/
-[5]: https://velero.io/docs/v1.5/upgrade-to-1.5
+[1]: /docs/v1.1.0/upgrade-to-1.1/
+[2]: /docs/v1.2.0/upgrade-to-1.2/
+[3]: /docs/v1.3.2/upgrade-to-1.3/
+[4]: /docs/v1.4/upgrade-to-1.4/
+[5]: /docs/v1.5/upgrade-to-1.5
 [6]: https://github.com/vmware-tanzu/velero/releases/tag/v1.4.2
 [7]: https://github.com/vmware-tanzu/velero/issues/2077
 [8]: https://github.com/vmware-tanzu/velero/issues/2311
-[9]: https://velero.io/docs/v1.6/locations
+[9]: /docs/v1.6/locations

--- a/site/content/docs/v1.6/website-guidelines.md
+++ b/site/content/docs/v1.6/website-guidelines.md
@@ -40,6 +40,6 @@ image: /img/posts/example-image.jpg
 tags: ['Velero Team', 'Nolan Brubaker']
 ```
 
-Include the `author_name` value in tags field so the page that lists the author's posts will work properly, for example https://velero.io/tags/carlisia-thompson/.
+Include the `author_name` value in tags field so the page that lists the author's posts will work properly, for example /tags/carlisia-thompson/.
 
 Ideally each blog will have a unique image to use on the blog home page, but if you do not include an image, the default Velero logo will be used instead. Use an image that is less than 70KB and add it to the `/site/static/img/posts` folder.

--- a/site/content/docs/v1.7/_index.md
+++ b/site/content/docs/v1.7/_index.md
@@ -33,7 +33,7 @@ If you encounter issues, review the [troubleshooting docs][30], [file an issue][
 
 ## Contributing
 
-If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](https://velero.io/docs/v1.7/start-contributing/) documentation for guidance on how to setup Velero for development.
+If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](/docs/v1.7/start-contributing/) documentation for guidance on how to setup Velero for development.
 
 ## Changelog
 

--- a/site/content/docs/v1.7/contributions/oracle-config.md
+++ b/site/content/docs/v1.7/contributions/oracle-config.md
@@ -5,7 +5,7 @@ layout: docs
 
 ## Introduction
 
-[Velero](https://velero.io/) is a tool used to backup and migrate Kubernetes applications. Here are the steps to use [Oracle Cloud Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a destination for Velero backups.
+[Velero](/) is a tool used to backup and migrate Kubernetes applications. Here are the steps to use [Oracle Cloud Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a destination for Velero backups.
 
 1. [Download Velero](#download-velero)
 2. [Create A Customer Secret Key](#create-a-customer-secret-key)
@@ -244,5 +244,5 @@ After creating the Velero server in your cluster, try this example:
 
 ## Additional Reading
 
-* [Official Velero Documentation](https://velero.io/docs/v1.7/)
+* [Official Velero Documentation](/docs/v1.7/)
 * [Oracle Cloud Infrastructure Documentation](https://docs.cloud.oracle.com/)

--- a/site/content/docs/v1.7/contributions/tencent-config.md
+++ b/site/content/docs/v1.7/contributions/tencent-config.md
@@ -37,7 +37,7 @@ aws_secret_access_key=<SecretKey>
 
 ## Install Velero Resources
 
-You need to install the Velero CLI first, see [Install the CLI](https://velero.io/docs/v1.5/basic-install/#install-the-cli)  for how to install.
+You need to install the Velero CLI first, see [Install the CLI](/docs/v1.5/basic-install/#install-the-cli)  for how to install.
 
 Follow the Velero installation command below to create velero and restic workloads and other necessary resource objects.
 
@@ -60,7 +60,7 @@ Description of the parameters:
 
 - `--secret-file`: Access tencent cloud COS access credential file for the "credentials-velero" credential file created above.
 
-- `--use-restic`: Back up and restore persistent volume data using the open source free backup tool [restic](https://github.com/restic/restic).  However, 'hostPath' volumes are not supported, see the [restic limit](https://velero.io/docs/v1.5/restic/#limitations) for details), an integration 		that complements Velero's backup capabilities and is recommended to be turned on.
+- `--use-restic`: Back up and restore persistent volume data using the open source free backup tool [restic](https://github.com/restic/restic).  However, 'hostPath' volumes are not supported, see the [restic limit](/docs/v1.5/restic/#limitations) for details), an integration 		that complements Velero's backup capabilities and is recommended to be turned on.
 
 - `--default-volumes-to-restic`: Enable the use of Restic to back up all Pod volumes, provided that the `--use-restic`parameter needs to be turned on.
 
@@ -84,7 +84,7 @@ Executing the 'velero backup-location get' command to view the storage location 
 
 {{< figure src="/docs/main/contributions/img-for-tencent/69194157ccd5e377d1e7d914fd8c0336.png" width="100%">}}
 
-At this point, The installation using Tencent Cloud COS as Velero storage location is complete, If you need more installation information about Velero, You can see the official website [Velero documentation](https://velero.io/docs/) .
+At this point, The installation using Tencent Cloud COS as Velero storage location is complete, If you need more installation information about Velero, You can see the official website [Velero documentation](/docs/) .
 
 ## Velero backup and restore example
 
@@ -164,5 +164,5 @@ kubectl delete crds -l component=velero
 
 ## Additional Reading
 
-- [Official Velero Documentation](https://velero.io/docs/)
+- [Official Velero Documentation](/docs/)
 - [Tencent Cloud Documentation](https://cloud.tencent.com/document/product)

--- a/site/content/docs/v1.7/maintainers.md
+++ b/site/content/docs/v1.7/maintainers.md
@@ -17,8 +17,8 @@ Please be sure to also go through the guidance under the entire [Contribute](sta
 - Be familiar with the [lazy consensus](https://github.com/vmware-tanzu/velero/blob/v1.7.0/GOVERNANCE.md#lazy-consensus) policy for the project.
 
 Some tips for doing reviews:
-- There are some [code standards and general guidelines](https://velero.io/docs/v1.7/code-standards) we aim for
-- We have [guidelines for writing and reviewing documentation](https://velero.io/docs/v1.7/style-guide/)
+- There are some [code standards and general guidelines](/docs/v1.7/code-standards) we aim for
+- We have [guidelines for writing and reviewing documentation](/docs/v1.7/style-guide/)
 - When reviewing a design document, ensure it follows [our format and guidelines]( https://github.com/vmware-tanzu/velero/blob/v1.7.0/design/_template.md). Also, when reviewing a PR that implements a previously accepted design, ensure the associated design doc is moved to the [design/implemented](https://github.com/vmware-tanzu/velero/tree/main/design/implemented) folder.
 
 

--- a/site/content/docs/v1.7/release-instructions.md
+++ b/site/content/docs/v1.7/release-instructions.md
@@ -74,7 +74,7 @@ For each major or minor release, create and publish a blog post to let folks kno
     - Delete the pre-release docs table of contents file, i.e. `site/data/docs/<pre-release-version>-toc.yml`.
     - Remove the pre-release docs table of contents mapping entry from `site/data/toc-mapping.yml`.
     - Remove all references to the pre-release docs from `site/config.yml`.
-1. Create the "Upgrade to $major.minor" page if it does not already exist ([example](https://velero.io/docs/v1.5/upgrade-to-1.5/)).
+1. Create the "Upgrade to $major.minor" page if it does not already exist ([example](/docs/v1.5/upgrade-to-1.5/)).
    If it already exists, update any usage of the previous version string within this file to use the new version string instead ([example](https://github.com/vmware-tanzu/velero/pull/2941/files#diff-d594f8fd0901fed79c39aab4b348193d)).
    This needs to be done in both the versioned and the `main` folders.
 1. Review and submit PR
@@ -156,6 +156,6 @@ What to include:
 * A brief list of highlights in the release
 * Link to the release blog post, release notes, and/or github release page
 
-[1]: https://velero.io/blog
+[1]: /blog
 [2]: website-guidelines.md
 [3]: https://github.com/vmware-tanzu/velero/tree/main/test/e2e

--- a/site/content/docs/v1.7/start-contributing.md
+++ b/site/content/docs/v1.7/start-contributing.md
@@ -20,9 +20,9 @@ You may join the Velero community and contribute in many different ways, includi
 
 You can also vote on issues using :+1: and :-1:, as explained in our [Feature enhancement request][3] and [Bug issue][4] templates. This will help us quantify importance and prioritize issues.
 
-For information on how to connect with our maintainers and community, join our online meetings, or find good first issues, start on our [Velero community](https://velero.io/community/) page.
+For information on how to connect with our maintainers and community, join our online meetings, or find good first issues, start on our [Velero community](/community/) page.
 
-Please browse our list of resources, including a playlist of past online community meetings, blog posts, and other resources to help you get familiar with our project: [Velero resources](https://velero.io/resources/).
+Please browse our list of resources, including a playlist of past online community meetings, blog posts, and other resources to help you get familiar with our project: [Velero resources](/resources/).
 
 ## Contributing
 

--- a/site/content/docs/v1.7/tilt.md
+++ b/site/content/docs/v1.7/tilt.md
@@ -24,7 +24,7 @@ files in this directory are gitignored so you may configure your setup according
 1. Clone the [Velero project](https://github.com/vmware-tanzu/velero) repository
    locally
 1. Access to an S3 object storage
-1. Clone any [provider plugin(s)](https://velero.io/plugins/) you want to make changes to and deploy (optional, must be configured to be deployed by the Velero Tilt's setup, [more info below](#provider-plugins))
+1. Clone any [provider plugin(s)](/plugins/) you want to make changes to and deploy (optional, must be configured to be deployed by the Velero Tilt's setup, [more info below](#provider-plugins))
 
 Note: To properly configure any plugin you use, please follow the plugin's documentation.
 
@@ -107,7 +107,7 @@ storage location. A sample file is provided that needs to be modified with the s
 configuration for your object storage. See the next sub-section for more details on this.
 
 ### Configure a backup storage location
-You will have to configure the `velero/tilt-resources/velero_v1_backupstoragelocation.yaml` with the proper values according to your storage provider. Read the [plugin documentation](https://velero.io/plugins/)
+You will have to configure the `velero/tilt-resources/velero_v1_backupstoragelocation.yaml` with the proper values according to your storage provider. Read the [plugin documentation](/plugins/)
 to learn what field/value pairs are required for your particular provider's backup storage location configuration.
 
 Below are some ways to configure a backup storage location for Velero.
@@ -146,7 +146,7 @@ necessary to expose MinIO outside the cluster.
 Please see our [locations documentation](locations/) to learn more how backup locations work.
 
 ### Configure the provider credentials (secret)
-Whatever object storage provider you use, configure the credentials for in the `velero/tilt-resources/cloud` file. Read the [plugin documentation](https://velero.io/plugins/)
+Whatever object storage provider you use, configure the credentials for in the `velero/tilt-resources/cloud` file. Read the [plugin documentation](/plugins/)
 to learn what field/value pairs are required for your provider's credentials. The Tilt file will invoke Kustomize to create the secret under the hard-coded key `secret.cloud-credentials.data.cloud` in the Velero namespace.
 
 There is a sample credentials file properly formatted for a MinIO storage credentials in `velero/tilt-resources/examples/cloud`.

--- a/site/content/docs/v1.7/upgrade-to-1.7.md
+++ b/site/content/docs/v1.7/upgrade-to-1.7.md
@@ -86,12 +86,12 @@ We have deprecated the way to indicate the default backup storage location. Prev
 After upgrading, if there is a previously created backup storage location with the name that matches what was defined on the server side as the default, it will be automatically set as the `default`.
 
 [0]: basic-install.md#install-the-cli
-[1]: https://velero.io/docs/v1.1.0/upgrade-to-1.1/
-[2]: https://velero.io/docs/v1.2.0/upgrade-to-1.2/
-[3]: https://velero.io/docs/v1.3.2/upgrade-to-1.3/
-[4]: https://velero.io/docs/v1.4/upgrade-to-1.4/
-[5]: https://velero.io/docs/v1.5/upgrade-to-1.5
-[6]: https://velero.io/docs/v1.6/upgrade-to-1.6
-[9]: https://velero.io/docs/v1.7/locations
+[1]: /docs/v1.1.0/upgrade-to-1.1/
+[2]: /docs/v1.2.0/upgrade-to-1.2/
+[3]: /docs/v1.3.2/upgrade-to-1.3/
+[4]: /docs/v1.4/upgrade-to-1.4/
+[5]: /docs/v1.5/upgrade-to-1.5
+[6]: /docs/v1.6/upgrade-to-1.6
+[9]: /docs/v1.7/locations
 [10]: https://github.com/vmware-tanzu/velero/issues/2077
 [11]: https://github.com/vmware-tanzu/velero/issues/2311

--- a/site/content/docs/v1.7/website-guidelines.md
+++ b/site/content/docs/v1.7/website-guidelines.md
@@ -40,6 +40,6 @@ image: /img/posts/example-image.jpg
 tags: ['Velero Team', 'Nolan Brubaker']
 ```
 
-Include the `author_name` value in tags field so the page that lists the author's posts will work properly, for example https://velero.io/tags/carlisia-thompson/.
+Include the `author_name` value in tags field so the page that lists the author's posts will work properly, for example /tags/carlisia-thompson/.
 
 Ideally each blog will have a unique image to use on the blog home page, but if you do not include an image, the default Velero logo will be used instead. Use an image that is less than 70KB and add it to the `/site/static/img/posts` folder.

--- a/site/content/docs/v1.8/_index.md
+++ b/site/content/docs/v1.8/_index.md
@@ -33,7 +33,7 @@ If you encounter issues, review the [troubleshooting docs][30], [file an issue][
 
 ## Contributing
 
-If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](https://velero.io/docs/v1.8.0/start-contributing/) documentation for guidance on how to setup Velero for development.
+If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing](/docs/v1.8.0/start-contributing/) documentation for guidance on how to setup Velero for development.
 
 ## Changelog
 

--- a/site/content/docs/v1.8/contributions/oracle-config.md
+++ b/site/content/docs/v1.8/contributions/oracle-config.md
@@ -5,7 +5,7 @@ layout: docs
 
 ## Introduction
 
-[Velero](https://velero.io/) is a tool used to backup and migrate Kubernetes applications. Here are the steps to use [Oracle Cloud Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a destination for Velero backups.
+[Velero](/) is a tool used to backup and migrate Kubernetes applications. Here are the steps to use [Oracle Cloud Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a destination for Velero backups.
 
 1. [Download Velero](#download-velero)
 2. [Create A Customer Secret Key](#create-a-customer-secret-key)
@@ -244,5 +244,5 @@ After creating the Velero server in your cluster, try this example:
 
 ## Additional Reading
 
-* [Official Velero Documentation](https://velero.io/docs/v1.8.0/)
+* [Official Velero Documentation](/docs/v1.8.0/)
 * [Oracle Cloud Infrastructure Documentation](https://docs.cloud.oracle.com/)

--- a/site/content/docs/v1.8/contributions/tencent-config.md
+++ b/site/content/docs/v1.8/contributions/tencent-config.md
@@ -37,7 +37,7 @@ aws_secret_access_key=<SecretKey>
 
 ## Install Velero Resources
 
-You need to install the Velero CLI first, see [Install the CLI](https://velero.io/docs/v1.5/basic-install/#install-the-cli)  for how to install.
+You need to install the Velero CLI first, see [Install the CLI](/docs/v1.5/basic-install/#install-the-cli)  for how to install.
 
 Follow the Velero installation command below to create velero and restic workloads and other necessary resource objects.
 
@@ -60,7 +60,7 @@ Description of the parameters:
 
 - `--secret-file`: Access tencent cloud COS access credential file for the "credentials-velero" credential file created above.
 
-- `--use-restic`: Back up and restore persistent volume data using the open source free backup tool [restic](https://github.com/restic/restic).  However, 'hostPath' volumes are not supported, see the [restic limit](https://velero.io/docs/v1.5/restic/#limitations) for details), an integration 		that complements Velero's backup capabilities and is recommended to be turned on.
+- `--use-restic`: Back up and restore persistent volume data using the open source free backup tool [restic](https://github.com/restic/restic).  However, 'hostPath' volumes are not supported, see the [restic limit](/docs/v1.5/restic/#limitations) for details), an integration 		that complements Velero's backup capabilities and is recommended to be turned on.
 
 - `--default-volumes-to-restic`: Enable the use of Restic to back up all Pod volumes, provided that the `--use-restic`parameter needs to be turned on.
 
@@ -84,7 +84,7 @@ Executing the 'velero backup-location get' command to view the storage location 
 
 {{< figure src="/docs/main/contributions/img-for-tencent/69194157ccd5e377d1e7d914fd8c0336.png" width="100%">}}
 
-At this point, The installation using Tencent Cloud COS as Velero storage location is complete, If you need more installation information about Velero, You can see the official website [Velero documentation](https://velero.io/docs/) .
+At this point, The installation using Tencent Cloud COS as Velero storage location is complete, If you need more installation information about Velero, You can see the official website [Velero documentation](/docs/) .
 
 ## Velero backup and restore example
 
@@ -164,5 +164,5 @@ kubectl delete crds -l component=velero
 
 ## Additional Reading
 
-- [Official Velero Documentation](https://velero.io/docs/)
+- [Official Velero Documentation](/docs/)
 - [Tencent Cloud Documentation](https://cloud.tencent.com/document/product)

--- a/site/content/docs/v1.8/maintainers.md
+++ b/site/content/docs/v1.8/maintainers.md
@@ -17,8 +17,8 @@ Please be sure to also go through the guidance under the entire [Contribute](sta
 - Be familiar with the [lazy consensus](https://github.com/vmware-tanzu/velero/blob/v1.8.0/GOVERNANCE.md#lazy-consensus) policy for the project.
 
 Some tips for doing reviews:
-- There are some [code standards and general guidelines](https://velero.io/docs/v1.8.0/code-standards) we aim for
-- We have [guidelines for writing and reviewing documentation](https://velero.io/docs/v1.8.0/style-guide/)
+- There are some [code standards and general guidelines](/docs/v1.8.0/code-standards) we aim for
+- We have [guidelines for writing and reviewing documentation](/docs/v1.8.0/style-guide/)
 - When reviewing a design document, ensure it follows [our format and guidelines]( https://github.com/vmware-tanzu/velero/blob/v1.8.0/design/_template.md). Also, when reviewing a PR that implements a previously accepted design, ensure the associated design doc is moved to the [design/implemented](https://github.com/vmware-tanzu/velero/tree/main/design/implemented) folder.
 
 

--- a/site/content/docs/v1.8/release-instructions.md
+++ b/site/content/docs/v1.8/release-instructions.md
@@ -74,7 +74,7 @@ For each major or minor release, create and publish a blog post to let folks kno
     - Delete the pre-release docs table of contents file, i.e. `site/data/docs/<pre-release-version>-toc.yml`.
     - Remove the pre-release docs table of contents mapping entry from `site/data/toc-mapping.yml`.
     - Remove all references to the pre-release docs from `site/config.yml`.
-1. Create the "Upgrade to $major.minor" page if it does not already exist ([example](https://velero.io/docs/v1.5/upgrade-to-1.5/)).
+1. Create the "Upgrade to $major.minor" page if it does not already exist ([example](/docs/v1.5/upgrade-to-1.5/)).
    If it already exists, update any usage of the previous version string within this file to use the new version string instead ([example](https://github.com/vmware-tanzu/velero/pull/2941/files#diff-d594f8fd0901fed79c39aab4b348193d)).
    This needs to be done in both the versioned and the `main` folders.
 1. Review and submit PR
@@ -162,6 +162,6 @@ What to include:
 * A brief list of highlights in the release
 * Link to the release blog post, release notes, and/or github release page
 
-[1]: https://velero.io/blog
+[1]: /blog
 [2]: website-guidelines.md
 [3]: https://github.com/vmware-tanzu/velero/tree/main/test/e2e

--- a/site/content/docs/v1.8/start-contributing.md
+++ b/site/content/docs/v1.8/start-contributing.md
@@ -20,9 +20,9 @@ You may join the Velero community and contribute in many different ways, includi
 
 You can also vote on issues using :+1: and :-1:, as explained in our [Feature enhancement request][3] and [Bug issue][4] templates. This will help us quantify importance and prioritize issues.
 
-For information on how to connect with our maintainers and community, join our online meetings, or find good first issues, start on our [Velero community](https://velero.io/community/) page.
+For information on how to connect with our maintainers and community, join our online meetings, or find good first issues, start on our [Velero community](/community/) page.
 
-Please browse our list of resources, including a playlist of past online community meetings, blog posts, and other resources to help you get familiar with our project: [Velero resources](https://velero.io/resources/).
+Please browse our list of resources, including a playlist of past online community meetings, blog posts, and other resources to help you get familiar with our project: [Velero resources](/resources/).
 
 ## Contributing
 

--- a/site/content/docs/v1.8/tilt.md
+++ b/site/content/docs/v1.8/tilt.md
@@ -24,7 +24,7 @@ files in this directory are gitignored so you may configure your setup according
 1. Clone the [Velero project](https://github.com/vmware-tanzu/velero) repository
    locally
 1. Access to an S3 object storage
-1. Clone any [provider plugin(s)](https://velero.io/plugins/) you want to make changes to and deploy (optional, must be configured to be deployed by the Velero Tilt's setup, [more info below](#provider-plugins))
+1. Clone any [provider plugin(s)](/plugins/) you want to make changes to and deploy (optional, must be configured to be deployed by the Velero Tilt's setup, [more info below](#provider-plugins))
 
 Note: To properly configure any plugin you use, please follow the plugin's documentation.
 
@@ -107,7 +107,7 @@ storage location. A sample file is provided that needs to be modified with the s
 configuration for your object storage. See the next sub-section for more details on this.
 
 ### Configure a backup storage location
-You will have to configure the `velero/tilt-resources/velero_v1_backupstoragelocation.yaml` with the proper values according to your storage provider. Read the [plugin documentation](https://velero.io/plugins/)
+You will have to configure the `velero/tilt-resources/velero_v1_backupstoragelocation.yaml` with the proper values according to your storage provider. Read the [plugin documentation](/plugins/)
 to learn what field/value pairs are required for your particular provider's backup storage location configuration.
 
 Below are some ways to configure a backup storage location for Velero.
@@ -146,7 +146,7 @@ necessary to expose MinIO outside the cluster.
 Please see our [locations documentation](locations/) to learn more how backup locations work.
 
 ### Configure the provider credentials (secret)
-Whatever object storage provider you use, configure the credentials for in the `velero/tilt-resources/cloud` file. Read the [plugin documentation](https://velero.io/plugins/)
+Whatever object storage provider you use, configure the credentials for in the `velero/tilt-resources/cloud` file. Read the [plugin documentation](/plugins/)
 to learn what field/value pairs are required for your provider's credentials. The Tilt file will invoke Kustomize to create the secret under the hard-coded key `secret.cloud-credentials.data.cloud` in the Velero namespace.
 
 There is a sample credentials file properly formatted for a MinIO storage credentials in `velero/tilt-resources/examples/cloud`.

--- a/site/content/docs/v1.8/upgrade-to-1.8.md
+++ b/site/content/docs/v1.8/upgrade-to-1.8.md
@@ -82,11 +82,11 @@ We have deprecated the way to indicate the default backup storage location. Prev
 After upgrading, if there is a previously created backup storage location with the name that matches what was defined on the server side as the default, it will be automatically set as the `default`.
 
 [0]: basic-install.md#install-the-cli
-[1]: https://velero.io/docs/v1.1.0/upgrade-to-1.1/
-[2]: https://velero.io/docs/v1.2.0/upgrade-to-1.2/
-[3]: https://velero.io/docs/v1.3.2/upgrade-to-1.3/
-[4]: https://velero.io/docs/v1.4/upgrade-to-1.4/
-[5]: https://velero.io/docs/v1.5/upgrade-to-1.5
-[6]: https://velero.io/docs/v1.6/upgrade-to-1.6
-[7]: https://velero.io/docs/v1.7/upgrade-to-1.7
-[9]: https://velero.io/docs/v1.8/locations
+[1]: /docs/v1.1.0/upgrade-to-1.1/
+[2]: /docs/v1.2.0/upgrade-to-1.2/
+[3]: /docs/v1.3.2/upgrade-to-1.3/
+[4]: /docs/v1.4/upgrade-to-1.4/
+[5]: /docs/v1.5/upgrade-to-1.5
+[6]: /docs/v1.6/upgrade-to-1.6
+[7]: /docs/v1.7/upgrade-to-1.7
+[9]: /docs/v1.8/locations

--- a/site/content/docs/v1.8/website-guidelines.md
+++ b/site/content/docs/v1.8/website-guidelines.md
@@ -40,6 +40,6 @@ image: /img/posts/example-image.jpg
 tags: ['Velero Team', 'Nolan Brubaker']
 ```
 
-Include the `author_name` value in tags field so the page that lists the author's posts will work properly, for example https://velero.io/tags/carlisia-thompson/.
+Include the `author_name` value in tags field so the page that lists the author's posts will work properly, for example /tags/carlisia-thompson/.
 
 Ideally each blog will have a unique image to use on the blog home page, but if you do not include an image, the default Velero logo will be used instead. Use an image that is less than 70KB and add it to the `/site/static/img/posts` folder.

--- a/site/content/plugins/_index.md
+++ b/site/content/plugins/_index.md
@@ -9,6 +9,6 @@ Velero uses plugins to integrate with a variety of storage systems and Kubernete
 
 Read more about how to use and create plugins [in our docs][1], a detailed list of [supported providers][2], and check out our [plugin-example repo][3].
 
-[1]: https://velero.io/docs
-[2]: https://velero.io/docs/supported-providers/
+[1]: /docs
+[2]: /docs/supported-providers/
 [3]: https://github.com/vmware-tanzu/velero-plugin-example

--- a/site/content/posts/2019-08-22-announcing-velero-1.1.md
+++ b/site/content/posts/2019-08-22-announcing-velero-1.1.md
@@ -28,7 +28,7 @@ A big focus of our work this cycle was continuing to improve support for restic.
 
 Along with our bug fixes, we’ve provided an easier way to move restic backups between storage providers. Different providers often have different StorageClasses, requiring user intervention to make restores successfully complete.
 
-To make cross-provider moves simpler, we’ve introduced a StorageClass remapping plug-in. It allows you to automatically translate one StorageClass on PersistentVolumeClaims and PersistentVolumes to another. You can read more about it in our [documentation](https://velero.io/docs/v1.1.0/restore-reference/#changing-pv-pvc-storage-classes).
+To make cross-provider moves simpler, we’ve introduced a StorageClass remapping plug-in. It allows you to automatically translate one StorageClass on PersistentVolumeClaims and PersistentVolumes to another. You can read more about it in our [documentation](/docs/v1.1.0/restore-reference/#changing-pv-pvc-storage-classes).
 
 ## Quality-of-Life Improvements
 
@@ -50,13 +50,13 @@ Velero has previously used a restore-only flag on the server to control whether 
 
 We appreciate all community contributions, whether they be pull requests, bug reports, feature requests, or just questions. With this release, we wanted to draw attention to a few contributions in particular:
 
-For users of node-based IAM authentication systems such as kube2iam, `velero install` now supports the `--pod-annotations` argument for applying necessary annotations at install time. This support should make `velero install` more flexible for scenarios that do not use Secrets for access to their cloud buckets and volumes. You can read more about how to use this new argument in our [AWS documentation](https://velero.io/docs/v1.1.0/aws-config/#alternative-setup-permissions-using-kube2iam). Huge thanks to [Traci Kamp](https://github.com/tlkamp) for this contribution.
+For users of node-based IAM authentication systems such as kube2iam, `velero install` now supports the `--pod-annotations` argument for applying necessary annotations at install time. This support should make `velero install` more flexible for scenarios that do not use Secrets for access to their cloud buckets and volumes. You can read more about how to use this new argument in our [AWS documentation](/docs/v1.1.0/aws-config/#alternative-setup-permissions-using-kube2iam). Huge thanks to [Traci Kamp](https://github.com/tlkamp) for this contribution.
 
 Structured logging is important for any application, and Velero is no different. Starting with version 1.1, the Velero server can now output its logs in a JSON format, allowing easier parsing and ingestion. Thank you to [Donovan Carthew](https://github.com/carthewd) for this feature.
 
 AWS supports multiple profiles for accessing object storage, but in the past Velero only used the default. With v.1.1, you can set the `profile` key on yourBackupStorageLocation to specify an alternate profile. If no profile is set, the default one is used, making this change backward compatible. Thanks [Pranav Gaikwad](https://github.com/pranavgaikwad) for this change.
 
-Finally, thanks to testing by [Dylan Murray](https://github.com/dymurray) and [Scott Seago](https://github.com/sseago), an issue with running Velero in non-default namespaces was found in our beta version for this release. If you’re running Velero in a namespace other than `velero`, please follow the [upgrade instructions](https://velero.io/docs/v1.1.0/upgrade-to-1.1/).
+Finally, thanks to testing by [Dylan Murray](https://github.com/dymurray) and [Scott Seago](https://github.com/sseago), an issue with running Velero in non-default namespaces was found in our beta version for this release. If you’re running Velero in a namespace other than `velero`, please follow the [upgrade instructions](/docs/v1.1.0/upgrade-to-1.1/).
 
 ## Help Us Build the Future
 
@@ -68,7 +68,7 @@ The team has also been discussing different approaches to concurrent backup jobs
 
 ## Take the Survey
 
-Finally, we’re running [a survey](https://velero.io/survey) for our users. Let us know how you use Velero and what you’d like the community to address in the future. We’ll be using this feedback to guide our roadmap planning. Anonymized results will be shared back with the community shortly after the survey closes.
+Finally, we’re running [a survey](/survey) for our users. Let us know how you use Velero and what you’d like the community to address in the future. We’ll be using this feedback to guide our roadmap planning. Anonymized results will be shared back with the community shortly after the survey closes.
 
 ## Join the Movement – Contribute!
 

--- a/site/content/posts/2019-10-01-announcing-gh-move.md
+++ b/site/content/posts/2019-10-01-announcing-gh-move.md
@@ -37,10 +37,10 @@ Instructions for upgrading to version 1.2 and installing Velero and its plugins 
 
 ## Feedback
 
-As always, we welcome feedback and participation in the development of Velero. All information on how to contact us or become involved can be found here: https://velero.io/community/
+As always, we welcome feedback and participation in the development of Velero. All information on how to contact us or become involved can be found here: /community/
 
 [1]: https://github.com/vmware-tanzu
 [2]: https://blogs.vmware.com/cloudnative/2019/10/01/open-source-in-vmware-tanzu/
 [3]: ../docs/main/supported-providers
-[4]: https://velero.io/docs/main/
+[4]: /docs/main/
 [5]: https://github.com/vmware-tanzu/velero/issues#workspaces/velero-5c59c15e39d47b774b5864e3/board?milestones=v1.2%232019-10-31&filterLogic=any&repos=99143276&showPipelineDescriptions=false

--- a/site/content/posts/2019-10-08-Velero-v1-1-on-vSphere.md
+++ b/site/content/posts/2019-10-08-Velero-v1-1-on-vSphere.md
@@ -254,6 +254,6 @@ Backups and Restores are now working on Kubernetes deployed on vSphere using Vel
 
 ## Feedback and Participation
 
-As always, we welcome feedback and participation in the development of Velero. [All information on how to contact us or become active can be found here](https://velero.io/community/)
+As always, we welcome feedback and participation in the development of Velero. [All information on how to contact us or become active can be found here](/community/)
 
 You can find us on [Kubernetes Slack in the #velero channel](https://kubernetes.slack.com/messages/C6VCGP4MT), and follow us on Twitter at [@projectvelero](https://twitter.com/projectvelero).

--- a/site/content/posts/2019-10-10-Velero-v1-1-Stateful-Backup-vSphere.md
+++ b/site/content/posts/2019-10-10-Velero-v1-1-Stateful-Backup-vSphere.md
@@ -24,7 +24,7 @@ Velero version 1.1 provides support to backup applications orchestrated on upstr
 ## What this post does not show
 
 * This tutorial does not show how to deploy Velero v1.1 on vSphere. This is available in other tutorials.
-* For this backup to be successful, Velero needs to be installed with the `use-restic` flag. [More details on using Restic for stateful backups can be found in the docs here](https://velero.io/docs/v1.1.0/restic/#Setup)
+* For this backup to be successful, Velero needs to be installed with the `use-restic` flag. [More details on using Restic for stateful backups can be found in the docs here](/docs/v1.1.0/restic/#Setup)
 * The assumption is that the Kubernetes nodes in your cluster have internet access in order to pull the necessary Velero images. This guide does not show how to pull images using a local repository.
 
 ## Download and Deploy Cassandra
@@ -463,6 +463,6 @@ It looks like the restore has been successful. Velero v1.1 has successfully rest
 
 ## Feedback and Participation
 
-As always, we welcome feedback and participation in the development of Velero. [All information on how to contact us or become active can be found here](https://velero.io/community/)
+As always, we welcome feedback and participation in the development of Velero. [All information on how to contact us or become active can be found here](/community/)
 
 You can find us on [Kubernetes Slack in the #velero channel](https://kubernetes.slack.com/messages/C6VCGP4MT), and follow us on Twitter at [@projectvelero](https://twitter.com/projectvelero).

--- a/site/content/posts/2019-11-07-Velero-1.2-Sets-Sail.md
+++ b/site/content/posts/2019-11-07-Velero-1.2-Sets-Sail.md
@@ -75,7 +75,7 @@ Check out these talks related to Velero:
 
 ## Join the Movement – Contribute!
 
-Velero is better because of our contributors and maintainers. It is because of you that we can bring great software to the community. Please join us during our [online community meetings every Tuesday](https://velero.io/community/) and catch up with past meetings on YouTube on the [Velero Community Meetings playlist](https://www.youtube.com/watch?v=nc48ocI-6go&list=PL7bmigfV0EqQRysvqvqOtRNk4L5S7uqwM).
+Velero is better because of our contributors and maintainers. It is because of you that we can bring great software to the community. Please join us during our [online community meetings every Tuesday](/community/) and catch up with past meetings on YouTube on the [Velero Community Meetings playlist](https://www.youtube.com/watch?v=nc48ocI-6go&list=PL7bmigfV0EqQRysvqvqOtRNk4L5S7uqwM).
 
 You can always find the latest project information at [velero.io](https://velero.io). Look for issues on GitHub marked [Good first issue](https://github.com/vmware-tanzu/velero/issues?q=is:open+is:issue+label:%22Good+first+issue%22) or [Help wanted](https://github.com/vmware-tanzu/velero/issues?utf8=✓&q=is:open+is:issue+label:%22Help+wanted%22+) if you want to roll up your sleeves and write some code with us.
 

--- a/site/content/posts/2020-03-02-Velero-1.3-Voyage-Continues.md
+++ b/site/content/posts/2020-03-02-Velero-1.3-Voyage-Continues.md
@@ -55,7 +55,7 @@ Our priorities have not changed, and we’re continuing to work hard on adding C
 
 ## Join the Movement – Contribute!
 
-Velero is better because of our contributors and maintainers. It is because of you that we can bring great software to the community. Please join us during our [online community meetings every Tuesday](https://velero.io/community/) and catch up with past meetings on YouTube on the [Velero Community Meetings playlist](https://www.youtube.com/watch?v=nc48ocI-6go&list=PL7bmigfV0EqQRysvqvqOtRNk4L5S7uqwM).
+Velero is better because of our contributors and maintainers. It is because of you that we can bring great software to the community. Please join us during our [online community meetings every Tuesday](/community/) and catch up with past meetings on YouTube on the [Velero Community Meetings playlist](https://www.youtube.com/watch?v=nc48ocI-6go&list=PL7bmigfV0EqQRysvqvqOtRNk4L5S7uqwM).
 
 You can always find the latest project information at [velero.io](https://velero.io). Look for issues on GitHub marked [Good first issue](https://github.com/vmware-tanzu/velero/issues?q=is:open+is:issue+label:%22Good+first+issue%22) or [Help wanted](https://github.com/vmware-tanzu/velero/issues?utf8=✓&q=is:open+is:issue+label:%22Help+wanted%22+) if you want to roll up your sleeves and write some code with us.
 

--- a/site/content/posts/2020-05-26-Velero-1.4-Community-Wave.md
+++ b/site/content/posts/2020-05-26-Velero-1.4-Community-Wave.md
@@ -16,7 +16,7 @@ Velero v1.4.0 now extends Velero’s support for snapshotting beyond Velero’s 
 
 The [Container Storage Interface](https://github.com/container-storage-interface/spec) (CSI) is a way for container orchestrators such as Kubernetes to provide a standard interface for storage systems, without having to create drivers for each orchestration system. While basic attach and detach volume operations are generally available in Kubernetes, the volume snapshotting APIs are still in beta. The Velero team is working with the Data Protection Working Group to ensure that the CSI snapshotting API specification is useful to end users and tool builders.  We intend to trail behind the official Kubernetes support for the feature, entering general availability sometime after the feature is GA in Kubernetes itself.
 
-Activating and using the CSI support in Velero will require enabling the `EnableCSI` feature flag and installing the [CSI plugin](https://github.com/vmware-tanzu/velero-plugin-for-csi/) alongside the Velero server. For full details on installing and using the feature, see our [CSI beta page](https://velero.io/docs/csi/).
+Activating and using the CSI support in Velero will require enabling the `EnableCSI` feature flag and installing the [CSI plugin](https://github.com/vmware-tanzu/velero-plugin-for-csi/) alongside the Velero server. For full details on installing and using the feature, see our [CSI beta page](/docs/csi/).
 
 As a very brief example of the seamless integration of CSI into Velero. We will back up and restore a sample workload in the `csi-app` namespace that is using volumes backed by the CSI hostpath plugin driver. Installing and configuring the driver is outside the scope of this blog post, but we will cover the complete example in the future.
 
@@ -80,7 +80,7 @@ We’re currently experimenting with being able to restore different versions, a
 
 ## Added support for custom certificates
 
-When deploying Velero on-premises, users have often asked for supporting a custom certificate authority. With Velero v1.4.0, this is now possible! Thanks to contributions from [Samuel Lucidi](https://github.com/mansam) and [Dylan McMurray](https://github.com/dymurray) from Red Hat, Velero now supports using custom certificates for accessing object stores. For more information, please see the [documentation on custom certificates](https://velero.io/docs/v1.4/self-signed-certificates/).
+When deploying Velero on-premises, users have often asked for supporting a custom certificate authority. With Velero v1.4.0, this is now possible! Thanks to contributions from [Samuel Lucidi](https://github.com/mansam) and [Dylan McMurray](https://github.com/dymurray) from Red Hat, Velero now supports using custom certificates for accessing object stores. For more information, please see the [documentation on custom certificates](/docs/v1.4/self-signed-certificates/).
 
 ## Better support for restoring custom resources from CustomResourceDefinition in the same restore operation
 
@@ -103,7 +103,7 @@ In order to keep up-to-date with our dependencies, we’ve moved our base contai
 
 Thanks again to all of our contributors who asked questions, filed issues, and wrote code for this release of Velero! We encourage you to try out these new features and provide feedback through our Slack channel or with an issue.
 
-If you’d like to get involved, please join us during our [online community meetings every Tuesday](https://velero.io/community/) and catch up with past meetings on YouTube on the [Velero Community Meetings playlist](https://www.youtube.com/watch?v=nc48ocI-6go&list=PL7bmigfV0EqQRysvqvqOtRNk4L5S7uqwM).
+If you’d like to get involved, please join us during our [online community meetings every Tuesday](/community/) and catch up with past meetings on YouTube on the [Velero Community Meetings playlist](https://www.youtube.com/watch?v=nc48ocI-6go&list=PL7bmigfV0EqQRysvqvqOtRNk4L5S7uqwM).
 
 You can always find the latest project information at [velero.io](https://velero.io). Look for issues on GitHub marked [Good first issue](https://github.com/vmware-tanzu/velero/issues?q=is:open+is:issue+label:%22Good+first+issue%22) or [Help wanted](https://github.com/vmware-tanzu/velero/issues?utf8=✓&q=is:open+is:issue+label:%22Help+wanted%22+) if you want to roll up your sleeves and write some code with us.
 

--- a/site/content/posts/2020-05-27-CSI-integration.md
+++ b/site/content/posts/2020-05-27-CSI-integration.md
@@ -43,7 +43,7 @@ This script will deploy the following CSI components, CRDs, and necessary RBAC:
 
 The CSI volume snapshot capability is currently, as of Velero 1.4, a beta feature behind the `EnableCSI` feature flag and is not enabled by default.
 
-Following instructions from our [docs website](https://velero.io/docs/csi/), install Velero with the [velero-plugin-for-csi](https://github.com/vmware-tanzu/velero-plugin-for-csi) and using the Azure Blob Store as our BackupStorageLocation. Please refer to our [velero-plugin-for-microsoft-azure documentation](https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure) for instructions on setting up the BackupStorageLocation. Please note that the BackupStorageLocation should be set up before installing Velero.
+Following instructions from our [docs website](/docs/csi/), install Velero with the [velero-plugin-for-csi](https://github.com/vmware-tanzu/velero-plugin-for-csi) and using the Azure Blob Store as our BackupStorageLocation. Please refer to our [velero-plugin-for-microsoft-azure documentation](https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure) for instructions on setting up the BackupStorageLocation. Please note that the BackupStorageLocation should be set up before installing Velero.
 
 Install Velero by running the below command
 
@@ -189,7 +189,7 @@ And that's all it takes to backup and restore a stateful application that uses C
 
 Please try out the CSI support in Velero 1.4. Feature requests, suggestions, bug reports, PRs are all welcome.
 
-Get in touch with us on [Kubernetes Slack #velero](https://kubernetes.slack.com/archives/C6VCGP4MT), [Twitter](https://twitter.com/projectvelero), or [Our weekly community calls](https://velero.io/community/)
+Get in touch with us on [Kubernetes Slack #velero](https://kubernetes.slack.com/archives/C6VCGP4MT), [Twitter](https://twitter.com/projectvelero), or [Our weekly community calls](/community/)
 
 
 ## Resources
@@ -197,6 +197,6 @@ Get in touch with us on [Kubernetes Slack #velero](https://kubernetes.slack.com/
 More details about CSI volume snapshotting and its support in Velero may be found in the following links:
 
 - [Kubernetes 1.17 Feature: Kubernetes Volume Snapshot Moves to Beta](https://kubernetes.io/blog/2019/12/09/kubernetes-1-17-feature-cis-volume-snapshot-beta/) for more information on the CSI beta snapshot APIs.
-- Prerequisites to use this feature is available [on our website](https://velero.io/docs/csi).
+- Prerequisites to use this feature is available [on our website](/docs/csi).
 - [Kubernetes CSI docs](https://kubernetes-csi.github.io/docs/sidecar-containers.html): To understand components in a CSI environment
 - [Velero plugin for CSI snapshots](https://github.com/vmware-tanzu/velero-plugin-for-csi) for implementation details of the CSI plugin.

--- a/site/content/posts/2020-09-16-Velero-1.5-For-And-By-Community.md
+++ b/site/content/posts/2020-09-16-Velero-1.5-For-And-By-Community.md
@@ -35,7 +35,7 @@ With the release of 1.5, Velero now has the ability to backup all pod volumes us
 1. Hostpath volumes
 1. Volumes mounting Kubernetes secrets and config maps.
 
-You can enable this feature on a per backup basis or as a default setting for all Velero backups. Read more about this feature on our [restic integration](https://velero.io/docs/v1.5/restic/) page on our documentation website.
+You can enable this feature on a per backup basis or as a default setting for all Velero backups. Read more about this feature on our [restic integration](/docs/v1.5/restic/) page on our documentation website.
 
 ### DeleteItemAction Plugins: A new way to customize Velero
 
@@ -48,11 +48,11 @@ The [velero-plugin-for-csi](https://github.com/vmware-tanzu/velero-plugin-for-cs
 
 Velero has been helping its users with disaster recovery for their Kubernetes clusters since its first release in August 2017. Over the past three years, there have been major improvements in the ecosystem, including new frameworks that make it easier to develop solutions for Kubernetes. This release marks the first steps in our journey to modernize the Velero codebase and take advantage of newer frameworks as we begin the adoption of [kubebuilder](https://book.kubebuilder.io/), the most popular framework to build custom Kubernetes APIs and their respective controllers. As this effort continues, we would like to invite more folks to be a part of our growing contributor base.
 
-Staying on the theme of using tools that are current and growing our contributor base: thanks to our community member and first-time contributor [@RobReus](https://github.com/RobReus), Velero now uses [docker buildx](https://docs.docker.com/buildx/working-with-buildx/) to build multi-arch images for Velero. You can read more about this on [our documentation website](https://velero.io/docs/main/build-from-source/#buildx) and [docker’s documentation](https://docs.docker.com/buildx/working-with-buildx/).
+Staying on the theme of using tools that are current and growing our contributor base: thanks to our community member and first-time contributor [@RobReus](https://github.com/RobReus), Velero now uses [docker buildx](https://docs.docker.com/buildx/working-with-buildx/) to build multi-arch images for Velero. You can read more about this on [our documentation website](/docs/main/build-from-source/#buildx) and [docker’s documentation](https://docs.docker.com/buildx/working-with-buildx/).
 
 ### Restore Hooks
 
-Using [Velero’s Backup Hooks](https://velero.io/docs/v1.5/backup-hooks/) functionality, users can quiesce and un-quiesce applications before and after backup operations. This allows users to take application consistent backups of volume data. However, similar functionality to perform custom actions during or after a restore operation was unavailable. This led our users to build custom extensions outside of Velero as a workaround.
+Using [Velero’s Backup Hooks](/docs/v1.5/backup-hooks/) functionality, users can quiesce and un-quiesce applications before and after backup operations. This allows users to take application consistent backups of volume data. However, similar functionality to perform custom actions during or after a restore operation was unavailable. This led our users to build custom extensions outside of Velero as a workaround.
 
 Driven wholly by the Velero community, we have a design for the missing Restore Hooks functionality. Thank you to our community members [@marccampbell](https://github.com/marccampbell) and [@areed](https://github.com/areed) for driving the design proposal, and to everyone who participated in the design discussions and reviews. In the design, there are two kinds of Restore Hooks:
 1. InitContainer Restore Hooks: These will add init containers into restored pods to perform any necessary setup before the application containers of the restored pod can start.
@@ -66,7 +66,7 @@ Velero can specify a custom order in which resources can be backed up. Thanks to
 
 
 These were just some highlights of the release. You can always find more information about the release in the [release change log](https://github.com/vmware-tanzu/velero/blob/v1.5.1/changelogs/CHANGELOG-1.5.md). 
-See the [1.5 upgrade instructions](https://velero.io/docs/v1.5/upgrade-to-1.5/) to start planning your upgrade today.
+See the [1.5 upgrade instructions](/docs/v1.5/upgrade-to-1.5/) to start planning your upgrade today.
 
 ## Join the Community and Make Velero Better
 

--- a/site/content/posts/2021-04-13-Velero-1.6-Bring-All-Your-Credentials.md
+++ b/site/content/posts/2021-04-13-Velero-1.6-Bring-All-Your-Credentials.md
@@ -29,7 +29,7 @@ With the release of Velero 1.6, users can now optionally configure credentials f
 Velero will then use those credentials when interacting with storage provider plugins.
 The v1.2.0 releases of all the plugins maintained by the Velero team support this new way of handling credentials and we look forward to collaborating with more community plugin providers to grow adoption of this feature.
 
-For more information, and detailed instructions on how to configure credentials for your Backup Storage Locations, please see our [documentation](https://velero.io/docs/v1.6/locations/#create-a-storage-location-that-uses-unique-credentials).
+For more information, and detailed instructions on how to configure credentials for your Backup Storage Locations, please see our [documentation](/docs/v1.6/locations/#create-a-storage-location-that-uses-unique-credentials).
 
 ### Restore Progress Reporting
 
@@ -48,7 +48,7 @@ For Velero 1.6, [Frankie Gold](https://github.com/codegold79) from VMware adapte
 This allows for much more flexibility when performing migrations into new clusters.
 
 Using this new feature requires the `EnableAPIGroupVersions` feature flag to be enabled in your Velero instance.
-For a detailed description of the feature, as well as more information about how Velero decides which version to restore, please see our [documentation](https://velero.io/docs/v1.6/enable-api-group-versions-feature/).
+For a detailed description of the feature, as well as more information about how Velero decides which version to restore, please see our [documentation](/docs/v1.6/enable-api-group-versions-feature/).
 
 ### Restic Upgrade
 
@@ -86,7 +86,7 @@ We’ve made huge improvements to the developer experience during this release c
 Using Tilt enables developers to make changes to Velero and its plugins, and have those changes automatically built and deployed to your cluster.
 This removes the need for any manual building or pushing of images, and provides a faster and much simpler workflow.
 Our Tilt configuration also enables contributors to more easily debug the Velero process using Delve, which has integrations with many editors and IDEs.
-If you would like to try it out, please see our [documentation](https://velero.io/docs/v1.6/tilt/).
+If you would like to try it out, please see our [documentation](/docs/v1.6/tilt/).
 
 ### Looking Forward
 

--- a/site/layouts/partials/contributors.html
+++ b/site/layouts/partials/contributors.html
@@ -11,7 +11,7 @@
                 href="{{ .Site.Params.Gh_repo }}/issues" class="light">GitHub issues page
           for {{ .Site.Title }}</a></strong>.</p>
     <p>The Velero project team welcomes contributions from the community, please see our <strong><a
-                href="https://velero.io/docs/main/start-contributing/" class="light">contributing
+                href="/docs/main/start-contributing/" class="light">contributing
           documentation</a></strong>.
     </p>
   </div>


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Use relative path in links. Tested on https://velero.tig.pw as part of providing temporary solution to https://github.com/vmware-tanzu/velero/issues/4579
Replaces `https://velero.io/` with `/` for all files in repo under site/
# Does your change fix a particular issue?
Fixes path when hosted from different domain names.
Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
