### PR TITLE
Fix E2E backup namespaces test

### DIFF
--- a/changelogs/unreleased/4634-qiuming-best
+++ b/changelogs/unreleased/4634-qiuming-best
@@ -1,0 +1,1 @@
+Fix E2E backup namespaces test

--- a/test/e2e/test/test.go
+++ b/test/e2e/test/test.go
@@ -39,6 +39,7 @@ depends on your test patterns.
 */
 type VeleroBackupRestoreTest interface {
 	Init() error
+	StartRun() error
 	CreateResources() error
 	Backup() error
 	Destroy() error
@@ -137,6 +138,10 @@ func (t *TestCase) CreateResources() error {
 	return nil
 }
 
+func (t *TestCase) StartRun() error {
+	return nil
+}
+
 func (t *TestCase) Backup() error {
 	if err := VeleroCmdExec(t.Ctx, VeleroCfg.VeleroCLI, t.BackupArgs); err != nil {
 		RunDebug(context.Background(), VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace, t.BackupName, "")
@@ -180,8 +185,11 @@ func RunTestCase(test VeleroBackupRestoreTest) error {
 	}
 
 	defer test.Clean()
-
-	err := test.CreateResources()
+	err := test.StartRun()
+	if err != nil {
+		return err
+	}
+	err = test.CreateResources()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Ming <mqiu@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)
e2e backup namespace test should  not include velero namespace 
# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
