### PR TITLE
Fix ordered resources cmd Stdout already set error

### DIFF
--- a/test/e2e/util/velero/velero_utils.go
+++ b/test/e2e/util/velero/velero_utils.go
@@ -234,8 +234,8 @@ func checkRestorePhase(ctx context.Context, veleroCLI string, veleroNamespace st
 }
 
 func checkSchedulePhase(ctx context.Context, veleroCLI, veleroNamespace, scheduleName string) error {
-	checkCMD := exec.CommandContext(ctx, veleroCLI, "--namespace", veleroNamespace, "schedule", "get", scheduleName, "-ojson")
 	return wait.PollImmediate(time.Second*5, time.Minute*2, func() (bool, error) {
+		checkCMD := exec.CommandContext(ctx, veleroCLI, "--namespace", veleroNamespace, "schedule", "get", scheduleName, "-ojson")
 		jsonBuf, err := CMDExecWithOutput(checkCMD)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
Signed-off-by: Ming <mqiu@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)
Fix #4974
The same command pipeline with polling execute will encountered with the error ` Stdout already set error`
# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
