### PR TITLE
Add note about non-destrutive restore

### DIFF
--- a/site/content/docs/main/how-velero-works.md
+++ b/site/content/docs/main/how-velero-works.md
@@ -38,6 +38,8 @@ By default, backup storage locations are created in read-write mode. However, du
 
 You can optionally specify restore hooks to be executed during a restore or after resources are restored. For example, you might need to perform a custom database restore operation before the database application containers start. [More about restore hooks][11].
 
+During a restore, Velero is non-destructive. That means that Velero will never overwrite a pre-existing resource which has the same name as a resource in the backup it is restoring. Similarly, if a persistent volume exists, Velero will not overwrite the data in it. This behavior is by design, so that you don't have to worry about accidentally overwriting your cluster's state when using Velero.
+
 ## Backup workflow
 
 When you run `velero backup create test-backup`:

--- a/site/content/docs/main/restore-reference.md
+++ b/site/content/docs/main/restore-reference.md
@@ -40,9 +40,9 @@ Available Commands:
 
 **Auto assigned** NodePorts **deleted** by default and Services get new **auto assigned** nodePorts after restore.
 
-**Explicitly specified** NodePorts auto detected using **`last-applied-config`** annotation and **preserved** after restore.  NodePorts can be explicitly specified as .spec.ports[*].nodePort field on Service definition.
+**Explicitly specified** NodePorts auto detected using **`last-applied-config`** annotation and **preserved** after restore.  NodePorts can be explicitly specified as `.spec.ports[*].nodePort` field on Service definition.
 
-#### Always Preserve NodePorts
+### Always Preserve NodePorts
 
 It is not always possible to set nodePorts explicitly on some big clusters because of operation complexity. Official Kubernetes documents states that preventing port collisions is responsibility of the user when explicitly specifying nodePorts:
 


### PR DESCRIPTION
Signed-off-by: Abigail McCarthy <mabigail@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Adds a note to the How Velero Works page about non-destructive nature of restores. 

Also fixes some minor formatting issues on the restore reference page. 

# Does your change fix a particular issue?

Fixes #https://github.com/vmware-tanzu/velero/issues/4571

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
