### PR TITLE
Added backupController's UT to test the prepareBackupRequest() method BackupStorageLocation processing logic

### DIFF
--- a/changelogs/unreleased/5329-kaovilai
+++ b/changelogs/unreleased/5329-kaovilai
@@ -1,0 +1,1 @@
+Cancel downloadRequest when timeout without downloadURL

--- a/changelogs/unreleased/5359-lyndon
+++ b/changelogs/unreleased/5359-lyndon
@@ -1,0 +1,1 @@
+Fix a repoEnsurer problem introduced by the refactor - The repoEnsurer didn't check "" state of BackupRepository, as a result, the function GetBackupRepository always returns without an error even though the ensreReady is specified.

--- a/changelogs/unreleased/5361-niulechuan
+++ b/changelogs/unreleased/5361-niulechuan
@@ -1,0 +1,1 @@
+Added backupController's UT to test the prepareBackupRequest() method BackupStorageLocation processing logic

--- a/pkg/controller/backup_controller_test.go
+++ b/pkg/controller/backup_controller_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/version"
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -283,6 +284,117 @@ func TestBackupLocationLabel(t *testing.T) {
 			res := c.prepareBackupRequest(test.backup)
 			assert.NotNil(t, res)
 			assert.Equal(t, test.expectedBackupLocation, res.Labels[velerov1api.StorageLocationLabel])
+		})
+	}
+}
+
+func Test_prepareBackupRequest_BackupStorageLocation(t *testing.T) {
+	var (
+		defaultBackupTTL      = metav1.Duration{Duration: 24 * 30 * time.Hour}
+		defaultBackupLocation = "default-location"
+	)
+
+	now, err := time.Parse(time.RFC1123Z, time.RFC1123Z)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name                             string
+		backup                           *velerov1api.Backup
+		backupLocationNameInBackup       string
+		backupLocationInApiServer        *velerov1api.BackupStorageLocation
+		defaultBackupLocationInApiServer *velerov1api.BackupStorageLocation
+		expectedBackupLocation           string
+		expectedSuccess                  bool
+		expectedValidationError          string
+	}{
+		{
+			name:                             "BackupLocation is specified in backup CR'spec and it can be found in ApiServer",
+			backup:                           builder.ForBackup("velero", "backup-1").Result(),
+			backupLocationNameInBackup:       "test-backup-location",
+			backupLocationInApiServer:        builder.ForBackupStorageLocation("velero", "test-backup-location").Result(),
+			defaultBackupLocationInApiServer: builder.ForBackupStorageLocation("velero", "default-location").Result(),
+			expectedBackupLocation:           "test-backup-location",
+			expectedSuccess:                  true,
+		},
+		{
+			name:                             "BackupLocation is specified in backup CR'spec and it can't be found in ApiServer",
+			backup:                           builder.ForBackup("velero", "backup-1").Result(),
+			backupLocationNameInBackup:       "test-backup-location",
+			backupLocationInApiServer:        nil,
+			defaultBackupLocationInApiServer: nil,
+			expectedSuccess:                  false,
+			expectedValidationError:          "an existing backup storage location wasn't specified at backup creation time and the default 'test-backup-location' wasn't found. Please address this issue (see `velero backup-location -h` for options) and create a new backup. Error: backupstoragelocations.velero.io \"test-backup-location\" not found",
+		},
+		{
+			name:                             "Using default BackupLocation and it can be found in ApiServer",
+			backup:                           builder.ForBackup("velero", "backup-1").Result(),
+			backupLocationNameInBackup:       "",
+			backupLocationInApiServer:        builder.ForBackupStorageLocation("velero", "test-backup-location").Result(),
+			defaultBackupLocationInApiServer: builder.ForBackupStorageLocation("velero", "default-location").Result(),
+			expectedBackupLocation:           defaultBackupLocation,
+			expectedSuccess:                  true,
+		},
+		{
+			name:                             "Using default BackupLocation and it can't be found in ApiServer",
+			backup:                           builder.ForBackup("velero", "backup-1").Result(),
+			backupLocationNameInBackup:       "",
+			backupLocationInApiServer:        nil,
+			defaultBackupLocationInApiServer: nil,
+			expectedSuccess:                  false,
+			expectedValidationError:          fmt.Sprintf("an existing backup storage location wasn't specified at backup creation time and the server default '%s' doesn't exist. Please address this issue (see `velero backup-location -h` for options) and create a new backup. Error: backupstoragelocations.velero.io \"%s\" not found", defaultBackupLocation, defaultBackupLocation),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Arrange
+			var (
+				formatFlag      = logging.FormatText
+				logger          = logging.DefaultLogger(logrus.DebugLevel, formatFlag)
+				apiServer       = velerotest.NewAPIServer(t)
+				sharedInformers = informers.NewSharedInformerFactory(apiServer.VeleroClient, 0)
+			)
+
+			// objects that should init with client
+			objects := make([]runtime.Object, 0)
+			if test.backupLocationInApiServer != nil {
+				objects = append(objects, test.backupLocationInApiServer)
+			}
+			if test.defaultBackupLocationInApiServer != nil {
+				objects = append(objects, test.defaultBackupLocationInApiServer)
+			}
+			fakeClient := velerotest.NewFakeControllerRuntimeClient(t, objects...)
+
+			discoveryHelper, err := discovery.NewHelper(apiServer.DiscoveryClient, logger)
+			require.NoError(t, err)
+
+			c := &backupController{
+				genericController:      newGenericController("backup-test", logger),
+				discoveryHelper:        discoveryHelper,
+				defaultBackupLocation:  defaultBackupLocation,
+				kbClient:               fakeClient,
+				snapshotLocationLister: sharedInformers.Velero().V1().VolumeSnapshotLocations().Lister(),
+				defaultBackupTTL:       defaultBackupTTL.Duration,
+				clock:                  clock.NewFakeClock(now),
+				formatFlag:             formatFlag,
+			}
+
+			test.backup.Spec.StorageLocation = test.backupLocationNameInBackup
+
+			// Run
+			res := c.prepareBackupRequest(test.backup)
+
+			// Assert
+			if test.expectedSuccess {
+				assert.Equal(t, test.expectedBackupLocation, res.Spec.StorageLocation)
+				assert.NotNil(t, res)
+			} else {
+				// in every test case, we only trigger one error at once
+				if len(res.Status.ValidationErrors) > 1 {
+					assert.Fail(t, "multi error found in request")
+				}
+				assert.Equal(t, test.expectedValidationError, res.Status.ValidationErrors[0])
+			}
 		})
 	}
 }

