### PR TITLE
When spec.RestoreStatus is empty, don't restore status (1.9 cherry-pick)

### DIFF
--- a/changelogs/unreleased/5015-sseago
+++ b/changelogs/unreleased/5015-sseago
@@ -1,0 +1,1 @@
+When spec.RestoreStatus is empty, don't restore status


### PR DESCRIPTION
Signed-off-by: Scott Seago <sseago@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Fix from #5008 cherry-picked to release 1.9

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
