### PR TITLE
Enable building and pushing image for release branches

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,7 +2,9 @@ name: Main CI
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - 'main'
+      - 'release-**'
     tags:
       - '*'
 

--- a/hack/docker-push.sh
+++ b/hack/docker-push.sh
@@ -56,9 +56,8 @@ elif [[ "$triggeredBy" == "tags" ]]; then
     TAG=$(echo $GITHUB_REF | cut -d / -f 3)
 fi
 
-if [[ "$BRANCH" == "main" ]]; then
-    VERSION="$BRANCH"
-elif [[ ! -z "$TAG" ]]; then
+if [[ ! -z "$TAG" ]]; then
+    echo "We're building tag $TAG"
     # Explicitly checkout tags when building from a git tag.
     # This is not needed when building from main
     git fetch --tags
@@ -66,16 +65,16 @@ elif [[ ! -z "$TAG" ]]; then
     highest_release
     VERSION="$TAG"
 else
-    echo "We're not on main and we're not building a tag, exit early."
-    exit 0
+    echo "We're on branch $BRANCH"
+    VERSION="$BRANCH"
 fi
 
 # Assume we're not tagging `latest` by default, and never on main.
 TAG_LATEST=false
-if [[ "$BRANCH" == "main" ]]; then
-    echo "Building main, not tagging latest."
-elif [[ "$TAG" == "$HIGHEST" ]]; then
+if [[ "$TAG" == "$HIGHEST" ]]; then
     TAG_LATEST=true
+else
+    echo "Building $BRANCH, not tagging latest"
 fi
 
 if [[ -z "$BUILDX_PLATFORMS" ]]; then


### PR DESCRIPTION
Enable building and pushing image for both  release branches

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
