### PR TITLE
restic backupper: ignore volumes of non-running pods

### DIFF
--- a/changelogs/unreleased/4584-bynare
+++ b/changelogs/unreleased/4584-bynare
@@ -1,0 +1,1 @@
+Skip volumes of non-running pods when backing up


### PR DESCRIPTION
This patch deals with cases like completed jobs failing to back up, by ignoring backup attempts for volumes of pods that are no longer running.

Fixes #2395

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
