### PR TITLE
Pod Volume Backup/Restore Refactor: Remove Restic in code

### DIFF
--- a/changelogs/unreleased/5444-lyndon
+++ b/changelogs/unreleased/5444-lyndon
@@ -1,0 +1,1 @@
+Remove irrational "Restic" names in Velero code after the PVBR refactor

--- a/pkg/apis/velero/v1/pod_volume_operation_progress.go
+++ b/pkg/apis/velero/v1/pod_volume_operation_progress.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1
 
 // PodVolumeOperationProgress represents the progress of a
-// PodVolumeBackup/Restore (restic) operation
+// PodVolumeBackup/Restore operation
 type PodVolumeOperationProgress struct {
 	// +optional
 	TotalBytes int64 `json:"totalBytes,omitempty"`

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -71,15 +71,15 @@ type Backupper interface {
 
 // kubernetesBackupper implements Backupper.
 type kubernetesBackupper struct {
-	backupClient             velerov1client.BackupsGetter
-	dynamicFactory           client.DynamicFactory
-	discoveryHelper          discovery.Helper
-	podCommandExecutor       podexec.PodCommandExecutor
-	resticBackupperFactory   podvolume.BackupperFactory
-	resticTimeout            time.Duration
-	defaultVolumesToFsBackup bool
-	clientPageSize           int
-	uploaderType             string
+	backupClient              velerov1client.BackupsGetter
+	dynamicFactory            client.DynamicFactory
+	discoveryHelper           discovery.Helper
+	podCommandExecutor        podexec.PodCommandExecutor
+	podVolumeBackupperFactory podvolume.BackupperFactory
+	podVolumeTimeout          time.Duration
+	defaultVolumesToFsBackup  bool
+	clientPageSize            int
+	uploaderType              string
 }
 
 func (i *itemKey) String() string {
@@ -102,22 +102,22 @@ func NewKubernetesBackupper(
 	discoveryHelper discovery.Helper,
 	dynamicFactory client.DynamicFactory,
 	podCommandExecutor podexec.PodCommandExecutor,
-	resticBackupperFactory podvolume.BackupperFactory,
-	resticTimeout time.Duration,
+	podVolumeBackupperFactory podvolume.BackupperFactory,
+	podVolumeTimeout time.Duration,
 	defaultVolumesToFsBackup bool,
 	clientPageSize int,
 	uploaderType string,
 ) (Backupper, error) {
 	return &kubernetesBackupper{
-		backupClient:             backupClient,
-		discoveryHelper:          discoveryHelper,
-		dynamicFactory:           dynamicFactory,
-		podCommandExecutor:       podCommandExecutor,
-		resticBackupperFactory:   resticBackupperFactory,
-		resticTimeout:            resticTimeout,
-		defaultVolumesToFsBackup: defaultVolumesToFsBackup,
-		clientPageSize:           clientPageSize,
-		uploaderType:             uploaderType,
+		backupClient:              backupClient,
+		discoveryHelper:           discoveryHelper,
+		dynamicFactory:            dynamicFactory,
+		podCommandExecutor:        podCommandExecutor,
+		podVolumeBackupperFactory: podVolumeBackupperFactory,
+		podVolumeTimeout:          podVolumeTimeout,
+		defaultVolumesToFsBackup:  defaultVolumesToFsBackup,
+		clientPageSize:            clientPageSize,
+		uploaderType:              uploaderType,
 	}, nil
 }
 
@@ -228,7 +228,7 @@ func (kb *kubernetesBackupper) BackupWithResolvers(log logrus.FieldLogger,
 
 	backupRequest.BackedUpItems = map[itemKey]struct{}{}
 
-	podVolumeTimeout := kb.resticTimeout
+	podVolumeTimeout := kb.podVolumeTimeout
 	if val := backupRequest.Annotations[velerov1api.PodVolumeOperationTimeoutAnnotation]; val != "" {
 		parsed, err := time.ParseDuration(val)
 		if err != nil {
@@ -241,9 +241,9 @@ func (kb *kubernetesBackupper) BackupWithResolvers(log logrus.FieldLogger,
 	ctx, cancelFunc := context.WithTimeout(context.Background(), podVolumeTimeout)
 	defer cancelFunc()
 
-	var resticBackupper podvolume.Backupper
-	if kb.resticBackupperFactory != nil {
-		resticBackupper, err = kb.resticBackupperFactory.NewBackupper(ctx, backupRequest.Backup, kb.uploaderType)
+	var podVolumeBackupper podvolume.Backupper
+	if kb.podVolumeBackupperFactory != nil {
+		podVolumeBackupper, err = kb.podVolumeBackupperFactory.NewBackupper(ctx, backupRequest.Backup, kb.uploaderType)
 		if err != nil {
 			log.WithError(errors.WithStack(err)).Debugf("Error from NewBackupper")
 			return errors.WithStack(err)
@@ -278,13 +278,13 @@ func (kb *kubernetesBackupper) BackupWithResolvers(log logrus.FieldLogger,
 	}
 
 	itemBackupper := &itemBackupper{
-		backupRequest:           backupRequest,
-		tarWriter:               tw,
-		dynamicFactory:          kb.dynamicFactory,
-		discoveryHelper:         kb.discoveryHelper,
-		resticBackupper:         resticBackupper,
-		resticSnapshotTracker:   newPVCSnapshotTracker(),
-		volumeSnapshotterGetter: volumeSnapshotterGetter,
+		backupRequest:            backupRequest,
+		tarWriter:                tw,
+		dynamicFactory:           kb.dynamicFactory,
+		discoveryHelper:          kb.discoveryHelper,
+		podVolumeBackupper:       podVolumeBackupper,
+		podVolumeSnapshotTracker: newPVCSnapshotTracker(),
+		volumeSnapshotterGetter:  volumeSnapshotterGetter,
 		itemHookHandler: &hook.DefaultItemHookHandler{
 			PodCommandExecutor: kb.podCommandExecutor,
 		},

--- a/pkg/backup/pvc_snapshot_tracker.go
+++ b/pkg/backup/pvc_snapshot_tracker.go
@@ -24,7 +24,7 @@ import (
 )
 
 // pvcSnapshotTracker keeps track of persistent volume claims that have been snapshotted
-// with restic.
+// with pod volume backup.
 type pvcSnapshotTracker struct {
 	pvcs sets.String
 }

--- a/pkg/buildinfo/buildinfo.go
+++ b/pkg/buildinfo/buildinfo.go
@@ -33,7 +33,7 @@ var (
 	GitTreeState string
 
 	// ImageRegistry is the image registry that this build of Velero should use by default to pull the
-	// Velero and Restic Restore Helper images from.
+	// Velero and Restore Helper images from.
 	ImageRegistry string
 )
 

--- a/pkg/cmd/cli/backuplocation/delete.go
+++ b/pkg/cmd/cli/backuplocation/delete.go
@@ -130,11 +130,11 @@ func Run(f client.Factory, o *cli.DeleteOptions) error {
 			errs = append(errs, deleteErrs...)
 		}
 
-		// Delete Restic repositories associated with the deleted BSL.
-		resticRepoList, err := findAssociatedResticRepos(kbClient, location.Name, f.Namespace())
+		// Delete backup repositories associated with the deleted BSL.
+		backupRepoList, err := findAssociatedBackupRepos(kbClient, location.Name, f.Namespace())
 		if err != nil {
-			errs = append(errs, fmt.Errorf("find Restic repositories associated with BSL %q: %w", location.Name, err))
-		} else if deleteErrs := deleteResticRepos(kbClient, resticRepoList); deleteErrs != nil {
+			errs = append(errs, fmt.Errorf("find backup repositories associated with BSL %q: %w", location.Name, err))
+		} else if deleteErrs := deleteBackupRepos(kbClient, backupRepoList); deleteErrs != nil {
 			errs = append(errs, deleteErrs...)
 		}
 	}
@@ -151,7 +151,7 @@ func findAssociatedBackups(client kbclient.Client, bslName, ns string) (velerov1
 	return backups, err
 }
 
-func findAssociatedResticRepos(client kbclient.Client, bslName, ns string) (velerov1api.BackupRepositoryList, error) {
+func findAssociatedBackupRepos(client kbclient.Client, bslName, ns string) (velerov1api.BackupRepositoryList, error) {
 	var repos velerov1api.BackupRepositoryList
 	err := client.List(context.Background(), &repos, &kbclient.ListOptions{
 		Namespace: ns,
@@ -172,14 +172,14 @@ func deleteBackups(client kbclient.Client, backups velerov1api.BackupList) []err
 	return errs
 }
 
-func deleteResticRepos(client kbclient.Client, repos velerov1api.BackupRepositoryList) []error {
+func deleteBackupRepos(client kbclient.Client, repos velerov1api.BackupRepositoryList) []error {
 	var errs []error
 	for _, repo := range repos.Items {
 		if err := client.Delete(context.Background(), &repo, &kbclient.DeleteOptions{}); err != nil {
-			errs = append(errs, errors.WithStack(fmt.Errorf("delete Restic repository %q associated with deleted BSL: %w", repo.Name, err)))
+			errs = append(errs, errors.WithStack(fmt.Errorf("delete backup repository %q associated with deleted BSL: %w", repo.Name, err)))
 			continue
 		}
-		fmt.Printf("Restic repository associated with deleted BSL(s) %q deleted successfully.\n", repo.Name)
+		fmt.Printf("Backup repository associated with deleted BSL(s) %q deleted successfully.\n", repo.Name)
 	}
 	return errs
 }

--- a/pkg/cmd/cli/install/install.go
+++ b/pkg/cmd/cli/install/install.go
@@ -86,10 +86,10 @@ func (o *InstallOptions) BindFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&o.SecretFile, "secret-file", o.SecretFile, "File containing credentials for backup and volume provider. If not specified, --no-secret must be used for confirmation. Optional.")
 	flags.BoolVar(&o.NoSecret, "no-secret", o.NoSecret, "Flag indicating if a secret should be created. Must be used as confirmation if --secret-file is not provided. Optional.")
 	flags.BoolVar(&o.NoDefaultBackupLocation, "no-default-backup-location", o.NoDefaultBackupLocation, "Flag indicating if a default backup location should be created. Must be used as confirmation if --bucket or --provider are not provided. Optional.")
-	flags.StringVar(&o.Image, "image", o.Image, "Image to use for the Velero and restic server pods. Optional.")
+	flags.StringVar(&o.Image, "image", o.Image, "Image to use for the Velero and node agent pods. Optional.")
 	flags.StringVar(&o.Prefix, "prefix", o.Prefix, "Prefix under which all Velero data should be stored within the bucket. Optional.")
-	flags.Var(&o.PodAnnotations, "pod-annotations", "Annotations to add to the Velero and restic pods. Optional. Format is key1=value1,key2=value2")
-	flags.Var(&o.PodLabels, "pod-labels", "Labels to add to the Velero and restic pods. Optional. Format is key1=value1,key2=value2")
+	flags.Var(&o.PodAnnotations, "pod-annotations", "Annotations to add to the Velero and node agent pods. Optional. Format is key1=value1,key2=value2")
+	flags.Var(&o.PodLabels, "pod-labels", "Labels to add to the Velero and node agent pods. Optional. Format is key1=value1,key2=value2")
 	flags.Var(&o.ServiceAccountAnnotations, "sa-annotations", "Annotations to add to the Velero ServiceAccount. Add iam.gke.io/gcp-service-account=[GSA_NAME]@[PROJECT_NAME].iam.gserviceaccount.com for workload identity. Optional. Format is key1=value1,key2=value2")
 	flags.StringVar(&o.VeleroPodCPURequest, "velero-pod-cpu-request", o.VeleroPodCPURequest, `CPU request for Velero pod. A value of "0" is treated as unbounded. Optional.`)
 	flags.StringVar(&o.VeleroPodMemRequest, "velero-pod-mem-request", o.VeleroPodMemRequest, `Memory request for Velero pod. A value of "0" is treated as unbounded. Optional.`)
@@ -233,7 +233,7 @@ This is useful as a starting point for more customized installations.
 
   # velero install --provider aws --plugins velero/velero-plugin-for-aws:v1.0.0 --bucket backups --secret-file ./aws-iam-creds --backup-location-config region=us-east-2 --snapshot-location-config region=us-east-2
 
-  # velero install --provider aws --plugins velero/velero-plugin-for-aws:v1.0.0 --bucket backups --secret-file ./aws-iam-creds --backup-location-config region=us-east-2 --snapshot-location-config region=us-east-2 --use-restic
+  # velero install --provider aws --plugins velero/velero-plugin-for-aws:v1.0.0 --bucket backups --secret-file ./aws-iam-creds --backup-location-config region=us-east-2 --snapshot-location-config region=us-east-2 --use-node-agent
 
   # velero install --provider gcp --plugins velero/velero-plugin-for-gcp:v1.0.0 --bucket gcp-backups --secret-file ./gcp-creds.json --wait
 
@@ -241,7 +241,7 @@ This is useful as a starting point for more customized installations.
 
   # velero install --provider gcp --plugins velero/velero-plugin-for-gcp:v1.0.0 --bucket gcp-backups --secret-file ./gcp-creds.json --velero-pod-cpu-request=1000m --velero-pod-cpu-limit=5000m --velero-pod-mem-request=512Mi --velero-pod-mem-limit=1024Mi
 
-  # velero install --provider gcp --plugins velero/velero-plugin-for-gcp:v1.0.0 --bucket gcp-backups --secret-file ./gcp-creds.json --restic-pod-cpu-request=1000m --restic-pod-cpu-limit=5000m --restic-pod-mem-request=512Mi --restic-pod-mem-limit=1024Mi
+  # velero install --provider gcp --plugins velero/velero-plugin-for-gcp:v1.0.0 --bucket gcp-backups --secret-file ./gcp-creds.json --node-agent-pod-cpu-request=1000m --node-agent-pod-cpu-limit=5000m --node-agent-pod-mem-request=512Mi --node-agent-pod-mem-limit=1024Mi
 
   # velero install --provider azure --plugins velero/velero-plugin-for-microsoft-azure:v1.0.0 --bucket $BLOB_CONTAINER --secret-file ./credentials-velero --backup-location-config resourceGroup=$AZURE_BACKUP_RESOURCE_GROUP,storageAccount=$AZURE_STORAGE_ACCOUNT_ID[,subscriptionId=$AZURE_BACKUP_SUBSCRIPTION_ID] --snapshot-location-config apiTimeout=<YOUR_TIMEOUT>[,resourceGroup=$AZURE_BACKUP_RESOURCE_GROUP,subscriptionId=$AZURE_BACKUP_SUBSCRIPTION_ID]`,
 		Run: func(c *cobra.Command, args []string) {

--- a/pkg/cmd/cli/nodeagent/server_test.go
+++ b/pkg/cmd/cli/nodeagent/server_test.go
@@ -94,7 +94,7 @@ func Test_validatePodVolumesHostPath(t *testing.T) {
 				}
 			}
 
-			s := &resticServer{
+			s := &nodeAgentServer{
 				logger:     testutil.NewLogger(),
 				fileSystem: fs,
 			}

--- a/pkg/cmd/server/server_test.go
+++ b/pkg/cmd/server/server_test.go
@@ -94,7 +94,7 @@ func TestRemoveControllers(t *testing.T) {
 				controller.BackupSync,
 				controller.DownloadRequest,
 				controller.GarbageCollection,
-				controller.ResticRepo,
+				controller.BackupRepo,
 				controller.Restore,
 				controller.Schedule,
 				controller.ServerStatusRequest,
@@ -130,7 +130,7 @@ func TestRemoveControllers(t *testing.T) {
 				controller.ServerStatusRequest: {},
 				controller.Schedule:            {},
 				controller.BackupDeletion:      {},
-				controller.ResticRepo:          {},
+				controller.BackupRepo:          {},
 				controller.DownloadRequest:     {},
 			}
 

--- a/pkg/cmd/util/output/backup_repo_printer.go
+++ b/pkg/cmd/util/output/backup_repo_printer.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	resticRepoColumns = []metav1.TableColumnDefinition{
+	backupRepoColumns = []metav1.TableColumnDefinition{
 		// name needs Type and Format defined for the decorator to identify it:
 		// https://github.com/kubernetes/kubernetes/blob/v1.15.3/pkg/printers/tableprinter.go#L204
 		{Name: "Name", Type: "string", Format: "name"},
@@ -33,16 +33,16 @@ var (
 	}
 )
 
-func printResticRepoList(list *v1.BackupRepositoryList) []metav1.TableRow {
+func printBackupRepoList(list *v1.BackupRepositoryList) []metav1.TableRow {
 	rows := make([]metav1.TableRow, 0, len(list.Items))
 
 	for i := range list.Items {
-		rows = append(rows, printResticRepo(&list.Items[i])...)
+		rows = append(rows, printBackupRepo(&list.Items[i])...)
 	}
 	return rows
 }
 
-func printResticRepo(repo *v1.BackupRepository) []metav1.TableRow {
+func printBackupRepo(repo *v1.BackupRepository) []metav1.TableRow {
 	row := metav1.TableRow{
 		Object: runtime.RawExtension{Object: repo},
 	}

--- a/pkg/cmd/util/output/output.go
+++ b/pkg/cmd/util/output/output.go
@@ -179,13 +179,13 @@ func printTable(cmd *cobra.Command, obj runtime.Object) (bool, error) {
 		}
 	case *velerov1api.BackupRepository:
 		table = &metav1.Table{
-			ColumnDefinitions: resticRepoColumns,
-			Rows:              printResticRepo(obj.(*velerov1api.BackupRepository)),
+			ColumnDefinitions: backupRepoColumns,
+			Rows:              printBackupRepo(obj.(*velerov1api.BackupRepository)),
 		}
 	case *velerov1api.BackupRepositoryList:
 		table = &metav1.Table{
-			ColumnDefinitions: resticRepoColumns,
-			Rows:              printResticRepoList(obj.(*velerov1api.BackupRepositoryList)),
+			ColumnDefinitions: backupRepoColumns,
+			Rows:              printBackupRepoList(obj.(*velerov1api.BackupRepositoryList)),
 		}
 	case *velerov1api.BackupStorageLocation:
 		table = &metav1.Table{

--- a/pkg/controller/backup_deletion_controller_test.go
+++ b/pkg/controller/backup_deletion_controller_test.go
@@ -91,7 +91,7 @@ func setupBackupDeletionControllerTest(t *testing.T, req *velerov1api.DeleteBack
 			velerotest.NewLogger(),
 			fakeClient,
 			NewBackupTracker(),
-			nil, // restic repository manager
+			nil, // repository manager
 			metrics.NewServerMetrics(),
 			nil, // discovery helper
 			func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager },

--- a/pkg/controller/constants.go
+++ b/pkg/controller/constants.go
@@ -25,7 +25,7 @@ const (
 	GarbageCollection     = "gc"
 	PodVolumeBackup       = "pod-volume-backup"
 	PodVolumeRestore      = "pod-volume-restore"
-	ResticRepo            = "restic-repo"
+	BackupRepo            = "backup-repo"
 	Restore               = "restore"
 	Schedule              = "schedule"
 	ServerStatusRequest   = "server-status-request"
@@ -38,7 +38,7 @@ var DisableableControllers = []string{
 	BackupSync,
 	DownloadRequest,
 	GarbageCollection,
-	ResticRepo,
+	BackupRepo,
 	Restore,
 	Schedule,
 	ServerStatusRequest,

--- a/pkg/controller/pod_volume_backup_controller.go
+++ b/pkg/controller/pod_volume_backup_controller.go
@@ -205,8 +205,8 @@ func (r *PodVolumeBackupReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	latencySeconds := float64(latencyDuration / time.Second)
 	backupName := fmt.Sprintf("%s/%s", req.Namespace, pvb.OwnerReferences[0].Name)
 	generateOpName := fmt.Sprintf("%s-%s-%s-%s-%s-backup", pvb.Name, backupRepo.Name, pvb.Spec.BackupStorageLocation, pvb.Namespace, pvb.Spec.UploaderType)
-	r.Metrics.ObserveResticOpLatency(r.NodeName, req.Name, generateOpName, backupName, latencySeconds)
-	r.Metrics.RegisterResticOpLatencyGauge(r.NodeName, req.Name, generateOpName, backupName, latencySeconds)
+	r.Metrics.ObservePodVolumeOpLatency(r.NodeName, req.Name, generateOpName, backupName, latencySeconds)
+	r.Metrics.RegisterPodVolumeOpLatencyGauge(r.NodeName, req.Name, generateOpName, backupName, latencySeconds)
 	r.Metrics.RegisterPodVolumeBackupDequeue(r.NodeName)
 
 	log.Info("PodVolumeBackup completed")

--- a/pkg/controller/pod_volume_backup_controller_test.go
+++ b/pkg/controller/pod_volume_backup_controller_test.go
@@ -145,7 +145,7 @@ var _ = Describe("PodVolumeBackup Reconciler", func() {
 			r := PodVolumeBackupReconciler{
 				Client:           fakeClient,
 				Clock:            clock.NewFakeClock(now),
-				Metrics:          metrics.NewResticServerMetrics(),
+				Metrics:          metrics.NewPodVolumeMetrics(),
 				CredentialGetter: &credentials.CredentialGetter{FromFile: credentialFileStore},
 				NodeName:         "test_node",
 				FileSystem:       fakeFS,

--- a/pkg/podvolume/backupper.go
+++ b/pkg/podvolume/backupper.go
@@ -38,7 +38,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/util/kube"
 )
 
-// Backupper can execute restic backups of volumes in a pod.
+// Backupper can execute pod volume backups of volumes in a pod.
 type Backupper interface {
 	// BackupPodVolumes backs up all specified volumes in a pod.
 	BackupPodVolumes(backup *velerov1api.Backup, pod *corev1api.Pod, volumesToBackup []string, log logrus.FieldLogger) ([]*velerov1api.PodVolumeBackup, []error)
@@ -190,7 +190,7 @@ func (b *backupper) BackupPodVolumes(backup *velerov1api.Backup, pod *corev1api.
 			continue
 		}
 		if isHostPath {
-			log.Warnf("Volume %s in pod %s/%s is a hostPath volume which is not supported for restic backup, skipping", volumeName, pod.Namespace, pod.Name)
+			log.Warnf("Volume %s in pod %s/%s is a hostPath volume which is not supported for pod volume backup, skipping", volumeName, pod.Namespace, pod.Name)
 			continue
 		}
 
@@ -304,7 +304,7 @@ func newPodVolumeBackup(backup *velerov1api.Backup, pod *corev1api.Pod, volume c
 
 	if pvc != nil {
 		// this annotation is used in pkg/restore to identify if a PVC
-		// has a restic backup.
+		// has a pod volume backup.
 		pvb.Annotations = map[string]string{
 			PVCNameAnnotation: pvc.Name,
 		}

--- a/pkg/podvolume/restorer.go
+++ b/pkg/podvolume/restorer.go
@@ -41,7 +41,7 @@ type RestoreData struct {
 	SourceNamespace, BackupLocation string
 }
 
-// Restorer can execute restic restores of volumes in a pod.
+// Restorer can execute pod volume restores of volumes in a pod.
 type Restorer interface {
 	// RestorePodVolumes restores all annotated volumes in a pod.
 	RestorePodVolumes(RestoreData) []error

--- a/pkg/podvolume/util_test.go
+++ b/pkg/podvolume/util_test.go
@@ -361,11 +361,11 @@ func TestGetVolumesByPod(t *testing.T) {
 			pod: &corev1api.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						VolumesToBackupAnnotation: "resticPV1,resticPV2,resticPV3",
+						VolumesToBackupAnnotation: "pvbPV1,pvbPV2,pvbPV3",
 					},
 				},
 			},
-			expected: []string{"resticPV1", "resticPV2", "resticPV3"},
+			expected: []string{"pvbPV1", "pvbPV2", "pvbPV3"},
 		},
 		{
 			name:                     "should get all pod volumes when defaultVolumesToFsBackup is true and no PVs are excluded",
@@ -373,12 +373,12 @@ func TestGetVolumesByPod(t *testing.T) {
 			pod: &corev1api.Pod{
 				Spec: corev1api.PodSpec{
 					Volumes: []corev1api.Volume{
-						// Restic Volumes
-						{Name: "resticPV1"}, {Name: "resticPV2"}, {Name: "resticPV3"},
+						// PVB Volumes
+						{Name: "pvbPV1"}, {Name: "pvbPV2"}, {Name: "pvbPV3"},
 					},
 				},
 			},
-			expected: []string{"resticPV1", "resticPV2", "resticPV3"},
+			expected: []string{"pvbPV1", "pvbPV2", "pvbPV3"},
 		},
 		{
 			name:                     "should get all pod volumes except ones excluded when defaultVolumesToFsBackup is true",
@@ -386,56 +386,56 @@ func TestGetVolumesByPod(t *testing.T) {
 			pod: &corev1api.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						VolumesToExcludeAnnotation: "nonResticPV1,nonResticPV2,nonResticPV3",
+						VolumesToExcludeAnnotation: "nonPvbPV1,nonPvbPV2,nonPvbPV3",
 					},
 				},
 				Spec: corev1api.PodSpec{
 					Volumes: []corev1api.Volume{
-						// Restic Volumes
-						{Name: "resticPV1"}, {Name: "resticPV2"}, {Name: "resticPV3"},
-						/// Excluded from restic through annotation
-						{Name: "nonResticPV1"}, {Name: "nonResticPV2"}, {Name: "nonResticPV3"},
+						// PVB Volumes
+						{Name: "pvbPV1"}, {Name: "pvbPV2"}, {Name: "pvbPV3"},
+						/// Excluded from PVB through annotation
+						{Name: "nonPvbPV1"}, {Name: "nonPvbPV2"}, {Name: "nonPvbPV3"},
 					},
 				},
 			},
-			expected: []string{"resticPV1", "resticPV2", "resticPV3"},
+			expected: []string{"pvbPV1", "pvbPV2", "pvbPV3"},
 		},
 		{
-			name:                     "should exclude default service account token from restic backup",
+			name:                     "should exclude default service account token from pod volume backup",
 			defaultVolumesToFsBackup: true,
 			pod: &corev1api.Pod{
 				Spec: corev1api.PodSpec{
 					Volumes: []corev1api.Volume{
-						// Restic Volumes
-						{Name: "resticPV1"}, {Name: "resticPV2"}, {Name: "resticPV3"},
-						/// Excluded from restic because colume mounting default service account token
+						// PVB Volumes
+						{Name: "pvbPV1"}, {Name: "pvbPV2"}, {Name: "pvbPV3"},
+						/// Excluded from PVB because colume mounting default service account token
 						{Name: "default-token-5xq45"},
 					},
 				},
 			},
-			expected: []string{"resticPV1", "resticPV2", "resticPV3"},
+			expected: []string{"pvbPV1", "pvbPV2", "pvbPV3"},
 		},
 		{
-			name:                     "should exclude host path volumes from restic backups",
+			name:                     "should exclude host path volumes from pod volume backups",
 			defaultVolumesToFsBackup: true,
 			pod: &corev1api.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						VolumesToExcludeAnnotation: "nonResticPV1,nonResticPV2,nonResticPV3",
+						VolumesToExcludeAnnotation: "nonPvbPV1,nonPvbPV2,nonPvbPV3",
 					},
 				},
 				Spec: corev1api.PodSpec{
 					Volumes: []corev1api.Volume{
-						// Restic Volumes
-						{Name: "resticPV1"}, {Name: "resticPV2"}, {Name: "resticPV3"},
-						/// Excluded from restic through annotation
-						{Name: "nonResticPV1"}, {Name: "nonResticPV2"}, {Name: "nonResticPV3"},
-						// Excluded from restic because hostpath
+						// PVB Volumes
+						{Name: "pvbPV1"}, {Name: "pvbPV2"}, {Name: "pvbPV3"},
+						/// Excluded from pod volume backup through annotation
+						{Name: "nonPvbPV1"}, {Name: "nonPvbPV2"}, {Name: "nonPvbPV3"},
+						// Excluded from pod volume backup because hostpath
 						{Name: "hostPath1", VolumeSource: corev1api.VolumeSource{HostPath: &corev1api.HostPathVolumeSource{Path: "/hostpathVol"}}},
 					},
 				},
 			},
-			expected: []string{"resticPV1", "resticPV2", "resticPV3"},
+			expected: []string{"pvbPV1", "pvbPV2", "pvbPV3"},
 		},
 		{
 			name:                     "should exclude volumes mounting secrets",
@@ -443,21 +443,21 @@ func TestGetVolumesByPod(t *testing.T) {
 			pod: &corev1api.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						VolumesToExcludeAnnotation: "nonResticPV1,nonResticPV2,nonResticPV3",
+						VolumesToExcludeAnnotation: "nonPvbPV1,nonPvbPV2,nonPvbPV3",
 					},
 				},
 				Spec: corev1api.PodSpec{
 					Volumes: []corev1api.Volume{
-						// Restic Volumes
-						{Name: "resticPV1"}, {Name: "resticPV2"}, {Name: "resticPV3"},
-						/// Excluded from restic through annotation
-						{Name: "nonResticPV1"}, {Name: "nonResticPV2"}, {Name: "nonResticPV3"},
-						// Excluded from restic because hostpath
+						// PVB Volumes
+						{Name: "pvbPV1"}, {Name: "pvbPV2"}, {Name: "pvbPV3"},
+						/// Excluded from pod volume backup through annotation
+						{Name: "nonPvbPV1"}, {Name: "nonPvbPV2"}, {Name: "nonPvbPV3"},
+						// Excluded from pod volume backup because hostpath
 						{Name: "superSecret", VolumeSource: corev1api.VolumeSource{Secret: &corev1api.SecretVolumeSource{SecretName: "super-secret"}}},
 					},
 				},
 			},
-			expected: []string{"resticPV1", "resticPV2", "resticPV3"},
+			expected: []string{"pvbPV1", "pvbPV2", "pvbPV3"},
 		},
 		{
 			name:                     "should exclude volumes mounting config maps",
@@ -465,21 +465,21 @@ func TestGetVolumesByPod(t *testing.T) {
 			pod: &corev1api.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						VolumesToExcludeAnnotation: "nonResticPV1,nonResticPV2,nonResticPV3",
+						VolumesToExcludeAnnotation: "nonPvbPV1,nonPvbPV2,nonPvbPV3",
 					},
 				},
 				Spec: corev1api.PodSpec{
 					Volumes: []corev1api.Volume{
-						// Restic Volumes
-						{Name: "resticPV1"}, {Name: "resticPV2"}, {Name: "resticPV3"},
-						/// Excluded from restic through annotation
-						{Name: "nonResticPV1"}, {Name: "nonResticPV2"}, {Name: "nonResticPV3"},
-						// Excluded from restic because hostpath
+						// PVB Volumes
+						{Name: "pvbPV1"}, {Name: "pvbPV2"}, {Name: "pvbPV3"},
+						/// Excluded from pod volume backup through annotation
+						{Name: "nonPvbPV1"}, {Name: "nonPvbPV2"}, {Name: "nonPvbPV3"},
+						// Excluded from pod volume backup because hostpath
 						{Name: "appCOnfig", VolumeSource: corev1api.VolumeSource{ConfigMap: &corev1api.ConfigMapVolumeSource{LocalObjectReference: corev1api.LocalObjectReference{Name: "app-config"}}}},
 					},
 				},
 			},
-			expected: []string{"resticPV1", "resticPV2", "resticPV3"},
+			expected: []string{"pvbPV1", "pvbPV2", "pvbPV3"},
 		},
 		{
 			name:                     "should exclude projected volumes",
@@ -487,12 +487,12 @@ func TestGetVolumesByPod(t *testing.T) {
 			pod: &corev1api.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						VolumesToExcludeAnnotation: "nonResticPV1,nonResticPV2,nonResticPV3",
+						VolumesToExcludeAnnotation: "nonPvbPV1,nonPvbPV2,nonPvbPV3",
 					},
 				},
 				Spec: corev1api.PodSpec{
 					Volumes: []corev1api.Volume{
-						{Name: "resticPV1"}, {Name: "resticPV2"}, {Name: "resticPV3"},
+						{Name: "pvbPV1"}, {Name: "pvbPV2"}, {Name: "pvbPV3"},
 						{
 							Name: "projected",
 							VolumeSource: corev1api.VolumeSource{
@@ -514,7 +514,7 @@ func TestGetVolumesByPod(t *testing.T) {
 					},
 				},
 			},
-			expected: []string{"resticPV1", "resticPV2", "resticPV3"},
+			expected: []string{"pvbPV1", "pvbPV2", "pvbPV3"},
 		},
 		{
 			name:                     "should exclude DownwardAPI volumes",
@@ -522,12 +522,12 @@ func TestGetVolumesByPod(t *testing.T) {
 			pod: &corev1api.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						VolumesToExcludeAnnotation: "nonResticPV1,nonResticPV2,nonResticPV3",
+						VolumesToExcludeAnnotation: "nonPvbPV1,nonPvbPV2,nonPvbPV3",
 					},
 				},
 				Spec: corev1api.PodSpec{
 					Volumes: []corev1api.Volume{
-						{Name: "resticPV1"}, {Name: "resticPV2"}, {Name: "resticPV3"},
+						{Name: "pvbPV1"}, {Name: "pvbPV2"}, {Name: "pvbPV3"},
 						{
 							Name: "downwardAPI",
 							VolumeSource: corev1api.VolumeSource{
@@ -547,7 +547,7 @@ func TestGetVolumesByPod(t *testing.T) {
 					},
 				},
 			},
-			expected: []string{"resticPV1", "resticPV2", "resticPV3"},
+			expected: []string{"pvbPV1", "pvbPV2", "pvbPV3"},
 		},
 	}
 

--- a/pkg/repository/keys/keys.go
+++ b/pkg/repository/keys/keys.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	credentialsSecretName = "velero-restic-credentials"
+	credentialsSecretName = "velero-repo-credentials"
 	credentialsKey        = "repository-password"
 
 	encryptionKey = "static-passw0rd"
@@ -65,10 +65,10 @@ func EnsureCommonRepositoryKey(secretClient corev1client.SecretsGetter, namespac
 }
 
 // RepoKeySelector returns the SecretKeySelector which can be used to fetch
-// the restic repository key.
+// the backup repository key.
 func RepoKeySelector() *corev1api.SecretKeySelector {
-	// For now, all restic repos share the same key so we don't need the repoName to fetch it.
-	// When we move to full-backup encryption, we'll likely have a separate key per restic repo
+	// For now, all backup repos share the same key so we don't need the repoName to fetch it.
+	// When we move to full-backup encryption, we'll likely have a separate key per backup repo
 	// (all within the Velero server's namespace) so RepoKeySelector will need to select the key
 	// for that repo.
 	return builder.ForSecretKeySelector(credentialsSecretName, credentialsKey).Result()

--- a/pkg/repository/locker.go
+++ b/pkg/repository/locker.go
@@ -19,7 +19,7 @@ package repository
 import "sync"
 
 // RepoLocker manages exclusive/non-exclusive locks for
-// operations against restic repositories. The semantics
+// operations against backup repositories. The semantics
 // of exclusive/non-exclusive locks are the same as for
 // a sync.RWMutex, where a non-exclusive lock is equivalent
 // to a read lock, and an exclusive lock is equivalent to

--- a/pkg/repository/manager.go
+++ b/pkg/repository/manager.go
@@ -31,18 +31,18 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/util/filesystem"
 )
 
-// SnapshotIdentifier uniquely identifies a restic snapshot
+// SnapshotIdentifier uniquely identifies a snapshot
 // taken by Velero.
 type SnapshotIdentifier struct {
 	// VolumeNamespace is the namespace of the pod/volume that
-	// the restic snapshot is for.
+	// the snapshot is for.
 	VolumeNamespace string
 
 	// BackupStorageLocation is the backup's storage location
 	// name.
 	BackupStorageLocation string
 
-	// SnapshotID is the short ID of the restic snapshot.
+	// SnapshotID is the short ID of the snapshot.
 	SnapshotID string
 
 	// RepositoryType is the type of the repository where the

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -107,8 +107,8 @@ type kubernetesRestorer struct {
 	discoveryHelper            discovery.Helper
 	dynamicFactory             client.DynamicFactory
 	namespaceClient            corev1.NamespaceInterface
-	resticRestorerFactory      podvolume.RestorerFactory
-	resticTimeout              time.Duration
+	podVolumeRestorerFactory   podvolume.RestorerFactory
+	podVolumeTimeout           time.Duration
 	resourceTerminatingTimeout time.Duration
 	resourcePriorities         []string
 	fileSystem                 filesystem.Interface
@@ -126,8 +126,8 @@ func NewKubernetesRestorer(
 	dynamicFactory client.DynamicFactory,
 	resourcePriorities []string,
 	namespaceClient corev1.NamespaceInterface,
-	resticRestorerFactory podvolume.RestorerFactory,
-	resticTimeout time.Duration,
+	podVolumeRestorerFactory podvolume.RestorerFactory,
+	podVolumeTimeout time.Duration,
 	resourceTerminatingTimeout time.Duration,
 	logger logrus.FieldLogger,
 	podCommandExecutor podexec.PodCommandExecutor,
@@ -139,8 +139,8 @@ func NewKubernetesRestorer(
 		discoveryHelper:            discoveryHelper,
 		dynamicFactory:             dynamicFactory,
 		namespaceClient:            namespaceClient,
-		resticRestorerFactory:      resticRestorerFactory,
-		resticTimeout:              resticTimeout,
+		podVolumeRestorerFactory:   podVolumeRestorerFactory,
+		podVolumeTimeout:           podVolumeTimeout,
 		resourceTerminatingTimeout: resourceTerminatingTimeout,
 		resourcePriorities:         resourcePriorities,
 		logger:                     logger,
@@ -238,7 +238,7 @@ func (kr *kubernetesRestorer) RestoreWithResolvers(
 		return Result{}, Result{Velero: []string{err.Error()}}
 	}
 
-	podVolumeTimeout := kr.resticTimeout
+	podVolumeTimeout := kr.podVolumeTimeout
 	if val := req.Restore.Annotations[velerov1api.PodVolumeOperationTimeoutAnnotation]; val != "" {
 		parsed, err := time.ParseDuration(val)
 		if err != nil {
@@ -254,9 +254,9 @@ func (kr *kubernetesRestorer) RestoreWithResolvers(
 	ctx, cancelFunc := go_context.WithTimeout(go_context.Background(), podVolumeTimeout)
 	defer cancelFunc()
 
-	var resticRestorer podvolume.Restorer
-	if kr.resticRestorerFactory != nil {
-		resticRestorer, err = kr.resticRestorerFactory.NewRestorer(ctx, req.Restore)
+	var podVolumeRestorer podvolume.Restorer
+	if kr.podVolumeRestorerFactory != nil {
+		podVolumeRestorer, err = kr.podVolumeRestorerFactory.NewRestorer(ctx, req.Restore)
 		if err != nil {
 			return Result{}, Result{Velero: []string{err.Error()}}
 		}
@@ -302,8 +302,8 @@ func (kr *kubernetesRestorer) RestoreWithResolvers(
 		restoreItemActions:             resolvedActions,
 		itemSnapshotterActions:         resolvedItemSnapshotterActions,
 		volumeSnapshotterGetter:        volumeSnapshotterGetter,
-		resticRestorer:                 resticRestorer,
-		resticErrs:                     make(chan error),
+		podVolumeRestorer:              podVolumeRestorer,
+		podVolumeErrs:                  make(chan error),
 		pvsToProvision:                 sets.NewString(),
 		pvRestorer:                     pvRestorer,
 		volumeSnapshots:                req.VolumeSnapshots,
@@ -345,9 +345,9 @@ type restoreContext struct {
 	restoreItemActions             []framework.RestoreItemResolvedAction
 	itemSnapshotterActions         []framework.ItemSnapshotterResolvedAction
 	volumeSnapshotterGetter        VolumeSnapshotterGetter
-	resticRestorer                 podvolume.Restorer
-	resticWaitGroup                sync.WaitGroup
-	resticErrs                     chan error
+	podVolumeRestorer              podvolume.Restorer
+	podVolumeWaitGroup             sync.WaitGroup
+	podVolumeErrs                  chan error
 	pvsToProvision                 sets.String
 	pvRestorer                     PVRestorer
 	volumeSnapshots                []*volume.Snapshot
@@ -557,29 +557,29 @@ func (ctx *restoreContext) execute() (Result, Result) {
 		ctx.log.WithError(errors.WithStack((err))).Warn("Updating restore status.progress")
 	}
 
-	// Wait for all of the restic restore goroutines to be done, which is
+	// Wait for all of the pod volume restore goroutines to be done, which is
 	// only possible once all of their errors have been received by the loop
-	// below, then close the resticErrs channel so the loop terminates.
+	// below, then close the podVolumeErrs channel so the loop terminates.
 	go func() {
-		ctx.log.Info("Waiting for all restic restores to complete")
+		ctx.log.Info("Waiting for all pod volume restores to complete")
 
 		// TODO timeout?
-		ctx.resticWaitGroup.Wait()
-		close(ctx.resticErrs)
+		ctx.podVolumeWaitGroup.Wait()
+		close(ctx.podVolumeErrs)
 	}()
 
-	// This loop will only terminate when the ctx.resticErrs channel is closed
+	// This loop will only terminate when the ctx.podVolumeErrs channel is closed
 	// in the above goroutine, *after* all errors from the goroutines have been
 	// received by this loop.
-	for err := range ctx.resticErrs {
+	for err := range ctx.podVolumeErrs {
 		// TODO: not ideal to be adding these to Velero-level errors
 		// rather than a specific namespace, but don't have a way
 		// to track the namespace right now.
 		errs.Velero = append(errs.Velero, err.Error())
 	}
-	ctx.log.Info("Done waiting for all restic restores to complete")
+	ctx.log.Info("Done waiting for all pod volume restores to complete")
 
-	// Wait for all post-restore exec hooks with same logic as restic wait above.
+	// Wait for all post-restore exec hooks with same logic as pod volume wait above.
 	go func() {
 		ctx.log.Info("Waiting for all post-restore-exec hooks to complete")
 
@@ -1100,8 +1100,8 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 				obj.SetAnnotations(annotations)
 			}
 
-		case hasResticBackup(obj, ctx):
-			ctx.log.Infof("Dynamically re-provisioning persistent volume because it has a restic backup to be restored.")
+		case hasPodVolumeBackup(obj, ctx):
+			ctx.log.Infof("Dynamically re-provisioning persistent volume because it has a pod volume backup to be restored.")
 			ctx.pvsToProvision.Insert(name)
 
 			// Return early because we don't want to restore the PV itself, we
@@ -1223,10 +1223,10 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 		}
 
 		if pvc.Spec.VolumeName != "" {
-			// This used to only happen with restic volumes, but now always remove this binding metadata
+			// This used to only happen with PVB volumes, but now always remove this binding metadata
 			obj = resetVolumeBindingInfo(obj)
 
-			// This is the case for restic volumes, where we need to actually have an empty volume created instead of restoring one.
+			// This is the case for PVB volumes, where we need to actually have an empty volume created instead of restoring one.
 			// The assumption is that any PV in pvsToProvision doesn't have an associated snapshot.
 			if ctx.pvsToProvision.Has(pvc.Spec.VolumeName) {
 				ctx.log.Infof("Resetting PersistentVolumeClaim %s/%s for dynamic provisioning", namespace, name)
@@ -1558,19 +1558,19 @@ func remapClaimRefNS(ctx *restoreContext, obj *unstructured.Unstructured) (bool,
 
 // restorePodVolumeBackups restores the PodVolumeBackups for the given restored pod
 func restorePodVolumeBackups(ctx *restoreContext, createdObj *unstructured.Unstructured, originalNamespace string) {
-	if ctx.resticRestorer == nil {
-		ctx.log.Warn("No restic restorer, not restoring pod's volumes")
+	if ctx.podVolumeRestorer == nil {
+		ctx.log.Warn("No pod volume restorer, not restoring pod's volumes")
 	} else {
-		ctx.resticWaitGroup.Add(1)
+		ctx.podVolumeWaitGroup.Add(1)
 		go func() {
 			// Done() will only be called after all errors have been successfully
-			// sent on the ctx.resticErrs channel
-			defer ctx.resticWaitGroup.Done()
+			// sent on the ctx.podVolumeErrs channel
+			defer ctx.podVolumeWaitGroup.Done()
 
 			pod := new(v1.Pod)
 			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(createdObj.UnstructuredContent(), &pod); err != nil {
 				ctx.log.WithError(err).Error("error converting unstructured pod")
-				ctx.resticErrs <- err
+				ctx.podVolumeErrs <- err
 				return
 			}
 
@@ -1581,11 +1581,11 @@ func restorePodVolumeBackups(ctx *restoreContext, createdObj *unstructured.Unstr
 				SourceNamespace:  originalNamespace,
 				BackupLocation:   ctx.backup.Spec.StorageLocation,
 			}
-			if errs := ctx.resticRestorer.RestorePodVolumes(data); errs != nil {
-				ctx.log.WithError(kubeerrs.NewAggregate(errs)).Error("unable to successfully complete restic restores of pod's volumes")
+			if errs := ctx.podVolumeRestorer.RestorePodVolumes(data); errs != nil {
+				ctx.log.WithError(kubeerrs.NewAggregate(errs)).Error("unable to successfully complete pod volume restores of pod's volumes")
 
 				for _, err := range errs {
-					ctx.resticErrs <- err
+					ctx.podVolumeErrs <- err
 				}
 			}
 		}()
@@ -1597,7 +1597,7 @@ func (ctx *restoreContext) waitExec(createdObj *unstructured.Unstructured) {
 	ctx.hooksWaitGroup.Add(1)
 	go func() {
 		// Done() will only be called after all errors have been successfully sent
-		// on the ctx.resticErrs channel.
+		// on the ctx.podVolumeErrs channel.
 		defer ctx.hooksWaitGroup.Done()
 
 		pod := new(v1.Pod)
@@ -1639,7 +1639,7 @@ func hasSnapshot(pvName string, snapshots []*volume.Snapshot) bool {
 	return false
 }
 
-func hasResticBackup(unstructuredPV *unstructured.Unstructured, ctx *restoreContext) bool {
+func hasPodVolumeBackup(unstructuredPV *unstructured.Unstructured, ctx *restoreContext) bool {
 	if len(ctx.podVolumeBackups) == 0 {
 		return false
 	}

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -2682,17 +2682,17 @@ func TestRestorePersistentVolumes(t *testing.T) {
 	}
 }
 
-type fakeResticRestorerFactory struct {
+type fakePodVolumeRestorerFactory struct {
 	restorer *uploadermocks.Restorer
 }
 
-func (f *fakeResticRestorerFactory) NewRestorer(context.Context, *velerov1api.Restore) (podvolume.Restorer, error) {
+func (f *fakePodVolumeRestorerFactory) NewRestorer(context.Context, *velerov1api.Restore) (podvolume.Restorer, error) {
 	return f.restorer, nil
 }
 
-// TestRestoreWithRestic verifies that a call to RestorePodVolumes was made as and when
-// expected for the given pods by using a mock for the restic restorer.
-func TestRestoreWithRestic(t *testing.T) {
+// TestRestoreWithPodVolume verifies that a call to RestorePodVolumes was made as and when
+// expected for the given pods by using a mock for the pod volume restorer.
+func TestRestoreWithPodVolume(t *testing.T) {
 	tests := []struct {
 		name                        string
 		restore                     *velerov1api.Restore
@@ -2753,7 +2753,7 @@ func TestRestoreWithRestic(t *testing.T) {
 			h := newHarness(t)
 			restorer := new(uploadermocks.Restorer)
 			defer restorer.AssertExpectations(t)
-			h.restorer.resticRestorerFactory = &fakeResticRestorerFactory{
+			h.restorer.podVolumeRestorerFactory = &fakePodVolumeRestorerFactory{
 				restorer: restorer,
 			}
 
@@ -3121,8 +3121,8 @@ func newHarness(t *testing.T) *harness {
 			fileSystem:                 testutil.NewFakeFileSystem(),
 
 			// unsupported
-			resticRestorerFactory: nil,
-			resticTimeout:         0,
+			podVolumeRestorerFactory: nil,
+			podVolumeTimeout:         0,
 		},
 		log: log,
 	}

--- a/tilt-resources/examples/tilt-settings.json
+++ b/tilt-resources/examples/tilt-settings.json
@@ -15,7 +15,7 @@
     "allowed_contexts": [
         "development"
     ],
-    "enable_restic": false,
+    "use_node_agent": false,
     "create_backup_locations": true,
     "setup-minio": true,
     "enable_debug": false,


### PR DESCRIPTION
Remove irrational "Restic" names in Velero code after the PVBR refactor