### PR TITLE
fix: use the right kind in getRestartableProcess logger

### DIFF
--- a/pkg/plugin/clientmgmt/manager.go
+++ b/pkg/plugin/clientmgmt/manager.go
@@ -107,7 +107,7 @@ func (m *manager) getRestartableProcess(kind framework.PluginKind, name string) 
 	defer m.lock.Unlock()
 
 	logger := m.logger.WithFields(logrus.Fields{
-		"kind": framework.PluginKindObjectStore.String(),
+		"kind": kind.String(),
 		"name": name,
 	})
 	logger.Debug("looking for plugin in registry")


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

use the right kind in getRestartableProcess logger, instead of always use PluginKindObjectStore kind

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
