### PR TITLE
Fix typo in doc (https://velero.io/docs/main/restore-reference/ "Restore order" section) 

### DIFF
--- a/changelogs/unreleased/5051-niulechuan
+++ b/changelogs/unreleased/5051-niulechuan
@@ -1,0 +1,1 @@
+Fix typo in doc, in https://velero.io/docs/main/restore-reference/ "Restore order" section, "Mamespace" should be "Namespace".

--- a/site/content/docs/main/restore-reference.md
+++ b/site/content/docs/main/restore-reference.md
@@ -73,7 +73,7 @@ The following is an overview of Velero's restore process that starts after you r
 By default, Velero will restore resources in the following order:
 
 * Custom Resource Definitions
-* Mamespaces
+* Namespaces
 * StorageClasses
 * VolumeSnapshotClass
 * VolumeSnapshotContents

--- a/site/content/docs/v1.9/restore-reference.md
+++ b/site/content/docs/v1.9/restore-reference.md
@@ -73,7 +73,7 @@ The following is an overview of Velero's restore process that starts after you r
 By default, Velero will restore resources in the following order:
 
 * Custom Resource Definitions
-* Mamespaces
+* Namespaces
 * StorageClasses
 * VolumeSnapshotClass
 * VolumeSnapshotContents


### PR DESCRIPTION
# Please add a summary of your change
Fix typo in doc (https://velero.io/docs/main/restore-reference/ "Restore order" section),
"Mamespace" should be "Namespace".

# Does your change fix a particular issue?
None

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
