### PR TITLE
Undo setting the VSC's deletion policy during backup

### DIFF
--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -1045,8 +1045,6 @@ func (c *backupController) recreateVolumeSnapshotContent(vsc *snapshotv1api.Volu
 		Namespace:  "ns-" + string(vsc.UID),
 		Name:       "name-" + string(vsc.UID),
 	}
-	// Revert DeletionPolicy to Delete
-	vsc.Spec.DeletionPolicy = snapshotv1api.VolumeSnapshotContentDelete
 	// ResourceVersion shouldn't exist for new creation.
 	vsc.ResourceVersion = ""
 	_, err = c.volumeSnapshotClient.SnapshotV1().VolumeSnapshotContents().Create(context.TODO(), vsc, metav1.CreateOptions{})


### PR DESCRIPTION
It's not necessary to set the deletion policy as the delete item action
plugin in CSI plugin will set it to Delete when the backup is deleted.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>

Thank you for contributing to Velero!


# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
