### PR TITLE
Add note about restoring when resource scaled to 0

### DIFF
--- a/site/content/docs/main/restic.md
+++ b/site/content/docs/main/restic.md
@@ -248,7 +248,7 @@ Instructions to back up using this approach are as follows:
 
 ### Using opt-in pod volume backup
 
-Velero, by default, uses this approach to discover pod volumes that need to be backed up using Restic, where every pod containing a volume to be backed up using Restic must be annotated with the volume's name.
+Velero, by default, uses this approach to discover pod volumes that need to be backed up using Restic. Every pod containing a volume to be backed up using Restic must be annotated with the volume's name using the `backup.velero.io/backup-volumes` annotation.
 
 Instructions to back up using this approach are as follows:
 
@@ -412,7 +412,7 @@ data:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
     runAsUser: 1001
-    runAsGroup: 999 
+    runAsGroup: 999
 
 ```
 
@@ -523,6 +523,8 @@ on this shortly)
 within each restored volume, under `.velero`, whose name is the UID of the Velero restore being run
 1. Once all such files are found, the init container's process terminates successfully and the pod moves
 on to running other init containers/the main containers.
+
+Velero won't restore a resource if a that resource is scaled to 0 and already exists in the cluster. If Velero restored the requested pods in this scenario, the Kubernetes reconciliation loops that manage resources would delete the running pods because its scaled to be 0. Velero will be able to restore once the resources is scaled up, and the pods are created and remain running.
 
 ## 3rd party controllers
 


### PR DESCRIPTION
Signed-off-by: Abigail McCarthy <mabigail@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change
This adds a note that Velero will not restore using restic when a resource is scaled to 0 on a cluster. Also makes it clear that volumes to be restore with restic i identified with the `backup.velero.io/backup-volumes` annotation.

# Does your change fix a particular issue?

Fixes https://github.com/vmware-tanzu/velero/issues/1919

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
