### PR TITLE
change CSISnapshotTimeout from pointer to normal variable

### DIFF
--- a/changelogs/unreleased/5294-cleverhu
+++ b/changelogs/unreleased/5294-cleverhu
@@ -1,0 +1,1 @@
+change CSISnapshotTimeout from pointer to normal variables.

--- a/pkg/cmd/util/output/backup_describer.go
+++ b/pkg/cmd/util/output/backup_describer.go
@@ -165,7 +165,7 @@ func DescribeBackupSpec(d *Describer, spec velerov1api.BackupSpec) {
 	d.Printf("TTL:\t%s\n", spec.TTL.Duration)
 
 	d.Println()
-	d.Printf("CSISnapshotTimeout:\t%s\n", &spec.CSISnapshotTimeout.Duration)
+	d.Printf("CSISnapshotTimeout:\t%s\n", spec.CSISnapshotTimeout.Duration)
 
 	d.Println()
 	if len(spec.Hooks.Resources) == 0 {


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
I'm sorry that I accidentally wrote the time as a pointer. I have tested that both pointers and normal variables are valid. I don't know what is the essential difference between them, but I think it's better to keep consistent with the TTL above.

change CSISnapshotTimeout from pointer to normal var.
# Does your change fix a particular issue?

Fixes None

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
