### PR TITLE
Check for nil before logging DefaultVolumesToRestic value

### DIFF
--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -200,7 +200,11 @@ func (kb *kubernetesBackupper) BackupWithResolvers(log logrus.FieldLogger,
 	backupRequest.ResourceIncludesExcludes = collections.GetResourceIncludesExcludes(kb.discoveryHelper, backupRequest.Spec.IncludedResources, backupRequest.Spec.ExcludedResources)
 	log.Infof("Including resources: %s", backupRequest.ResourceIncludesExcludes.IncludesString())
 	log.Infof("Excluding resources: %s", backupRequest.ResourceIncludesExcludes.ExcludesString())
-	log.Infof("Backing up all pod volumes using restic: %t", *backupRequest.Backup.Spec.DefaultVolumesToRestic)
+	if backupRequest.Backup.Spec.DefaultVolumesToRestic != nil {
+		log.Infof("Backing up all pod volumes using Restic: %t", *backupRequest.Backup.Spec.DefaultVolumesToRestic)
+	} else {
+		log.Infof("DefaultVolumesToRestic for backing up all pod volumes using Restic is %v", backupRequest.Backup.Spec.DefaultVolumesToRestic)
+	}
 
 	var err error
 	backupRequest.ResourceHooks, err = getResourceHooks(backupRequest.Spec.Hooks.Resources, kb.discoveryHelper)

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -1,5 +1,5 @@
 /*
-Copyright the Velero contributors.
+Copyright the Velero Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -47,6 +47,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	"github.com/vmware-tanzu/velero/pkg/podexec"
 	"github.com/vmware-tanzu/velero/pkg/restic"
+	"github.com/vmware-tanzu/velero/pkg/util/boolptr"
 	"github.com/vmware-tanzu/velero/pkg/util/collections"
 )
 
@@ -200,11 +201,7 @@ func (kb *kubernetesBackupper) BackupWithResolvers(log logrus.FieldLogger,
 	backupRequest.ResourceIncludesExcludes = collections.GetResourceIncludesExcludes(kb.discoveryHelper, backupRequest.Spec.IncludedResources, backupRequest.Spec.ExcludedResources)
 	log.Infof("Including resources: %s", backupRequest.ResourceIncludesExcludes.IncludesString())
 	log.Infof("Excluding resources: %s", backupRequest.ResourceIncludesExcludes.ExcludesString())
-	if backupRequest.Backup.Spec.DefaultVolumesToRestic != nil {
-		log.Infof("Backing up all pod volumes using Restic: %t", *backupRequest.Backup.Spec.DefaultVolumesToRestic)
-	} else {
-		log.Infof("DefaultVolumesToRestic for backing up all pod volumes using Restic is %v", backupRequest.Backup.Spec.DefaultVolumesToRestic)
-	}
+	log.Infof("Backing up all pod volumes using Restic: %t", boolptr.IsSetToTrue(backupRequest.Backup.Spec.DefaultVolumesToRestic))
 
 	var err error
 	backupRequest.ResourceHooks, err = getResourceHooks(backupRequest.Spec.Hooks.Resources, kb.discoveryHelper)


### PR DESCRIPTION
Signed-off-by: F. Gold <fgold@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

Check for nil value for `backupRequest.Backup.Spec.DefaultVolumesToRestic` (a pointer to a boolean) before dereferencing. Although I could not reproduce the problem, panics have been reported to have happened due to attempting to do an info log with the pointer value.

# Does your change fix a particular issue?

Fixes #4617

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
