### PR TITLE
Check for empty ns list before checking nslist[0]

### DIFF
--- a/changelogs/unreleased/5236-sseago
+++ b/changelogs/unreleased/5236-sseago
@@ -1,0 +1,1 @@
+Check for empty ns list before checking nslist[0]

--- a/pkg/backup/item_collector.go
+++ b/pkg/backup/item_collector.go
@@ -225,8 +225,11 @@ func (r *itemCollector) getResourceItems(log logrus.FieldLogger, gv schema.Group
 
 	namespacesToList := getNamespacesToList(r.backupRequest.NamespaceIncludesExcludes)
 
-	// Check if we're backing up namespaces, and only certain ones
-	if gr == kuberesource.Namespaces && namespacesToList[0] != "" {
+	// Check if we're backing up namespaces for a less-than-full backup.
+	// We enter this block if resource is Namespaces and the namespae list is either empty or contains
+	// an explicit namespace list. (We skip this block if the list contains "" since that indicates
+	// a full-cluster backup
+	if gr == kuberesource.Namespaces && (len(namespacesToList) == 0 || namespacesToList[0] != "") {
 		resourceClient, err := r.dynamicFactory.ClientForGroupVersionResource(gv, resource, "")
 		if err != nil {
 			log.WithError(err).Error("Error getting dynamic client")


### PR DESCRIPTION
In determining whether a backup includes all namespaces, item_collector
checks for an empty string in the first element of the ns list. If processing
includes+excludes results in an empty list, treat this as another case
of a not-all-namespaces backup rather than crashing velero.

Signed-off-by: Scott Seago <sseago@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
In determining whether a backup includes all namespaces, item_collector
checks for an empty string in the first element of the ns list. If processing
includes+excludes results in an empty list, treat this as another case
of a not-all-namespaces backup rather than crashing velero.

# Does your change fix a particular issue?

Fixes #5235

# Please indicate you've done the following:

- [x ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
