### PR TITLE
support  sort-by when use cli `get`

### DIFF
--- a/changelogs/unreleased/5296-cleverhu
+++ b/changelogs/unreleased/5296-cleverhu
@@ -1,0 +1,1 @@
+Support input sort-by when use cli `get`.

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/bombsimon/logrusr v1.1.0
 	github.com/evanphx/json-patch v4.11.0+incompatible
 	github.com/fatih/color v1.13.0
+	github.com/fvbommel/sortorder v1.0.2
 	github.com/gobwas/glob v0.2.3
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/golang/protobuf v1.5.2
@@ -49,7 +50,9 @@ require (
 	k8s.io/cli-runtime v0.22.2
 	k8s.io/client-go v0.22.2
 	k8s.io/klog v1.0.0
+	k8s.io/klog/v2 v2.9.0
 	k8s.io/kube-aggregator v0.19.12
+	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b
 	sigs.k8s.io/controller-runtime v0.10.2
 	sigs.k8s.io/yaml v1.3.0
 )
@@ -140,9 +143,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/component-base v0.22.2 // indirect
-	k8s.io/klog/v2 v2.9.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
-	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -279,6 +279,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
+github.com/fvbommel/sortorder v1.0.2 h1:mV4o8B2hKboCdkJm+a7uX/SIpZob4JzUpc5GGnM45eo=
+github.com/fvbommel/sortorder v1.0.2/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/pkg/cmd/util/output/backup_printer.go
+++ b/pkg/cmd/util/output/backup_printer.go
@@ -45,7 +45,7 @@ var (
 )
 
 func printBackupList(list *velerov1api.BackupList) []metav1.TableRow {
-	sortBackupsByPrefixAndTimestamp(list)
+	// sortBackupsByPrefixAndTimestamp(list)
 	rows := make([]metav1.TableRow, 0, len(list.Items))
 
 	for i := range list.Items {

--- a/pkg/cmd/util/output/sorter.go
+++ b/pkg/cmd/util/output/sorter.go
@@ -1,0 +1,354 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package output
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"sort"
+
+	"github.com/fvbommel/sortorder"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/jsonpath"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/integer"
+)
+
+// Sorter sorts the given obj list.
+// Non-list types are simply passed through
+type Sorter struct {
+	SortField string
+	Decoder   runtime.Decoder
+}
+
+func (s *Sorter) SortObj(obj runtime.Object) error {
+	objs, err := meta.ExtractList(obj)
+	if err != nil {
+		return err
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+
+	sorter, err := SortObjects(nil, objs, s.SortField)
+	if err != nil {
+		return err
+	}
+
+	switch list := obj.(type) {
+	case *corev1.List:
+		outputList := make([]runtime.RawExtension, len(objs))
+		for ix := range objs {
+			outputList[ix] = list.Items[sorter.OriginalPosition(ix)]
+		}
+		list.Items = outputList
+		return nil
+	}
+	return meta.SetList(obj, objs)
+}
+
+var jsonRegexp = regexp.MustCompile(`^\{\.?([^{}]+)\}$|^\.?([^{}]+)$`)
+
+// RelaxedJSONPathExpression attempts to be flexible with JSONPath expressions, it accepts:
+//   - metadata.name (no leading '.' or curly braces '{...}'
+//   - {metadata.name} (no leading '.')
+//   - .metadata.name (no curly braces '{...}')
+//   - {.metadata.name} (complete expression)
+//
+// And transforms them all into a valid jsonpath expression:
+//
+//	{.metadata.name}
+func RelaxedJSONPathExpression(pathExpression string) (string, error) {
+	if len(pathExpression) == 0 {
+		return pathExpression, nil
+	}
+	submatches := jsonRegexp.FindStringSubmatch(pathExpression)
+	if submatches == nil {
+		return "", fmt.Errorf("unexpected path string, expected a 'name1.name2' or '.name1.name2' or '{name1.name2}' or '{.name1.name2}'")
+	}
+	if len(submatches) != 3 {
+		return "", fmt.Errorf("unexpected submatch list: %v", submatches)
+	}
+	var fieldSpec string
+	if len(submatches[1]) != 0 {
+		fieldSpec = submatches[1]
+	} else {
+		fieldSpec = submatches[2]
+	}
+	return fmt.Sprintf("{.%s}", fieldSpec), nil
+}
+
+// SortObjects sorts the runtime.Object based on fieldInput and returns RuntimeSort that implements
+// the golang sort interface
+func SortObjects(decoder runtime.Decoder, objs []runtime.Object, fieldInput string) (*RuntimeSort, error) {
+	for ix := range objs {
+		item := objs[ix]
+		switch u := item.(type) {
+		case *runtime.Unknown:
+			var err error
+			// decode runtime.Unknown to runtime.Unstructured for sorting.
+			// we don't actually want the internal versions of known types.
+			if objs[ix], _, err = decoder.Decode(u.Raw, nil, &unstructured.Unstructured{}); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	field, err := RelaxedJSONPathExpression(fieldInput)
+	if err != nil {
+		return nil, err
+	}
+
+	parser := jsonpath.New("sorting").AllowMissingKeys(true)
+	if err := parser.Parse(field); err != nil {
+		return nil, err
+	}
+
+	// We don't do any model validation here, so we traverse all objects to be sorted
+	// and, if the field is valid to at least one of them, we consider it to be a
+	// valid field; otherwise error out.
+	// Note that this requires empty fields to be considered later, when sorting.
+	var fieldFoundOnce bool
+	for _, obj := range objs {
+		values, err := findJSONPathResults(parser, obj)
+		if err != nil {
+			return nil, err
+		}
+		if len(values) > 0 && len(values[0]) > 0 {
+			fieldFoundOnce = true
+			break
+		}
+	}
+	if !fieldFoundOnce {
+		return nil, fmt.Errorf("couldn't find any field with path %q in the list of objects", field)
+	}
+
+	sorter := NewRuntimeSort(field, objs)
+	sort.Sort(sorter)
+	return sorter, nil
+}
+
+// RuntimeSort is an implementation of the golang sort interface that knows how to sort
+// lists of runtime.Object
+type RuntimeSort struct {
+	field        string
+	objs         []runtime.Object
+	origPosition []int
+}
+
+// NewRuntimeSort creates a new RuntimeSort struct that implements golang sort interface
+func NewRuntimeSort(field string, objs []runtime.Object) *RuntimeSort {
+	sorter := &RuntimeSort{field: field, objs: objs, origPosition: make([]int, len(objs))}
+	for ix := range objs {
+		sorter.origPosition[ix] = ix
+	}
+	return sorter
+}
+
+func (r *RuntimeSort) Len() int {
+	return len(r.objs)
+}
+
+func (r *RuntimeSort) Swap(i, j int) {
+	r.objs[i], r.objs[j] = r.objs[j], r.objs[i]
+	r.origPosition[i], r.origPosition[j] = r.origPosition[j], r.origPosition[i]
+}
+
+func isLess(i, j reflect.Value) (bool, error) {
+	switch i.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return i.Int() < j.Int(), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return i.Uint() < j.Uint(), nil
+	case reflect.Float32, reflect.Float64:
+		return i.Float() < j.Float(), nil
+	case reflect.String:
+		return sortorder.NaturalLess(i.String(), j.String()), nil
+	case reflect.Ptr:
+		return isLess(i.Elem(), j.Elem())
+	case reflect.Struct:
+		// sort metav1.Time
+		in := i.Interface()
+		if t, ok := in.(metav1.Time); ok {
+			time := j.Interface().(metav1.Time)
+			return t.Before(&time), nil
+		}
+		// sort resource.Quantity
+		if iQuantity, ok := in.(resource.Quantity); ok {
+			jQuantity := j.Interface().(resource.Quantity)
+			return iQuantity.Cmp(jQuantity) < 0, nil
+		}
+		// fallback to the fields comparison
+		for idx := 0; idx < i.NumField(); idx++ {
+			less, err := isLess(i.Field(idx), j.Field(idx))
+			if err != nil || !less {
+				return less, err
+			}
+		}
+		return true, nil
+	case reflect.Array, reflect.Slice:
+		// note: the length of i and j may be different
+		for idx := 0; idx < integer.IntMin(i.Len(), j.Len()); idx++ {
+			less, err := isLess(i.Index(idx), j.Index(idx))
+			if err != nil || !less {
+				return less, err
+			}
+		}
+		return true, nil
+	case reflect.Interface:
+		if i.IsNil() && j.IsNil() {
+			return false, nil
+		} else if i.IsNil() {
+			return true, nil
+		} else if j.IsNil() {
+			return false, nil
+		}
+		switch itype := i.Interface().(type) {
+		case uint8:
+			if jtype, ok := j.Interface().(uint8); ok {
+				return itype < jtype, nil
+			}
+		case uint16:
+			if jtype, ok := j.Interface().(uint16); ok {
+				return itype < jtype, nil
+			}
+		case uint32:
+			if jtype, ok := j.Interface().(uint32); ok {
+				return itype < jtype, nil
+			}
+		case uint64:
+			if jtype, ok := j.Interface().(uint64); ok {
+				return itype < jtype, nil
+			}
+		case int8:
+			if jtype, ok := j.Interface().(int8); ok {
+				return itype < jtype, nil
+			}
+		case int16:
+			if jtype, ok := j.Interface().(int16); ok {
+				return itype < jtype, nil
+			}
+		case int32:
+			if jtype, ok := j.Interface().(int32); ok {
+				return itype < jtype, nil
+			}
+		case int64:
+			if jtype, ok := j.Interface().(int64); ok {
+				return itype < jtype, nil
+			}
+		case uint:
+			if jtype, ok := j.Interface().(uint); ok {
+				return itype < jtype, nil
+			}
+		case int:
+			if jtype, ok := j.Interface().(int); ok {
+				return itype < jtype, nil
+			}
+		case float32:
+			if jtype, ok := j.Interface().(float32); ok {
+				return itype < jtype, nil
+			}
+		case float64:
+			if jtype, ok := j.Interface().(float64); ok {
+				return itype < jtype, nil
+			}
+		case string:
+			if jtype, ok := j.Interface().(string); ok {
+				// check if it's a Quantity
+				itypeQuantity, err := resource.ParseQuantity(itype)
+				if err != nil {
+					return sortorder.NaturalLess(itype, jtype), nil
+				}
+				jtypeQuantity, err := resource.ParseQuantity(jtype)
+				if err != nil {
+					return sortorder.NaturalLess(itype, jtype), nil
+				}
+				// Both strings are quantity
+				return itypeQuantity.Cmp(jtypeQuantity) < 0, nil
+			}
+		default:
+			return false, fmt.Errorf("unsortable type: %T", itype)
+		}
+		return false, fmt.Errorf("unsortable interface: %v", i.Kind())
+
+	default:
+		return false, fmt.Errorf("unsortable type: %v", i.Kind())
+	}
+}
+
+func (r *RuntimeSort) Less(i, j int) bool {
+	iObj := r.objs[i]
+	jObj := r.objs[j]
+
+	var iValues [][]reflect.Value
+	var jValues [][]reflect.Value
+	var err error
+
+	parser := jsonpath.New("sorting").AllowMissingKeys(true)
+	err = parser.Parse(r.field)
+	if err != nil {
+		panic(err)
+	}
+
+	iValues, err = findJSONPathResults(parser, iObj)
+	if err != nil {
+		klog.Fatalf("Failed to get i values for %#v using %s (%#v)", iObj, r.field, err)
+	}
+
+	jValues, err = findJSONPathResults(parser, jObj)
+	if err != nil {
+		klog.Fatalf("Failed to get j values for %#v using %s (%v)", jObj, r.field, err)
+	}
+
+	if len(iValues) == 0 || len(iValues[0]) == 0 {
+		return true
+	}
+	if len(jValues) == 0 || len(jValues[0]) == 0 {
+		return false
+	}
+	iField := iValues[0][0]
+	jField := jValues[0][0]
+
+	less, err := isLess(iField, jField)
+	if err != nil {
+		klog.Exitf("Field %s in %T is an unsortable type: %s, err: %v", r.field, iObj, iField.Kind().String(), err)
+	}
+	return less
+}
+
+// OriginalPosition returns the starting (original) position of a particular index.
+// e.g. If OriginalPosition(0) returns 5 than the
+// the item currently at position 0 was at position 5 in the original unsorted array.
+func (r *RuntimeSort) OriginalPosition(ix int) int {
+	if ix < 0 || ix > len(r.origPosition) {
+		return -1
+	}
+	return r.origPosition[ix]
+}
+
+func findJSONPathResults(parser *jsonpath.JSONPath, from runtime.Object) ([][]reflect.Value, error) {
+	if unstructuredObj, ok := from.(*unstructured.Unstructured); ok {
+		return parser.FindResults(unstructuredObj.Object)
+	}
+	return parser.FindResults(reflect.ValueOf(from).Elem().Interface())
+}

--- a/pkg/cmd/util/output/sorter_test.go
+++ b/pkg/cmd/util/output/sorter_test.go
@@ -1,0 +1,197 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package output
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func createPodSpecResource(t *testing.T, memReq, memLimit, cpuReq, cpuLimit string) corev1.PodSpec {
+	t.Helper()
+	podSpec := corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{},
+					Limits:   corev1.ResourceList{},
+				},
+			},
+		},
+	}
+
+	req := podSpec.Containers[0].Resources.Requests
+	if memReq != "" {
+		memReq, err := resource.ParseQuantity(memReq)
+		if err != nil {
+			t.Errorf("memory request string is not a valid quantity")
+		}
+		req["memory"] = memReq
+	}
+	if cpuReq != "" {
+		cpuReq, err := resource.ParseQuantity(cpuReq)
+		if err != nil {
+			t.Errorf("cpu request string is not a valid quantity")
+		}
+		req["cpu"] = cpuReq
+	}
+	limit := podSpec.Containers[0].Resources.Limits
+	if memLimit != "" {
+		memLimit, err := resource.ParseQuantity(memLimit)
+		if err != nil {
+			t.Errorf("memory limit string is not a valid quantity")
+		}
+		limit["memory"] = memLimit
+	}
+	if cpuLimit != "" {
+		cpuLimit, err := resource.ParseQuantity(cpuLimit)
+		if err != nil {
+			t.Errorf("cpu limit string is not a valid quantity")
+		}
+		limit["cpu"] = cpuLimit
+	}
+
+	return podSpec
+}
+
+func TestRuntimeSortLess(t *testing.T) {
+	var testobj runtime.Object
+
+	testobj = &corev1.PodList{
+		Items: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "b",
+				},
+				Spec: createPodSpecResource(t, "0.5", "", "1Gi", ""),
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c",
+				},
+				Spec: createPodSpecResource(t, "2", "", "1Ti", ""),
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+				Spec: createPodSpecResource(t, "10m", "", "1Ki", ""),
+			},
+		},
+	}
+
+	testobjs, err := meta.ExtractList(testobj)
+	if err != nil {
+		t.Fatalf("ExtractList testobj got unexpected error: %v", err)
+	}
+
+	testfieldName := "{.metadata.name}"
+	testruntimeSortName := NewRuntimeSort(testfieldName, testobjs)
+
+	testfieldCPU := "{.spec.containers[].resources.requests.cpu}"
+	testruntimeSortCPU := NewRuntimeSort(testfieldCPU, testobjs)
+
+	testfieldMemory := "{.spec.containers[].resources.requests.memory}"
+	testruntimeSortMemory := NewRuntimeSort(testfieldMemory, testobjs)
+
+	tests := []struct {
+		name         string
+		runtimeSort  *RuntimeSort
+		i            int
+		j            int
+		expectResult bool
+		expectErr    bool
+	}{
+		{
+			name:         "test name b c less true",
+			runtimeSort:  testruntimeSortName,
+			i:            0,
+			j:            1,
+			expectResult: true,
+		},
+		{
+			name:         "test name c a less false",
+			runtimeSort:  testruntimeSortName,
+			i:            1,
+			j:            2,
+			expectResult: false,
+		},
+		{
+			name:         "test name b a less false",
+			runtimeSort:  testruntimeSortName,
+			i:            0,
+			j:            2,
+			expectResult: false,
+		},
+		{
+			name:         "test cpu 0.5 2 less true",
+			runtimeSort:  testruntimeSortCPU,
+			i:            0,
+			j:            1,
+			expectResult: true,
+		},
+		{
+			name:         "test cpu 2 10mi less false",
+			runtimeSort:  testruntimeSortCPU,
+			i:            1,
+			j:            2,
+			expectResult: false,
+		},
+		{
+			name:         "test cpu 0.5 10mi less false",
+			runtimeSort:  testruntimeSortCPU,
+			i:            0,
+			j:            2,
+			expectResult: false,
+		},
+		{
+			name:         "test memory 1Gi 1Ti less true",
+			runtimeSort:  testruntimeSortMemory,
+			i:            0,
+			j:            1,
+			expectResult: true,
+		},
+		{
+			name:         "test memory 1Ti 1Ki less false",
+			runtimeSort:  testruntimeSortMemory,
+			i:            1,
+			j:            2,
+			expectResult: false,
+		},
+		{
+			name:         "test memory 1Gi 1Ki less false",
+			runtimeSort:  testruntimeSortMemory,
+			i:            0,
+			j:            2,
+			expectResult: false,
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := test.runtimeSort.Less(test.i, test.j)
+			if result != test.expectResult {
+				t.Errorf("case[%d]:%s Expected result: %v, Got result: %v", i, test.name, test.expectResult, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
add sort-by args when use get cli

# Does your change fix a particular issue?

Fixes https://github.com/vmware-tanzu/velero/issues/4355

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
