### PR TITLE
Update e2e test image to gcr.io

### DIFF
--- a/changelogs/unreleased/4639-jxun
+++ b/changelogs/unreleased/4639-jxun
@@ -1,0 +1,1 @@
+Update image used by E2E test to gcr.io

--- a/test/e2e/util/k8s/deployment.go
+++ b/test/e2e/util/k8s/deployment.go
@@ -62,7 +62,7 @@ func NewDeployment(name, ns string, replicas int32, labels map[string]string) *a
 					Containers: []v1.Container{
 						{
 							Name:    name,
-							Image:   "busybox:latest",
+							Image:   "gcr.io/velero-gcp/busybox:latest",
 							Command: []string{"sleep", "1000000"},
 						},
 					},


### PR DESCRIPTION
By now, only busybox:latest is used by e2e. It is already upload to gcr.io/velero-gcp/busybox:latest
Change the image to gcr.io to avoid pulling rate limitation from docker hub.

Signed-off-by: Xun Jiang <jxun@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
