### PR TITLE
When spec.RestoreStatus is empty, don't restore status

### DIFF
--- a/changelogs/unreleased/5008-sseago
+++ b/changelogs/unreleased/5008-sseago
@@ -1,0 +1,1 @@
+When spec.RestoreStatus is empty, don't restore status


### PR DESCRIPTION
Signed-off-by: Scott Seago <sseago@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Fixes a bug in the restoreStatus functionality -- when the spec field is missing, don't restore any status, rather than restoring every status.

# Does your change fix a particular issue?

Fixes #5007

# Please indicate you've done the following:

- [x ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
