### PR TITLE
Bump up golang to 1.17.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM --platform=$BUILDPLATFORM golang:1.17.6 as builder-env
+FROM --platform=$BUILDPLATFORM golang:1.17.8 as builder-env
 
 ARG GOPROXY
 ARG PKG

--- a/changelogs/CHANGELOG-1.8.md
+++ b/changelogs/CHANGELOG-1.8.md
@@ -16,6 +16,7 @@ https://velero.io/docs/v1.8/upgrade-to-1.8/
 ### All changes
 * Bypass the remap CRD version plugin when v1beta1 CRD is not supported (#4706, @reasonerjt)
 * Support regional pv for GKE (#4691, @jxun)
+* Bump up golang to 1.17.8 (#4721, @ywk253100)
 
 ## v1.8.0
 ### 2022-01-14

--- a/hack/build-image/Dockerfile
+++ b/hack/build-image/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17.6
+FROM golang:1.17.8
 
 ARG GOPROXY
 


### PR DESCRIPTION
Bump up golang to 1.17.8

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
