### PR TITLE
Bugs fixing: use patch to update status and set default GC period

### DIFF
--- a/pkg/controller/backup_sync_controller.go
+++ b/pkg/controller/backup_sync_controller.go
@@ -337,7 +337,7 @@ func (c *backupSyncController) run() {
 		// update the location's last-synced time field
 		statusPatch := client.MergeFrom(location.DeepCopy())
 		location.Status.LastSyncedTime = &metav1.Time{Time: time.Now().UTC()}
-		if err := c.kbClient.Status().Patch(context.Background(), &location, statusPatch); err != nil {
+		if err := c.kbClient.Patch(context.Background(), &location, statusPatch); err != nil {
 			log.WithError(errors.WithStack(err)).Error("Error patching backup location's last-synced time")
 			continue
 		}

--- a/pkg/controller/gc_controller.go
+++ b/pkg/controller/gc_controller.go
@@ -79,7 +79,7 @@ func NewGCController(
 
 	c.syncHandler = c.processQueueItem
 	c.resyncPeriod = frequency
-	if c.resyncPeriod < 0 {
+	if c.resyncPeriod <= 0 {
 		c.resyncPeriod = defaultGCFrequency
 	}
 	logger.Infof("Garbage collection frequency: %s", c.resyncPeriod.String())


### PR DESCRIPTION
1. Use patch rather status patch in backup sync controller as we have disable status as sub resource
2. Set the GC period with default value if it isn't set

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
