### PR TITLE
[cherry-pick]Enable building and pushing image for release branches

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,7 +2,9 @@ name: Main CI
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - 'main'
+      - 'release-**'
     tags:
       - '*'
 

--- a/hack/docker-push.sh
+++ b/hack/docker-push.sh
@@ -71,6 +71,9 @@ if [[ ! -z "$TAG" ]]; then
 else
     echo "We're on branch $BRANCH"
     VERSION="$BRANCH"
+    if [[ "$VERSION" == release-* ]]; then
+      VERSION=${VERSION}-dev
+    fi
 fi
 
 if [[ -z "$BUILDX_PLATFORMS" ]]; then
@@ -82,6 +85,7 @@ echo "Highest tag found: $HIGHEST"
 echo "BRANCH: $BRANCH"
 echo "TAG: $TAG"
 echo "TAG_LATEST: $TAG_LATEST"
+echo "VERSION: $VERSION"
 echo "BUILDX_PLATFORMS: $BUILDX_PLATFORMS"
 
 echo "Building and pushing container images."

--- a/hack/docker-push.sh
+++ b/hack/docker-push.sh
@@ -56,26 +56,21 @@ elif [[ "$triggeredBy" == "tags" ]]; then
     TAG=$(echo $GITHUB_REF | cut -d / -f 3)
 fi
 
-if [[ "$BRANCH" == "main" ]]; then
-    VERSION="$BRANCH"
-elif [[ ! -z "$TAG" ]]; then
+TAG_LATEST=false
+if [[ ! -z "$TAG" ]]; then
+    echo "We're building tag $TAG"
+    VERSION="$TAG"
     # Explicitly checkout tags when building from a git tag.
     # This is not needed when building from main
     git fetch --tags
     # Calculate the latest release if there's a tag.
     highest_release
-    VERSION="$TAG"
+    if [[ "$TAG" == "$HIGHEST" ]]; then
+      TAG_LATEST=true
+    fi
 else
-    echo "We're not on main and we're not building a tag, exit early."
-    exit 0
-fi
-
-# Assume we're not tagging `latest` by default, and never on main.
-TAG_LATEST=false
-if [[ "$BRANCH" == "main" ]]; then
-    echo "Building main, not tagging latest."
-elif [[ "$TAG" == "$HIGHEST" ]]; then
-    TAG_LATEST=true
+    echo "We're on branch $BRANCH"
+    VERSION="$BRANCH"
 fi
 
 if [[ -z "$BUILDX_PLATFORMS" ]]; then


### PR DESCRIPTION
Enable building and pushing image for release branches

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
