### PR TITLE
Propose Shubham Pampattiwar as a maintainer

### DIFF
--- a/.github/auto-assignees.yml
+++ b/.github/auto-assignees.yml
@@ -15,6 +15,7 @@ reviewers:
       - ywk253100
       - blackpiglet
       - qiuming-best
+      - shubham-pampattiwar
 
     tech-writer:
       - a-mccarthy

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,6 +12,7 @@
 | Wenkai Yin | [ywk253100](https://github.com/ywk253100) | [VMware](https://www.github.com/vmware/) |
 | Xun Jiang | [blackpiglet](https://github.com/blackpiglet) | [VMware](https://www.github.com/vmware/) |
 | Ming Qiu | [qiuming-best](https://github.com/qiuming-best) | [VMware](https://www.github.com/vmware/) |
+| Shubham Pampattiwar | [shubham-pampattiwar](https://github.com/shubham-pampattiwar) | [OpenShift](https://github.com/openshift)
 
 ## Emeritus Maintainers
 * Adnan Abdulhussein ([prydonius](https://github.com/prydonius))


### PR DESCRIPTION
    Shubham Pampattiwar has made several contributions to Velero,
    most recently in designing and implementing two v1.9
    features, including the following:
    - [Add design for enabling multiple label support](https://github.com/vmware-tanzu/velero/pull/4619)
    - [Add multiple label selector support to Velero Backup and Restore APIs](https://github.com/vmware-tanzu/velero/pull/4650)
    - [Add design for enabling support for ExistingResourcePolicy to restore API](https://github.com/vmware-tanzu/velero/pull/4613)
    - [Add existingResourcePolicy to Restore API](https://github.com/vmware-tanzu/velero/pull/4628)
    
    Shubham has also been driving forward the data mover requirements and design discussions for velero 1.10:
    - [Add datamover design](https://github.com/vmware-tanzu/velero/pull/4768)
