### PR TITLE
Add more exempt labels for stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -14,9 +14,15 @@ exemptLabels:
   - Area/Design
   - Area/Documentation
   - Area/Plugins
+  - Bug
   - Enhancement/User
+  - kind/requirement
+  - kind/refactor
   - kind/tech-debt
+  - limitation
   - Needs investigation
+  - Needs triage
+  - Needs Product
   - P0 - Hair on fire
   - P1 - Important
   - P2 - Long-term important


### PR DESCRIPTION
Signed-off-by: Daniel Jiang <jiangd@vmware.com>

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [X] Updated the corresponding documentation in `site/content/docs/main`.
