### PR TITLE
Add shorthand for labels columns

### DIFF
--- a/changelogs/unreleased/5291-cleverhu
+++ b/changelogs/unreleased/5291-cleverhu
@@ -1,0 +1,1 @@
+Add more detailed comments for labels columns.

--- a/pkg/cmd/util/output/output.go
+++ b/pkg/cmd/util/output/output.go
@@ -41,7 +41,7 @@ const downloadRequestTimeout = 30 * time.Second
 func BindFlags(flags *pflag.FlagSet) {
 	flags.StringP("output", "o", "table", "Output display format. For create commands, display the object but do not send it to the server. Valid formats are 'table', 'json', and 'yaml'. 'table' is not valid for the install command.")
 	labelColumns := flag.NewStringArray()
-	flags.Var(&labelColumns, "label-columns", "A comma-separated list of labels to be displayed as columns")
+	flags.VarP(&labelColumns, "label-columns", "L", "Accepts a comma separated list of labels that are going to be presented as columns. Names are case-sensitive. You can also use multiple flag options like -L label1 -L label2...")
 	flags.Bool("show-labels", false, "Show labels in the last column")
 }
 


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
The user has some questions about the usage of `--label-columns`, so I add more detailed comments for
labels columns. 

# Does your change fix a particular issue?
Fixes https://github.com/vmware-tanzu/velero/issues/4710

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
