### PR TITLE
Fix E2E test [Backups][Deletion][Restic] on GCP

### DIFF
--- a/changelogs/unreleased/4968-jxun
+++ b/changelogs/unreleased/4968-jxun
@@ -1,0 +1,1 @@
+Fix E2E test [Backups][Deletion][Restic] on GCP.


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
[Backups][Deletion][Restic] case failed on GCP. Looks like the verify deletion a non-existing backup step is buggy. Modify checking logic to let it pass.

# Does your change fix a particular issue?

Fixes #4949

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
