### PR TITLE
E2E SSR test add retry mechanism and logs

### DIFF
--- a/changelogs/unreleased/4594-mqiu
+++ b/changelogs/unreleased/4594-mqiu
@@ -1,0 +1,1 @@
+E2E SSR test add retry mechanism and logs 

--- a/test/e2e/privilegesmgmt/ssr.go
+++ b/test/e2e/privilegesmgmt/ssr.go
@@ -73,16 +73,30 @@ func SSRTest() {
 			fmt.Sprintf("Failed to create an ssr object in %s namespace", VeleroCfg.VeleroNamespace))
 
 		ssrListResp := new(v1.ServerStatusRequestList)
-
 		By(fmt.Sprintf("Check ssr object in %s namespace", VeleroCfg.VeleroNamespace))
-		Expect(client.Kubebuilder.List(ctx, ssrListResp, &kbclient.ListOptions{Namespace: VeleroCfg.VeleroNamespace})).To(Succeed(),
-			fmt.Sprintf("Failed to list ssr object in %s namespace", VeleroCfg.VeleroNamespace))
-		Expect(len(ssrListResp.Items)).To(BeNumerically("==", 1),
-			fmt.Sprintf("Count of ssr object in %s namespace is not 1", VeleroCfg.VeleroNamespace))
-		Expect(ssrListResp.Items[0].Status.ServerVersion).NotTo(BeEmpty(),
-			fmt.Sprintf("ServerVersion of ssr object in %s namespace should not empty", VeleroCfg.VeleroNamespace))
-		Expect(ssrListResp.Items[0].Status.Phase == "Processed").To(BeTrue(),
-			fmt.Sprintf("Phase of ssr object in %s namespace should be Processed", VeleroCfg.VeleroNamespace))
+		err = waitutil.PollImmediate(5*time.Second, time.Minute,
+			func() (bool, error) {
+				if err = client.Kubebuilder.List(ctx, ssrListResp, &kbclient.ListOptions{Namespace: VeleroCfg.VeleroNamespace}); err != nil {
+					return false, fmt.Errorf("failed to list ssr object in %s namespace with err %v", VeleroCfg.VeleroNamespace, err)
+				}
+				if len(ssrListResp.Items) != 1 {
+					return false, fmt.Errorf("count of ssr object in %s namespace is not 1", VeleroCfg.VeleroNamespace)
+				}
+
+				if ssrListResp.Items[0].Status.ServerVersion == "" {
+					fmt.Printf("ServerVersion of ssr object in %s namespace should not empty, current response result %v\n", VeleroCfg.VeleroNamespace, ssrListResp)
+					return false, nil
+				}
+
+				if ssrListResp.Items[0].Status.Phase != "Processed" {
+					return false, fmt.Errorf("phase of ssr object in %s namespace should be Processed but got phase %s", VeleroCfg.VeleroNamespace, ssrListResp.Items[0].Status.Phase)
+				}
+				return true, nil
+			})
+		if err == waitutil.ErrWaitTimeout {
+			fmt.Printf("exceed test case deadline and failed to check ssr object in %s namespace", VeleroCfg.VeleroNamespace)
+		}
+		Expect(err).To(Succeed(), fmt.Sprintf("Failed to check ssr object in %s namespace", VeleroCfg.VeleroNamespace))
 
 		By(fmt.Sprintf("Check ssr object in %s namespace", testNS))
 		Expect(client.Kubebuilder.List(ctx, ssrListResp, &kbclient.ListOptions{Namespace: testNS})).To(Succeed(),


### PR DESCRIPTION
Signed-off-by: Ming <mqiu@vmware.com>

Thank you for contributing to Velero!
Fixes #(issue)
it reference to #4590, E2E SSR test add retry mechanism and logs
# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
