### PR TITLE
Fix CVE-2022-1962 by bumping up golang version to 1.17.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM --platform=$BUILDPLATFORM golang:1.17 as builder-env
+FROM --platform=$BUILDPLATFORM golang:1.17.13 as builder-env
 
 ARG GOPROXY
 ARG PKG

--- a/changelogs/unreleased/5287-qiuming-best
+++ b/changelogs/unreleased/5287-qiuming-best
@@ -1,0 +1,1 @@
+Fix CVE-2022-1962 by bumping up golang version to 1.17.13 

--- a/hack/build-image/Dockerfile
+++ b/hack/build-image/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17
+FROM golang:1.17.13
 
 ARG GOPROXY
 


### PR DESCRIPTION
Signed-off-by: Ming [mqiu@vmware.com](mailto:mqiu@vmware.com)

components using Go parser are effected. Update to golang version <=1.17.12 is the solution according to the https://nvd.nist.gov/vuln/detail/CVE-2022-1962

the pr is reference to https://github.com/vmware-tanzu/velero/pull/5249

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
