### PR TITLE
Fix E2E test and Git action CI issues

### DIFF
--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -117,12 +117,17 @@ jobs:
           aws_access_key_id=minio
           aws_secret_access_key=minio123
           EOF
+
+          # Match kubectl version to k8s server version
+          curl -LO https://dl.k8s.io/release/v${{ matrix.k8s }}/bin/linux/amd64/kubectl
+          sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+
           GOPATH=~/go CLOUD_PROVIDER=kind \
               OBJECT_STORE_PROVIDER=aws BSL_CONFIG=region=minio,s3ForcePathStyle="true",s3Url=http://$(hostname -i):9000 \
               CREDS_FILE=/tmp/credential BSL_BUCKET=bucket \
               ADDITIONAL_OBJECT_STORE_PROVIDER=aws ADDITIONAL_BSL_CONFIG=region=minio,s3ForcePathStyle="true",s3Url=http://$(hostname -i):9000 \
               ADDITIONAL_CREDS_FILE=/tmp/credential ADDITIONAL_BSL_BUCKET=additional-bucket \
-              GINKGO_FOCUS='Basic\].+\[ClusterResource' VELERO_IMAGE=velero:pr-test \
+              GINKGO_FOCUS='Basic\]\[ClusterResource' VELERO_IMAGE=velero:pr-test \
               make -C test/e2e run
         timeout-minutes: 30
       - name: Upload debug bundle

