### PR TITLE
Make restic enc password configurable

### DIFF
--- a/changelogs/unreleased/4961-menzbua
+++ b/changelogs/unreleased/4961-menzbua
@@ -1,0 +1,6 @@
+Added functionality to deploy a specific Restic encryption password.
+The behavior currently is that the Restic encryption password is hard-coded. I've implemented that the 
+encryption password can be controlled by an environment variable "RESTIC_PASSWORD". If the environment
+variable is not set, the default password would be set to the old hard-coded password. Because of this,
+there should be no problem for users that do not set this variable.
+I've added this functionality because we don't want to use the default password for the restic encryption.

--- a/pkg/restic/repository_keys_test.go
+++ b/pkg/restic/repository_keys_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package restic
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,4 +28,11 @@ func TestRepoKeySelector(t *testing.T) {
 
 	require.Equal(t, credentialsSecretName, selector.Name)
 	require.Equal(t, credentialsKey, selector.Key)
+}
+
+func Test_getEncryptionKey(t *testing.T) {
+	require.Equal(t, "static-passw0rd", "static-passw0rd")
+
+	os.Setenv("RESTIC_PASSWORD", "variable-passw0rd")
+	require.Equal(t, "variable-passw0rd", "variable-passw0rd")
 }

--- a/site/content/docs/main/restic.md
+++ b/site/content/docs/main/restic.md
@@ -336,7 +336,7 @@ Regardless of how volumes are discovered for backup using Restic, the process of
 - Those of you familiar with [restic][1] may know that it encrypts all of its data. Velero uses a static,
 common encryption key for all Restic repositories it creates. **This means that anyone who has access to your
 bucket can decrypt your Restic backup data**. Make sure that you limit access to the Restic bucket
-appropriately.
+appropriately. You can overwrite that static key with an `configuration.extraEnvVars` variable named "RESTIC_PASSWORD". The value of the Key would be the encryption key for Restic.
 - An incremental backup chain will be maintained across pod reschedules for PVCs. However, for pod volumes that are *not*
 PVCs, such as `emptyDir` volumes, when a pod is deleted/recreated (for example, by a ReplicaSet/Deployment), the next backup of those
 volumes will be full rather than incremental, because the pod volume's lifecycle is assumed to be defined by its pod.


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
I've make the Restic encryption key configurable by an environment variable. At the moment the encryption key is hardcoded. This hardcoded string is my fallback if the environment variable "RESTIC_PASSWORD" is not set.
# Does your change fix a particular issue?
#1053

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
