### PR TITLE
Fix issues of E2E test for API group, migration and pv opt-out backup 

### DIFF
--- a/test/e2e/basic/enable_api_group_versions.go
+++ b/test/e2e/basic/enable_api_group_versions.go
@@ -36,7 +36,6 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/builder"
 	veleroexec "github.com/vmware-tanzu/velero/pkg/util/exec"
 	. "github.com/vmware-tanzu/velero/test/e2e"
-	. "github.com/vmware-tanzu/velero/test/e2e/util/common"
 	. "github.com/vmware-tanzu/velero/test/e2e/util/k8s"
 	. "github.com/vmware-tanzu/velero/test/e2e/util/velero"
 )
@@ -450,8 +449,7 @@ func runEnableAPIGroupVersionsTests(ctx context.Context, client TestClient, reso
 			// No custom resource should have been restored. Expect "no resource found"
 			// error during restore.
 			err := VeleroRestore(ctx, VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace, restore, backup, "")
-
-			if err.Error() != "Unexpected restore phase got PartiallyFailed, expecting Completed" {
+			if !strings.Contains(err.Error(), "Unexpected restore phase got PartiallyFailed, expecting Completed") {
 				return errors.New("expected error but not none")
 			}
 		}
@@ -467,7 +465,7 @@ func runEnableAPIGroupVersionsTests(ctx context.Context, client TestClient, reso
 
 func installCRD(ctx context.Context, yaml string) error {
 	fmt.Printf("Install CRD with %s.\n", yaml)
-	err := KubectlApplyFile(ctx, yaml)
+	err := KubectlApplyByFile(ctx, yaml)
 	return err
 }
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -81,7 +81,7 @@ func init() {
 	flag.StringVar(&VeleroCfg.UploaderType, "uploader-type", "", "Identify persistent volume backup uploader.")
 }
 
-var _ = Describe("[APIGroup] Velero tests with various CRD API group versions", APIGropuVersionsTest)
+var _ = Describe("[APIGroup][Common] Velero tests with various CRD API group versions", APIGropuVersionsTest)
 var _ = Describe("[APIGroup][APIExtensions] CRD of apiextentions v1beta1 should be B/R successfully from cluster(k8s version < 1.22) to cluster(k8s version >= 1.22)", APIExtensionsVersionsTest)
 
 // Test backup and restore of Kibishi using restic

--- a/test/e2e/migration/migration.go
+++ b/test/e2e/migration/migration.go
@@ -113,11 +113,9 @@ func MigrationTest(useVolumeSnapshots bool, veleroCLI2Version VeleroCLI2Version)
 					}
 				})
 			}
