### PR TITLE
Add ClusterClasses to the restore priority list

### DIFF
--- a/changelogs/unreleased/4866-reasonerjt
+++ b/changelogs/unreleased/4866-reasonerjt
@@ -1,0 +1,1 @@
+Add ClusterClasses to the restore priority list

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -476,6 +476,7 @@ func (s *server) veleroResourcesExist() error {
 //	 have restic restores run before controllers adopt the pods.
 // - Replica sets go before deployments/other controllers so they can be explicitly
 //	 restored and be adopted by controllers.
+// - CAPI ClusterClasses go before Clusters.
 // - CAPI Clusters come before ClusterResourceSets because failing to do so means the CAPI controller-manager will panic.
 //	 Both Clusters and ClusterResourceSets need to come before ClusterResourceSetBinding in order to properly restore workload clusters.
 //   See https://github.com/kubernetes-sigs/cluster-api/issues/4105
@@ -498,6 +499,7 @@ var defaultRestorePriorities = []string{
 	// to ensure that we prioritize restoring from "apps" too, since this is how they're stored
 	// in the backup.
 	"replicasets.apps",
+	"clusterclasses.cluster.x-k8s.io",
 	"clusters.cluster.x-k8s.io",
 	"clusterresourcesets.addons.cluster.x-k8s.io",
 }


### PR DESCRIPTION
Make sure ClusterClasses are stored before Clusters.
Fixes #4767

Signed-off-by: Daniel Jiang <jiangd@vmware.com>

Thank you for contributing to Velero!

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
