### PR TITLE
Don't panic when storageClassName is not set in stateful sets

### DIFF
--- a/changelogs/unreleased/5301-divolgin
+++ b/changelogs/unreleased/5301-divolgin
@@ -1,0 +1,1 @@
+Fix nil pointer panic when restoring StatefulSets

--- a/pkg/restore/change_storageclass_action.go
+++ b/pkg/restore/change_storageclass_action.go
@@ -99,7 +99,7 @@ func (a *ChangeStorageClassAction) Execute(input *velero.RestoreItemActionExecut
 
 		if len(sts.Spec.VolumeClaimTemplates) > 0 {
 			for index, pvc := range sts.Spec.VolumeClaimTemplates {
-				exists, newStorageClass, err := a.isStorageClassExist(log, *pvc.Spec.StorageClassName, config)
+				exists, newStorageClass, err := a.isStorageClassExist(log, pvc.Spec.StorageClassName, config)
 				if err != nil {
 					return nil, err
 				} else if !exists {
@@ -124,7 +124,7 @@ func (a *ChangeStorageClassAction) Execute(input *velero.RestoreItemActionExecut
 			return nil, errors.Wrap(err, "error getting item's spec.storageClassName")
 		}
 
-		exists, newStorageClass, err := a.isStorageClassExist(log, storageClass, config)
+		exists, newStorageClass, err := a.isStorageClassExist(log, &storageClass, config)
 		if err != nil {
 			return nil, err
 		} else if !exists {
@@ -140,15 +140,15 @@ func (a *ChangeStorageClassAction) Execute(input *velero.RestoreItemActionExecut
 	return velero.NewRestoreItemActionExecuteOutput(obj), nil
 }
 
-func (a *ChangeStorageClassAction) isStorageClassExist(log *logrus.Entry, storageClass string, cm *corev1.ConfigMap) (exists bool, newStorageClass string, err error) {
-	if storageClass == "" {
+func (a *ChangeStorageClassAction) isStorageClassExist(log *logrus.Entry, storageClass *string, cm *corev1.ConfigMap) (exists bool, newStorageClass string, err error) {
+	if storageClass == nil || *storageClass == "" {
 		log.Debug("Item has no storage class specified")
 		return false, "", nil
 	}
 
-	newStorageClass, ok := cm.Data[storageClass]
+	newStorageClass, ok := cm.Data[*storageClass]
 	if !ok {
-		log.Debugf("No mapping found for storage class %s", storageClass)
+		log.Debugf("No mapping found for storage class %s", *storageClass)
 		return false, "", nil
 	}
 


### PR DESCRIPTION
Signed-off-by: divolgin <dmitriy@replicated.com>

Thank you for contributing to Velero!

# Please add a summary of your change
When reassigning storage class names, there needs to be a nil pointer check because the value is optional and the variable is a pointer to a string.
# Does your change fix a particular issue?

Fixes #(issue)
Fixes https://github.com/vmware-tanzu/velero/issues/4782
#5266
# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
