### PR TITLE
cleanup restic helper folder when done

### DIFF
--- a/changelogs/unreleased/4872-big-appled
+++ b/changelogs/unreleased/4872-big-appled
@@ -1,0 +1,1 @@
+Cleanup the .velero folder after restic done

--- a/cmd/velero-restic-restore-helper/velero-restic-restore-helper.go
+++ b/cmd/velero-restic-restore-helper/velero-restic-restore-helper.go
@@ -41,8 +41,9 @@ func main() {
 				err := removeFolder()
 				if err != nil {
 					fmt.Println(err)
+				} else {
+					fmt.Println("Done cleanup .velero folder")
 				}
-				fmt.Println("Cleanup .velero folder")
 				return
 			}
 		}
@@ -85,7 +86,6 @@ func done() bool {
 func removeFolder() error {
 	children, err := ioutil.ReadDir("/restores")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR reading /restores directory: %s\n", err)
 		return err
 	}
 

--- a/cmd/velero-restic-restore-helper/velero-restic-restore-helper.go
+++ b/cmd/velero-restic-restore-helper/velero-restic-restore-helper.go
@@ -38,6 +38,11 @@ func main() {
 		case <-ticker.C:
 			if done() {
 				fmt.Println("All restic restores are done")
+				err := removeFolder()
+				if err != nil {
+					fmt.Println(err)
+				}
+				fmt.Println("Cleanup .velero folder")
 				return
 			}
 		}
@@ -74,4 +79,30 @@ func done() bool {
 	}
 
 	return true
+}
+
+// remove .velero folder
+func removeFolder() error {
+	children, err := ioutil.ReadDir("/restores")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR reading /restores directory: %s\n", err)
+		return err
+	}
+
+	for _, child := range children {
+		if !child.IsDir() {
+			fmt.Printf("%s is not a directory, skipping.\n", child.Name())
+			continue
+		}
+
+		donePath := filepath.Join("/restores", child.Name(), ".velero")
+
+		err = os.RemoveAll(donePath)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Deleted %s", donePath)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
There will be a folder named .velero left in user volume when restore data with restic. We need to remove it when the restic-helper init container done.

# Does your change fix a particular issue?
no
Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
