### PR TITLE
Fix the golang lint error: Variable 'session' collides with imported package name

### DIFF
--- a/pkg/restic/config.go
+++ b/pkg/restic/config.go
@@ -113,14 +113,14 @@ func GetRepoIdentifier(location *velerov1api.BackupStorageLocation, name string)
 func getBucketRegion(bucket string) (string, error) {
 	var region string
 
-	session, err := session.NewSession()
+	sess, err := session.NewSession()
 	if err != nil {
 		return "", errors.WithStack(err)
 	}
 
 	for _, partition := range endpoints.DefaultPartitions() {
 		for regionHint := range partition.Regions() {
-			region, _ = s3manager.GetBucketRegion(context.Background(), session, bucket, regionHint)
+			region, _ = s3manager.GetBucketRegion(context.Background(), sess, bucket, regionHint)
 
 			// we only need to try a single region hint per partition, so break after the first
 			break


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

Fix the golang lint error: Variable 'session' collides with imported package name

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.

/kind changelog-not-required