### PR TITLE
Fix Test_prepareBackupRequest_BackupStorageLocation UT failure.

### DIFF
--- a/changelogs/unreleased/5394-blackpiglet
+++ b/changelogs/unreleased/5394-blackpiglet
@@ -1,0 +1,1 @@
+Fix Test_prepareBackupRequest_BackupStorageLocation UT failure.

--- a/pkg/controller/backup_controller_test.go
+++ b/pkg/controller/backup_controller_test.go
@@ -382,7 +382,7 @@ func Test_prepareBackupRequest_BackupStorageLocation(t *testing.T) {
 			test.backup.Spec.StorageLocation = test.backupLocationNameInBackup
 
 			// Run
-			res := c.prepareBackupRequest(test.backup)
+			res := c.prepareBackupRequest(test.backup, logger)
 
 			// Assert
 			if test.expectedSuccess {


### PR DESCRIPTION
Signed-off-by: Xun Jiang <blackpiglet@gmail.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Fix UT case `Test_prepareBackupRequest_BackupStorageLocation` introduced by https://github.com/vmware-tanzu/velero/pull/5362 failure.
function `prepareBackupRequest` add an additional logger parameter in #5370 .

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
