### PR TITLE
Fix bug when pushing the build-image

### DIFF
--- a/.github/workflows/push-builder.yml
+++ b/.github/workflows/push-builder.yml
@@ -12,7 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
+      with:
+        # The default value is "1" which fetches only a single commit. If we merge PR without squash or rebase,
+        # there are at least two commits: the first one is the merge commit and the second one is the real commit
+        # contains the changes.
+        # As we use the Dockerfile's commit ID as the tag of the build-image, fetching only 1 commit causes the merge
+        # commit ID to be the tag.
+        # While when running make commands locally, as the local git repository usually contains all commits, the Dockerfile's
+        # commit ID is the second one. This is mismatch with the images in Dockerhub
+        fetch-depth: 2
 
     - name: Build
       run: make build-image


### PR DESCRIPTION
Checkout 2 commits to avoid mismatch of image tag when pushing the build-image

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
