### PR TITLE
Undeprecate the volumesnapshot plugin

### DIFF
--- a/site/content/docs/main/custom-plugins.md
+++ b/site/content/docs/main/custom-plugins.md
@@ -54,14 +54,10 @@ You will need to give your plugin(s) the full name when registering them by call
 Velero supports the following kinds of plugins:
 
 - **Object Store** - persists and retrieves backups, backup logs and restore logs
-- **Item Snapshotter** - creates snapshots for Kubernetes objects during backup and restores the object from snapshots during restore.  ItemSnapshotters
-  are typically used with the [Astrolabe](https://github.com/vmware-tanzu/astrolabe) framework.
+- **Volume Snapshotter** - creates volume snapshots (during backup) and restores volumes from snapshots (during restore)
 - **Backup Item Action** - executes arbitrary logic for individual items prior to storing them in a backup file
 - **Restore Item Action** - executes arbitrary logic for individual items prior to restoring them into a cluster
 - **Delete Item Action** - executes arbitrary logic based on individual items within a backup prior to deleting the backup
-## Deprecated plugin kinds
-- **Volume Snapshotter** - creates volume snapshots (during backup) and restores volumes from snapshots (during restore)  VolumeSnapshotters
-are deprecated and will be replaced with ItemSnapshotter/Astrolabe plugins.
 
 ## Plugin Logging
 


### PR DESCRIPTION
Since Itemsnapshotter plugin is still WIP.
Removing the reference and the deprecation of volumeSnapshotter plugin
to avoid confusion.
We'll update the doc when it's ready and we have a reference
implementation.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