--- a/pkg/podvolume/restorer_test.go
+++ b/pkg/podvolume/restorer_test.go
@@ -28,6 +28,7 @@ func TestGetVolumesRepositoryType(t *testing.T) {
 		volumes     map[string]volumeBackupInfo
 		expected    string
 		expectedErr string
+		prefixOnly  bool
 	}{
 		{
 			name:        "empty volume",
@@ -65,7 +66,8 @@ func TestGetVolumesRepositoryType(t *testing.T) {
 				"volume1": {"", "", "fake-type1"},
 				"volume2": {"fake-snapshot-id-2", "fake-uploader-2", "fake-type2"},
 			},
-			expectedErr: "multiple repository type in one backup, current type fake-type1, differential one [type fake-type2, snapshot ID fake-snapshot-id-2, uploader fake-uploader-2]",
+			prefixOnly:  true,
+			expectedErr: "multiple repository type in one backup",
 		},
 		{
 			name: "success",
@@ -84,9 +86,17 @@ func TestGetVolumesRepositoryType(t *testing.T) {
 			assert.Equal(t, tc.expected, actual)
 
 			if err != nil {
-				assert.EqualError(t, err, tc.expectedErr)
+				if tc.prefixOnly {
+					errMsg := err.Error()
+					if len(errMsg) >= len(tc.expectedErr) {
+						errMsg = errMsg[0:len(tc.expectedErr)]
+					}
+
+					assert.Equal(t, tc.expectedErr, errMsg)
+				} else {
+					assert.EqualError(t, err, tc.expectedErr)
+				}
 			}
 		})
-
 	}
 }

--- a/pkg/repository/backup_repo_op.go
+++ b/pkg/repository/backup_repo_op.go
@@ -83,7 +83,7 @@ func GetBackupRepository(ctx context.Context, cli client.Client, namespace strin
 			return nil, errors.Errorf("backup repository is not ready: %s", repo.Status.Message)
 		}
 
