### PR TITLE
Propose Yonghui as a maintainer

### DIFF
--- a/.github/auto-assignees.yml
+++ b/.github/auto-assignees.yml
@@ -16,6 +16,7 @@ reviewers:
       - blackpiglet
       - qiuming-best
       - shubham-pampattiwar
+      - Lyndon-Li
 
     tech-writer:
       - a-mccarthy

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,6 +13,7 @@
 | Xun Jiang | [blackpiglet](https://github.com/blackpiglet) | [VMware](https://www.github.com/vmware/) |
 | Ming Qiu | [qiuming-best](https://github.com/qiuming-best) | [VMware](https://www.github.com/vmware/) |
 | Shubham Pampattiwar | [shubham-pampattiwar](https://github.com/shubham-pampattiwar) | [OpenShift](https://github.com/openshift)
+| Yonghui Li | [Lyndon-Li](https://github.com/Lyndon-Li) | [VMware](https://www.github.com/vmware/) |
 
 ## Emeritus Maintainers
 * Adnan Abdulhussein ([prydonius](https://github.com/prydonius))


### PR DESCRIPTION
Yonghui joined the velero team earlier this year.

He has been leading the effort for kopia integration, and delivered the
comprehensive comparison report for kopia .vs. restic
https://docs.google.com/document/d/1BMLuRzEpYWYE-Ci_eLg8gWbjDv4DSyqj/edit

and the detailed design for using kopia as the unified repository:
https://github.com/vmware-tanzu/velero/pull/4926

Signed-off-by: Daniel Jiang <jiangd@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
