### PR TITLE
continue rather than return for non-matching restore action label

### DIFF
--- a/changelogs/unreleased/4890-sseago
+++ b/changelogs/unreleased/4890-sseago
@@ -1,0 +1,1 @@
+continue rather than return for non-matching restore action label

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1106,7 +1106,7 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 
 	for _, action := range ctx.getApplicableActions(groupResource, namespace) {
 		if !action.Selector.Matches(labels.Set(obj.GetLabels())) {
-			return warnings, errs
+			continue
 		}
 
 		ctx.log.Infof("Executing item action for %v", &groupResource)


### PR DESCRIPTION
When iterating over applicable restore actions, if a non-matching label
selector is found, velero should continue to the next action rather than
returning from the restoreItem func, which ends up preventing the item's
restore entirely.

Signed-off-by: Scott Seago <sseago@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
When restore was refactored to add additionalItems a few years ago, a bug was introduced. At the beginning of each run through the loop that executes RestoreItemActions, there's a label selector check. The previous code had a `continue` call for non-matching labels, meaning that the action would be skipped, moving on to the next. The refactored code returns from the `restoreItem` func instead, meaning that a single action for the resource with a non-matching label selector included will prevent restore from happening at all. This fix restores the correct behavior. 

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
