### PR TITLE
Migrate backup sync controller from code-generator to kubebuilder

### DIFF
--- a/changelogs/unreleased/5216-jxun
+++ b/changelogs/unreleased/5216-jxun
@@ -1,0 +1,1 @@
+Migrate backup sync controller from code-generator to kubebuilder.

--- a/pkg/controller/backup_sync_controller.go
+++ b/pkg/controller/backup_sync_controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 the Velero contributors.
+Copyright The Velero Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,138 +21,68 @@ import (
 	"time"
 
 	snapshotv1api "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
-	snapshotterClientSet "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned"
-	snapshotv1listers "github.com/kubernetes-csi/external-snapshotter/client/v4/listers/volumesnapshot/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	kuberrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/kubernetes"
 
 	"github.com/vmware-tanzu/velero/pkg/util/kube"
 
 	"github.com/vmware-tanzu/velero/internal/storage"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/features"
-	velerov1client "github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned/typed/velero/v1"
-	velerov1listers "github.com/vmware-tanzu/velero/pkg/generated/listers/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/label"
 	"github.com/vmware-tanzu/velero/pkg/persistence"
 	"github.com/vmware-tanzu/velero/pkg/plugin/clientmgmt"
 
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-type backupSyncController struct {
-	*genericController
+const (
+	backupSyncReconcilePeriod = 30 * time.Second
+)
 
-	backupClient            velerov1client.BackupsGetter
-	kbClient                client.Client
-	podVolumeBackupClient   velerov1client.PodVolumeBackupsGetter
-	backupLister            velerov1listers.BackupLister
-	csiVSLister             snapshotv1listers.VolumeSnapshotLister
-	csiSnapshotClient       *snapshotterClientSet.Clientset
-	kubeClient              kubernetes.Interface
-	namespace               string
-	defaultBackupLocation   string
-	defaultBackupSyncPeriod time.Duration
-	newPluginManager        func(logrus.FieldLogger) clientmgmt.Manager
-	backupStoreGetter       persistence.ObjectBackupStoreGetter
+type BackupSyncReconciler struct {
+	Client                  client.Client
+	Namespace               string
+	DefaultBackupSyncPeriod time.Duration
+	NewPluginManager        func(logrus.FieldLogger) clientmgmt.Manager
+	BackupStoreGetter       persistence.ObjectBackupStoreGetter
+	Logger                  logrus.FieldLogger
 }
 
-func NewBackupSyncController(
-	backupClient velerov1client.BackupsGetter,
-	kbClient client.Client,
-	podVolumeBackupClient velerov1client.PodVolumeBackupsGetter,
-	backupLister velerov1listers.BackupLister,
-	csiVSLister snapshotv1listers.VolumeSnapshotLister,
-	syncPeriod time.Duration,
-	namespace string,
-	csiSnapshotClient *snapshotterClientSet.Clientset,
-	kubeClient kubernetes.Interface,
-	defaultBackupLocation string,
-	newPluginManager func(logrus.FieldLogger) clientmgmt.Manager,
-	backupStoreGetter persistence.ObjectBackupStoreGetter,
-	logger logrus.FieldLogger,
-) Interface {
-	if syncPeriod <= 0 {
-		syncPeriod = time.Minute
-	}
-	logger.Infof("Backup sync period is %v", syncPeriod)
+func (b *BackupSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := b.Logger.WithField("controller", BackupSync)
+	log.Debug("Checking for existing backup storage locations to sync into cluster.")
 
-	c := &backupSyncController{
-		genericController:       newGenericController(BackupSync, logger),
-		backupClient:            backupClient,
-		kbClient:                kbClient,
-		podVolumeBackupClient:   podVolumeBackupClient,
-		namespace:               namespace,
-		defaultBackupLocation:   defaultBackupLocation,
-		defaultBackupSyncPeriod: syncPeriod,
-		backupLister:            backupLister,
-		csiVSLister:             csiVSLister,
-		csiSnapshotClient:       csiSnapshotClient,
-		kubeClient:              kubeClient,
-
-		// use variables to refer to these functions so they can be
-		// replaced with fakes for testing.
-		newPluginManager:  newPluginManager,
-		backupStoreGetter: backupStoreGetter,
-	}
-
-	c.resyncFunc = c.run
-	c.resyncPeriod = 30 * time.Second
-
-	return c
-}
-
-// orderedBackupLocations returns a new slice with the default backup location first (if it exists),
-// followed by the rest of the locations in no particular order.
-func orderedBackupLocations(locationList *velerov1api.BackupStorageLocationList, defaultLocationName string) []velerov1api.BackupStorageLocation {
-	var result []velerov1api.BackupStorageLocation
-
-	for i := range locationList.Items {
-		if locationList.Items[i].Name == defaultLocationName {
-			// put the default location first
-			result = append(result, locationList.Items[i])
-			// append everything before the default
-			result = append(result, locationList.Items[:i]...)
-			// append everything after the default
-			result = append(result, locationList.Items[i+1:]...)
-
-			return result
-		}
-	}
-
-	return locationList.Items
-}
-
-func (c *backupSyncController) run() {
-	c.logger.Debug("Checking for existing backup storage locations to sync into cluster")
-
-	locationList, err := storage.ListBackupStorageLocations(context.Background(), c.kbClient, c.namespace)
+	locationList, err := storage.ListBackupStorageLocations(ctx, b.Client, b.Namespace)
 	if err != nil {
-		c.logger.WithError(err).Error("No backup storage locations found, at least one is required")
-		return
+		log.WithError(err).Error("No backup storage locations found, at least one is required")
+		return ctrl.Result{}, err
 	}
 
 	// sync the default backup storage location first, if it exists
+	defaultBackupLocationName := ""
 	for _, location := range locationList.Items {
 		if location.Spec.Default {
-			c.defaultBackupLocation = location.Name
+			defaultBackupLocationName = location.Name
 			break
 		}
 	}
-	locations := orderedBackupLocations(&locationList, c.defaultBackupLocation)
+	locations := orderedBackupLocations(&locationList, defaultBackupLocationName)
 
-	pluginManager := c.newPluginManager(c.logger)
+	pluginManager := b.NewPluginManager(log)
 	defer pluginManager.CleanupClients()
 
 	for _, location := range locations {
-		log := c.logger.WithField("backupLocation", location.Name)
+		log := log.WithField("backupLocation", location.Name)
 
-		syncPeriod := c.defaultBackupSyncPeriod
+		syncPeriod := b.DefaultBackupSyncPeriod
 		if location.Spec.BackupSyncPeriod != nil {
 			syncPeriod = location.Spec.BackupSyncPeriod.Duration
 			if syncPeriod == 0 {
@@ -162,7 +92,7 @@ func (c *backupSyncController) run() {
 
 			if syncPeriod < 0 {
 				log.Debug("Backup sync period must be non-negative")
-				syncPeriod = c.defaultBackupSyncPeriod
+				syncPeriod = b.DefaultBackupSyncPeriod
 			}
 		}
 
@@ -177,7 +107,7 @@ func (c *backupSyncController) run() {
 
 		log.Debug("Checking backup location for backups to sync into cluster")
 
-		backupStore, err := c.backupStoreGetter.Get(&location, pluginManager, log)
+		backupStore, err := b.BackupStoreGetter.Get(&location, pluginManager, log)
 		if err != nil {
 			log.WithError(err).Error("Error getting backup store for this location")
 			continue
@@ -193,16 +123,21 @@ func (c *backupSyncController) run() {
 		log.WithField("backupCount", len(backupStoreBackups)).Debug("Got backups from backup store")
 
 		// get a list of all the backups that exist as custom resources in the cluster
-		clusterBackups, err := c.backupLister.Backups(c.namespace).List(labels.Everything())
+		var clusterBackupList velerov1api.BackupList
+		listOption := client.ListOptions{
+			LabelSelector: labels.Everything(),
+		}
+
+		err = b.Client.List(ctx, &clusterBackupList, &listOption)
 		if err != nil {
 			log.WithError(errors.WithStack(err)).Error("Error getting backups from cluster, proceeding with sync into cluster")
 		} else {
-			log.WithField("backupCount", len(clusterBackups)).Debug("Got backups from cluster")
+			log.WithField("backupCount", len(clusterBackupList.Items)).Debug("Got backups from cluster")
 		}
 
 		// get a list of backups that *are* in the backup storage location and *aren't* in the cluster
 		clusterBackupsSet := sets.NewString()
-		for _, b := range clusterBackups {
+		for _, b := range clusterBackupList.Items {
 			clusterBackupsSet.Insert(b.Name)
 		}
 		backupsToSync := backupStoreBackups.Difference(clusterBackupsSet)
@@ -224,7 +159,7 @@ func (c *backupSyncController) run() {
 				continue
 			}
 
-			backup.Namespace = c.namespace
+			backup.Namespace = b.Namespace
 			backup.ResourceVersion = ""
 
 			// update the StorageLocation field and label since the name of the location
@@ -237,7 +172,7 @@ func (c *backupSyncController) run() {
 			backup.Labels[velerov1api.StorageLocationLabel] = label.GetValidName(backup.Spec.StorageLocation)
 
 			// attempt to create backup custom resource via API
-			backup, err = c.backupClient.Backups(backup.Namespace).Create(context.TODO(), backup, metav1.CreateOptions{})
+			err = b.Client.Create(ctx, backup, &client.CreateOptions{})
 			switch {
 			case err != nil && kuberrs.IsAlreadyExists(err):
 				log.Debug("Backup already exists in cluster")
@@ -274,7 +209,7 @@ func (c *backupSyncController) run() {
 				podVolumeBackup.Namespace = backup.Namespace
 				podVolumeBackup.ResourceVersion = ""
 
-				_, err = c.podVolumeBackupClient.PodVolumeBackups(backup.Namespace).Create(context.TODO(), podVolumeBackup, metav1.CreateOptions{})
+				err = b.Client.Create(ctx, podVolumeBackup, &client.CreateOptions{})
 				switch {
 				case err != nil && kuberrs.IsAlreadyExists(err):
 					log.Debug("Pod volume backup already exists in cluster")
@@ -298,12 +233,12 @@ func (c *backupSyncController) run() {
 				}
 				for _, vsClass := range vsClasses {
 					vsClass.ResourceVersion = ""
-					created, err := c.csiSnapshotClient.SnapshotV1().VolumeSnapshotClasses().Create(context.TODO(), vsClass, metav1.CreateOptions{})
+					err := b.Client.Create(context.TODO(), vsClass, &client.CreateOptions{})
 					if err != nil {
 						log.WithError(errors.WithStack(err)).Errorf("Error syncing volumesnapshotclass %s into cluster", vsClass.Name)
 						continue
 					}
-					log.Infof("Created CSI volumesnapshotclass %s", created.Name)
+					log.Infof("Created CSI volumesnapshotclass %s", vsClass.Name)
 				}
 
 				log.Info("Syncing CSI volumesnapshotcontents in backup")
@@ -317,7 +252,7 @@ func (c *backupSyncController) run() {
 				for _, snapCont := range snapConts {
 					// TODO: Reset ResourceVersion prior to persisting VolumeSnapshotContents
 					snapCont.ResourceVersion = ""
-					created, err := c.csiSnapshotClient.SnapshotV1().VolumeSnapshotContents().Create(context.TODO(), snapCont, metav1.CreateOptions{})
+					err := b.Client.Create(ctx, snapCont, &client.CreateOptions{})
 					switch {
 					case err != nil && kuberrs.IsAlreadyExists(err):
 						log.Debugf("volumesnapshotcontent %s already exists in cluster", snapCont.Name)
@@ -326,73 +261,132 @@ func (c *backupSyncController) run() {
 						log.WithError(errors.WithStack(err)).Errorf("Error syncing volumesnapshotcontent %s into cluster", snapCont.Name)
 						continue
 					default:
-						log.Infof("Created CSI volumesnapshotcontent %s", created.Name)
+						log.Infof("Created CSI volumesnapshotcontent %s", snapCont.Name)
 					}
 				}
 			}
 		}
 
-		c.deleteOrphanedBackups(location.Name, backupStoreBackups, log)
+		b.deleteOrphanedBackups(ctx, location.Name, backupStoreBackups, log)
 
 		// update the location's last-synced time field
 		statusPatch := client.MergeFrom(location.DeepCopy())
 		location.Status.LastSyncedTime = &metav1.Time{Time: time.Now().UTC()}
-		if err := c.kbClient.Patch(context.Background(), &location, statusPatch); err != nil {
+		if err := b.Client.Status().Patch(ctx, &location, statusPatch); err != nil {
 			log.WithError(errors.WithStack(err)).Error("Error patching backup location's last-synced time")
 			continue
 		}
 	}
+
+	return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 30}, nil
+}
+
+func (b *BackupSyncReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	backupSyncSource := kube.NewPeriodicalEnqueueSource(
+		b.Logger,
+		mgr.GetClient(),
+		&velerov1api.BackupList{},
+		backupSyncReconcilePeriod,
+	)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&velerov1api.BackupStorageLocation{}).
+		WithEventFilter(predicate.Funcs{
+			CreateFunc: func(ce event.CreateEvent) bool {
+				return false
+			},
+			UpdateFunc: func(ue event.UpdateEvent) bool {
+				return false
+			},
+			DeleteFunc: func(de event.DeleteEvent) bool {
+				return false
+			},
+			GenericFunc: func(ge event.GenericEvent) bool {
+				return false
+			},
+		}).
+		Watches(backupSyncSource, nil).
+		Complete(b)
 }
 
 // deleteOrphanedBackups deletes backup objects (CRDs) from Kubernetes that have the specified location
 // and a phase of Completed, but no corresponding backup in object storage.
-func (c *backupSyncController) deleteOrphanedBackups(locationName string, backupStoreBackups sets.String, log logrus.FieldLogger) {
-	locationSelector := labels.Set(map[string]string{
-		velerov1api.StorageLocationLabel: label.GetValidName(locationName),
-	}).AsSelector()
-
-	backups, err := c.backupLister.Backups(c.namespace).List(locationSelector)
+func (b *BackupSyncReconciler) deleteOrphanedBackups(ctx context.Context, locationName string, backupStoreBackups sets.String, log logrus.FieldLogger) {
+	var backupList velerov1api.BackupList
+	listOption := client.ListOptions{
+		LabelSelector: labels.Set(map[string]string{
+			velerov1api.StorageLocationLabel: label.GetValidName(locationName),
+		}).AsSelector(),
+	}
+	err := b.Client.List(ctx, &backupList, &listOption)
 	if err != nil {
 		log.WithError(errors.WithStack(err)).Error("Error listing backups from cluster")
 		return
 	}
-	if len(backups) == 0 {
+
+	if len(backupList.Items) == 0 {
 		return
 	}
 
-	for _, backup := range backups {
+	for _, backup := range backupList.Items {
 		log = log.WithField("backup", backup.Name)
 		if backup.Status.Phase != velerov1api.BackupPhaseCompleted || backupStoreBackups.Has(backup.Name) {
 			continue
 		}
-		if err := c.backupClient.Backups(backup.Namespace).Delete(context.TODO(), backup.Name, metav1.DeleteOptions{}); err != nil {
+
+		if err := b.Client.Delete(ctx, &backup, &client.DeleteOptions{}); err != nil {
 			log.WithError(errors.WithStack(err)).Error("Error deleting orphaned backup from cluster")
 		} else {
 			log.Debug("Deleted orphaned backup from cluster")
-			c.deleteCSISnapshotsByBackup(backup.Name, log)
+			b.deleteCSISnapshotsByBackup(ctx, backup.Name, log)
 		}
 	}
 }
 
-func (c *backupSyncController) deleteCSISnapshotsByBackup(backupName string, log logrus.FieldLogger) {
+func (b *BackupSyncReconciler) deleteCSISnapshotsByBackup(ctx context.Context, backupName string, log logrus.FieldLogger) {
 	if !features.IsEnabled(velerov1api.CSIFeatureFlag) {
 		return
 	}
 	m := client.MatchingLabels{velerov1api.BackupNameLabel: label.GetValidName(backupName)}
-	if vsList, err := c.csiVSLister.List(label.NewSelectorForBackup(label.GetValidName(backupName))); err != nil {
+	var vsList snapshotv1api.VolumeSnapshotList
+	listOptions := &client.ListOptions{
+		LabelSelector: label.NewSelectorForBackup(label.GetValidName(backupName)),
+	}
+	if err := b.Client.List(ctx, &vsList, listOptions); err != nil {
 		log.WithError(err).Warnf("Failed to list volumesnapshots for backup: %s, the deletion will be skipped", backupName)
 	} else {
-		for _, vs := range vsList {
+		for _, vs := range vsList.Items {
 			name := kube.NamespaceAndName(vs.GetObjectMeta())
 			log.Debugf("Deleting volumesnapshot %s", name)
-			if err := c.kbClient.Delete(context.TODO(), vs); err != nil {
+			if err := b.Client.Delete(context.TODO(), &vs); err != nil {
 				log.WithError(err).Warnf("Failed to delete volumesnapshot %s", name)
 			}
 		}
 	}
 	vsc := &snapshotv1api.VolumeSnapshotContent{}
 	log.Debugf("Deleting volumesnapshotcontents for backup: %s", backupName)
-	if err := c.kbClient.DeleteAllOf(context.TODO(), vsc, m); err != nil {
+	if err := b.Client.DeleteAllOf(context.TODO(), vsc, m); err != nil {
 		log.WithError(err).Warnf("Failed to delete volumesnapshotcontents for backup: %s", backupName)
 	}
+}
+
+// orderedBackupLocations returns a new slice with the default backup location first (if it exists),
+// followed by the rest of the locations in no particular order.
+func orderedBackupLocations(locationList *velerov1api.BackupStorageLocationList, defaultLocationName string) []velerov1api.BackupStorageLocation {
+	var result []velerov1api.BackupStorageLocation
+
+	for i := range locationList.Items {
+		if locationList.Items[i].Name == defaultLocationName {
+			// put the default location first
+			result = append(result, locationList.Items[i])
+			// append everything before the default
+			result = append(result, locationList.Items[:i]...)
+			// append everything after the default
+			result = append(result, locationList.Items[i+1:]...)
+
+			return result
+		}
+	}
+
+	return locationList.Items
 }

--- a/pkg/controller/backup_sync_controller_test.go
+++ b/pkg/controller/backup_sync_controller_test.go
@@ -18,21 +18,25 @@ package controller
 
 import (
 	"context"
-	"testing"
+	"fmt"
 	"time"
 
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	core "k8s.io/client-go/testing"
 
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/builder"
-	"github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned/fake"
-	informers "github.com/vmware-tanzu/velero/pkg/generated/informers/externalversions"
 	"github.com/vmware-tanzu/velero/pkg/label"
 	persistencemocks "github.com/vmware-tanzu/velero/pkg/persistence/mocks"
 	"github.com/vmware-tanzu/velero/pkg/plugin/clientmgmt"
@@ -107,264 +111,266 @@ func defaultLocationsListWithLongerLocationName(namespace string) []*velerov1api
 	}
 }
 
-func TestBackupSyncControllerRun(t *testing.T) {
-	type cloudBackupData struct {
-		backup           *velerov1api.Backup
-		podVolumeBackups []*velerov1api.PodVolumeBackup
+func numBackups(c ctrlClient.WithWatch, ns string) (int, error) {
+	var existingK8SBackups velerov1api.BackupList
+	err := c.List(context.TODO(), &existingK8SBackups, &ctrlClient.ListOptions{})
+	if err != nil {
+		return 0, err
 	}
 
-	tests := []struct {
-		name                     string
-		namespace                string
-		locations                []*velerov1api.BackupStorageLocation
-		cloudBuckets             map[string][]*cloudBackupData
-		existingBackups          []*velerov1api.Backup
-		existingPodVolumeBackups []*velerov1api.PodVolumeBackup
-		longLocationNameEnabled  bool
-	}{
-		{
-			name: "no cloud backups",
-		},
-		{
-			name:      "normal case",
-			namespace: "ns-1",
-			locations: defaultLocationsList("ns-1"),
-			cloudBuckets: map[string][]*cloudBackupData{
-				"bucket-1": {
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-1", "backup-1").Result(),
-					},
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-1", "backup-2").Result(),
-					},
-				},
-				"bucket-2": {
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-1", "backup-3").Result(),
-					},
-				},
-			},
-		},
-		{
-			name:      "all synced backups get created in Velero server's namespace",
-			namespace: "velero",
-			locations: defaultLocationsList("velero"),
-			cloudBuckets: map[string][]*cloudBackupData{
-				"bucket-1": {
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-1", "backup-1").Result(),
-					},
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-1", "backup-2").Result(),
-					},
-				},
-				"bucket-2": {
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-2", "backup-3").Result(),
-					},
-					&cloudBackupData{
-						backup: builder.ForBackup("velero", "backup-4").Result(),
-					},
-				},
-			},
-		},
-		{
-			name:      "new backups get synced when some cloud backups already exist in the cluster",
-			namespace: "ns-1",
-			locations: defaultLocationsList("ns-1"),
-			cloudBuckets: map[string][]*cloudBackupData{
-				"bucket-1": {
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-1", "backup-1").Result(),
-					},
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-1", "backup-2").Result(),
-					},
-				},
-				"bucket-2": {
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-1", "backup-3").Result(),
-					},
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-1", "backup-4").Result(),
-					},
-				},
-			},
-			existingBackups: []*velerov1api.Backup{
-				// add a label to each existing backup so we can differentiate it from the cloud
-				// backup during verification
-				builder.ForBackup("ns-1", "backup-1").StorageLocation("location-1").ObjectMeta(builder.WithLabels("i-exist", "true")).Result(),
-				builder.ForBackup("ns-1", "backup-3").StorageLocation("location-2").ObjectMeta(builder.WithLabels("i-exist", "true")).Result(),
-			},
-		},
-		{
-			name:      "existing backups without a StorageLocation get it filled in",
-			namespace: "ns-1",
-			locations: defaultLocationsList("ns-1"),
-			cloudBuckets: map[string][]*cloudBackupData{
-				"bucket-1": {
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-1", "backup-1").Result(),
-					},
-				},
-			},
-			existingBackups: []*velerov1api.Backup{
-				// add a label to each existing backup so we can differentiate it from the cloud
-				// backup during verification
-				builder.ForBackup("ns-1", "backup-1").ObjectMeta(builder.WithLabels("i-exist", "true")).StorageLocation("location-1").Result(),
-			},
-		},
-		{
-			name:      "backup storage location names and labels get updated",
-			namespace: "ns-1",
-			locations: defaultLocationsList("ns-1"),
-			cloudBuckets: map[string][]*cloudBackupData{
-				"bucket-1": {
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-1", "backup-1").StorageLocation("foo").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "foo")).Result(),
-					},
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-1", "backup-2").Result(),
-					},
-				},
-				"bucket-2": {
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-1", "backup-3").StorageLocation("bar").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "bar")).Result(),
-					},
-				},
-			},
-		},
-		{
-			name:                    "backup storage location names and labels get updated with location name greater than 63 chars",
-			namespace:               "ns-1",
-			locations:               defaultLocationsListWithLongerLocationName("ns-1"),
-			longLocationNameEnabled: true,
-			cloudBuckets: map[string][]*cloudBackupData{
-				"bucket-1": {
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-1", "backup-1").StorageLocation("foo").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "foo")).Result(),
-					},
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-1", "backup-2").Result(),
-					},
-				},
-				"bucket-2": {
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-1", "backup-3").StorageLocation("bar").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "bar")).Result(),
-					},
-				},
-			},
-		},
-		{
-			name:      "all synced backups and pod volume backups get created in Velero server's namespace",
-			namespace: "ns-1",
-			locations: defaultLocationsList("ns-1"),
-			cloudBuckets: map[string][]*cloudBackupData{
-				"bucket-1": {
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-1", "backup-1").Result(),
-						podVolumeBackups: []*velerov1api.PodVolumeBackup{
-							builder.ForPodVolumeBackup("ns-1", "pvb-1").Result(),
-						},
-					},
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-1", "backup-2").Result(),
-						podVolumeBackups: []*velerov1api.PodVolumeBackup{
-							builder.ForPodVolumeBackup("ns-1", "pvb-2").Result(),
-						},
-					},
-				},
-				"bucket-2": {
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-1", "backup-3").Result(),
-					},
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-1", "backup-4").Result(),
-						podVolumeBackups: []*velerov1api.PodVolumeBackup{
-							builder.ForPodVolumeBackup("ns-1", "pvb-1").Result(),
-							builder.ForPodVolumeBackup("ns-1", "pvb-2").Result(),
-							builder.ForPodVolumeBackup("ns-1", "pvb-3").Result(),
-						},
-					},
-				},
-			},
-		},
-		{
-			name:      "new pod volume backups get synched when some pod volume backups already exist in the cluster",
-			namespace: "ns-1",
-			locations: defaultLocationsList("ns-1"),
-			cloudBuckets: map[string][]*cloudBackupData{
-				"bucket-1": {
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-1", "backup-1").Result(),
-						podVolumeBackups: []*velerov1api.PodVolumeBackup{
-							builder.ForPodVolumeBackup("ns-1", "pvb-1").Result(),
-						},
-					},
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-1", "backup-2").Result(),
-						podVolumeBackups: []*velerov1api.PodVolumeBackup{
-							builder.ForPodVolumeBackup("ns-1", "pvb-3").Result(),
-						},
-					},
-				},
-				"bucket-2": {
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-1", "backup-3").Result(),
-					},
-					&cloudBackupData{
-						backup: builder.ForBackup("ns-1", "backup-4").Result(),
-						podVolumeBackups: []*velerov1api.PodVolumeBackup{
-							builder.ForPodVolumeBackup("ns-1", "pvb-1").Result(),
-							builder.ForPodVolumeBackup("ns-1", "pvb-5").Result(),
-							builder.ForPodVolumeBackup("ns-1", "pvb-6").Result(),
-						},
-					},
-				},
-			},
-			existingPodVolumeBackups: []*velerov1api.PodVolumeBackup{
-				builder.ForPodVolumeBackup("ns-1", "pvb-1").Result(),
-				builder.ForPodVolumeBackup("ns-1", "pvb-2").Result(),
-			},
-		},
-	}
+	return len(existingK8SBackups.Items), nil
+}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+var _ = Describe("Backup Sync Reconciler", func() {
+	It("Test Backup Sync Reconciler basic function", func() {
+		type cloudBackupData struct {
+			backup           *velerov1api.Backup
+			podVolumeBackups []*velerov1api.PodVolumeBackup
+		}
+
+		tests := []struct {
+			name                     string
+			namespace                string
+			locations                []*velerov1api.BackupStorageLocation
+			cloudBuckets             map[string][]*cloudBackupData
+			existingBackups          []*velerov1api.Backup
+			existingPodVolumeBackups []*velerov1api.PodVolumeBackup
+			longLocationNameEnabled  bool
+		}{
+			{
+				name:      "no cloud backups",
+				namespace: "ns-1",
+				locations: defaultLocationsList("ns-1"),
+			},
+			{
+				name:      "normal case",
+				namespace: "ns-1",
+				locations: defaultLocationsList("ns-1"),
+				cloudBuckets: map[string][]*cloudBackupData{
+					"bucket-1": {
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-1", "backup-1").Result(),
+						},
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-1", "backup-2").Result(),
+						},
+					},
+					"bucket-2": {
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-1", "backup-3").Result(),
+						},
+					},
+				},
+			},
+			{
+				name:      "all synced backups get created in Velero server's namespace",
+				namespace: "velero",
+				locations: defaultLocationsList("velero"),
+				cloudBuckets: map[string][]*cloudBackupData{
+					"bucket-1": {
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-1", "backup-1").Result(),
+						},
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-1", "backup-2").Result(),
+						},
+					},
+					"bucket-2": {
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-2", "backup-3").Result(),
+						},
+						&cloudBackupData{
+							backup: builder.ForBackup("velero", "backup-4").Result(),
+						},
+					},
+				},
+			},
+			{
+				name:      "new backups get synced when some cloud backups already exist in the cluster",
+				namespace: "ns-1",
+				locations: defaultLocationsList("ns-1"),
+				cloudBuckets: map[string][]*cloudBackupData{
+					"bucket-1": {
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-1", "backup-1").Result(),
+						},
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-1", "backup-2").Result(),
+						},
+					},
+					"bucket-2": {
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-1", "backup-3").Result(),
+						},
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-1", "backup-4").Result(),
+						},
+					},
+				},
+				existingBackups: []*velerov1api.Backup{
+					// add a label to each existing backup so we can differentiate it from the cloud
+					// backup during verification
+					builder.ForBackup("ns-1", "backup-1").StorageLocation("location-1").ObjectMeta(builder.WithLabels("i-exist", "true")).Result(),
+					builder.ForBackup("ns-1", "backup-3").StorageLocation("location-2").ObjectMeta(builder.WithLabels("i-exist", "true")).Result(),
+				},
+			},
+			{
+				name:      "existing backups without a StorageLocation get it filled in",
+				namespace: "ns-1",
+				locations: defaultLocationsList("ns-1"),
+				cloudBuckets: map[string][]*cloudBackupData{
+					"bucket-1": {
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-1", "backup-1").Result(),
+						},
+					},
+				},
+				existingBackups: []*velerov1api.Backup{
+					// add a label to each existing backup so we can differentiate it from the cloud
+					// backup during verification
+					builder.ForBackup("ns-1", "backup-1").ObjectMeta(builder.WithLabels("i-exist", "true")).StorageLocation("location-1").Result(),
+				},
+			},
+			{
+				name:      "backup storage location names and labels get updated",
+				namespace: "ns-1",
+				locations: defaultLocationsList("ns-1"),
+				cloudBuckets: map[string][]*cloudBackupData{
+					"bucket-1": {
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-1", "backup-1").StorageLocation("foo").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "foo")).Result(),
+						},
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-1", "backup-2").Result(),
+						},
+					},
+					"bucket-2": {
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-1", "backup-3").StorageLocation("bar").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "bar")).Result(),
+						},
+					},
+				},
+			},
+			{
+				name:                    "backup storage location names and labels get updated with location name greater than 63 chars",
+				namespace:               "ns-1",
+				locations:               defaultLocationsListWithLongerLocationName("ns-1"),
+				longLocationNameEnabled: true,
+				cloudBuckets: map[string][]*cloudBackupData{
+					"bucket-1": {
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-1", "backup-1").StorageLocation("foo").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "foo")).Result(),
+						},
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-1", "backup-2").Result(),
+						},
+					},
+					"bucket-2": {
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-1", "backup-3").StorageLocation("bar").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "bar")).Result(),
+						},
+					},
+				},
+			},
+			{
+				name:      "all synced backups and pod volume backups get created in Velero server's namespace",
+				namespace: "ns-1",
+				locations: defaultLocationsList("ns-1"),
+				cloudBuckets: map[string][]*cloudBackupData{
+					"bucket-1": {
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-1", "backup-1").Result(),
+							podVolumeBackups: []*velerov1api.PodVolumeBackup{
+								builder.ForPodVolumeBackup("ns-1", "pvb-1").Result(),
+							},
+						},
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-1", "backup-2").Result(),
+							podVolumeBackups: []*velerov1api.PodVolumeBackup{
+								builder.ForPodVolumeBackup("ns-1", "pvb-2").Result(),
+							},
+						},
+					},
+					"bucket-2": {
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-1", "backup-3").Result(),
+						},
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-1", "backup-4").Result(),
+							podVolumeBackups: []*velerov1api.PodVolumeBackup{
+								builder.ForPodVolumeBackup("ns-1", "pvb-1").Result(),
+								builder.ForPodVolumeBackup("ns-1", "pvb-2").Result(),
+								builder.ForPodVolumeBackup("ns-1", "pvb-3").Result(),
+							},
+						},
+					},
+				},
+			},
+			{
+				name:      "new pod volume backups get synched when some pod volume backups already exist in the cluster",
+				namespace: "ns-1",
+				locations: defaultLocationsList("ns-1"),
+				cloudBuckets: map[string][]*cloudBackupData{
+					"bucket-1": {
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-1", "backup-1").Result(),
+							podVolumeBackups: []*velerov1api.PodVolumeBackup{
+								builder.ForPodVolumeBackup("ns-1", "pvb-1").Result(),
+							},
+						},
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-1", "backup-2").Result(),
+							podVolumeBackups: []*velerov1api.PodVolumeBackup{
+								builder.ForPodVolumeBackup("ns-1", "pvb-3").Result(),
+							},
+						},
+					},
+					"bucket-2": {
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-1", "backup-3").Result(),
+						},
+						&cloudBackupData{
+							backup: builder.ForBackup("ns-1", "backup-4").Result(),
+							podVolumeBackups: []*velerov1api.PodVolumeBackup{
+								builder.ForPodVolumeBackup("ns-1", "pvb-1").Result(),
+								builder.ForPodVolumeBackup("ns-1", "pvb-5").Result(),
+								builder.ForPodVolumeBackup("ns-1", "pvb-6").Result(),
+							},
+						},
+					},
+				},
+				existingPodVolumeBackups: []*velerov1api.PodVolumeBackup{
+					builder.ForPodVolumeBackup("ns-1", "pvb-1").Result(),
+					builder.ForPodVolumeBackup("ns-1", "pvb-2").Result(),
+				},
+			},
+		}
+
+		for _, test := range tests {
 			var (
-				client          = fake.NewSimpleClientset()
-				fakeClient      = velerotest.NewFakeControllerRuntimeClient(t)
-				sharedInformers = informers.NewSharedInformerFactory(client, 0)
-				pluginManager   = &pluginmocks.Manager{}
-				backupStores    = make(map[string]*persistencemocks.BackupStore)
+				client        = ctrlfake.NewClientBuilder().Build()
+				pluginManager = &pluginmocks.Manager{}
+				backupStores  = make(map[string]*persistencemocks.BackupStore)
 			)
 
-			c := NewBackupSyncController(
-				client.VeleroV1(),
-				fakeClient,
-				client.VeleroV1(),
-				sharedInformers.Velero().V1().Backups().Lister(),
-				nil, // csiVSLister
-				time.Duration(0),
-				test.namespace,
-				nil, // csiSnapshotClient
-				nil, // kubeClient
-				"",
-				func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager },
-				NewFakeObjectBackupStoreGetter(backupStores),
-				velerotest.NewLogger(),
-			).(*backupSyncController)
-
 			pluginManager.On("CleanupClients").Return(nil)
