### PR TITLE
E2E test logs output error info

### DIFF
--- a/changelogs/unreleased/4631-qiuming-best
+++ b/changelogs/unreleased/4631-qiuming-best
@@ -1,0 +1,1 @@
+E2E test logs output error info

--- a/test/e2e/backups/deletion.go
+++ b/test/e2e/backups/deletion.go
@@ -52,7 +52,7 @@ func backup_deletion_test(useVolumeSnapshots bool) {
 	)
 
 	client, err := NewTestClient()
-	Expect(err).To(Succeed(), "Failed to instantiate cluster client for backup deletion tests")
+	Expect(err).To(Succeed(), "Failed to instantiate cluster client for backup deletion tests with error %v", err)
 
 	BeforeEach(func() {
 		if useVolumeSnapshots && VeleroCfg.CloudProvider == "kind" {
@@ -61,24 +61,25 @@ func backup_deletion_test(useVolumeSnapshots bool) {
 		var err error
 		flag.Parse()
 		UUIDgen, err = uuid.NewRandom()
-		Expect(err).To(Succeed())
+		Expect(err).To(Succeed(), "Failed to generate uuid with error %v", err)
 		if VeleroCfg.InstallVelero {
-			Expect(VeleroInstall(context.Background(), &VeleroCfg, "", useVolumeSnapshots)).To(Succeed())
+			err = VeleroInstall(context.Background(), &VeleroCfg, "", useVolumeSnapshots)
+			Expect(err).To(Succeed(), "Failed to install velero with error %v", err)
 		}
 	})
 
 	AfterEach(func() {
 		if VeleroCfg.InstallVelero {
 			err = VeleroUninstall(context.Background(), VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace)
-			Expect(err).To(Succeed())
+			Expect(err).To(Succeed(), "Failed to uninstall velero with error %v", err)
 		}
 	})
 
 	When("kibishii is the sample workload", func() {
 		It("Deleted backups are deleted from object storage and backups deleted from object storage can be deleted locally", func() {
 			backupName = "backup-" + UUIDgen.String()
-			Expect(runBackupDeletionTests(client, VeleroCfg.VeleroCLI, VeleroCfg.CloudProvider, VeleroCfg.VeleroNamespace, backupName, "", useVolumeSnapshots, VeleroCfg.RegistryCredentialFile, VeleroCfg.BSLPrefix, VeleroCfg.BSLConfig)).To(Succeed(),
-				"Failed to run backup deletion test")
+			err = runBackupDeletionTests(client, VeleroCfg.VeleroCLI, VeleroCfg.CloudProvider, VeleroCfg.VeleroNamespace, backupName, "", useVolumeSnapshots, VeleroCfg.RegistryCredentialFile, VeleroCfg.BSLPrefix, VeleroCfg.BSLConfig)
+			Expect(err).To(Succeed(), "Failed to run backup deletion test with error %v", err)
 		})
 	})
 }

--- a/test/e2e/basic/enable_api_group_versions.go
+++ b/test/e2e/basic/enable_api_group_versions.go
@@ -48,7 +48,7 @@ func APIGropuVersionsTest() {
 	)
 
 	client, err := NewTestClient()
-	Expect(err).To(Succeed(), "Failed to instantiate cluster client for group version tests")
+	Expect(err).To(Succeed(), "Failed to instantiate cluster client for group version tests with error %v", err)
 
 	BeforeEach(func() {
 		resource = "rockbands"
@@ -60,7 +60,7 @@ func APIGropuVersionsTest() {
 		// removed and velero installation becomes the same as other e2e tests.
 		if VeleroCfg.InstallVelero {
 			err = VeleroInstall(context.Background(), &VeleroCfg, "EnableAPIGroupVersions", false)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "Failed to install velero with error %v", err)
 		}
 	})
 
@@ -72,11 +72,11 @@ func APIGropuVersionsTest() {
 			fmt.Printf("Ignore error: %v\n", stderr)
 			err = nil
 		}
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "Failed to clean up resource with error %v", err)
 
 		if VeleroCfg.InstallVelero {
 			err = VeleroUninstall(ctx, VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "Failed to install velero with error %v", err)
 		}
 
 	})

