### PR TITLE
Avoid unnecessary restic unlocks

### DIFF
--- a/changelogs/unreleased/5171-szpadel
+++ b/changelogs/unreleased/5171-szpadel
@@ -1,0 +1,1 @@
+Avoid unnecessary restic unlocks

--- a/pkg/controller/restic_repository_controller.go
+++ b/pkg/controller/restic_repository_controller.go
@@ -97,14 +97,6 @@ func (r *ResticRepoReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, nil
 	}
 
-	// If the repository is ready or not-ready, check it for stale locks, but if
-	// this fails for any reason, it's non-critical so we still continue on to the
-	// rest of the "process" logic.
-	log.Debug("Checking repository for stale locks")
-	if err := r.repositoryManager.UnlockRepo(resticRepo); err != nil {
-		log.WithError(err).Error("Error checking repository for stale locks")
-	}
-
 	switch resticRepo.Status.Phase {
 	case velerov1api.BackupRepositoryPhaseReady:
 		return ctrl.Result{}, r.runMaintenanceIfDue(ctx, resticRepo, log)

--- a/pkg/restic/lock_cleanup_throttle.go
+++ b/pkg/restic/lock_cleanup_throttle.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2018 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package restic
+
+import (
+    "time"
+    "sync"
+)
+
+const (
+    cleanupEvery = 30 * time.Minute
+)
+
+type lockCleanupThrottle struct {
+    mu           sync.Mutex
+    last_cleanup map[string]time.Time
+}
+
+func newLockCleanupThrottle() *lockCleanupThrottle {
+    return &lockCleanupThrottle{
+        last_cleanup: make(map[string]time.Time),
+    }
+}
+
+func (l *lockCleanupThrottle) shouldPerformCleanup(name string) bool {
+    l.mu.Lock()
+	defer l.mu.Unlock()
+
+    if t, ok := l.last_cleanup[name]; !ok {
+        return time.Since(t) > cleanupEvery
+    }
+
+    return true
+}
+
+func (l *lockCleanupThrottle) locksCleanedUp(name string) {
+    l.mu.Lock()
+	defer l.mu.Unlock()
+
+    l.last_cleanup[name] = time.Now()
+}


### PR DESCRIPTION
This greatly reduces amount of s3 requests when idling
fixes #2820