### PR TITLE
Make garbage collection for expired backups configurable

### DIFF
--- a/changelogs/unreleased/4897-ywk253100
+++ b/changelogs/unreleased/4897-ywk253100
@@ -1,0 +1,1 @@
+Make garbage collection for expired backups configurable

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -121,6 +121,7 @@ type serverConfig struct {
 	profilerAddress                                                         string
 	formatFlag                                                              *logging.FormatFlag
 	defaultResticMaintenanceFrequency                                       time.Duration
+	garbageCollectionFrequency                                              time.Duration
 	defaultVolumesToRestic                                                  bool
 }
 
@@ -214,6 +215,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 	command.Flags().DurationVar(&config.resourceTerminatingTimeout, "terminating-resource-timeout", config.resourceTerminatingTimeout, "How long to wait on persistent volumes and namespaces to terminate during a restore before timing out.")
 	command.Flags().DurationVar(&config.defaultBackupTTL, "default-backup-ttl", config.defaultBackupTTL, "How long to wait by default before backups can be garbage collected.")
 	command.Flags().DurationVar(&config.defaultResticMaintenanceFrequency, "default-restic-prune-frequency", config.defaultResticMaintenanceFrequency, "How often 'restic prune' is run for restic repositories by default.")
+	command.Flags().DurationVar(&config.garbageCollectionFrequency, "garbage-collection-frequency", config.garbageCollectionFrequency, "How often garbage collection is run for expired backups.")
 	command.Flags().BoolVar(&config.defaultVolumesToRestic, "default-volumes-to-restic", config.defaultVolumesToRestic, "Backup all volumes with restic by default.")
 
 	return command
@@ -669,6 +671,7 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 			s.sharedInformerFactory.Velero().V1().DeleteBackupRequests().Lister(),
 			s.veleroClient.VeleroV1(),
 			s.mgr.GetClient(),
+			s.config.garbageCollectionFrequency,
 		)
 
 		return controllerRunInfo{

--- a/pkg/controller/gc_controller_test.go
+++ b/pkg/controller/gc_controller_test.go
@@ -53,6 +53,7 @@ func TestGCControllerEnqueueAllBackups(t *testing.T) {
 			sharedInformers.Velero().V1().DeleteBackupRequests().Lister(),
 			client.VeleroV1(),
 			nil,
+			defaultGCFrequency,
 		).(*gcController)
 	)
 
@@ -114,6 +115,7 @@ func TestGCControllerHasUpdateFunc(t *testing.T) {
 		sharedInformers.Velero().V1().DeleteBackupRequests().Lister(),
 		client.VeleroV1(),
 		nil,
+		defaultGCFrequency,
 	).(*gcController)
 
 	keys := make(chan string)
@@ -262,6 +264,7 @@ func TestGCControllerProcessQueueItem(t *testing.T) {
 				sharedInformers.Velero().V1().DeleteBackupRequests().Lister(),
 				client.VeleroV1(),
 				fakeClient,
+				defaultGCFrequency,
 			).(*gcController)
 			controller.clock = fakeClock
 

--- a/pkg/install/deployment.go
+++ b/pkg/install/deployment.go
@@ -40,6 +40,7 @@ type podTemplateConfig struct {
 	resources                         corev1.ResourceRequirements
 	withSecret                        bool
 	defaultResticMaintenanceFrequency time.Duration
+	garbageCollectionFrequency        time.Duration
 	plugins                           []string
 	features                          []string
 	defaultVolumesToRestic            bool
@@ -101,6 +102,12 @@ func WithResources(resources corev1.ResourceRequirements) podTemplateOption {
 func WithDefaultResticMaintenanceFrequency(val time.Duration) podTemplateOption {
 	return func(c *podTemplateConfig) {
 		c.defaultResticMaintenanceFrequency = val
+	}
+}
+
+func WithGarbageCollectionFrequency(val time.Duration) podTemplateOption {
+	return func(c *podTemplateConfig) {
+		c.garbageCollectionFrequency = val
 	}
 }
 
@@ -273,6 +280,10 @@ func Deployment(namespace string, opts ...podTemplateOption) *appsv1.Deployment 
 
 	if c.defaultResticMaintenanceFrequency > 0 {
 		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--default-restic-prune-frequency=%v", c.defaultResticMaintenanceFrequency))
+	}
+
+	if c.garbageCollectionFrequency > 0 {
+		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--garbage-collection-frequency=%v", c.garbageCollectionFrequency))
 	}
 
 	if len(c.plugins) > 0 {

--- a/pkg/install/deployment_test.go
+++ b/pkg/install/deployment_test.go
@@ -50,6 +50,10 @@ func TestDeployment(t *testing.T) {
 	assert.Len(t, deploy.Spec.Template.Spec.Containers[0].Args, 2)
 	assert.Equal(t, "--default-restic-prune-frequency=24h0m0s", deploy.Spec.Template.Spec.Containers[0].Args[1])
 
+	deploy = Deployment("velero", WithGarbageCollectionFrequency(24*time.Hour))
+	assert.Len(t, deploy.Spec.Template.Spec.Containers[0].Args, 2)
+	assert.Equal(t, "--garbage-collection-frequency=24h0m0s", deploy.Spec.Template.Spec.Containers[0].Args[1])
+
 	deploy = Deployment("velero", WithFeatures([]string{"EnableCSI", "foo", "bar", "baz"}))
 	assert.Len(t, deploy.Spec.Template.Spec.Containers[0].Args, 2)
 	assert.Equal(t, "--features=EnableCSI,foo,bar,baz", deploy.Spec.Template.Spec.Containers[0].Args[1])

--- a/pkg/install/resources.go
+++ b/pkg/install/resources.go
@@ -226,6 +226,7 @@ type VeleroOptions struct {
 	BSLConfig                         map[string]string
 	VSLConfig                         map[string]string
 	DefaultResticMaintenanceFrequency time.Duration
+	GarbageCollectionFrequency        time.Duration
 	Plugins                           []string
 	NoDefaultBackupLocation           bool
 	CACertData                        []byte
@@ -285,6 +286,7 @@ func AllResources(o *VeleroOptions) *unstructured.UnstructuredList {
 		WithResources(o.VeleroPodResources),
 		WithSecret(secretPresent),
 		WithDefaultResticMaintenanceFrequency(o.DefaultResticMaintenanceFrequency),
+		WithGarbageCollectionFrequency(o.GarbageCollectionFrequency),
 	}
 
 	if len(o.Features) > 0 {


### PR DESCRIPTION
Make garbage collection for expired backups configurable

Fixes #4875

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
