### PR TITLE
Dump stack trace when the plugin server handles panic

### DIFF
--- a/changelogs/unreleased/5110-reasonerjt
+++ b/changelogs/unreleased/5110-reasonerjt
@@ -1,0 +1,1 @@
+Dump stack trace when the plugin server handles panic

--- a/pkg/plugin/framework/handle_panic.go
+++ b/pkg/plugin/framework/handle_panic.go
@@ -17,6 +17,8 @@ limitations under the License.
 package framework
 
 import (
+	"runtime/debug"
+
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 )
@@ -38,7 +40,8 @@ func handlePanic(p interface{}) error {
 		if _, ok := panicErr.(stackTracer); ok {
 			err = panicErr
 		} else {
-			err = errors.Wrap(panicErr, "plugin panicked")
+			errWithStacktrace := errors.Errorf("%v, stack trace: %s", panicErr, debug.Stack())
+			err = errors.Wrap(errWithStacktrace, "plugin panicked")
 		}
 	}
 


### PR DESCRIPTION
Mitigate the issue mentioned in #4782
When there's a bug or misconfiguration that causes nil pointer there
will be more stack trace information to help us debug.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #4815

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
