### PR TITLE
Clean backups after each test and fix exclude label test issue

### DIFF
--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -89,6 +89,9 @@ ADDITIONAL_BSL_CONFIG ?=
 FEATURES ?=
 DEBUG_E2E_TEST ?= false
 
+# Parameters to run migration tests along with all other E2E tests, and both of them should
+#   be provided or left them all empty to skip migration tests with no influence to other
+#   E2E tests.
 DEFAULT_CLUSTER ?=
 STANDBY_CLUSTER ?=
 

--- a/test/e2e/backup/backup.go
+++ b/test/e2e/backup/backup.go
@@ -59,8 +59,11 @@ func BackupRestoreTest(useVolumeSnapshots bool) {
 	})
 
 	AfterEach(func() {
-		if VeleroCfg.InstallVelero {
-			if !VeleroCfg.Debug {
+		if !VeleroCfg.Debug {
+			By("Clean backups after test", func() {
+				DeleteBackups(context.Background(), *VeleroCfg.ClientToInstallVelero)
+			})
+			if VeleroCfg.InstallVelero {
 				err = VeleroUninstall(context.Background(), VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace)
 				Expect(err).To(Succeed())
 			}

--- a/test/e2e/backups/deletion.go
+++ b/test/e2e/backups/deletion.go
@@ -64,12 +64,16 @@ func backup_deletion_test(useVolumeSnapshots bool) {
 	})
 
 	AfterEach(func() {
-		if VeleroCfg.InstallVelero {
-			if !VeleroCfg.Debug {
+		if !VeleroCfg.Debug {
+			By("Clean backups after test", func() {
+				DeleteBackups(context.Background(), *VeleroCfg.ClientToInstallVelero)
+			})
+			if VeleroCfg.InstallVelero {
 				err = VeleroUninstall(context.Background(), VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace)
 				Expect(err).To(Succeed())
 			}
 		}
+
 	})
 
 	When("kibishii is the sample workload", func() {

--- a/test/e2e/backups/ttl.go
+++ b/test/e2e/backups/ttl.go
@@ -76,12 +76,15 @@ func TTLTest() {
 	})
 
 	AfterEach(func() {
-		if VeleroCfg.InstallVelero {
-			VeleroCfg.GCFrequency = ""
-			if !VeleroCfg.Debug {
+		VeleroCfg.GCFrequency = ""
+		if !VeleroCfg.Debug {
+			By("Clean backups after test", func() {
+				DeleteBackups(context.Background(), *VeleroCfg.ClientToInstallVelero)
+			})
+			if VeleroCfg.InstallVelero {
 				Expect(VeleroUninstall(context.Background(), VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace)).To(Succeed())
-				Expect(DeleteNamespace(test.ctx, client, test.testNS, false)).To(Succeed(), fmt.Sprintf("Failed to delete the namespace %s", test.testNS))
 			}
+			Expect(DeleteNamespace(test.ctx, client, test.testNS, false)).To(Succeed(), fmt.Sprintf("Failed to delete the namespace %s", test.testNS))
 		}
 	})
 

--- a/test/e2e/bsl-mgmt/deletion.go
+++ b/test/e2e/bsl-mgmt/deletion.go
@@ -71,15 +71,23 @@ func BslDeletionTest(useVolumeSnapshots bool) {
 	})
 
 	AfterEach(func() {
-		if VeleroCfg.InstallVelero {
-			if !VeleroCfg.Debug {
+		if !VeleroCfg.Debug {
+			By("Clean backups after test", func() {
+				DeleteBackups(context.Background(), *VeleroCfg.DefaultClient)
+			})
+			By(fmt.Sprintf("Delete sample workload namespace %s", bslDeletionTestNs), func() {
 				Expect(DeleteNamespace(context.Background(), *VeleroCfg.ClientToInstallVelero, bslDeletionTestNs,
 					true)).To(Succeed(), fmt.Sprintf("failed to delete the namespace %q",
 					bslDeletionTestNs))
-				Expect(VeleroUninstall(context.Background(), VeleroCfg.VeleroCLI,
-					VeleroCfg.VeleroNamespace)).To(Succeed())
+			})
+			if VeleroCfg.InstallVelero {
+				By("Uninstall Velero", func() {
+					Expect(VeleroUninstall(context.Background(), VeleroCfg.VeleroCLI,
+						VeleroCfg.VeleroNamespace)).To(Succeed())
+				})
 			}
 		}
+
 	})
 
 	When("kibishii is the sample workload", func() {

--- a/test/e2e/migration/migration.go
+++ b/test/e2e/migration/migration.go
@@ -68,8 +68,11 @@ func MigrationTest(useVolumeSnapshots bool, veleroCLI2Version VeleroCLI2Version)
 		}
 	})
 	AfterEach(func() {
-		if VeleroCfg.InstallVelero {
-			if !VeleroCfg.Debug {
+		if !VeleroCfg.Debug {
+			By("Clean backups after test", func() {
+				DeleteBackups(context.Background(), *VeleroCfg.DefaultClient)
+			})
+			if VeleroCfg.InstallVelero {
 				By(fmt.Sprintf("Uninstall Velero and delete sample workload namespace %s", migrationNamespace), func() {
 					Expect(KubectlConfigUseContext(context.Background(), VeleroCfg.DefaultCluster)).To(Succeed())
 					Expect(VeleroUninstall(context.Background(), VeleroCfg.VeleroCLI,
@@ -81,12 +84,13 @@ func MigrationTest(useVolumeSnapshots bool, veleroCLI2Version VeleroCLI2Version)
 						VeleroCfg.VeleroNamespace)).To(Succeed())
 					DeleteNamespace(context.Background(), *VeleroCfg.StandbyClient, migrationNamespace, true)
 				})
-				By(fmt.Sprintf("Switch to default kubeconfig context %s", VeleroCfg.DefaultClient), func() {
-					Expect(KubectlConfigUseContext(context.Background(), VeleroCfg.DefaultCluster)).To(Succeed())
-					VeleroCfg.ClientToInstallVelero = VeleroCfg.DefaultClient
-				})
 			}
+			By(fmt.Sprintf("Switch to default kubeconfig context %s", VeleroCfg.DefaultClient), func() {
+				Expect(KubectlConfigUseContext(context.Background(), VeleroCfg.DefaultCluster)).To(Succeed())
+				VeleroCfg.ClientToInstallVelero = VeleroCfg.DefaultClient
+			})
 		}
+
 	})
 	When("kibishii is the sample workload", func() {
 		It("should be successfully backed up and restored to the default BackupStorageLocation", func() {

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -70,11 +70,14 @@ func BackupUpgradeRestoreTest(useVolumeSnapshots bool, veleroCLI2Version VeleroC
 		}
 	})
 	AfterEach(func() {
-		if VeleroCfg.InstallVelero {
-			if !VeleroCfg.Debug {
-				By(fmt.Sprintf("Delete sample workload namespace %s", upgradeNamespace), func() {
-					DeleteNamespace(context.Background(), *VeleroCfg.ClientToInstallVelero, upgradeNamespace, true)
-				})
+		if !VeleroCfg.Debug {
+			By("Clean backups after test", func() {
+				DeleteBackups(context.Background(), *VeleroCfg.ClientToInstallVelero)
+			})
+			By(fmt.Sprintf("Delete sample workload namespace %s", upgradeNamespace), func() {
+				DeleteNamespace(context.Background(), *VeleroCfg.ClientToInstallVelero, upgradeNamespace, true)
+			})
+			if VeleroCfg.InstallVelero {
 				By("Uninstall Velero", func() {
 					Expect(VeleroUninstall(context.Background(), VeleroCfg.VeleroCLI,
 						VeleroCfg.VeleroNamespace)).To(Succeed())


### PR DESCRIPTION
1. Clean backups after each test to avoid exceeding limitation of storage capability during E2E test;
2. Fix exlude label issue that namespace should not be included and excluded at the same time no matter by which way to config.

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #5194 #5229

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
