### PR TITLE
Bug fixing, only check whether the tag is the latest version when tag isn't empty

### DIFF
--- a/hack/docker-push.sh
+++ b/hack/docker-push.sh
@@ -56,25 +56,21 @@ elif [[ "$triggeredBy" == "tags" ]]; then
     TAG=$(echo $GITHUB_REF | cut -d / -f 3)
 fi
 
+TAG_LATEST=false
 if [[ ! -z "$TAG" ]]; then
     echo "We're building tag $TAG"
+    VERSION="$TAG"
     # Explicitly checkout tags when building from a git tag.
     # This is not needed when building from main
     git fetch --tags
     # Calculate the latest release if there's a tag.
     highest_release
-    VERSION="$TAG"
+    if [[ "$TAG" == "$HIGHEST" ]]; then
+      TAG_LATEST=true
+    fi
 else
     echo "We're on branch $BRANCH"
     VERSION="$BRANCH"
-fi
-
-# Assume we're not tagging `latest` by default, and never on main.
-TAG_LATEST=false
-if [[ "$TAG" == "$HIGHEST" ]]; then
-    TAG_LATEST=true
-else
-    echo "Building $BRANCH, not tagging latest"
 fi
 
 if [[ -z "$BUILDX_PLATFORMS" ]]; then


### PR DESCRIPTION
Bug fixing, only check whether the tag is the latest version when tag isn't empty

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
