### PR TITLE
Allow GH Actions to publish image to GitHub registry in forks

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,6 +13,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
 
     - name: Set up Go
@@ -58,13 +60,30 @@ jobs:
 
     # Use the JSON key in secret to login gcr.io
     - uses: 'docker/login-action@v1'
+      id: gcr-login
       with:
         registry: 'gcr.io' # or REGION.docker.pkg.dev
         username: '_json_key'
         password: '${{ secrets.GCR_SA_KEY }}'
+      continue-on-error: true
 
     # Push image to GCR to facilitate some environments that have rate limitation to docker hub, e.g. vSphere.
     - name: Publish container image to GCR
-      if: github.repository == 'vmware-tanzu/velero'
+      if: github.repository == 'vmware-tanzu/velero' && steps.gcr-login.outcome == 'success'
       run: |
         REGISTRY=gcr.io/velero-gcp ./hack/docker-push.sh
+
+    - name: Login to GitHub registry if it's a fork
+      if: github.event_name != 'pull_request' && github.repository != 'vmware-tanzu/velero'
+      id: ghcr-login
+      uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Publish container image to GitHub registry if it's a fork
+      if: github.event_name != 'pull_request' && github.repository != 'vmware-tanzu/velero' && steps.ghcr-login.outcome == 'success'
+      run: |
+        REGISTRY=ghcr.io/${{ github.actor }} ./hack/docker-push.sh
+


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Allows Main CI action to push to registry on forks without needing additional credentials set for other registries.
- ghcr.io/<user>/imagename:latest
This will help users be able to test their changes without having to run docker build on their own machine which could prove problematic because
1. Docker Desktop is no longer free on non-linux systems
2. podman have unresolved compatibility issues with makefile in velero

Could even consider (not yet implemented in this PR) allowing this to run on non-main then use that non-main branch name as tags, but may have to be a separate file or put in a bunch of if statements to only run in forks. May help with branch specific testing.
- ghcr.io/<user>/imagename:<branch-name>


https://github.com/kaovilai/velero
Now shows container images built by this action changes.
You may need to manually mark container package as public manually the first time the action is ran to pull anonymously.

Workflow run example https://github.com/kaovilai/velero/runs/5639221555?check_suite_focus=true
# Does your change fix a particular issue?
No
Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
