### PR TITLE
Document preserveNodePorts option in Restore spec.

### DIFF
--- a/site/content/docs/main/api-types/restore.md
+++ b/site/content/docs/main/api-types/restore.md
@@ -91,6 +91,9 @@ spec:
   # RestorePVs specifies whether to restore all included PVs
   # from snapshot (via the cloudprovider).
   restorePVs: true
+  # PreserveNodePorts specifies whether to restore old
+  # nodePorts from backup.
+  preserveNodePorts: true
   # ScheduleName is the unique name of the Velero schedule
   # to restore from. If specified, and BackupName is empty, Velero will
   # restore from the most recent successful backup created from this schedule.

--- a/site/content/docs/v1.6/api-types/restore.md
+++ b/site/content/docs/v1.6/api-types/restore.md
@@ -69,6 +69,9 @@ spec:
   # RestorePVs specifies whether to restore all included PVs
   # from snapshot (via the cloudprovider).
   restorePVs: true
+  # PreserveNodePorts specifies whether to restore old
+  # nodePorts from backup.
+  preserveNodePorts: true
   # ScheduleName is the unique name of the Velero schedule
   # to restore from. If specified, and BackupName is empty, Velero will
   # restore from the most recent successful backup created from this schedule.

--- a/site/content/docs/v1.7/api-types/restore.md
+++ b/site/content/docs/v1.7/api-types/restore.md
@@ -69,6 +69,9 @@ spec:
   # RestorePVs specifies whether to restore all included PVs
   # from snapshot (via the cloudprovider).
   restorePVs: true
+  # PreserveNodePorts specifies whether to restore old
+  # nodePorts from backup.
+  preserveNodePorts: true
   # ScheduleName is the unique name of the Velero schedule
   # to restore from. If specified, and BackupName is empty, Velero will
   # restore from the most recent successful backup created from this schedule.

--- a/site/content/docs/v1.8/api-types/restore.md
+++ b/site/content/docs/v1.8/api-types/restore.md
@@ -69,6 +69,9 @@ spec:
   # RestorePVs specifies whether to restore all included PVs
   # from snapshot (via the cloudprovider).
   restorePVs: true
+  # PreserveNodePorts specifies whether to restore old
+  # nodePorts from backup.
+  preserveNodePorts: true
   # ScheduleName is the unique name of the Velero schedule
   # to restore from. If specified, and BackupName is empty, Velero will
   # restore from the most recent successful backup created from this schedule.

--- a/site/content/docs/v1.9/api-types/restore.md
+++ b/site/content/docs/v1.9/api-types/restore.md
@@ -91,6 +91,9 @@ spec:
   # RestorePVs specifies whether to restore all included PVs
   # from snapshot (via the cloudprovider).
   restorePVs: true
+  # PreserveNodePorts specifies whether to restore old
+  # nodePorts from backup.
+  preserveNodePorts: true
   # ScheduleName is the unique name of the Velero schedule
   # to restore from. If specified, and BackupName is empty, Velero will
   # restore from the most recent successful backup created from this schedule.


### PR DESCRIPTION
Signed-off-by: Raghuram Devarakonda <draghuram@gmail.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Restore API doc is missing the field "preserveNodePorts" and this PR adds it (to all the versions starting from 1.6 where this flag was introduced). 

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [Yes ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ Yes] Updated the corresponding documentation in `site/content/docs/main`.
