### PR TITLE
Fix restore cmd extraflag overwrite bug

### DIFF
--- a/changelogs/unreleased/5347-qiuming-best
+++ b/changelogs/unreleased/5347-qiuming-best
@@ -1,0 +1,1 @@
+Fix restore cmd extraflag overwrite bug

--- a/pkg/uploader/provider/restic.go
+++ b/pkg/uploader/provider/restic.go
@@ -91,11 +91,18 @@ func NewResticUploaderProvider(
 }
 
 func (rp *resticProvider) Close(ctx context.Context) error {
-	if err := os.Remove(rp.credentialsFile); err != nil {
-		rp.log.Warnf("Failed to remove file %s with err %v", rp.credentialsFile, err)
+	_, err := os.Stat(rp.credentialsFile)
+	if err == nil {
+		return os.Remove(rp.credentialsFile)
+	} else if !os.IsNotExist(err) {
+		return errors.Errorf("failed to get file %s info with error %v", rp.credentialsFile, err)
 	}
-	if err := os.Remove(rp.caCertFile); err != nil {
-		rp.log.Warnf("Failed to remove file %s with err %v", rp.caCertFile, err)
+
+	_, err = os.Stat(rp.caCertFile)
+	if err == nil {
+		return os.Remove(rp.caCertFile)
+	} else if !os.IsNotExist(err) {
+		return errors.Errorf("failed to get file %s info with error %v", rp.caCertFile, err)
 	}
 	return nil
 }
@@ -134,7 +141,7 @@ func (rp *resticProvider) RunBackup(
 			log.Debugf("Restic backup got empty dir with %s path", path)
 			return "", true, nil
 		}
-		return "", false, errors.WithStack(fmt.Errorf("error running restic backup with error: %v", err))
+		return "", false, errors.WithStack(fmt.Errorf("error running restic backup command %s with error: %v stderr: %v", backupCmd.String(), err, stderrBuf))
 	}
 	// GetSnapshotID
 	snapshotIdCmd := restic.GetSnapshotCommand(rp.repoIdentifier, rp.credentialsFile, tags)
@@ -145,7 +152,7 @@ func (rp *resticProvider) RunBackup(
 	if err != nil {
 		return "", false, errors.WithStack(fmt.Errorf("error getting snapshot id with error: %v", err))
 	}
-	log.Debugf("Run command=%s, stdout=%s, stderr=%s", backupCmd.String(), summary, stderrBuf)
+	log.Infof("Run command=%s, stdout=%s, stderr=%s", backupCmd.String(), summary, stderrBuf)
 	return snapshotID, false, nil
 }
 
@@ -167,10 +174,11 @@ func (rp *resticProvider) RunRestore(
 	restoreCmd := ResticRestoreCMDFunc(rp.repoIdentifier, rp.credentialsFile, snapshotID, volumePath)
 	restoreCmd.Env = rp.cmdEnv
 	restoreCmd.CACertFile = rp.caCertFile
-	restoreCmd.ExtraFlags = rp.extraFlags
-
+	if len(rp.extraFlags) != 0 {
+		restoreCmd.ExtraFlags = append(restoreCmd.ExtraFlags, rp.extraFlags...)
+	}
 	stdout, stderr, err := restic.RunRestore(restoreCmd, log, updater)
 
-	log.Debugf("Run command=%s, stdout=%s, stderr=%s", restoreCmd.Command, stdout, stderr)
+	log.Infof("Run command=%s, stdout=%s, stderr=%s", restoreCmd.Command, stdout, stderr)
 	return err
 }


### PR DESCRIPTION
Signed-off-by: Ming <mqiu@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Fix restore from backup will override extraflag bug
Change RunBackup and RunRestore debug log into Info level log for error tracking
Check credentialsFile and caCertFile file whether are exist before remove
# Does your change fix a particular issue?

Fixes #(issue)
#5346
# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
