### PR TITLE
Add parameter "uploader-type" to velero server

### DIFF
--- a/changelogs/unreleased/5212-reasonerjt
+++ b/changelogs/unreleased/5212-reasonerjt
@@ -1,0 +1,1 @@
+Add parameter "uploader-type" to velero server

--- a/pkg/install/deployment.go
+++ b/pkg/install/deployment.go
@@ -44,6 +44,7 @@ type podTemplateConfig struct {
 	plugins                           []string
 	features                          []string
 	defaultVolumesToRestic            bool
+	uploaderType                      string
 }
 
 func WithImage(image string) podTemplateOption {
@@ -83,7 +84,6 @@ func WithEnvFromSecretKey(varName, secret, key string) podTemplateOption {
 func WithSecret(secretPresent bool) podTemplateOption {
 	return func(c *podTemplateConfig) {
 		c.withSecret = secretPresent
-
 	}
 }
 
@@ -123,6 +123,12 @@ func WithFeatures(features []string) podTemplateOption {
 	}
 }
 
+func WithUploaderType(t string) podTemplateOption {
+	return func(c *podTemplateConfig) {
+		c.uploaderType = t
+	}
+}
+
 func WithDefaultVolumesToRestic() podTemplateOption {
 	return func(c *podTemplateConfig) {
 		c.defaultVolumesToRestic = true
@@ -153,6 +159,10 @@ func Deployment(namespace string, opts ...podTemplateOption) *appsv1.Deployment 
 
 	if c.defaultVolumesToRestic {
 		args = append(args, "--default-volumes-to-restic=true")
+	}
+
+	if len(c.uploaderType) > 0 {
+		args = append(args, fmt.Sprintf("--uploader-type=%s", c.uploaderType))
 	}
 
 	deployment := &appsv1.Deployment{

--- a/pkg/install/deployment_test.go
+++ b/pkg/install/deployment_test.go
@@ -57,4 +57,8 @@ func TestDeployment(t *testing.T) {
 	deploy = Deployment("velero", WithFeatures([]string{"EnableCSI", "foo", "bar", "baz"}))
 	assert.Len(t, deploy.Spec.Template.Spec.Containers[0].Args, 2)
 	assert.Equal(t, "--features=EnableCSI,foo,bar,baz", deploy.Spec.Template.Spec.Containers[0].Args[1])
+
+	deploy = Deployment("velero", WithUploaderType("kopia"))
+	assert.Len(t, deploy.Spec.Template.Spec.Containers[0].Args, 2)
+	assert.Equal(t, "--uploader-type=kopia", deploy.Spec.Template.Spec.Containers[0].Args[1])
 }

--- a/pkg/install/resources.go
+++ b/pkg/install/resources.go
@@ -232,6 +232,7 @@ type VeleroOptions struct {
 	CACertData                        []byte
 	Features                          []string
 	DefaultVolumesToRestic            bool
+	UploaderType                      string
 }
 
 func AllCRDs() *unstructured.UnstructuredList {
@@ -287,6 +288,7 @@ func AllResources(o *VeleroOptions) *unstructured.UnstructuredList {
 		WithSecret(secretPresent),
 		WithDefaultResticMaintenanceFrequency(o.DefaultResticMaintenanceFrequency),
 		WithGarbageCollectionFrequency(o.GarbageCollectionFrequency),
+		WithUploaderType(o.UploaderType),
 	}
 
 	if len(o.Features) > 0 {

--- a/pkg/uploader/types.go
+++ b/pkg/uploader/types.go
@@ -1,9 +1,12 @@
 /*
-Copyright The Velero Contributors.
+Copyright the Velero contributors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,10 +16,27 @@ limitations under the License.
 
 package uploader
 
-const (
-	VeleroBackup  string = "backup"
-	VeleroRestore string = "restore"
+import (
+	"fmt"
+	"strings"
 )
+
+const (
+	ResticType    = "restic"
+	KopiaType     = "kopia"
+	VeleroBackup  = "backup"
+	VeleroRestore = "restore"
+)
+
+// ValidateUploaderType validates if the input param is a valid uploader type.
+// It will return an error if it's invalid.
+func ValidateUploaderType(t string) error {
+	t = strings.TrimSpace(t)
+	if t != ResticType && t != KopiaType {
+		return fmt.Errorf("invalid uploader type '%s', valid upload types are: '%s', '%s'", t, ResticType, KopiaType)
+	}
+	return nil
+}
 
 type SnapshotInfo struct {
 	ID   string `json:"id"`

--- a/pkg/uploader/types_test.go
+++ b/pkg/uploader/types_test.go
@@ -1,0 +1,34 @@
+package uploader
+
+import "testing"
+
+func TestValidateUploaderType(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			"'restic' is a valid type",
+			"restic",
+			false,
+		},
+		{
+			"'   kopia  ' is a valid type (space will be trimmed)",
+			"   kopia  ",
+			false,
+		},
+		{
+			"'anything_else' is invalid",
+			"anything_else",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateUploaderType(tt.input); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateUploaderType(), input = '%s' error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit adds the parameter "uploader-type" to velero server, add exposes the
setting via "velero install" in CLI.

fixes #5062

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
