### PR TITLE
Let "make shell xxx" respect GOPROXY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,7 @@ shell: build-dirs build-env
 	@# under $GOPATH).
 	@docker run \
 		-e GOFLAGS \
+		-e GOPROXY \
 		-i $(TTY) \
 		--rm \
 		-u $$(id -u):$$(id -g) \

--- a/changelogs/unreleased/5128-reasonerjt
+++ b/changelogs/unreleased/5128-reasonerjt
@@ -1,0 +1,1 @@
+Let "make shell xxx" respect GOPROXY


### PR DESCRIPTION
This commit mitigates the issue for running "make update" locally when
the network is not friendly for accessing the default "proxy.golang.org"

Signed-off-by: Daniel Jiang <jiangd@vmware.com>

Thank you for contributing to Velero!

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
