### PR TITLE
Don't exit when getting no match for grep

### DIFF
--- a/hack/release-tools/tag-release.sh
+++ b/hack/release-tools/tag-release.sh
@@ -138,8 +138,8 @@ if [[ -n $release_branch_name ]]; then
     remote_release_branch_name="$remote/$release_branch_name"
 
     # Determine whether the local and remote release branches already exist
-    local_branch=$(git branch | grep "$release_branch_name")
-    remote_branch=$(git branch -r | grep "$remote_release_branch_name")
+    local_branch=$(git branch | { grep "$release_branch_name" || true; })
+    remote_branch=$(git branch -r | { grep "$remote_release_branch_name" || true;})
     if [[ -z $remote_branch ]]; then
         echo "The branch $remote_release_branch_name must be created before you tag the release."
         exit 1


### PR DESCRIPTION
Don't exit when getting no match for grep

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
