### PR TITLE
Fix labels removed in ObjectMeta

### DIFF
--- a/pkg/install/resources.go
+++ b/pkg/install/resources.go
@@ -91,6 +91,7 @@ func objectMeta(namespace, name string) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
 		Name:      name,
 		Namespace: namespace,
+		Labels:    Labels(),
 	}
 }
 


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Fix labels on object removed by my previous PR (I force push a little late the moment I saw my error cf https://github.com/vmware-tanzu/velero/pull/4694)
My previous PR added support for labels from command-line on pods. However my change removed the label component=velero from other objects (which was not intended).

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.

/kind changelog-not-required