### PR TITLE
Avoid duplicated snapshotting, when CSI is enabled

### DIFF
--- a/changelogs/unreleased/4797-jxun
+++ b/changelogs/unreleased/4797-jxun
@@ -1,0 +1,1 @@
+Do not take snapshot for PV to avoid duplicated snapshotting, when CSI feature is enabled.


### PR DESCRIPTION
Do not take snapshot for PV to avoid duplicated snapshotting, when CSI feature is enabled.

Signed-off-by: Xun Jiang <jxun@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #4758 

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
