### PR TITLE
Cancel downloadRequest when timeout without downloadURL

### DIFF
--- a/changelogs/unreleased/5329-kaovilai
+++ b/changelogs/unreleased/5329-kaovilai
@@ -1,0 +1,1 @@
+Cancel downloadRequest when timeout without downloadURL


### PR DESCRIPTION
Tested with `go install ./cmd/velero`

Result takes about one minute to fail log command for a backup that no longer have backup storage location in the cluster. One minute default came from 
https://github.com/vmware-tanzu/velero/blob/11bfe82342c9f54c63f40d3e97313ce763b446f2/pkg/cmd/cli/backup/logs.go#L41

```
❯ time velero backup logs mongo-csi-e2e-61f370ce-3056-11ed-a685-1acc26a6847e --timeout 5s
I0914 11:52:41.073495   80568 request.go:665] Waited for 1.063170625s due to client-side throttling, not priority and fairness, request: GET:https://api.cluster-tkaovila-apr23-410.tkaovila-apr23-410.mg.dog8code.com:6443/apis/samples.operator.openshift.io/v1?timeout=32s
An error occurred: download request download url timeout, check velero server logs for errors. backup storage location may not be available
velero backup logs mongo-csi-e2e-61f370ce-3056-11ed-a685-1acc26a6847e  5s  0.10s user 0.06s system 1% cpu 10.193 total
```


Thank you for contributing to Velero!

# Please add a summary of your change
Cancel download request if timeout waiting for download URL

# Does your change fix a particular issue?

Fixes #5324

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
