### PR TITLE
add @once schedule

### DIFF
--- a/pkg/controller/schedule_controller.go
+++ b/pkg/controller/schedule_controller.go
@@ -223,8 +223,12 @@ func parseCronSchedule(itm *api.Schedule, logger logrus.FieldLogger) (cron.Sched
 				validationErrors = append(validationErrors, fmt.Sprintf("invalid schedule: %v", r))
 			}
 		}()
+		var scheduleStr = itm.Spec.Schedule
+		if itm.Spec.Schedule == "@once" {
+			scheduleStr = "@every 876000h"
+		}
 
-		if res, err := cron.ParseStandard(itm.Spec.Schedule); err != nil {
+		if res, err := cron.ParseStandard(scheduleStr); err != nil {
 			log.WithError(errors.WithStack(err)).WithField("schedule", itm.Spec.Schedule).Debug("Error parsing schedule")
 			validationErrors = append(validationErrors, fmt.Sprintf("invalid schedule: %v", err))
 		} else {

--- a/pkg/controller/schedule_controller_test.go
+++ b/pkg/controller/schedule_controller_test.go
@@ -116,6 +116,12 @@ func TestProcessSchedule(t *testing.T) {
 			expectedBackupCreate: builder.ForBackup("ns", "name-20170101120000").ObjectMeta(builder.WithLabels(velerov1api.ScheduleNameLabel, "name")).Result(),
 			expectedLastBackup:   "2017-01-01 12:00:00",
 		},
+		{
+			name:          "schedule that just run once time",
+			schedule:      newScheduleBuilder(velerov1api.SchedulePhaseEnabled).CronSchedule("@once").LastBackupTime("2000-01-01 00:00:00").Result(),
+			fakeClockTime: "2027-01-01 12:00:00",
+			expectedErr:   false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
In some cases, we don't want to create a backup directly, but rather a schedule that runs only once.
