### PR TITLE
Make the vsc created by backup sync controller deletable

### DIFF
--- a/changelogs/unreleased/4832-reasonerjt
+++ b/changelogs/unreleased/4832-reasonerjt
@@ -1,0 +1,1 @@
+Make the vsc created by backup sync controller deletable

--- a/pkg/persistence/mocks/backup_store.go
+++ b/pkg/persistence/mocks/backup_store.go
@@ -284,6 +284,11 @@ func (_m *BackupStore) GetCSIVolumeSnapshotContents(backup string) ([]*snapshotv
 	return nil, nil
 }
 
+func (_m *BackupStore) GetCSIVolumeSnapshotClasses(backup string) ([]*snapshotv1api.VolumeSnapshotClass, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+
 func (_m *BackupStore) GetItemSnapshots(name string) ([]*volume.ItemSnapshot, error) {
 	panic("implement me")
 }

--- a/pkg/persistence/object_store_layout.go
+++ b/pkg/persistence/object_store_layout.go
@@ -111,3 +111,7 @@ func (l *ObjectStoreLayout) getCSIVolumeSnapshotKey(backup string) string {
 func (l *ObjectStoreLayout) getCSIVolumeSnapshotContentsKey(backup string) string {
 	return path.Join(l.subdirs["backups"], backup, fmt.Sprintf("%s-csi-volumesnapshotcontents.json.gz", backup))
 }
+
+func (l *ObjectStoreLayout) getCSIVolumeSnapshotClassesKey(backup string) string {
+	return path.Join(l.subdirs["backups"], backup, fmt.Sprintf("%s-csi-volumesnapshotclasses.json.gz", backup))
+}

--- a/pkg/util/csi/reset.go
+++ b/pkg/util/csi/reset.go
@@ -1,0 +1,42 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csi
+
+import (
+	"fmt"
+
+	snapshotv1api "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ResetVolumeSnapshotContent make changes to the volumesnapshot content before it's persisted
+// It will move the snapshot Handle to the source to avoid the snapshot-controller creating a snapshot when it's
+// synced by the backup sync controller.
+// It will return an error if the snapshot handle is not set, which should not happen when this func is called.
+func ResetVolumeSnapshotContent(snapCont *snapshotv1api.VolumeSnapshotContent) error {
+	if snapCont.Status != nil && snapCont.Status.SnapshotHandle != nil && len(*snapCont.Status.SnapshotHandle) > 0 {
+		v := *snapCont.Status.SnapshotHandle
+		snapCont.Spec.Source = snapshotv1api.VolumeSnapshotContentSource{
+			SnapshotHandle: &v,
+		}
+	} else {
+		return fmt.Errorf("the volumesnapshotcontent '%s' does not have snapshothandle set", snapCont.Name)
+	}
+
+	snapCont.Spec.VolumeSnapshotRef = corev1.ObjectReference{}
+	return nil
+}


### PR DESCRIPTION
Fixes #4760

This commit make changes in 2 parts:
1) When a volumesnapshotcontent is persisted during backup, velero will reset its
   `Source` field to remove the VolumeHandle, so that the
   csi-snapshotter will not try to call `CreateSnapshot` when its synced
   to another cluster with a backup.
2) Make sure the referenced volumesnapshotclasses are persisted and
   synced with the backup, so that when the volumesnapshotcontent is
   deleted the storage snapshot is also removed.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
