### PR TITLE
Update docs for flag to skip TLS validation

### DIFF
--- a/site/content/docs/main/self-signed-certificates.md
+++ b/site/content/docs/main/self-signed-certificates.md
@@ -46,3 +46,12 @@ Error 116 represents certificate required as seen here in [error codes](https://
 Velero as a client does not include its certificate while performing SSL handshake with the server.
 From [TLS 1.3 spec](https://tools.ietf.org/html/rfc8446), verifying client certificate is optional on the server.
 You will need to change this setting on the server to make it work.
+
+
+## Skipping TLS verification
+
+**Note:** The `--insecure-skip-tls-verify` flag is insecure and susceptible to man-in-the-middle attacks and meant to help your testing and developing scenarios in an on-premise environment. Using this flag in production is not recommended.
+
+Velero provides a way for you to skip TLS verification on the object store by passing the `--insecure-skip-tls-verify` flag with Velero commands. If true, the object store's TLS certificate will not be checked for validity before Velero connects to the object store or Restic repo. You can permanently skip TLS verification for an object store by setting `Spec.Config.InsecureSkipTLSVerify` to true in the [BackupStorageLocation](api-types/backupstoragelocation.md) CRD.
+
+This flag is currently only implemented for use with AWS provider plugin and Restic.

--- a/site/content/docs/main/self-signed-certificates.md
+++ b/site/content/docs/main/self-signed-certificates.md
@@ -52,6 +52,14 @@ You will need to change this setting on the server to make it work.
 
 **Note:** The `--insecure-skip-tls-verify` flag is insecure and susceptible to man-in-the-middle attacks and meant to help your testing and developing scenarios in an on-premise environment. Using this flag in production is not recommended.
 
-Velero provides a way for you to skip TLS verification on the object store by passing the `--insecure-skip-tls-verify` flag with Velero commands. If true, the object store's TLS certificate will not be checked for validity before Velero connects to the object store or Restic repo. You can permanently skip TLS verification for an object store by setting `Spec.Config.InsecureSkipTLSVerify` to true in the [BackupStorageLocation](api-types/backupstoragelocation.md) CRD.
+Velero provides a way for you to skip TLS verification on the object store when using the [AWS provider plugin](https://github.com/vmware-tanzu/velero-plugin-for-aws) or [Restic](restic.md) by passing the `--insecure-skip-tls-verify` flag with the following Velero commands,
 
-This flag is currently only implemented for use with AWS provider plugin and Restic.
+* velero backup describe
+* velero backup download
+* velero backup logs
+* velero restore describe
+* velero restore log
+
+If true, the object store's TLS certificate will not be checked for validity before Velero connects to the object store or Restic repo. You can permanently skip TLS verification for an object store by setting `Spec.Config.InsecureSkipTLSVerify` to true in the [BackupStorageLocation](api-types/backupstoragelocation.md) CRD.
+
+Note that Velero's Restic integration uses Restic commands to do data transfer between object store and Kubernetes cluster disks. This means that when you specify `--insecure-skip-tls-verify` in Velero operations that involve interacting with Restic, Velero will add the Restic global command parameter `--insecure-skip` to Restic commands.

--- a/site/content/docs/main/self-signed-certificates.md
+++ b/site/content/docs/main/self-signed-certificates.md
@@ -62,4 +62,4 @@ Velero provides a way for you to skip TLS verification on the object store when 
 
 If true, the object store's TLS certificate will not be checked for validity before Velero connects to the object store or Restic repo. You can permanently skip TLS verification for an object store by setting `Spec.Config.InsecureSkipTLSVerify` to true in the [BackupStorageLocation](api-types/backupstoragelocation.md) CRD.
 
-Note that Velero's Restic integration uses Restic commands to do data transfer between object store and Kubernetes cluster disks. This means that when you specify `--insecure-skip-tls-verify` in Velero operations that involve interacting with Restic, Velero will add the Restic global command parameter `--insecure-skip` to Restic commands.
+Note that Velero's Restic integration uses Restic commands to do data transfer between object store and Kubernetes cluster disks. This means that when you specify `--insecure-skip-tls-verify` in Velero operations that involve interacting with Restic, Velero will add the Restic global command parameter `--insecure-tls` to Restic commands.


### PR DESCRIPTION
Signed-off-by: Abigail McCarthy <mabigail@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change
This updates the docs with information about using the `--insecure-skip-tls-verify` flag.

# Does your change fix a particular issue?

Fixes https://github.com/vmware-tanzu/velero/issues/4848

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
