### PR TITLE
fix issue#2413: treat namespaces with exclude label as excludedNamespaces

### DIFF
--- a/changelogs/unreleased/5178-allenxu404
+++ b/changelogs/unreleased/5178-allenxu404
@@ -1,0 +1,2 @@
+Treat namespaces with exclude label as excludedNamespaces
+Related issue: #2413


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

- add namespaces with label velero.io/exclude-from-backup=true into request.Spec.ExcludedNamespaces, in this way, adding the label velero.io/exclude-from-backup=true to a namespace would be equivalent to setting spec.ExcludedNamespaces

# Does your change fix a particular issue?

Fixes #2413

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
