### PR TITLE
Make velero completion zsh command output can be used by `source` com…

### DIFF
--- a/changelogs/unreleased/4914-jxun
+++ b/changelogs/unreleased/4914-jxun
@@ -1,0 +1,1 @@
+Make velero completion zsh command output can be used by `source` command.

--- a/pkg/cmd/cli/completion/completion.go
+++ b/pkg/cmd/cli/completion/completion.go
@@ -66,7 +66,15 @@ $ velero completion fish > ~/.config/fish/completions/velero.fish
 			case "bash":
 				cmd.Root().GenBashCompletion(os.Stdout)
 			case "zsh":
-				cmd.Root().GenZshCompletion(os.Stdout)
+				// # fix #4912
+				// cobra does not support zsh completion ouptput used by source command
+				// according to https://github.com/spf13/cobra/issues/1529
+				// Need to append compdef manually to do that.
+				zshHead := "#compdef velero\ncompdef _velero velero\n"
+				out := os.Stdout
+				out.Write([]byte(zshHead))
+
+				cmd.Root().GenZshCompletion(out)
 			case "fish":
 				cmd.Root().GenFishCompletion(os.Stdout, true)
 			default:


### PR DESCRIPTION
…mand.

Signed-off-by: Xun Jiang <jxun@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #4912 

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
