### PR TITLE
Insert all restore errors and warnings into restore log

### DIFF
--- a/changelogs/unreleased/4743-sseago
+++ b/changelogs/unreleased/4743-sseago
@@ -1,0 +1,1 @@
+Insert all restore errors and warnings into restore log.

--- a/pkg/controller/restore_controller.go
+++ b/pkg/controller/restore_controller.go
@@ -486,6 +486,30 @@ func (c *restoreController) runValidatedRestore(restore *api.Restore, info backu
 	}
 	restoreWarnings, restoreErrors := c.restorer.RestoreWithResolvers(restoreReq, actionsResolver, snapshotItemResolver,
 		c.snapshotLocationLister, pluginManager)
+
+	// log errors and warnings to the restore log
+	for _, msg := range restoreErrors.Velero {
+		restoreLog.Errorf("Velero restore error: %v", msg)
+	}
+	for _, msg := range restoreErrors.Cluster {
+		restoreLog.Errorf("Cluster resource restore error: %v", msg)
+	}
+	for ns, errs := range restoreErrors.Namespaces {
+		for _, msg := range errs {
+			restoreLog.Errorf("Namespace %v, resource restore error: %v", ns, msg)
+		}
+	}
+	for _, msg := range restoreWarnings.Velero {
+		restoreLog.Warnf("Velero restore warning: %v", msg)
+	}
+	for _, msg := range restoreWarnings.Cluster {
+		restoreLog.Warnf("Cluster resource restore warning: %v", msg)
+	}
+	for ns, errs := range restoreWarnings.Namespaces {
+		for _, msg := range errs {
+			restoreLog.Warnf("Namespace %v, resource restore warning: %v", ns, msg)
+		}
+	}
 	restoreLog.Info("restore completed")
 
 	// re-instantiate the backup store because credentials could have changed since the original


### PR DESCRIPTION

Signed-off-by: Scott Seago <sseago@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
This allows a user inspecting the restore logs to see any
errors or warnings generated by the restore so that they
will be seen even without having to use the describe cli.

# Does your change fix a particular issue?

Fixes #4742

# Please indicate you've done the following:

- [ x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