-
+			OriginVeleroCfg := VeleroCfg
 			By(fmt.Sprintf("Install Velero in cluster-A (%s) to backup workload", VeleroCfg.DefaultCluster), func() {
 				Expect(KubectlConfigUseContext(context.Background(), VeleroCfg.DefaultCluster)).To(Succeed())
-
-				OriginVeleroCfg := VeleroCfg
 				OriginVeleroCfg.MigrateFromVeleroVersion = veleroCLI2Version.VeleroVersion
 				OriginVeleroCfg.VeleroCLI = veleroCLI2Version.VeleroCLI
 				OriginVeleroCfg.ClientToInstallVelero = OriginVeleroCfg.DefaultClient
@@ -158,9 +156,14 @@ func MigrationTest(useVolumeSnapshots bool, veleroCLI2Version VeleroCLI2Version)
 				BackupStorageClassCfg.BackupName = backupScName
 				BackupStorageClassCfg.IncludeResources = "StorageClass"
 				BackupStorageClassCfg.IncludeClusterResources = true
+				//TODO Remove UseRestic parameter once minor version is 1.10 or upper
+				BackupStorageClassCfg.UseRestic = true
+				if veleroCLI2Version.VeleroVersion == "self" {
+					BackupStorageClassCfg.UseRestic = false
+				}
 
-				Expect(VeleroBackupNamespace(context.Background(), VeleroCfg.VeleroCLI,
-					VeleroCfg.VeleroNamespace, BackupStorageClassCfg)).To(Succeed(), func() string {
+				Expect(VeleroBackupNamespace(context.Background(), OriginVeleroCfg.VeleroCLI,
+					OriginVeleroCfg.VeleroNamespace, BackupStorageClassCfg)).To(Succeed(), func() string {
 					RunDebug(context.Background(), VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace, BackupStorageClassCfg.BackupName, "")
 					return "Fail to backup workload"
 				})
@@ -171,9 +174,14 @@ func MigrationTest(useVolumeSnapshots bool, veleroCLI2Version VeleroCLI2Version)
 				BackupCfg.UseVolumeSnapshots = useVolumeSnapshots
 				BackupCfg.BackupLocation = ""
 				BackupCfg.Selector = ""
-				Expect(VeleroBackupNamespace(context.Background(), VeleroCfg.VeleroCLI,
-					VeleroCfg.VeleroNamespace, BackupCfg)).To(Succeed(), func() string {
-					RunDebug(context.Background(), VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace, BackupCfg.BackupName, "")
+				//TODO Remove UseRestic parameter once minor version is 1.10 or upper
+				BackupCfg.UseRestic = true
+				if veleroCLI2Version.VeleroVersion == "self" {
+					BackupCfg.UseRestic = false
+				}
+				Expect(VeleroBackupNamespace(context.Background(), OriginVeleroCfg.VeleroCLI,
+					OriginVeleroCfg.VeleroNamespace, BackupCfg)).To(Succeed(), func() string {
+					RunDebug(context.Background(), OriginVeleroCfg.VeleroCLI, OriginVeleroCfg.VeleroNamespace, BackupCfg.BackupName, "")
 					return "Fail to backup workload"
 				})
 			})

--- a/test/e2e/pv-backup/pv-backup-filter.go
+++ b/test/e2e/pv-backup/pv-backup-filter.go
@@ -12,7 +12,6 @@ import (
 
 	. "github.com/vmware-tanzu/velero/test/e2e"
 	. "github.com/vmware-tanzu/velero/test/e2e/test"
-	. "github.com/vmware-tanzu/velero/test/e2e/util/common"
 	. "github.com/vmware-tanzu/velero/test/e2e/util/k8s"
 )
 
@@ -46,7 +45,7 @@ func (p *PVBackupFiltering) Init() error {
 }
 
 func (p *PVBackupFiltering) StartRun() error {
-	err := installStorageClass(p.Ctx, fmt.Sprintf("testdata/storage-class/%s.yaml", VeleroCfg.CloudProvider))
+	err := installStorageClass(context.Background(), fmt.Sprintf("testdata/storage-class/%s.yaml", VeleroCfg.CloudProvider))
 	if err != nil {
 		return err
 	}
@@ -57,8 +56,10 @@ func (p *PVBackupFiltering) StartRun() error {
 		"--include-namespaces", strings.Join(*p.NSIncluded, ","),
 		"--snapshot-volumes=false", "--wait",
 	}
+	// "--default-volumes-to-fs-backup" is an overall switch, if it's set, then opt-in
+	//   annotation will be ignored, so it's only set for opt-out test
 	if p.annotation == OPT_OUT_ANN {
-		p.BackupArgs = append(p.BackupArgs, "--default-volumes-to-restic")
+		p.BackupArgs = append(p.BackupArgs, "--default-volumes-to-fs-backup")
 
 	}
 	p.RestoreArgs = []string{
@@ -204,6 +205,6 @@ func fileNotExist(ctx context.Context, namespace, podName, volume string) error 
 
 func installStorageClass(ctx context.Context, yaml string) error {
 	fmt.Printf("Install storage class with %s.\n", yaml)
-	err := KubectlApplyFile(ctx, yaml)
+	err := KubectlApplyByFile(ctx, yaml)
 	return err
 }

--- a/test/e2e/util/common/common.go
+++ b/test/e2e/util/common/common.go
@@ -6,10 +6,6 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
-
-	"github.com/pkg/errors"
-
-	veleroexec "github.com/vmware-tanzu/velero/pkg/util/exec"
 )
 
 type OsCommandLine struct {
@@ -55,16 +51,4 @@ func GetListBy2Pipes(ctx context.Context, cmdline1, cmdline2, cmdline3 OsCommand
 	}
 
 	return ret, nil
-}
-
-func KubectlApplyFile(ctx context.Context, yaml string) error {
-	fmt.Printf("Kube apply file %s.\n", yaml)
-	cmd := exec.CommandContext(ctx, "kubectl", "apply", "-f", yaml)
-
-	_, stderr, err := veleroexec.RunCommand(cmd)
-	if err != nil {
-		return errors.Wrap(err, stderr)
-	}
-
-	return nil
 }

--- a/test/e2e/util/velero/velero_utils.go
+++ b/test/e2e/util/velero/velero_utils.go
@@ -443,7 +443,7 @@ func VeleroCmdExec(ctx context.Context, veleroCLI string, args []string) error {
 	err := cmd.Run()
 	retAll := outBuf.String() + " " + errBuf.String()
 	if strings.Contains(strings.ToLower(retAll), "failed") {
-		return errors.New(fmt.Sprintf("velero cmd =%v return with failure\n", cmd))
+		return errors.Wrap(err, fmt.Sprintf("velero cmd =%v return with failure\n", cmd))
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
1. One of API group test failed due to other PR with fix for treat PartiallyFailed as failure to collect debugbundle without wrap the origin error;
2. Fix migration test issue of wrong velero cli for backup commmand;
3. Fix wrong pararmeter name issue for pv opt-out backup test.

Signed-off-by: danfengl <danfengl@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
