### PR TITLE
Modify BackupStoreGetter to avoid BSL spec changes

### DIFF
--- a/changelogs/unreleased/5134-sseago
+++ b/changelogs/unreleased/5134-sseago
@@ -1,0 +1,1 @@
+Modify BackupStoreGetter to avoid BSL spec changes


### PR DESCRIPTION
(cherry-picked from #5122 to release-1.9)

Pass in a new copy of the map of config values rather than
modifying the BSL Spec.Config and then pass in that field.

Signed-off-by: Scott Seago <sseago@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
