### PR TITLE
Update storage sync docs to note that failed backups are not included

### DIFF
--- a/site/content/docs/main/how-velero-works.md
+++ b/site/content/docs/main/how-velero-works.md
@@ -86,7 +86,7 @@ Velero treats object storage as the source of truth. It continuously checks to s
 
 This allows restore functionality to work in a cluster migration scenario, where the original backup objects do not exist in the new cluster.
 
-Likewise, if a backup object exists in Kubernetes but not in object storage, it will be deleted from Kubernetes since the backup tarball no longer exists.
+Likewise, if a backup object exists in Kubernetes but not in object storage, it will be deleted from Kubernetes since the backup tarball no longer exists. Velero's object storage syncing only handles completed backups, if a backup is failed or partially failed, it will not be deleted via this process.
 
 [10]: backup-hooks.md
 [11]: restore-hooks.md


### PR DESCRIPTION
Signed-off-by: Abigail McCarthy <mabigail@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

This updates the object storage syncing docs to include a message that failed or partially failed backups will not be removed by Velero.

# Does your change fix a particular issue?

Fixes https://github.com/vmware-tanzu/velero/issues/4483

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