+			r := BackupSyncReconciler{
+				Client:                  client,
+				Namespace:               test.namespace,
+				DefaultBackupSyncPeriod: time.Second * 10,
+				NewPluginManager:        func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager },
+				BackupStoreGetter:       NewFakeObjectBackupStoreGetter(backupStores),
+				Logger:                  velerotest.NewLogger(),
+			}
 
 			for _, location := range test.locations {
-				require.NoError(t, fakeClient.Create(context.Background(), location))
+				Expect(r.Client.Create(ctx, location)).ShouldNot(HaveOccurred())
 				backupStores[location.Name] = &persistencemocks.BackupStore{}
 			}
 
 			for _, location := range test.locations {
 				backupStore, ok := backupStores[location.Name]
-				require.True(t, ok, "no mock backup store for location %s", location.Name)
+				Expect(ok).To(BeTrue(), "no mock backup store for location %s", location.Name)
 
 				var backupNames []string
 				for _, bucket := range test.cloudBuckets[location.Spec.ObjectStorage.Bucket] {
@@ -376,21 +382,21 @@ func TestBackupSyncControllerRun(t *testing.T) {
 			}
 
 			for _, existingBackup := range test.existingBackups {
-				require.NoError(t, sharedInformers.Velero().V1().Backups().Informer().GetStore().Add(existingBackup))
-
-				_, err := client.VeleroV1().Backups(test.namespace).Create(context.TODO(), existingBackup, metav1.CreateOptions{})
-				require.NoError(t, err)
+				err := client.Create(context.TODO(), existingBackup, &ctrlClient.CreateOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
 			}
 
 			for _, existingPodVolumeBackup := range test.existingPodVolumeBackups {
-				require.NoError(t, sharedInformers.Velero().V1().PodVolumeBackups().Informer().GetStore().Add(existingPodVolumeBackup))
-
-				_, err := client.VeleroV1().PodVolumeBackups(test.namespace).Create(context.TODO(), existingPodVolumeBackup, metav1.CreateOptions{})
-				require.NoError(t, err)
+				err := client.Create(context.TODO(), existingPodVolumeBackup, &ctrlClient.CreateOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
 			}
-			client.ClearActions()
 
-			c.run()
+			actualResult, err := r.Reconcile(ctx, ctrl.Request{
+				NamespacedName: types.NamespacedName{Namespace: "ns-1"},
+			})
+
+			Expect(actualResult).To(BeEquivalentTo(ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}))
+			Expect(err).To(BeNil())
 
 			for bucket, backupDataSet := range test.cloudBuckets {
 				// figure out which location this bucket is for; we need this for verification
@@ -402,12 +408,18 @@ func TestBackupSyncControllerRun(t *testing.T) {
 						break
 					}
 				}
-				require.NotNil(t, location)
+				Expect(location).NotTo(BeNil())
 
 				// process the cloud backups
 				for _, cloudBackupData := range backupDataSet {
-					obj, err := client.VeleroV1().Backups(test.namespace).Get(context.TODO(), cloudBackupData.backup.Name, metav1.GetOptions{})
-					require.NoError(t, err)
+					obj := &velerov1api.Backup{}
+					err := client.Get(
+						context.TODO(),
+						types.NamespacedName{
+							Namespace: cloudBackupData.backup.Namespace,
+							Name:      cloudBackupData.backup.Name},
+						obj)
+					Expect(err).To(BeNil())
 
 					// did this cloud backup already exist in the cluster?
 					var existing *velerov1api.Backup
@@ -426,23 +438,30 @@ func TestBackupSyncControllerRun(t *testing.T) {
 						expected := existing.DeepCopy()
 						expected.Spec.StorageLocation = location.Name
 
-						assert.Equal(t, expected, obj)
+						Expect(expected).To(BeEquivalentTo(obj))
 					} else {
 						// verify that the storage location field and label are set properly
-						assert.Equal(t, location.Name, obj.Spec.StorageLocation)
+						Expect(location.Name).To(BeEquivalentTo(obj.Spec.StorageLocation))
 
 						locationName := location.Name
 						if test.longLocationNameEnabled {
 							locationName = label.GetValidName(locationName)
 						}
-						assert.Equal(t, locationName, obj.Labels[velerov1api.StorageLocationLabel])
-						assert.Equal(t, true, len(obj.Labels[velerov1api.StorageLocationLabel]) <= validation.DNS1035LabelMaxLength)
+						Expect(locationName).To(BeEquivalentTo(obj.Labels[velerov1api.StorageLocationLabel]))
+						Expect(len(obj.Labels[velerov1api.StorageLocationLabel]) <= validation.DNS1035LabelMaxLength).To(BeTrue())
 					}
 
 					// process the cloud pod volume backups for this backup, if any
 					for _, podVolumeBackup := range cloudBackupData.podVolumeBackups {
-						objPodVolumeBackup, err := client.VeleroV1().PodVolumeBackups(test.namespace).Get(context.TODO(), podVolumeBackup.Name, metav1.GetOptions{})
-						require.NoError(t, err)
+						objPodVolumeBackup := &velerov1api.PodVolumeBackup{}
+						err := client.Get(
+							context.TODO(),
+							types.NamespacedName{
+								Namespace: podVolumeBackup.Namespace,
+								Name:      podVolumeBackup.Name,
+							},
+							objPodVolumeBackup)
+						Expect(err).ShouldNot(HaveOccurred())
 
 						// did this cloud pod volume backup already exist in the cluster?
 						var existingPodVolumeBackup *velerov1api.PodVolumeBackup
@@ -457,281 +476,178 @@ func TestBackupSyncControllerRun(t *testing.T) {
 							// if this cloud pod volume backup already exists in the cluster, make sure that what we get from the
 							// client is the existing backup, not the cloud one.
 							expected := existingPodVolumeBackup.DeepCopy()
-							assert.Equal(t, expected, objPodVolumeBackup)
+							Expect(expected).To(BeEquivalentTo(objPodVolumeBackup))
 						}
 					}
 				}
 			}
-		})
-	}
-}
-
-func TestDeleteOrphanedBackups(t *testing.T) {
-	baseBuilder := func(name string) *builder.BackupBuilder {
-		return builder.ForBackup("ns-1", name).ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "default"))
-	}
-
-	tests := []struct {
-		name            string
-		cloudBackups    sets.String
-		k8sBackups      []*velerov1api.Backup
-		namespace       string
-		expectedDeletes sets.String
-	}{
-		{
-			name:         "no overlapping backups",
-			namespace:    "ns-1",
-			cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
-			k8sBackups: []*velerov1api.Backup{
-				baseBuilder("backupA").Phase(velerov1api.BackupPhaseCompleted).Result(),
-				baseBuilder("backupB").Phase(velerov1api.BackupPhaseCompleted).Result(),
-				baseBuilder("backupC").Phase(velerov1api.BackupPhaseCompleted).Result(),
-			},
-			expectedDeletes: sets.NewString("backupA", "backupB", "backupC"),
-		},
-		{
-			name:         "some overlapping backups",
-			namespace:    "ns-1",
-			cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
-			k8sBackups: []*velerov1api.Backup{
-				baseBuilder("backup-1").Phase(velerov1api.BackupPhaseCompleted).Result(),
-				baseBuilder("backup-2").Phase(velerov1api.BackupPhaseCompleted).Result(),
-				baseBuilder("backup-C").Phase(velerov1api.BackupPhaseCompleted).Result(),
-			},
-			expectedDeletes: sets.NewString("backup-C"),
-		},
-		{
-			name:         "all overlapping backups",
-			namespace:    "ns-1",
-			cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
-			k8sBackups: []*velerov1api.Backup{
-				baseBuilder("backup-1").Phase(velerov1api.BackupPhaseCompleted).Result(),
-				baseBuilder("backup-2").Phase(velerov1api.BackupPhaseCompleted).Result(),
-				baseBuilder("backup-3").Phase(velerov1api.BackupPhaseCompleted).Result(),
-			},
-			expectedDeletes: sets.NewString(),
-		},
-		{
-			name:         "no overlapping backups but including backups that are not complete",
-			namespace:    "ns-1",
-			cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
-			k8sBackups: []*velerov1api.Backup{
-				baseBuilder("backupA").Phase(velerov1api.BackupPhaseCompleted).Result(),
-				baseBuilder("Deleting").Phase(velerov1api.BackupPhaseDeleting).Result(),
-				baseBuilder("Failed").Phase(velerov1api.BackupPhaseFailed).Result(),
-				baseBuilder("FailedValidation").Phase(velerov1api.BackupPhaseFailedValidation).Result(),
-				baseBuilder("InProgress").Phase(velerov1api.BackupPhaseInProgress).Result(),
-				baseBuilder("New").Phase(velerov1api.BackupPhaseNew).Result(),
-			},
-			expectedDeletes: sets.NewString("backupA"),
-		},
-		{
-			name:         "all overlapping backups and all backups that are not complete",
-			namespace:    "ns-1",
-			cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
-			k8sBackups: []*velerov1api.Backup{
-				baseBuilder("backup-1").Phase(velerov1api.BackupPhaseFailed).Result(),
-				baseBuilder("backup-2").Phase(velerov1api.BackupPhaseFailedValidation).Result(),
-				baseBuilder("backup-3").Phase(velerov1api.BackupPhaseInProgress).Result(),
-			},
-			expectedDeletes: sets.NewString(),
-		},
-		{
-			name:         "no completed backups in other locations are deleted",
-			namespace:    "ns-1",
-			cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
-			k8sBackups: []*velerov1api.Backup{
-				baseBuilder("backup-1").Phase(velerov1api.BackupPhaseCompleted).Result(),
-				baseBuilder("backup-2").Phase(velerov1api.BackupPhaseCompleted).Result(),
-				baseBuilder("backup-C").Phase(velerov1api.BackupPhaseCompleted).Result(),
-
-				baseBuilder("backup-4").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "alternate")).Phase(velerov1api.BackupPhaseCompleted).Result(),
-				baseBuilder("backup-5").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "alternate")).Phase(velerov1api.BackupPhaseCompleted).Result(),
-				baseBuilder("backup-6").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "alternate")).Phase(velerov1api.BackupPhaseCompleted).Result(),
-			},
-			expectedDeletes: sets.NewString("backup-C"),
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			var (
-				client          = fake.NewSimpleClientset()
-				fakeClient      = velerotest.NewFakeControllerRuntimeClient(t)
-				sharedInformers = informers.NewSharedInformerFactory(client, 0)
-			)
-
-			c := NewBackupSyncController(
-				client.VeleroV1(),
-				fakeClient,
-				client.VeleroV1(),
-				sharedInformers.Velero().V1().Backups().Lister(),
-				nil, // csiVSLister
-				time.Duration(0),
-				test.namespace,
-				nil, // csiSnapshotClient
-				nil, // kubeClient
-				"",
-				nil, // new plugin manager func
-				nil, // backupStoreGetter
-				velerotest.NewLogger(),
-			).(*backupSyncController)
-
-			expectedDeleteActions := make([]core.Action, 0)
-
-			for _, backup := range test.k8sBackups {
-				// add test backup to informer
-				require.NoError(t, sharedInformers.Velero().V1().Backups().Informer().GetStore().Add(backup), "Error adding backup to informer")
-
-				// add test backup to client
-				_, err := client.VeleroV1().Backups(test.namespace).Create(context.TODO(), backup, metav1.CreateOptions{})
-				require.NoError(t, err, "Error adding backup to clientset")
-
-				// if we expect this backup to be deleted, set up the expected DeleteAction
-				if test.expectedDeletes.Has(backup.Name) {
-					actionDelete := core.NewDeleteAction(
-						velerov1api.SchemeGroupVersion.WithResource("backups"),
-						test.namespace,
-						backup.Name,
-					)
-					expectedDeleteActions = append(expectedDeleteActions, actionDelete)
-				}
-			}
-
-			c.deleteOrphanedBackups("default", test.cloudBackups, velerotest.NewLogger())
-
-			numBackups, err := numBackups(t, client, c.namespace)
-			assert.NoError(t, err)
-
-			expected := len(test.k8sBackups) - len(test.expectedDeletes)
-			assert.Equal(t, expected, numBackups)
-
-			velerotest.CompareActions(t, expectedDeleteActions, getDeleteActions(client.Actions()))
-		})
-	}
-}
-
-func TestStorageLabelsInDeleteOrphanedBackups(t *testing.T) {
-	longLabelName := "the-really-long-location-name-that-is-much-more-than-63-characters"
-	tests := []struct {
-		name            string
-		cloudBackups    sets.String
-		k8sBackups      []*velerov1api.Backup
-		namespace       string
-		expectedDeletes sets.String
-	}{
-		{
-			name:         "some overlapping backups",
-			namespace:    "ns-1",
-			cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
-			k8sBackups: []*velerov1api.Backup{
-				builder.ForBackup("ns-1", "backup-1").
-					ObjectMeta(
-						builder.WithLabels(velerov1api.StorageLocationLabel, "the-really-long-location-name-that-is-much-more-than-63-c69e779"),
-					).
-					Phase(velerov1api.BackupPhaseCompleted).
-					Result(),
-				builder.ForBackup("ns-1", "backup-2").
-					ObjectMeta(
-						builder.WithLabels(velerov1api.StorageLocationLabel, "the-really-long-location-name-that-is-much-more-than-63-c69e779"),
-					).
-					Phase(velerov1api.BackupPhaseCompleted).
-					Result(),
-				builder.ForBackup("ns-1", "backup-C").
-					ObjectMeta(
-						builder.WithLabels(velerov1api.StorageLocationLabel, "the-really-long-location-name-that-is-much-more-than-63-c69e779"),
-					).
-					Phase(velerov1api.BackupPhaseCompleted).
-					Result(),
-			},
-			expectedDeletes: sets.NewString("backup-C"),
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			var (
-				client          = fake.NewSimpleClientset()
-				fakeClient      = velerotest.NewFakeControllerRuntimeClient(t)
-				sharedInformers = informers.NewSharedInformerFactory(client, 0)
-			)
-
-			c := NewBackupSyncController(
-				client.VeleroV1(),
-				fakeClient,
-				client.VeleroV1(),
-				sharedInformers.Velero().V1().Backups().Lister(),
-				nil, // csiVSLister
-				time.Duration(0),
-				test.namespace,
-				nil, // csiSnapshotClient
-				nil, // kubeClient
-				"",
-				nil, // new plugin manager func
-				nil, // backupStoreGetter
-				velerotest.NewLogger(),
-			).(*backupSyncController)
-
-			expectedDeleteActions := make([]core.Action, 0)
-
-			for _, backup := range test.k8sBackups {
-				// add test backup to informer
-				require.NoError(t, sharedInformers.Velero().V1().Backups().Informer().GetStore().Add(backup), "Error adding backup to informer")
-
-				// add test backup to client
-				_, err := client.VeleroV1().Backups(test.namespace).Create(context.TODO(), backup, metav1.CreateOptions{})
-				require.NoError(t, err, "Error adding backup to clientset")
-
-				// if we expect this backup to be deleted, set up the expected DeleteAction
-				if test.expectedDeletes.Has(backup.Name) {
-					actionDelete := core.NewDeleteAction(
-						velerov1api.SchemeGroupVersion.WithResource("backups"),
-						test.namespace,
-						backup.Name,
-					)
-					expectedDeleteActions = append(expectedDeleteActions, actionDelete)
-				}
-			}
-
-			c.deleteOrphanedBackups(longLabelName, test.cloudBackups, velerotest.NewLogger())
-
-			numBackups, err := numBackups(t, client, c.namespace)
-			assert.NoError(t, err)
-
-			expected := len(test.k8sBackups) - len(test.expectedDeletes)
-			assert.Equal(t, expected, numBackups)
-
-			velerotest.CompareActions(t, expectedDeleteActions, getDeleteActions(client.Actions()))
-		})
-	}
-}
-
-func getDeleteActions(actions []core.Action) []core.Action {
-	var deleteActions []core.Action
-	for _, action := range actions {
-		if action.GetVerb() == "delete" {
-			deleteActions = append(deleteActions, action)
 		}
-	}
-	return deleteActions
-}
+	})
 
