### PR TITLE
Add pushing image to GCR in github workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,6 +6,22 @@ on:
     tags:
       - '*'
 
+# id-token is added to enable OIDC token generation. All the others are copied from "Set up job" GITHUB_TOKEN Permissions
+permissions:
+  actions: write
+  checks: write
+  contents: write
+  deployments: write
+  discussions: write
+  issues: write
+  packages: write
+  pages: write
+  pull-requests: write
+  repository-projects: write
+  security-events: write
+  statuses: write
+  id-token: write
+
 jobs:
 
   build:
@@ -47,21 +63,27 @@ jobs:
         docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
         ./hack/docker-push.sh
 
+    # actions/checkout MUST come before auth
+    - uses: 'actions/checkout@v2'
+
+    # auth to GCP with OIDC token from GCP Workload Identity Provider. Output auth result to access token.
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
       uses: 'google-github-actions/auth@v0.6.0'
       with:
         workload_identity_provider: 'projects/298797809281/locations/global/workloadIdentityPools/velero-pool/providers/velero-provider'
         service_account: 'gcraccount@velero-gcp.iam.gserviceaccount.com'
+        token_format: 'access_token'
 
-    - name: Set up gCloud SDK
-      uses: 'google-github-actions/setup-gcloud@v0.5.0'
-
-    - name: Configure docker for GCR
-      run: |
-        gcloud auth configure-docker --quiet
+    # Use access_token generated above to login gcr.io
+    - uses: 'docker/login-action@v1'
+      with:
+        registry: 'gcr.io' # or REGION.docker.pkg.dev
+        username: 'oauth2accesstoken'
+        password: '${{ steps.auth.outputs.access_token }}'
 
     # Push image to GCR to facilitate some environments that have rate limitation to docker hub, e.g. vSphere.
     - name: Publish container image to GCR
+      if: github.repository == 'vmware-tanzu/velero'
       run: |
         REGISTRY=gcr.io/velero-gcp ./hack/docker-push.sh

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -47,23 +47,12 @@ jobs:
         docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
         ./hack/docker-push.sh
 
-    # actions/checkout MUST come before auth
-    - uses: 'actions/checkout@v2'
-
-    # auth to GCP with OIDC token from GCP Workload Identity Provider. Output auth result to access token.
-    - id: 'auth'
-      name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v0.6.0'
-      with:
-        credentials_json: '${{ secrets.GCR_SA_KEY }}'
-        token_format: 'access_token'
-
-    # Use access_token generated above to login gcr.io
+    # Use the JSON key in secret to login gcr.io
     - uses: 'docker/login-action@v1'
       with:
         registry: 'gcr.io' # or REGION.docker.pkg.dev
-        username: 'oauth2accesstoken'
-        password: '${{ steps.auth.outputs.access_token }}'
+        username: '_json_key'
+        password: '${{ secrets.GCR_SA_KEY }}'
 
     # Push image to GCR to facilitate some environments that have rate limitation to docker hub, e.g. vSphere.
     - name: Publish container image to GCR

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -46,3 +46,22 @@ jobs:
       run: |
         docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
         ./hack/docker-push.sh
+
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v0.6.0'
+      with:
+        workload_identity_provider: 'projects/298797809281/locations/global/workloadIdentityPools/velero-pool/providers/velero-provider'
+        service_account: 'gcraccount@velero-gcp.iam.gserviceaccount.com'
+
+    - name: Set up gCloud SDK
+      uses: 'google-github-actions/setup-gcloud@v0.5.0'
+
+    - name: Configure docker for GCR
+      run: |
+        gcloud auth configure-docker --quiet
+
+    # Push image to GCR to facilitate some environments that have rate limitation to docker hub, e.g. vSphere.
+    - name: Publish container image to GCR
+      run: |
+        REGISTRY=gcr.io/velero-gcp ./hack/docker-push.sh

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,22 +6,6 @@ on:
     tags:
       - '*'
 
-# id-token is added to enable OIDC token generation. All the others are copied from "Set up job" GITHUB_TOKEN Permissions
-permissions:
-  actions: write
-  checks: write
-  contents: write
-  deployments: write
-  discussions: write
-  issues: write
-  packages: write
-  pages: write
-  pull-requests: write
-  repository-projects: write
-  security-events: write
-  statuses: write
-  id-token: write
-
 jobs:
 
   build:
@@ -71,8 +55,7 @@ jobs:
       name: 'Authenticate to Google Cloud'
       uses: 'google-github-actions/auth@v0.6.0'
       with:
-        workload_identity_provider: 'projects/298797809281/locations/global/workloadIdentityPools/velero-pool/providers/velero-provider'
-        service_account: 'gcraccount@velero-gcp.iam.gserviceaccount.com'
+        credentials_json: '${{ secrets.GCR_SA_KEY }}'
         token_format: 'access_token'
 
     # Use access_token generated above to login gcr.io

--- a/changelogs/unreleased/4623-jxun
+++ b/changelogs/unreleased/4623-jxun
@@ -1,0 +1,1 @@
+Add pushing image to GCR in github workflow to facilitate some environments that have rate limitation to docker hub, e.g. vSphere.


### PR DESCRIPTION
Push to GCR in github workflow to faciliate some environments that have rate limitation to docker hub, e.g. vSphere.

Signed-off-by: Xun Jiang <jxun@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
