### PR TITLE
support custom file when download backup

### DIFF
--- a/changelogs/unreleased/5378-cleverhu
+++ b/changelogs/unreleased/5378-cleverhu
@@ -1,0 +1,1 @@
+Support download custom backup resources.


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
support custom file when download backup.

# Does your change fix a particular issue?

Fixes https://github.com/vmware-tanzu/velero/issues/5376 https://github.com/vmware-tanzu/velero/issues/5371

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