-func numBackups(t *testing.T, c *fake.Clientset, ns string) (int, error) {
-	t.Helper()
-	existingK8SBackups, err := c.VeleroV1().Backups(ns).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return 0, err
-	}
+	It("Test deleting orphaned backups.", func() {
+		longLabelName := "the-really-long-location-name-that-is-much-more-than-63-characters"
 
-	return len(existingK8SBackups.Items), nil
-}
+		baseBuilder := func(name string) *builder.BackupBuilder {
+			return builder.ForBackup("ns-1", name).ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "default"))
+		}
 
-func numPodVolumeBackups(t *testing.T, c *fake.Clientset, ns string) (int, error) {
-	t.Helper()
-	existingK8SPodvolumeBackups, err := c.VeleroV1().PodVolumeBackups(ns).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return 0, err
-	}
+		tests := []struct {
+			name            string
+			cloudBackups    sets.String
+			k8sBackups      []*velerov1api.Backup
+			namespace       string
+			expectedDeletes sets.String
+			useLongBSLName  bool
+		}{
+			{
+				name:         "no overlapping backups",
+				namespace:    "ns-1",
+				cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
+				k8sBackups: []*velerov1api.Backup{
+					baseBuilder("backupA").Phase(velerov1api.BackupPhaseCompleted).Result(),
+					baseBuilder("backupB").Phase(velerov1api.BackupPhaseCompleted).Result(),
+					baseBuilder("backupC").Phase(velerov1api.BackupPhaseCompleted).Result(),
+				},
+				expectedDeletes: sets.NewString("backupA", "backupB", "backupC"),
+			},
+			{
+				name:         "some overlapping backups",
+				namespace:    "ns-1",
+				cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
+				k8sBackups: []*velerov1api.Backup{
+					baseBuilder("backup-1").Phase(velerov1api.BackupPhaseCompleted).Result(),
+					baseBuilder("backup-2").Phase(velerov1api.BackupPhaseCompleted).Result(),
+					baseBuilder("backup-C").Phase(velerov1api.BackupPhaseCompleted).Result(),
+				},
+				expectedDeletes: sets.NewString("backup-C"),
+			},
+			{
+				name:         "all overlapping backups",
+				namespace:    "ns-1",
+				cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
+				k8sBackups: []*velerov1api.Backup{
+					baseBuilder("backup-1").Phase(velerov1api.BackupPhaseCompleted).Result(),
+					baseBuilder("backup-2").Phase(velerov1api.BackupPhaseCompleted).Result(),
+					baseBuilder("backup-3").Phase(velerov1api.BackupPhaseCompleted).Result(),
+				},
+				expectedDeletes: sets.NewString(),
+			},
+			{
+				name:         "no overlapping backups but including backups that are not complete",
+				namespace:    "ns-1",
+				cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
+				k8sBackups: []*velerov1api.Backup{
+					baseBuilder("backupA").Phase(velerov1api.BackupPhaseCompleted).Result(),
+					baseBuilder("Deleting").Phase(velerov1api.BackupPhaseDeleting).Result(),
+					baseBuilder("Failed").Phase(velerov1api.BackupPhaseFailed).Result(),
+					baseBuilder("FailedValidation").Phase(velerov1api.BackupPhaseFailedValidation).Result(),
+					baseBuilder("InProgress").Phase(velerov1api.BackupPhaseInProgress).Result(),
+					baseBuilder("New").Phase(velerov1api.BackupPhaseNew).Result(),
+				},
+				expectedDeletes: sets.NewString("backupA"),
+			},
+			{
+				name:         "all overlapping backups and all backups that are not complete",
+				namespace:    "ns-1",
+				cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
+				k8sBackups: []*velerov1api.Backup{
+					baseBuilder("backup-1").Phase(velerov1api.BackupPhaseFailed).Result(),
+					baseBuilder("backup-2").Phase(velerov1api.BackupPhaseFailedValidation).Result(),
+					baseBuilder("backup-3").Phase(velerov1api.BackupPhaseInProgress).Result(),
+				},
+				expectedDeletes: sets.NewString(),
+			},
+			{
+				name:         "no completed backups in other locations are deleted",
+				namespace:    "ns-1",
+				cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
+				k8sBackups: []*velerov1api.Backup{
+					baseBuilder("backup-1").Phase(velerov1api.BackupPhaseCompleted).Result(),
+					baseBuilder("backup-2").Phase(velerov1api.BackupPhaseCompleted).Result(),
+					baseBuilder("backup-C").Phase(velerov1api.BackupPhaseCompleted).Result(),
 
-	return len(existingK8SPodvolumeBackups.Items), nil
-}
+					baseBuilder("backup-4").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "alternate")).Phase(velerov1api.BackupPhaseCompleted).Result(),
+					baseBuilder("backup-5").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "alternate")).Phase(velerov1api.BackupPhaseCompleted).Result(),
+					baseBuilder("backup-6").ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, "alternate")).Phase(velerov1api.BackupPhaseCompleted).Result(),
+				},
+				expectedDeletes: sets.NewString("backup-C"),
+			},
+			{
+				name:         "some overlapping backups",
+				namespace:    "ns-1",
+				cloudBackups: sets.NewString("backup-1", "backup-2", "backup-3"),
+				k8sBackups: []*velerov1api.Backup{
+					builder.ForBackup("ns-1", "backup-1").
+						ObjectMeta(
+							builder.WithLabels(velerov1api.StorageLocationLabel, "the-really-long-location-name-that-is-much-more-than-63-c69e779"),
+						).
+						Phase(velerov1api.BackupPhaseCompleted).
+						Result(),
+					builder.ForBackup("ns-1", "backup-2").
+						ObjectMeta(
+							builder.WithLabels(velerov1api.StorageLocationLabel, "the-really-long-location-name-that-is-much-more-than-63-c69e779"),
+						).
+						Phase(velerov1api.BackupPhaseCompleted).
+						Result(),
+					builder.ForBackup("ns-1", "backup-C").
+						ObjectMeta(
+							builder.WithLabels(velerov1api.StorageLocationLabel, "the-really-long-location-name-that-is-much-more-than-63-c69e779"),
+						).
+						Phase(velerov1api.BackupPhaseCompleted).
+						Result(),
+				},
+				expectedDeletes: sets.NewString("backup-C"),
+				useLongBSLName:  true,
+			},
+		}
+
+		for _, test := range tests {
+			var (
+				client        = ctrlfake.NewClientBuilder().Build()
+				pluginManager = &pluginmocks.Manager{}
+				backupStores  = make(map[string]*persistencemocks.BackupStore)
+			)
+
+			r := BackupSyncReconciler{
+				Client:                  client,
+				Namespace:               test.namespace,
+				DefaultBackupSyncPeriod: time.Second * 10,
+				NewPluginManager:        func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager },
+				BackupStoreGetter:       NewFakeObjectBackupStoreGetter(backupStores),
+				Logger:                  velerotest.NewLogger(),
+			}
+
+			expectedDeleteActions := make([]core.Action, 0)
+
+			for _, backup := range test.k8sBackups {
+				// add test backup to client
+				err := client.Create(context.TODO(), backup, &ctrlClient.CreateOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+
+				// if we expect this backup to be deleted, set up the expected DeleteAction
+				if test.expectedDeletes.Has(backup.Name) {
+					actionDelete := core.NewDeleteAction(
+						velerov1api.SchemeGroupVersion.WithResource("backups"),
+						test.namespace,
+						backup.Name,
+					)
+					expectedDeleteActions = append(expectedDeleteActions, actionDelete)
+				}
+			}
+
+			bslName := "default"
+			if test.useLongBSLName {
+				bslName = longLabelName
+			}
+			r.deleteOrphanedBackups(ctx, bslName, test.cloudBackups, velerotest.NewLogger())
+
+			numBackups, err := numBackups(client, r.Namespace)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			fmt.Println("")
+
+			expected := len(test.k8sBackups) - len(test.expectedDeletes)
+			Expect(expected).To(BeEquivalentTo(numBackups))
+		}
+	})
+})


### PR DESCRIPTION
1. use kubebuilder's reconcile logic to replace controller's old logic.
2. use ginkgo and gomega to replace testing.
3. Remove DefaultBackupLocation
4. Remove unneccessary comment line
5. Add syncPeriod default value setting logic
6. Modify ListBackupStorageLocations function's context parameter
7. Add RequeueAfter parameter in Reconcile function return value
8. Use context passed from parameter, instead of using Reconciler struct's context.
9. Delete Reconciler struct's context member.
10. Modify test case accordingly.

Signed-off-by: Xun Jiang <blackpiglet@gmail.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #5022 

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
