### PR TITLE
A little note about TTL expiration

### DIFF
--- a/site/content/docs/v1.9/how-velero-works.md
+++ b/site/content/docs/v1.9/how-velero-works.md
@@ -88,6 +88,8 @@ When you create a backup, you can specify a TTL (time to live) by adding the fla
 
 The TTL flag allows the user to specify the backup retention period with the value specified in hours, minutes and seconds in the form `--ttl 24h0m0s`. If not specified, a default TTL value of 30 days will be applied.
 
+The effects of expiration are not applied immediately, they are applied when the gc-controller runs its reconciliation loop every hour.
+
 If backup fails to delete, a label `velero.io/gc-failure=<Reason>` will be added to the backup custom resource.
 
 You can use this label to filter and select backups that failed to delete.


### PR DESCRIPTION
I think this little comment about TTL expiration is needed, because it can be confusing when the expiration time has passed and the data allocated and the snapshots are not erased at that time.

Signed-off-by: Aaron Arias <33655005+aaronariasperez@users.noreply.github.com>

Thank you for contributing to Velero!

# Please add a summary of your change
I think this little comment about TTL expiration is needed, because it can be confusing when the expiration time has passed and the data allocated and the snapshots are not erased at that time.

# Does your change fix a particular issue?
No.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