--- a/pkg/cmd/cli/install/install.go
+++ b/pkg/cmd/cli/install/install.go
@@ -43,29 +43,31 @@ import (
 
 // InstallOptions collects all the options for installing Velero into a Kubernetes cluster.
 type InstallOptions struct {
-	Namespace                       string
-	Image                           string
-	BucketName                      string
-	Prefix                          string
-	ProviderName                    string
-	PodAnnotations                  flag.Map
-	PodLabels                       flag.Map
-	ServiceAccountAnnotations       flag.Map
-	VeleroPodCPURequest             string
-	VeleroPodMemRequest             string
-	VeleroPodCPULimit               string
-	VeleroPodMemLimit               string
-	NodeAgentPodCPURequest          string
-	NodeAgentPodMemRequest          string
-	NodeAgentPodCPULimit            string
-	NodeAgentPodMemLimit            string
-	RestoreOnly                     bool
-	SecretFile                      string
-	NoSecret                        bool
-	DryRun                          bool
-	BackupStorageConfig             flag.Map
-	VolumeSnapshotConfig            flag.Map
-	UseNodeAgent                    bool
+	Namespace                 string
+	Image                     string
+	BucketName                string
+	Prefix                    string
+	ProviderName              string
+	PodAnnotations            flag.Map
+	PodLabels                 flag.Map
+	ServiceAccountAnnotations flag.Map
+	VeleroPodCPURequest       string
+	VeleroPodMemRequest       string
+	VeleroPodCPULimit         string
+	VeleroPodMemLimit         string
+	NodeAgentPodCPURequest    string
+	NodeAgentPodMemRequest    string
+	NodeAgentPodCPULimit      string
+	NodeAgentPodMemLimit      string
+	RestoreOnly               bool
+	SecretFile                string
+	NoSecret                  bool
+	DryRun                    bool
+	BackupStorageConfig       flag.Map
+	VolumeSnapshotConfig      flag.Map
+	UseNodeAgent              bool
+	//TODO remove UseRestic when migration test out of using it
+	UseRestic                       bool
 	Wait                            bool
 	UseVolumeSnapshots              bool
 	DefaultRepoMaintenanceFrequency time.Duration

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -48,6 +48,7 @@ OUTPUT_DIR := _output/$(GOOS)/$(GOARCH)/bin
 GINKGO_FOCUS ?=
 GINKGO_SKIP ?=
 SKIP_STR := $(foreach var, $(subst ., ,$(GINKGO_SKIP)),-skip "$(var)")
+FOCUS_STR := $(foreach var, $(subst ., ,$(GINKGO_FOCUS)),-focus "$(var)")
 VELERO_CLI ?=$$(pwd)/../../_output/bin/$(GOOS)/$(GOARCH)/velero
 VELERO_IMAGE ?= velero/velero:main
 VELERO_VERSION ?= $(VERSION)
@@ -110,7 +111,7 @@ run: ginkgo
 			(echo "Bucket to store the backups from E2E tests is required, please re-run with BSL_BUCKET=<BucketName>"; exit 1 )
 		@[ "${CLOUD_PROVIDER}" ] && echo "Using cloud provider ${CLOUD_PROVIDER}" || \
 			(echo "Cloud provider for target cloud/plug-in provider is required, please rerun with CLOUD_PROVIDER=<aws,azure,kind,vsphere>"; exit 1)
-	@$(GINKGO) -v -focus="$(GINKGO_FOCUS)" $(SKIP_STR) . -- -velerocli=$(VELERO_CLI) \
+	@$(GINKGO) -v $(FOCUS_STR) $(SKIP_STR) . -- -velerocli=$(VELERO_CLI) \
 		-velero-image=$(VELERO_IMAGE) \
 		-plugins=$(PLUGINS) \
 		-velero-version=$(VELERO_VERSION) \

--- a/test/e2e/basic/resources-check/namespaces.go
+++ b/test/e2e/basic/resources-check/namespaces.go
@@ -121,6 +121,7 @@ func (m *MultiNSBackup) Verify() error {
 }
 
 func (m *MultiNSBackup) Destroy() error {
+	m.Ctx, _ = context.WithTimeout(context.Background(), 60*time.Minute)
 	err := CleanupNamespaces(m.Ctx, m.Client, m.NSBaseName)
 	if err != nil {
 		return errors.Wrap(err, "Could cleanup retrieve namespaces")

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -37,6 +37,7 @@ import (
 	. "github.com/vmware-tanzu/velero/test/e2e/privilegesmgmt"
 	. "github.com/vmware-tanzu/velero/test/e2e/pv-backup"
 	. "github.com/vmware-tanzu/velero/test/e2e/resource-filtering"
+
 	. "github.com/vmware-tanzu/velero/test/e2e/scale"
 	. "github.com/vmware-tanzu/velero/test/e2e/upgrade"
 
@@ -126,8 +127,10 @@ var _ = Describe("[Migration][Snapshot]", MigrationWithSnapshots)
 
 var _ = Describe("[Schedule][OrederedResources] Backup resources should follow the specific order in schedule", ScheduleOrderedResources)
 
-var _ = Describe("[NamespaceMapping][Single] Backup resources should follow the specific order in schedule", OneNamespaceMappingTest)
-var _ = Describe("[NamespaceMapping][Multiple] Backup resources should follow the specific order in schedule", MultiNamespacesMappingTest)
+var _ = Describe("[NamespaceMapping][Single][Restic] Backup resources should follow the specific order in schedule", OneNamespaceMappingResticTest)
+var _ = Describe("[NamespaceMapping][Multiple][Restic]  Backup resources should follow the specific order in schedule", MultiNamespacesMappingResticTest)
+var _ = Describe("[NamespaceMapping][Single][Snapshot]  Backup resources should follow the specific order in schedule", OneNamespaceMappingSnapshotTest)
+var _ = Describe("[NamespaceMapping][Multiple][Snapshot]  Backup resources should follow the specific order in schedule", MultiNamespacesMappingSnapshotTest)
 
 var _ = Describe("[pv-backup][Opt-In] Backup resources should follow the specific order in schedule", OptInPVBackupTest)
 var _ = Describe("[pv-backup][Opt-Out] Backup resources should follow the specific order in schedule", OptOutPVBackupTest)

--- a/test/e2e/migration/migration.go
+++ b/test/e2e/migration/migration.go
@@ -126,6 +126,8 @@ func MigrationTest(useVolumeSnapshots bool, veleroCLI2Version VeleroCLI2Version)
 					OriginVeleroCfg.Plugins = ""
 					//TODO: Remove this once origin Velero version is 1.10 and upper
 					OriginVeleroCfg.UploaderType = ""
+					OriginVeleroCfg.UseNodeAgent = false
+					OriginVeleroCfg.UseRestic = !useVolumeSnapshots
 				}
 				fmt.Println(OriginVeleroCfg)
 				Expect(VeleroInstall(context.Background(), &OriginVeleroCfg, useVolumeSnapshots)).To(Succeed())
@@ -157,9 +159,9 @@ func MigrationTest(useVolumeSnapshots bool, veleroCLI2Version VeleroCLI2Version)
 				BackupStorageClassCfg.IncludeResources = "StorageClass"
 				BackupStorageClassCfg.IncludeClusterResources = true
 				//TODO Remove UseRestic parameter once minor version is 1.10 or upper
-				BackupStorageClassCfg.UseRestic = true
+				BackupStorageClassCfg.UseResticIfFSBackup = true
 				if veleroCLI2Version.VeleroVersion == "self" {
-					BackupStorageClassCfg.UseRestic = false
+					BackupStorageClassCfg.UseResticIfFSBackup = false
 				}
 
 				Expect(VeleroBackupNamespace(context.Background(), OriginVeleroCfg.VeleroCLI,
@@ -175,9 +177,9 @@ func MigrationTest(useVolumeSnapshots bool, veleroCLI2Version VeleroCLI2Version)
 				BackupCfg.BackupLocation = ""
 				BackupCfg.Selector = ""
 				//TODO Remove UseRestic parameter once minor version is 1.10 or upper
-				BackupCfg.UseRestic = true
+				BackupCfg.UseResticIfFSBackup = true
 				if veleroCLI2Version.VeleroVersion == "self" {
-					BackupCfg.UseRestic = false
+					BackupCfg.UseResticIfFSBackup = false
 				}
 				Expect(VeleroBackupNamespace(context.Background(), OriginVeleroCfg.VeleroCLI,
 					OriginVeleroCfg.VeleroNamespace, BackupCfg)).To(Succeed(), func() string {
@@ -235,6 +237,8 @@ func MigrationTest(useVolumeSnapshots bool, veleroCLI2Version VeleroCLI2Version)
 
 				VeleroCfg.ObjectStoreProvider = ""
 				VeleroCfg.ClientToInstallVelero = VeleroCfg.StandbyClient
+				VeleroCfg.UseNodeAgent = !useVolumeSnapshots
+				VeleroCfg.UseRestic = false
 				Expect(VeleroInstall(context.Background(), &VeleroCfg, useVolumeSnapshots)).To(Succeed())
 			})
 

--- a/test/e2e/privilegesmgmt/ssr.go
+++ b/test/e2e/privilegesmgmt/ssr.go
@@ -62,16 +62,14 @@ func SSRTest() {
 		Expect(CreateNamespace(ctx, *VeleroCfg.ClientToInstallVelero, testNS)).To(Succeed(),
 			fmt.Sprintf("Failed to create %s namespace", testNS))
 
-		By(fmt.Sprintf("Get version in %s namespace", testNS))
-		cmd := []string{"version", "-n", testNS}
-		Expect(VeleroCmdExec(context.Background(), VeleroCfg.VeleroCLI, cmd)).To(Succeed(),
-			fmt.Sprintf("Failed to create an ssr object in the %s namespace", testNS))
-
-		By(fmt.Sprintf("Get version in %s namespace", VeleroCfg.VeleroNamespace))
-		cmd = []string{"version", "-n", VeleroCfg.VeleroNamespace}
-		Expect(VeleroCmdExec(context.Background(), VeleroCfg.VeleroCLI, cmd)).To(Succeed(),
-			fmt.Sprintf("Failed to create an ssr object in %s namespace", VeleroCfg.VeleroNamespace))
-
+		By(fmt.Sprintf("Get version in %s namespace", testNS), func() {
+			Expect(VeleroVersion(context.Background(), VeleroCfg.VeleroCLI, testNS)).To(Succeed(),
+				fmt.Sprintf("Failed to create an ssr object in the %s namespace", testNS))
+		})
+		By(fmt.Sprintf("Get version in %s namespace", VeleroCfg.VeleroNamespace), func() {
+			Expect(VeleroVersion(context.Background(), VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace)).To(Succeed(),
+				fmt.Sprintf("Failed to create an ssr object in %s namespace", VeleroCfg.VeleroNamespace))
+		})
 		ssrListResp := new(v1.ServerStatusRequestList)
 		By(fmt.Sprintf("Check ssr object in %s namespace", VeleroCfg.VeleroNamespace))
 		err = waitutil.PollImmediate(5*time.Second, time.Minute,

--- a/test/e2e/pv-backup/pv-backup-filter.go
+++ b/test/e2e/pv-backup/pv-backup-filter.go
@@ -49,8 +49,8 @@ func (p *PVBackupFiltering) StartRun() error {
 	if err != nil {
 		return err
 	}
-	p.BackupName = p.BackupName + "backup-opt-in-" + UUIDgen.String()
-	p.RestoreName = p.RestoreName + "restore-opt-in-" + UUIDgen.String()
+	p.BackupName = p.BackupName + "backup-" + p.id + "-" + UUIDgen.String()
+	p.RestoreName = p.RestoreName + "restore-" + p.id + "-" + UUIDgen.String()
 	p.BackupArgs = []string{
 		"create", "--namespace", VeleroCfg.VeleroNamespace, "backup", p.BackupName,
 		"--include-namespaces", strings.Join(*p.NSIncluded, ","),
@@ -84,7 +84,7 @@ func (p *PVBackupFiltering) CreateResources() error {
 				for j := 0; j <= VOLUME_COUNT_PER_POD-1; j++ {
 					volume := fmt.Sprintf("volume-%s-%d-%d", p.id, i, j)
 					volumes = append(volumes, volume)
-					//Volumes cherry pick policy for opt-in/out annotation to pods
+					//Volumes cherry-pick policy for opt-in/out annotation to apply
 					if j%2 == 0 {
 						volumeToAnnotationList = append(volumeToAnnotationList, volume)
 					}

--- a/test/e2e/test/test.go
+++ b/test/e2e/test/test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -47,6 +48,7 @@ type VeleroBackupRestoreTest interface {
 	Verify() error
 	Clean() error
 	GetTestMsg() *TestMSG
+	GetTestCase() *TestCase
 }
 
 type TestMSG struct {
@@ -56,16 +58,17 @@ type TestMSG struct {
 }
 
 type TestCase struct {
-	BackupName      string
-	RestoreName     string
-	NSBaseName      string
-	BackupArgs      []string
-	RestoreArgs     []string
-	NamespacesTotal int
-	TestMsg         *TestMSG
-	Client          TestClient
-	Ctx             context.Context
-	NSIncluded      *[]string
+	BackupName         string
+	RestoreName        string
+	NSBaseName         string
+	BackupArgs         []string
+	RestoreArgs        []string
+	NamespacesTotal    int
+	TestMsg            *TestMSG
+	Client             TestClient
+	Ctx                context.Context
+	NSIncluded         *[]string
+	UseVolumeSnapshots bool
 }
 
 var TestClientInstance TestClient
@@ -79,7 +82,7 @@ func TestFunc(test VeleroBackupRestoreTest) func() {
 		BeforeEach(func() {
 			flag.Parse()
 			if VeleroCfg.InstallVelero {
-				Expect(VeleroInstall(context.Background(), &VeleroCfg, false)).To(Succeed())
+				Expect(VeleroInstall(context.Background(), &VeleroCfg, test.GetTestCase().UseVolumeSnapshots)).To(Succeed())
 			}
 		})
 		AfterEach(func() {
@@ -101,16 +104,17 @@ func TestFuncWithMultiIt(tests []VeleroBackupRestoreTest) func() {
 		By("Create test client instance", func() {
 			TestClientInstance = *VeleroCfg.ClientToInstallVelero
 		})
-
+		var useVolumeSnapshots bool
 		for k := range tests {
 			Expect(tests[k].Init()).To(Succeed(), fmt.Sprintf("Failed to instantiate test %s case", tests[k].GetTestMsg().Desc))
+			useVolumeSnapshots = tests[k].GetTestCase().UseVolumeSnapshots
 		}
 
 		BeforeEach(func() {
 			flag.Parse()
 			if VeleroCfg.InstallVelero {
 				if countIt == 0 {
-					Expect(VeleroInstall(context.Background(), &VeleroCfg, false)).To(Succeed())
+					Expect(VeleroInstall(context.Background(), &VeleroCfg, useVolumeSnapshots)).To(Succeed())
 				}
 				countIt++
 			}
@@ -148,7 +152,7 @@ func (t *TestCase) StartRun() error {
 }
 
 func (t *TestCase) Backup() error {
-	if err := VeleroCmdExec(t.Ctx, VeleroCfg.VeleroCLI, t.BackupArgs); err != nil {
+	if err := VeleroBackupExec(t.Ctx, VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace, t.BackupName, t.BackupArgs); err != nil {
 		RunDebug(context.Background(), VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace, t.BackupName, "")
 		return errors.Wrapf(err, "Failed to backup resources")
 	}
@@ -164,9 +168,17 @@ func (t *TestCase) Destroy() error {
 }
 
 func (t *TestCase) Restore() error {
+	// the snapshots of AWS may be still in pending status when do the restore, wait for a while
+	// to avoid this https://github.com/vmware-tanzu/velero/issues/1799
+	// TODO remove this after https://github.com/vmware-tanzu/velero/issues/3533 is fixed
+	if t.UseVolumeSnapshots {
+		fmt.Println("Waiting 5 minutes to make sure the snapshots are ready...")
+		time.Sleep(5 * time.Minute)
+	}
+
 	By("Start to restore ......", func() {
-		Expect(VeleroCmdExec(t.Ctx, VeleroCfg.VeleroCLI, t.RestoreArgs)).To(Succeed(), func() string {
-			RunDebug(context.Background(), VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace, t.BackupName, "")
+		Expect(VeleroRestoreExec(t.Ctx, VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace, t.RestoreName, t.RestoreArgs)).To(Succeed(), func() string {
+			RunDebug(context.Background(), VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace, "", t.RestoreName)
 			return "Fail to restore workload"
 		})
 	})
@@ -193,6 +205,9 @@ func (t *TestCase) GetTestMsg() *TestMSG {
 	return t.TestMsg
 }
 
+func (t *TestCase) GetTestCase() *TestCase {
+	return t
+}
 func RunTestCase(test VeleroBackupRestoreTest) error {
 	fmt.Printf("Running test case %s\n", test.GetTestMsg().Desc)
 	if test == nil {

--- a/test/e2e/types.go
+++ b/test/e2e/types.go
@@ -64,6 +64,8 @@ type VerleroConfig struct {
 	DefaultClient            *TestClient
 	StandbyClient            *TestClient
 	UploaderType             string
+	UseNodeAgent             bool
+	UseRestic                bool
 }
 
 type SnapshotCheckPoint struct {
@@ -87,7 +89,7 @@ type BackupConfig struct {
 	ExcludeResources        string
 	IncludeClusterResources bool
 	OrderedResources        string
-	UseRestic               bool
+	UseResticIfFSBackup     bool
 }
 
 type VeleroCLI2Version struct {

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -113,6 +113,8 @@ func BackupUpgradeRestoreTest(useVolumeSnapshots bool, veleroCLI2Version VeleroC
 				tmpCfgForOldVeleroInstall.ResticHelperImage = ""
 				tmpCfgForOldVeleroInstall.Plugins = ""
 				tmpCfgForOldVeleroInstall.UploaderType = ""
+				tmpCfgForOldVeleroInstall.UseNodeAgent = false
+				tmpCfgForOldVeleroInstall.UseRestic = !useVolumeSnapshots
 
 				Expect(VeleroInstall(context.Background(), &tmpCfgForOldVeleroInstall,
 					useVolumeSnapshots)).To(Succeed())
@@ -144,8 +146,8 @@ func BackupUpgradeRestoreTest(useVolumeSnapshots bool, veleroCLI2Version VeleroC
 				BackupCfg.BackupLocation = ""
 				BackupCfg.UseVolumeSnapshots = useVolumeSnapshots
 				BackupCfg.Selector = ""
-				//TODO: pay attention to this param
-				BackupCfg.UseRestic = true
+				//TODO: pay attention to this param, remove it when restic is not the default backup tool any more.
+				BackupCfg.UseResticIfFSBackup = true
 				Expect(VeleroBackupNamespace(oneHourTimeout, tmpCfg.UpgradeFromVeleroCLI,
 					tmpCfg.VeleroNamespace, BackupCfg)).To(Succeed(), func() string {
 					RunDebug(context.Background(), tmpCfg.UpgradeFromVeleroCLI, tmpCfg.VeleroNamespace,
@@ -196,6 +198,8 @@ func BackupUpgradeRestoreTest(useVolumeSnapshots bool, veleroCLI2Version VeleroC
 
 			By(fmt.Sprintf("Upgrade Velero by CLI %s", tmpCfg.VeleroCLI), func() {
 				tmpCfg.GCFrequency = ""
+				tmpCfg.UseNodeAgent = !useVolumeSnapshots
+				tmpCfg.UseRestic = false
 				Expect(VeleroInstall(context.Background(), &tmpCfg, useVolumeSnapshots)).To(Succeed())
 				Expect(CheckVeleroVersion(context.Background(), tmpCfg.VeleroCLI,
 					tmpCfg.VeleroVersion)).To(Succeed())

--- a/test/e2e/util/providers/azure_utils.go
+++ b/test/e2e/util/providers/azure_utils.go
@@ -364,10 +364,10 @@ func (s AzureStorage) IsSnapshotExisted(cloudCredentialsFile, bslConfig, backupN
 	snapshotCountFound := 0
 	backupNameInSnapshot := ""
 	if err != nil {
-		errors.Wrap(err, fmt.Sprintf("Fail to list snapshots %s\n", envVars[resourceGroupEnvVar]))
+		return errors.Wrap(err, fmt.Sprintf("Fail to list snapshots %s\n", envVars[resourceGroupEnvVar]))
 	}
 	if result.Value == nil {
-		errors.New(fmt.Sprintf("No snapshots in Azure resource group %s\n", envVars[resourceGroupEnvVar]))
+		return errors.New(fmt.Sprintf("No snapshots in Azure resource group %s\n", envVars[resourceGroupEnvVar]))
 	}
 	for _, v := range *result.Value {
 		if snapshotCheck.EnableCSI {

--- a/test/e2e/util/providers/common.go
+++ b/test/e2e/util/providers/common.go
@@ -46,7 +46,7 @@ func ObjectsShouldBeInBucket(cloudProvider, cloudCredentialsFile, bslBucket, bsl
 func ObjectsShouldNotBeInBucket(cloudProvider, cloudCredentialsFile, bslBucket, bslPrefix, bslConfig, backupName, subPrefix string, retryTimes int) error {
 	var err error
 	var exist bool
-	fmt.Printf("|| VERIFICATION || - %s %s should not exist in storage %s\n", subPrefix, backupName, bslPrefix)
+	fmt.Printf("|| VERIFICATION || - %s %s should not exist in object store %s\n", subPrefix, backupName, bslPrefix)
 	for i := 0; i < retryTimes; i++ {
 		exist, err = IsObjectsInBucket(cloudProvider, cloudCredentialsFile, bslBucket, bslPrefix, bslConfig, backupName, subPrefix)
 		if err != nil {
@@ -114,9 +114,9 @@ func SnapshotsShouldNotExistInCloud(cloudProvider, cloudCredentialsFile, bslBuck
 	snapshotCheckPoint.ExpectCount = 0
 	err := IsSnapshotExisted(cloudProvider, cloudCredentialsFile, bslBucket, bslConfig, backupName, snapshotCheckPoint)
 	if err != nil {
-		return errors.Wrapf(err, fmt.Sprintf("|| UNEXPECTED ||Snapshots %s is existed in cloud after backup as expected", backupName))
+		return errors.Wrapf(err, fmt.Sprintf("|| UNEXPECTED ||Snapshots %s exist in cloud after backup as expected", backupName))
 	}
-	fmt.Printf("|| EXPECTED || - Snapshots are not existed in cloud, backup %s\n", backupName)
+	fmt.Printf("|| EXPECTED || - Snapshots do not exist in cloud, backup %s\n", backupName)
 	return nil
 }
 
@@ -124,9 +124,9 @@ func SnapshotsShouldBeCreatedInCloud(cloudProvider, cloudCredentialsFile, bslBuc
 	fmt.Printf("|| VERIFICATION || - Snapshots should exist in cloud, backup %s\n", backupName)
 	err := IsSnapshotExisted(cloudProvider, cloudCredentialsFile, bslBucket, bslConfig, backupName, snapshotCheckPoint)
 	if err != nil {
-		return errors.Wrapf(err, fmt.Sprintf("|| UNEXPECTED ||Snapshots %s are not existed in cloud after backup as expected", backupName))
+		return errors.Wrapf(err, fmt.Sprintf("|| UNEXPECTED ||Snapshots %s do not exist in cloud after backup as expected", backupName))
 	}
-	fmt.Printf("|| EXPECTED || - Snapshots are existed in cloud, backup %s\n", backupName)
+	fmt.Printf("|| EXPECTED || - Snapshots exist in cloud, backup %s\n", backupName)
 	return nil
 }
 

--- a/test/e2e/util/velero/install.go
+++ b/test/e2e/util/velero/install.go
@@ -87,7 +87,10 @@ func VeleroInstall(ctx context.Context, veleroCfg *VerleroConfig, useVolumeSnaps
 		return errors.WithMessagef(err, "Failed to get Velero InstallOptions for plugin provider %s", veleroCfg.ObjectStoreProvider)
 	}
 	veleroInstallOptions.UseVolumeSnapshots = useVolumeSnapshots
-	veleroInstallOptions.UseNodeAgent = !useVolumeSnapshots
+	if !veleroCfg.UseRestic {
+		veleroInstallOptions.UseNodeAgent = !useVolumeSnapshots
+	}
+	veleroInstallOptions.UseRestic = veleroCfg.UseRestic
 	veleroInstallOptions.Image = veleroCfg.VeleroImage
 	veleroInstallOptions.Namespace = veleroCfg.VeleroNamespace
 	veleroInstallOptions.UploaderType = veleroCfg.UploaderType
@@ -174,6 +177,9 @@ func installVeleroServer(ctx context.Context, cli string, options *installOption
 	}
 	if options.UseNodeAgent {
 		args = append(args, "--use-node-agent")
+	}
+	if options.UseRestic {
+		args = append(args, "--use-restic")
 	}
 	if options.UseVolumeSnapshots {
 		args = append(args, "--use-volume-snapshots")
@@ -285,7 +291,7 @@ func createVelereResources(ctx context.Context, cli, namespace string, args []st
 	cmd.Stderr = os.Stderr
 	fmt.Printf("Running cmd %q \n", cmd.String())
 	if err = cmd.Run(); err != nil {
-		return errors.Wrapf(err, "failed to apply velere resources")
+		return errors.Wrapf(err, "failed to apply Velero resources")
 	}
 
 	return nil


### PR DESCRIPTION
1. Fix issue of kubectl client and server mismatch version in GitAction E2E job, refer to https://github.com/elastic/cloud-on-k8s/issues/4737;
2. Adapt to the changing of keyword for involing Kpoia as fs backupper, new installtion breaked upgrade and migration tests;
3. Accept multi-labels of Ginkgo focus as input of E2E make command;
4. Distinguish workload namespace from each tests;
5. Fix issues of not using Velero util to perform Velero commands;
6. Add snapshot test case for NamespaceMapping E2E test;
7. Collect debug bundle after catching error of Velero backup or restore command;


Signed-off-by: danfengl <danfengl@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
