### PR TITLE
[1.9.x] - Skip the exclusion check for additional resources returned by BIA

### DIFF
--- a/changelogs/unreleased/5406-reasonerjt
+++ b/changelogs/unreleased/5406-reasonerjt
@@ -1,0 +1,1 @@
+Skip the exclusion check for additional resources returned by BIA

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -408,7 +408,7 @@ func (kb *kubernetesBackupper) BackupWithResolvers(log logrus.FieldLogger,
 }
 
 func (kb *kubernetesBackupper) backupItem(log logrus.FieldLogger, gr schema.GroupResource, itemBackupper *itemBackupper, unstructured *unstructured.Unstructured, preferredGVR schema.GroupVersionResource) bool {
-	backedUpItem, err := itemBackupper.backupItem(log, unstructured, gr, preferredGVR)
+	backedUpItem, err := itemBackupper.backupItem(log, unstructured, gr, preferredGVR, false)
 	if aggregate, ok := err.(kubeerrs.Aggregate); ok {
 		log.WithField("name", unstructured.GetName()).Infof("%d errors encountered backup up item", len(aggregate.Errors()))
 		// log each error separately so we get error location info in the log, and an


### PR DESCRIPTION
Introduce a simple contract so that BIA plugin developer can force the additional items be backed up

Signed-off-by: Daniel Jiang <jiangd@vmware.com>

Thank you for contributing to Velero!

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
