### PR TITLE
Make in-progress PVB/PVR as failed when restic controller restarts to avoid hanging backup/restore

### DIFF
--- a/changelogs/unreleased/4893-ywk253100
+++ b/changelogs/unreleased/4893-ywk253100
@@ -1,0 +1,1 @@
+Make in-progress PVB/PVR as failed when restic controller restarts to avoid hanging backup/restore

--- a/pkg/controller/pod_volume_backup_controller_test.go
+++ b/pkg/controller/pod_volume_backup_controller_test.go
@@ -179,16 +179,16 @@ var _ = Describe("PodVolumeBackup Reconciler", func() {
 				Result(),
 			expectedRequeue: ctrl.Result{},
 		}),
-		Entry("in progress phase pvb on same node should not be processed", request{
+		Entry("in progress phase pvb on same node should be marked as failed", request{
 			pvb: pvbBuilder().
 				Phase(velerov1api.PodVolumeBackupPhaseInProgress).
 				Node("test_node").
 				Result(),
 			pod:               podBuilder().Result(),
 			bsl:               bslBuilder().Result(),
-			expectedProcessed: false,
+			expectedProcessed: true,
 			expected: builder.ForPodVolumeBackup(velerov1api.DefaultNamespace, "pvb-1").
-				Phase(velerov1api.PodVolumeBackupPhaseInProgress).
+				Phase(velerov1api.PodVolumeBackupPhaseFailed).
 				Result(),
 			expectedRequeue: ctrl.Result{},
 		}),

--- a/pkg/util/kube/utils.go
+++ b/pkg/util/kube/utils.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -238,4 +239,13 @@ func IsCRDReady(crd *unstructured.Unstructured) (bool, error) {
 	default:
 		return false, fmt.Errorf("unable to handle CRD with version %s", ver)
 	}
+}
+
+// Patch the given object
+func Patch(ctx context.Context, original, updated client.Object, client client.Client) error {
+	helper, err := patch.NewHelper(original, client)
+	if err != nil {
+		return err
+	}
+	return helper.Patch(ctx, updated)
 }

--- a/pkg/util/kube/utils_test.go
+++ b/pkg/util/kube/utils_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/vmware-tanzu/velero/pkg/builder"
@@ -424,4 +425,26 @@ func TestIsCRDReady(t *testing.T) {
 	require.NoError(t, err)
 	_, err = IsCRDReady(obj)
 	assert.NotNil(t, err)
+}
+
+func TestPatch(t *testing.T) {
+	original := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "pod",
+		},
+	}
+	cli := fake.NewClientBuilder().WithObjects(original).Build()
+
+	updated := original.DeepCopy()
+	updated.SetLabels(map[string]string{"key": "value"})
+
+	ctx := context.Background()
+	err := Patch(ctx, original, updated, cli)
+	require.Nil(t, err)
+
+	pod := &corev1.Pod{}
+	err = cli.Get(ctx, types.NamespacedName{Namespace: "default", Name: "pod"}, pod)
+	require.Nil(t, err)
+	assert.Equal(t, 1, len(pod.GetLabels()))
 }


### PR DESCRIPTION
Make in-progress PVB/PVR as failed when restic controller restarts to avoid hanging backup/restore

Fixes #4772

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
