### PR TITLE
Update integrated Restic version and add insecureSkipTLSVerify for Re…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ see: https://velero.io/docs/main/build-from-source/#making-images-and-updating-v
 endef
 
 # The version of restic binary to be downloaded
-RESTIC_VERSION ?= 0.12.1
+RESTIC_VERSION ?= 0.13.1
 
 CLI_PLATFORMS ?= linux-amd64 linux-arm linux-arm64 darwin-amd64 darwin-arm64 windows-amd64 linux-ppc64le
 BUILDX_PLATFORMS ?= $(subst -,/,$(ARCH))

--- a/changelogs/unreleased/4839-jxun
+++ b/changelogs/unreleased/4839-jxun
@@ -1,0 +1,1 @@
+Update integrated Restic version and add insecureSkipTLSVerify for Restic CLI.

--- a/pkg/controller/pod_volume_restore_controller.go
+++ b/pkg/controller/pod_volume_restore_controller.go
@@ -385,6 +385,14 @@ func (c *podVolumeRestoreController) restorePodVolume(req *velerov1api.PodVolume
 	}
 	resticCmd.Env = env
 
+	// #4820: restrieve insecureSkipTLSVerify from BSL configuration for
+	// AWS plugin. If nothing is return, that means insecureSkipTLSVerify
+	// is not enable for Restic command.
+	skipTLSRet := restic.GetInsecureSkipTLSVerifyFromBSL(backupLocation, log)
+	if len(skipTLSRet) > 0 {
+		resticCmd.ExtraFlags = append(resticCmd.ExtraFlags, skipTLSRet)
+	}
+
 	var stdout, stderr string
 
 	if stdout, stderr, err = restic.RunRestore(resticCmd, log, c.updateRestoreProgressFunc(req, log)); err != nil {

--- a/pkg/restic/command_factory.go
+++ b/pkg/restic/command_factory.go
@@ -64,7 +64,8 @@ func GetSnapshotCommand(repoIdentifier, passwordFile string, tags map[string]str
 		Command:        "snapshots",
 		RepoIdentifier: repoIdentifier,
 		PasswordFile:   passwordFile,
-		ExtraFlags:     []string{"--json", "--last", getSnapshotTagFlag(tags)},
+		// "--last" is replaced by "--latest=1" in restic v0.12.1
+		ExtraFlags: []string{"--json", "--latest=1", getSnapshotTagFlag(tags)},
 	}
 }
 

--- a/pkg/restic/command_factory_test.go
+++ b/pkg/restic/command_factory_test.go
@@ -58,7 +58,7 @@ func TestGetSnapshotCommand(t *testing.T) {
 	assert.Equal(t, "password-file", c.PasswordFile)
 
 	// set up expected flag names
-	expectedFlags := []string{"--json", "--last", "--tag"}
+	expectedFlags := []string{"--json", "--latest=1", "--tag"}
 	// for tracking actual flag names
 	actualFlags := []string{}
 	// for tracking actual --tag values as a map
@@ -68,10 +68,11 @@ func TestGetSnapshotCommand(t *testing.T) {
 	for _, flag := range c.ExtraFlags {
 		// split into 2 parts from the first = sign (if any)
 		parts := strings.SplitN(flag, "=", 2)
-		// parts[0] is the flag name
-		actualFlags = append(actualFlags, parts[0])
+
 		// convert --tag data to a map
 		if parts[0] == "--tag" {
+			actualFlags = append(actualFlags, parts[0])
+
 			// split based on ,
 			tags := strings.Split(parts[1], ",")
 			// loop through each key-value tag pair
@@ -81,6 +82,8 @@ func TestGetSnapshotCommand(t *testing.T) {
 				// record actual key & value
 				actualTags[kvs[0]] = kvs[1]
 			}
+		} else {
+			actualFlags = append(actualFlags, flag)
 		}
 	}
 

--- a/pkg/restic/repository_manager_test.go
+++ b/pkg/restic/repository_manager_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restic
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+)
+
+func TestGetInsecureSkipTLSVerifyFromBSL(t *testing.T) {
+	log := logrus.StandardLogger()
+	tests := []struct {
+		name           string
+		backupLocation *velerov1api.BackupStorageLocation
+		logger         logrus.FieldLogger
+		expected       string
+	}{
+		{
+			"Test with nil BSL. Should return empty string.",
+			nil,
+			log,
+			"",
+		},
+		{
+			"Test BSL with no configuration. Should return empty string.",
+			&velerov1api.BackupStorageLocation{
+				Spec: velerov1api.BackupStorageLocationSpec{
+					Provider: "azure",
+				},
+			},
+			log,
+			"",
+		},
+		{
+			"Test with AWS BSL's insecureSkipTLSVerify set to false.",
+			&velerov1api.BackupStorageLocation{
+				Spec: velerov1api.BackupStorageLocationSpec{
+					Provider: "aws",
+					Config: map[string]string{
+						"insecureSkipTLSVerify": "false",
+					},
+				},
+			},
+			log,
+			"",
+		},
+		{
+			"Test with AWS BSL's insecureSkipTLSVerify set to true.",
+			&velerov1api.BackupStorageLocation{
+				Spec: velerov1api.BackupStorageLocationSpec{
+					Provider: "aws",
+					Config: map[string]string{
+						"insecureSkipTLSVerify": "true",
+					},
+				},
+			},
+			log,
+			"--insecure-tls=true",
+		},
+		{
+			"Test with Azure BSL's insecureSkipTLSVerify set to invalid.",
+			&velerov1api.BackupStorageLocation{
+				Spec: velerov1api.BackupStorageLocationSpec{
+					Provider: "azure",
+					Config: map[string]string{
+						"insecureSkipTLSVerify": "invalid",
+					},
+				},
+			},
+			log,
+			"",
+		},
+		{
+			"Test with GCP without insecureSkipTLSVerify.",
+			&velerov1api.BackupStorageLocation{
+				Spec: velerov1api.BackupStorageLocationSpec{
+					Provider: "gcp",
+					Config:   map[string]string{},
+				},
+			},
+			log,
+			"",
+		},
+		{
+			"Test with AWS without config.",
+			&velerov1api.BackupStorageLocation{
+				Spec: velerov1api.BackupStorageLocationSpec{
+					Provider: "aws",
+				},
+			},
+			log,
+			"",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			res := GetInsecureSkipTLSVerifyFromBSL(test.backupLocation, test.logger)
+
+			assert.Equal(t, test.expected, res)
+		})
+	}
+}


### PR DESCRIPTION
…stic CLI

1. Add --insecure-tls for ResticManager's commands.
2. Add --insecure-tls in PodVolumeBackup and PodVolumeRestore controller.
3. Upgrade integrated Restic version to v0.13.1
4. Change --last flag in Restic command to --latest=1 due to Restic version update.

Signed-off-by: Xun Jiang <jxun@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #4820

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
