### PR TITLE
[fix] Add regional PV support for GKE

### DIFF
--- a/changelogs/unreleased/4680-jxun
+++ b/changelogs/unreleased/4680-jxun
@@ -1,0 +1,1 @@
+Support regional pv for GKE

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -385,7 +385,7 @@ const (
 	awsEbsCsiZoneKey = "topology.ebs.csi.aws.com/zone"
 	azureCsiZoneKey  = "topology.disk.csi.azure.com/zone"
 	gkeCsiZoneKey    = "topology.gke.io/zone"
-	zoneSeparator    = "__"
+	gkeZoneSeparator = "__"
 )
 
 // takePVSnapshot triggers a snapshot for the volume/disk underlying a PersistentVolume if the provided
@@ -560,7 +560,7 @@ func zoneFromPVNodeAffinity(res *corev1api.PersistentVolume, topologyKeys ...str
 	}
 
 	if providerGke {
-		return gkeCsiZoneKey, strings.Join(zones, zoneSeparator)
+		return gkeCsiZoneKey, strings.Join(zones, gkeZoneSeparator)
 	}
 
 	return "", ""

--- a/pkg/backup/item_backupper_test.go
+++ b/pkg/backup/item_backupper_test.go
@@ -131,6 +131,21 @@ func Test_zoneFromPVNodeAffinity(t *testing.T) {
 			wantKey:   "topology.disk.csi.azure.com/zone",
 			wantValue: "us-central",
 		},
+		{
+			name: "Volume with multiple valid keys, and provider is gke, returns the all match", // it should never happen
+			pv: builder.ForPersistentVolume("multi-matching-pv").NodeAffinityRequired(
+				builder.ForNodeSelector(
+					*builder.NewNodeSelectorTermBuilder().WithMatchExpression("topology.gke.io/zone",
+						"In", "us-central1-c").Result(),
+					*builder.NewNodeSelectorTermBuilder().WithMatchExpression("topology.gke.io/zone",
+						"In", "us-east-2c", "us-east-2b").Result(),
+					*builder.NewNodeSelectorTermBuilder().WithMatchExpression("topology.gke.io/zone",
+						"In", "europe-north1-a").Result(),
+				).Result(),
+			).Result(),
+			wantKey:   "topology.gke.io/zone",
+			wantValue: "us-central1-c__us-east-2c__europe-north1-a",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/backup/item_backupper_test.go
+++ b/pkg/backup/item_backupper_test.go
@@ -132,7 +132,22 @@ func Test_zoneFromPVNodeAffinity(t *testing.T) {
 			wantValue: "us-central",
 		},
 		{
-			name: "Volume with multiple valid keys, and provider is gke, returns the all match", // it should never happen
+			/* an valid example of node affinity in a GKE's regional PV
+			nodeAffinity:
+			  required:
+			    nodeSelectorTerms:
+			    - matchExpressions:
+			      - key: topology.gke.io/zone
+			        operator: In
+			        values:
+			        - us-central1-a
+			    - matchExpressions:
+			      - key: topology.gke.io/zone
+			        operator: In
+			        values:
+			        - us-central1-c
+			*/
+			name: "Volume with multiple valid keys, and provider is gke, returns all valid entries's first zone value",
 			pv: builder.ForPersistentVolume("multi-matching-pv").NodeAffinityRequired(
 				builder.ForNodeSelector(
 					*builder.NewNodeSelectorTermBuilder().WithMatchExpression("topology.gke.io/zone",


### PR DESCRIPTION
fix #4663.
For GKE pv, when create backup, return all zones retrived from node affinity.

Signed-off-by: Xun Jiang <jxun@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
