### PR TITLE
Check pod status before hook

### DIFF
--- a/changelogs/unreleased/5211-cleverhu
+++ b/changelogs/unreleased/5211-cleverhu
@@ -1,0 +1,1 @@
+fix run preHook and postHook on completed pods

--- a/pkg/podexec/pod_command_executor.go
+++ b/pkg/podexec/pod_command_executor.go
@@ -123,6 +123,12 @@ func (e *defaultPodCommandExecutor) ExecutePodCommand(log logrus.FieldLogger, it
 			"hookTimeout":   localHook.Timeout,
 		},
 	)
+
+	if pod.Status.Phase == corev1api.PodSucceeded || pod.Status.Phase == corev1api.PodFailed {
+		hookLog.Infof("Pod entered phase %s before some post-backup exec hooks ran", pod.Status.Phase)
+		return nil
+	}
+
 	hookLog.Info("running exec hook")
 
 	req := e.restClient.Post().


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Skip exec pod command when pod's phase is succeeded or failed.

# Does your change fix a particular issue?
Fixes #5137

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
