### PR TITLE
Return err when backup resources is empty

### DIFF
--- a/changelogs/unreleased/5258-cleverhu
+++ b/changelogs/unreleased/5258-cleverhu
@@ -1,0 +1,1 @@
+Return err when backup resources is empty. 

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -404,6 +404,10 @@ func (kb *kubernetesBackupper) BackupWithResolvers(log logrus.FieldLogger,
 
 	log.WithField("progress", "").Infof("Backed up a total of %d items", len(backupRequest.BackedUpItems))
 
+	if len(backupRequest.BackedUpItems) == 0 {
+		return errors.New("Backed up resources is empty")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
return error when back up resources is empty

# Does your change fix a particular issue?

Fixes https://github.com/vmware-tanzu/velero/issues/3565

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
