### PR TITLE
[Cherry pick to v1.9.x] Increase restic ensure repo timeout

### DIFF
--- a/changelogs/unreleased/5336-shubham-pampattiwar
+++ b/changelogs/unreleased/5336-shubham-pampattiwar
@@ -1,0 +1,1 @@
+Increase ensure restic repository timeout to 5m

--- a/pkg/restic/repository_ensurer.go
+++ b/pkg/restic/repository_ensurer.go
@@ -176,7 +176,7 @@ func (r *repositoryEnsurer) EnsureRepo(ctx context.Context, namespace, volumeNam
 	select {
 	// repositories should become either ready or not ready quickly if they're
 	// newly created.
-	case <-time.After(time.Minute):
+	case <-time.After(time.Minute * 5):
 		return nil, errors.New("timed out waiting for restic repository to become ready")
 	case <-ctx.Done():
 		return nil, errors.New("timed out waiting for restic repository to become ready")


### PR DESCRIPTION
Signed-off-by: Shubham Pampattiwar <spampatt@redhat.com>

Fixes https://github.com/vmware-tanzu/velero/issues/5334

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