--- a/test/e2e/privilegesmgmt/ssr.go
+++ b/test/e2e/privilegesmgmt/ssr.go
@@ -45,84 +45,91 @@ func SSRTest() {
 	BeforeEach(func() {
 		flag.Parse()
 		if VeleroCfg.InstallVelero {
-			Expect(VeleroInstall(context.Background(), &VeleroCfg, "", false)).To(Succeed())
+			err = VeleroInstall(context.Background(), &VeleroCfg, "", false)
+			Expect(err).To(Succeed(), "Failed to install velero with error %v", err)
 		}
 	})
 
 	AfterEach(func() {
 		if VeleroCfg.InstallVelero {
-			Expect(VeleroUninstall(context.Background(), VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace)).To(Succeed())
+			err = VeleroUninstall(context.Background(), VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace)
+			Expect(err).To(Succeed(), "Failed to install velero with error %v", err)
 		}
 	})
 
 	It(fmt.Sprintf("Should create an ssr object in the %s namespace and later removed by controller", VeleroCfg.VeleroNamespace), func() {
-		defer DeleteNamespace(context.TODO(), client, testNS, false)
+		defer func() {
+			err = DeleteNamespace(context.TODO(), client, testNS, false)
+			Expect(err).To(Succeed(), "Failed to delete the namespace %s with error %v", testNS, err)
+		}()
 		ctx, _ := context.WithTimeout(context.Background(), time.Duration(time.Minute*10))
-		By(fmt.Sprintf("Create %s namespace", testNS))
-		Expect(CreateNamespace(ctx, client, testNS)).To(Succeed(),
-			fmt.Sprintf("Failed to create %s namespace", testNS))
+		By(fmt.Sprintf("Create %s namespace", testNS), func() {
+			err = CreateNamespace(ctx, client, testNS)
+			Expect(err).To(Succeed(), "Failed to create %s namespace with error %v", testNS, err)
+		})
 
-		By(fmt.Sprintf("Get version in %s namespace", testNS))
-		cmd := []string{"version", "-n", testNS}
-		Expect(VeleroCmdExec(context.Background(), VeleroCfg.VeleroCLI, cmd)).To(Succeed(),
-			fmt.Sprintf("Failed to create an ssr object in the %s namespace", testNS))
+		By(fmt.Sprintf("Get version in %s namespace", testNS), func() {
+			cmd := []string{"version", "-n", testNS}
+			err = VeleroCmdExec(context.Background(), VeleroCfg.VeleroCLI, cmd)
+			Expect(err).To(Succeed(), "Failed to create an ssr object in the %s namespace with error %v", testNS, err)
+		})
 
-		By(fmt.Sprintf("Get version in %s namespace", VeleroCfg.VeleroNamespace))
-		cmd = []string{"version", "-n", VeleroCfg.VeleroNamespace}
-		Expect(VeleroCmdExec(context.Background(), VeleroCfg.VeleroCLI, cmd)).To(Succeed(),
-			fmt.Sprintf("Failed to create an ssr object in %s namespace", VeleroCfg.VeleroNamespace))
+		By(fmt.Sprintf("Get version in %s namespace", VeleroCfg.VeleroNamespace), func() {
+			cmd := []string{"version", "-n", VeleroCfg.VeleroNamespace}
+			err = VeleroCmdExec(context.Background(), VeleroCfg.VeleroCLI, cmd)
+			Expect(err).To(Succeed(), "Failed to create an ssr object in %s namespace with error %v", VeleroCfg.VeleroNamespace, err)
+		})
 
 		ssrListResp := new(v1.ServerStatusRequestList)
-		By(fmt.Sprintf("Check ssr object in %s namespace", VeleroCfg.VeleroNamespace))
-		err = waitutil.PollImmediate(5*time.Second, time.Minute,
-			func() (bool, error) {
-				if err = client.Kubebuilder.List(ctx, ssrListResp, &kbclient.ListOptions{Namespace: VeleroCfg.VeleroNamespace}); err != nil {
-					return false, fmt.Errorf("failed to list ssr object in %s namespace with err %v", VeleroCfg.VeleroNamespace, err)
-				}
-				if len(ssrListResp.Items) != 1 {
-					return false, fmt.Errorf("count of ssr object in %s namespace is not 1", VeleroCfg.VeleroNamespace)
-				}
-
-				if ssrListResp.Items[0].Status.ServerVersion == "" {
-					fmt.Printf("ServerVersion of ssr object in %s namespace should not empty, current response result %v\n", VeleroCfg.VeleroNamespace, ssrListResp)
-					return false, nil
-				}
-
-				if ssrListResp.Items[0].Status.Phase != "Processed" {
-					return false, fmt.Errorf("phase of ssr object in %s namespace should be Processed but got phase %s", VeleroCfg.VeleroNamespace, ssrListResp.Items[0].Status.Phase)
-				}
-				return true, nil
-			})
-		if err == waitutil.ErrWaitTimeout {
-			fmt.Printf("exceed test case deadline and failed to check ssr object in %s namespace", VeleroCfg.VeleroNamespace)
-		}
-		Expect(err).To(Succeed(), fmt.Sprintf("Failed to check ssr object in %s namespace", VeleroCfg.VeleroNamespace))
-
-		By(fmt.Sprintf("Check ssr object in %s namespace", testNS))
-		Expect(client.Kubebuilder.List(ctx, ssrListResp, &kbclient.ListOptions{Namespace: testNS})).To(Succeed(),
-			fmt.Sprintf("Failed to list ssr object in %s namespace", testNS))
-		Expect(len(ssrListResp.Items)).To(BeNumerically("==", 1),
-			fmt.Sprintf("Count of ssr object in %s namespace is not 1", testNS))
-		Expect(ssrListResp.Items[0].Status.Phase).To(BeEmpty(),
-			fmt.Sprintf("Status of ssr object in %s namespace should be empty", testNS))
-		Expect(ssrListResp.Items[0].Status.ServerVersion).To(BeEmpty(),
-			fmt.Sprintf("ServerVersion of ssr object in %s namespace should be empty", testNS))
-
-		By(fmt.Sprintf("Waiting ssr object in %s namespace deleted", VeleroCfg.VeleroNamespace))
-		err = waitutil.PollImmediateInfinite(5*time.Second,
-			func() (bool, error) {
-				if err = client.Kubebuilder.List(ctx, ssrListResp, &kbclient.ListOptions{Namespace: VeleroCfg.VeleroNamespace}); err != nil {
-					if apierrors.IsNotFound(err) {
-						return true, nil
+		By(fmt.Sprintf("Check ssr object in %s namespace", VeleroCfg.VeleroNamespace), func() {
+			err = waitutil.PollImmediate(5*time.Second, time.Minute,
+				func() (bool, error) {
+					if err = client.Kubebuilder.List(ctx, ssrListResp, &kbclient.ListOptions{Namespace: VeleroCfg.VeleroNamespace}); err != nil {
+						return false, fmt.Errorf("failed to list ssr object in %s namespace with error %v", VeleroCfg.VeleroNamespace, err)
 					}
-					return false, err
-				}
-				if len(ssrListResp.Items) != 0 {
-					return false, nil
-				}
-				return true, nil
-			})
+					if len(ssrListResp.Items) != 1 {
+						return false, fmt.Errorf("count of ssr object in %s namespace is not 1", VeleroCfg.VeleroNamespace)
+					}
 
-		Expect(err).To(Succeed(), fmt.Sprintf("ssr object in %s namespace is not been deleted by controller", VeleroCfg.VeleroNamespace))
+					if ssrListResp.Items[0].Status.ServerVersion == "" {
+						fmt.Printf("ServerVersion of ssr object in %s namespace should not empty, current response result %v\n", VeleroCfg.VeleroNamespace, ssrListResp)
+						return false, nil
+					}
+
+					if ssrListResp.Items[0].Status.Phase != "Processed" {
+						return false, fmt.Errorf("phase of ssr object in %s namespace should be Processed but got phase %s", VeleroCfg.VeleroNamespace, ssrListResp.Items[0].Status.Phase)
+					}
+					return true, nil
+				})
+			if err == waitutil.ErrWaitTimeout {
+				fmt.Printf("exceed test case deadline and failed to check ssr object in %s namespace", VeleroCfg.VeleroNamespace)
+			}
+			Expect(err).To(Succeed(), "Failed to check ssr object in %s namespace with error %v", VeleroCfg.VeleroNamespace, err)
+		})
+
+		By(fmt.Sprintf("Check ssr object in %s namespace", testNS), func() {
+			err = client.Kubebuilder.List(ctx, ssrListResp, &kbclient.ListOptions{Namespace: testNS})
+			Expect(err).To(Succeed(), "Failed to list ssr object in %s namespace with error %v", testNS, err)
+			Expect(len(ssrListResp.Items)).To(BeNumerically("==", 1), "Count of ssr object in %s namespace is not 1", testNS)
+			Expect(ssrListResp.Items[0].Status.Phase).To(BeEmpty(), "Status of ssr object in %s namespace should be empty", testNS)
+			Expect(ssrListResp.Items[0].Status.ServerVersion).To(BeEmpty(), "ServerVersion of ssr object in %s namespace should be empty", testNS)
+		})
+
+		By(fmt.Sprintf("Waiting ssr object in %s namespace deleted", VeleroCfg.VeleroNamespace), func() {
+			err = waitutil.PollImmediateInfinite(5*time.Second,
+				func() (bool, error) {
+					if err = client.Kubebuilder.List(ctx, ssrListResp, &kbclient.ListOptions{Namespace: VeleroCfg.VeleroNamespace}); err != nil {
+						if apierrors.IsNotFound(err) {
+							return true, nil
+						}
+						return false, err
+					}
+					if len(ssrListResp.Items) != 0 {
+						return false, nil
+					}
+					return true, nil
+				})
+			Expect(err).To(Succeed(), "ssr object in %s namespace is not been deleted by controller with error %v", VeleroCfg.VeleroNamespace, err)
+		})
 	})
 }

--- a/test/e2e/test/test.go
+++ b/test/e2e/test/test.go
@@ -73,21 +73,25 @@ func TestFunc(test VeleroBackupRestoreTest) func() {
 	return func() {
 		var err error
 		TestClientInstance, err = NewTestClient()
-		Expect(err).To(Succeed(), "Failed to instantiate cluster client for backup tests")
-		Expect(test.Init()).To(Succeed(), "Failed to instantiate test cases")
+		Expect(err).To(Succeed(), "Failed to instantiate cluster client for backup tests with error %v", err)
+		err = test.Init()
+		Expect(err).To(Succeed(), "Failed to instantiate test cases with error %v", err)
 		BeforeEach(func() {
 			flag.Parse()
 			if VeleroCfg.InstallVelero {
-				Expect(VeleroInstall(context.Background(), &VeleroCfg, "", false)).To(Succeed())
+				err = VeleroInstall(context.Background(), &VeleroCfg, "", false)
+				Expect(err).To(Succeed(), "Failed to install velero with error %v", err)
 			}
 		})
 		AfterEach(func() {
 			if VeleroCfg.InstallVelero {
-				Expect(VeleroUninstall(context.Background(), VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace)).To((Succeed()))
+				err = VeleroUninstall(context.Background(), VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace)
+				Expect(err).To(Succeed(), "Failed to install velero with error %v", err)
 			}
 		})
 		It(test.GetTestMsg().Text, func() {
-			Expect(RunTestCase(test)).To(Succeed(), test.GetTestMsg().FailedMSG)
+			err = RunTestCase(test)
+			Expect(err).To(Succeed(), fmt.Sprintf("%s with error %v", test.GetTestMsg().FailedMSG, err))
 		})
 	}
 }
@@ -99,14 +103,16 @@ func TestFuncWithMultiIt(tests []VeleroBackupRestoreTest) func() {
 		TestClientInstance, err = NewTestClient()
 		Expect(err).To(Succeed(), "Failed to instantiate cluster client for backup tests")
 		for k := range tests {
-			Expect(tests[k].Init()).To(Succeed(), fmt.Sprintf("Failed to instantiate test %s case", tests[k].GetTestMsg().Desc))
+			err = tests[k].Init()
+			Expect(err).To(Succeed(), "Failed to instantiate test %s case with error %v", tests[k].GetTestMsg().Desc, err)
 		}
 
 		BeforeEach(func() {
 			flag.Parse()
 			if VeleroCfg.InstallVelero {
 				if countIt == 0 {
-					Expect(VeleroInstall(context.Background(), &VeleroCfg, "", false)).To(Succeed())
+					err = VeleroInstall(context.Background(), &VeleroCfg, "", false)
+					Expect(err).To(Succeed(), "Failed to install velero with error %v", err)
 				}
 				countIt++
 			}
@@ -115,7 +121,8 @@ func TestFuncWithMultiIt(tests []VeleroBackupRestoreTest) func() {
 		AfterEach(func() {
 			if VeleroCfg.InstallVelero {
 				if countIt == len(tests) {
-					Expect(VeleroUninstall(context.Background(), VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace)).To((Succeed()))
+					err = VeleroUninstall(context.Background(), VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace)
+					Expect(err).To(Succeed(), "Failed to uninstall velero with error %v", err)
 				}
 			}
 		})
@@ -123,7 +130,8 @@ func TestFuncWithMultiIt(tests []VeleroBackupRestoreTest) func() {
 		for k := range tests {
 			curTest := tests[k]
 			It(curTest.GetTestMsg().Text, func() {
-				Expect(RunTestCase(curTest)).To(Succeed(), curTest.GetTestMsg().FailedMSG)
+				err = RunTestCase(curTest)
+				Expect(err).To(Succeed(), fmt.Sprintf("%s with error %v", curTest.GetTestMsg().FailedMSG, err))
 			})
 		}
 	}

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -50,7 +50,7 @@ func BackupUpgradeRestoreTest(useVolumeSnapshots bool) {
 	)
 
 	client, err := NewTestClient()
-	Expect(err).To(Succeed(), "Failed to instantiate cluster client for backup tests")
+	Expect(err).To(Succeed(), "Failed to instantiate cluster client for backup tests with error %v", err)
 
 	BeforeEach(func() {
 		if (len(VeleroCfg.UpgradeFromVeleroVersion)) == 0 {
@@ -63,7 +63,7 @@ func BackupUpgradeRestoreTest(useVolumeSnapshots bool) {
 		var err error
 		flag.Parse()
 		UUIDgen, err = uuid.NewRandom()
-		Expect(err).To(Succeed())
+		Expect(err).To(Succeed(), "Failed to generate uuid with error %v", err)
 		if VeleroCfg.InstallVelero {
 			//Set VeleroImage and ResticHelperImage to blank
 			//VeleroImage and ResticHelperImage should be the default value in originalCli
@@ -76,10 +76,12 @@ func BackupUpgradeRestoreTest(useVolumeSnapshots bool) {
 			if (len(VeleroCfg.UpgradeFromVeleroCLI)) == 0 {
 				tmpCfg.VeleroCLI, err = InstallVeleroCLI(VeleroCfg.UpgradeFromVeleroVersion)
 				upgradeFromVeleroCLI = tmpCfg.VeleroCLI
-				Expect(err).To(Succeed())
+				Expect(err).To(Succeed(), "Failed to upgrade velero with error %v", err)
 			}
-			Expect(VeleroInstall(context.Background(), &tmpCfg, "", useVolumeSnapshots)).To(Succeed())
-			Expect(CheckVeleroVersion(context.Background(), tmpCfg.VeleroCLI, tmpCfg.UpgradeFromVeleroVersion)).To(Succeed())
+			err = VeleroInstall(context.Background(), &tmpCfg, "", useVolumeSnapshots)
+			Expect(err).To(Succeed(), "Failed to install velero with error %v", err)
+			err = CheckVeleroVersion(context.Background(), tmpCfg.VeleroCLI, tmpCfg.UpgradeFromVeleroVersion)
+			Expect(err).To(Succeed(), "Failed to check velero version with error %v", err)
 		} else {
 			Skip("Upgrade test is skipped since user don't want to install any other velero")
 		}
@@ -88,7 +90,7 @@ func BackupUpgradeRestoreTest(useVolumeSnapshots bool) {
 	AfterEach(func() {
 		if VeleroCfg.InstallVelero {
 			err = VeleroUninstall(context.Background(), VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace)
-			Expect(err).To(Succeed())
+			Expect(err).To(Succeed(), "Failed to uninstall velero with error %v", err)
 		}
 	})
 
@@ -99,10 +101,9 @@ func BackupUpgradeRestoreTest(useVolumeSnapshots bool) {
 			tmpCfg := VeleroCfg
 			if (len(VeleroCfg.UpgradeFromVeleroCLI)) == 0 {
 				tmpCfg.UpgradeFromVeleroCLI = upgradeFromVeleroCLI
-				Expect(err).To(Succeed())
 			}
-			Expect(runUpgradeTests(client, &tmpCfg, backupName, restoreName, "", useVolumeSnapshots)).To(Succeed(),
-				"Failed to successfully backup and restore Kibishii namespace")
+			err = runUpgradeTests(client, &tmpCfg, backupName, restoreName, "", useVolumeSnapshots)
+			Expect(err).To(Succeed(), "Failed to successfully backup and restore Kibishii namespace with error %v", err)
 		})
 	})
 }


### PR DESCRIPTION
Signed-off-by: Ming <mqiu@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Most of the e2e test error info is not output into logs, It's not easy to troubleshoot problems, so adjust the test logs, refer to #4580
# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
