### PR TITLE
[cherry-pick][release-1.9] Exclude "csinodes.storage.k8s.io" and "volumeattachments.storage.k8s.…

### DIFF
--- a/changelogs/unreleased/5448-jxun
+++ b/changelogs/unreleased/5448-jxun
@@ -1,0 +1,1 @@
+Exclude "csinodes.storage.k8s.io" and "volumeattachments.storage.k8s.io" from restore by default.

--- a/pkg/controller/restore_controller.go
+++ b/pkg/controller/restore_controller.go
@@ -75,6 +75,12 @@ var nonRestorableResources = []string{
 	// created as needed if they don't exist.
 	// https://github.com/vmware-tanzu/velero/issues/1113
 	"resticrepositories.velero.io",
+
+	// CSINode delegates cluster node for CSI operation.
+	// VolumeAttachement records PV mounts to which node.
+	// https://github.com/vmware-tanzu/velero/issues/4823
+	"csinodes.storage.k8s.io",
+	"volumeattachments.storage.k8s.io",
 }
 
 type restoreController struct {


### PR DESCRIPTION
…io" from backup and restore by default.

Signed-off-by: Xun Jiang <jxun@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #5411

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
