### PR TITLE
Remove blocking indexing of our versioned docs

### DIFF
--- a/site/layouts/docs/docs.html
+++ b/site/layouts/docs/docs.html
@@ -2,10 +2,6 @@
 <html lang="en">
 {{ partial "head-docs.html" . }}
 
-{{ if ne .Params.version "master" }}
-  <!-- Block google from indexing versioned docs -->
-  <meta name="robots" content="noindex">
-{{ end }}
 {{ $fileName := "" }}
 {{ with .File }}{{ $fileName = .LogicalName }}{{ end }}
 {{ if eq $fileName "_index.md" }}


### PR DESCRIPTION
Signed-off-by: Jonas Rosland <jrosland@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Remove blocking indexing of our versioned docs

# Does your change fix a particular issue?
Our docs aren't being indexed by search engines at the moment, this fixes that.

Fixes #(issue)

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [X] Updated the corresponding documentation in `site/content/docs/main`.
