### PR TITLE
optimize code for restore exists resources

### DIFF
--- a/changelogs/unreleased/5293-cleverhu
+++ b/changelogs/unreleased/5293-cleverhu
@@ -1,0 +1,1 @@
+Optimize code for restore exists resources.


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Optimize the previous logic and handle errors uniformly. If the resource exists but cannot be found, the 'get' error will be returned; otherwise, the creation error will be returned.

# Does your change fix a particular issue?

Fixes https://github.com/vmware-tanzu/velero/issues/5288

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