-		if repo.Status.Phase == velerov1api.BackupRepositoryPhaseNew {
+		if repo.Status.Phase == "" || repo.Status.Phase == velerov1api.BackupRepositoryPhaseNew {
 			return nil, backupRepoNotProvisionedError
 		}
 	}

--- a/pkg/repository/backup_repo_op_test.go
+++ b/pkg/repository/backup_repo_op_test.go
@@ -97,6 +97,14 @@ func TestGetBackupRepository(t *testing.T) {
 			expected:            buildBackupRepoPointer(BackupRepositoryKey{"fake-volume-ns-02", "fake-bsl-02", "fake-repository-type-02"}, velerov1api.BackupRepositoryPhaseNew, "02"),
 		},
 		{
+			name: "repository state is empty, not expect ready",
+			backupRepositories: []velerov1api.BackupRepository{
+				buildBackupRepo(BackupRepositoryKey{"fake-volume-ns-01", "fake-bsl-01", "fake-repository-type-01"}, velerov1api.BackupRepositoryPhaseReady, "01"),
+				buildBackupRepo(BackupRepositoryKey{"fake-volume-ns-02", "fake-bsl-02", "fake-repository-type-02"}, "", "02")},
+			backupRepositoryKey: BackupRepositoryKey{"fake-volume-ns-02", "fake-bsl-02", "fake-repository-type-02"},
+			expected:            buildBackupRepoPointer(BackupRepositoryKey{"fake-volume-ns-02", "fake-bsl-02", "fake-repository-type-02"}, "", "02"),
+		},
+		{
 			name: "repository not ready, expect ready",
 			backupRepositories: []velerov1api.BackupRepository{
 				buildBackupRepo(BackupRepositoryKey{"fake-volume-ns-01", "fake-bsl-01", "fake-repository-type-01"}, velerov1api.BackupRepositoryPhaseReady, "01"),
@@ -110,6 +118,15 @@ func TestGetBackupRepository(t *testing.T) {
 			backupRepositories: []velerov1api.BackupRepository{
 				buildBackupRepo(BackupRepositoryKey{"fake-volume-ns-01", "fake-bsl-01", "fake-repository-type-01"}, velerov1api.BackupRepositoryPhaseReady, "01"),
 				buildBackupRepo(BackupRepositoryKey{"fake-volume-ns-02", "fake-bsl-02", "fake-repository-type-02"}, velerov1api.BackupRepositoryPhaseNew, "02")},
+			backupRepositoryKey: BackupRepositoryKey{"fake-volume-ns-02", "fake-bsl-02", "fake-repository-type-02"},
+			ensureReady:         true,
+			expectedErr:         "backup repository not provisioned",
+		},
+		{
+			name: "repository state is empty, expect ready",
+			backupRepositories: []velerov1api.BackupRepository{
+				buildBackupRepo(BackupRepositoryKey{"fake-volume-ns-01", "fake-bsl-01", "fake-repository-type-01"}, velerov1api.BackupRepositoryPhaseReady, "01"),
+				buildBackupRepo(BackupRepositoryKey{"fake-volume-ns-02", "fake-bsl-02", "fake-repository-type-02"}, "", "02")},
 			backupRepositoryKey: BackupRepositoryKey{"fake-volume-ns-02", "fake-bsl-02", "fake-repository-type-02"},
 			ensureReady:         true,
 			expectedErr:         "backup repository not provisioned",
@@ -135,7 +152,7 @@ func TestGetBackupRepository(t *testing.T) {
 
 			backupRepo, err := GetBackupRepository(context.Background(), fakeClient, velerov1api.DefaultNamespace, tc.backupRepositoryKey, tc.ensureReady)
 
-			if backupRepo != nil {
+			if backupRepo != nil && tc.expected != nil {
 				backupRepo.ResourceVersion = tc.expected.ResourceVersion
 				require.Equal(t, *tc.expected, *backupRepo)
 			} else {


### PR DESCRIPTION
# Please add a summary of your change

Added backupController's UT to test the prepareBackupRequest() method BackupStorageLocation processing logic. This important test was missing in the original UT.

The current test for prepareBackupRequest() is:
1. Is the backupLocationLabel set correctly?
2. Is backupTTL set correctly?

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:


- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.

/kind changelog-not-required