### PR TITLE
Modify BackupStoreGetter to avoid BSL spec changes

### DIFF
--- a/changelogs/unreleased/5122-sseago
+++ b/changelogs/unreleased/5122-sseago
@@ -1,0 +1,1 @@
+Modify BackupStoreGetter to avoid BSL spec changes


### PR DESCRIPTION
Signed-off-by: Scott Seago <sseago@redhat.com>

Thank you for contributing to Velero!

Modify BackupStoreGetter to avoid BSL spec changes
    
Pass in a new copy of the map of config values rather than
modifying the BSL Spec.Config and then pass in that field.

Those extra fields in spec.config are only needed for the in-memory copy passed into plugins. Without this change to the BackupStoreGetter, the BSL spec is modified on disk and in the OADP case, the OADP controller then noticed the change and removed the fields, causing constant BSL spec updates, causing constant validation reconciles.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
