### PR TITLE
Issue fix 5477

### DIFF
--- a/changelogs/unreleased/5478-lyndon
+++ b/changelogs/unreleased/5478-lyndon
@@ -1,0 +1,1 @@
+Issue fix 5477: create the common way to support S3 compatible object storages that work for both Restic and Kopia; Keep the resticRepoPrefix parameter for compatibility

--- a/pkg/repository/config/config_test.go
+++ b/pkg/repository/config/config_test.go
@@ -48,7 +48,7 @@ func TestGetRepoIdentifier(t *testing.T) {
 				},
 			},
 			repoName:    "repo-1",
-			expectedErr: "restic repository prefix (resticRepoPrefix) not specified in backup storage location's config",
+			expectedErr: "invalid backend type velero.io/unsupported-provider, provider unsupported-provider",
 		},
 		{
 			name: "resticRepoPrefix in BSL config is used if set",
@@ -68,6 +68,25 @@ func TestGetRepoIdentifier(t *testing.T) {
 			},
 			repoName: "repo-1",
 			expected: "custom:prefix:/restic/repo-1",
+		},
+		{
+			name: "s3Url in BSL config is used",
+			bsl: &velerov1api.BackupStorageLocation{
+				Spec: velerov1api.BackupStorageLocationSpec{
+					Provider: "custom-repo-identifier",
+					Config: map[string]string{
+						"s3Url": "s3Url",
+					},
+					StorageType: velerov1api.StorageType{
+						ObjectStorage: &velerov1api.ObjectStorageLocation{
+							Bucket: "bucket",
+							Prefix: "prefix",
+						},
+					},
+				},
+			},
+			repoName: "repo-1",
+			expected: "s3:s3Url/bucket/prefix/restic/repo-1",
 		},
 		{
 			name: "s3.amazonaws.com URL format is used if region cannot be determined for AWS BSL",

--- a/pkg/repository/provider/unified_repo.go
+++ b/pkg/repository/provider/unified_repo.go
@@ -344,7 +344,7 @@ func getRepoPassword(secretStore credentials.SecretStore) (string, error) {
 }
 
 func getStorageType(backupLocation *velerov1api.BackupStorageLocation) string {
-	backendType := repoconfig.GetBackendType(backupLocation.Spec.Provider)
+	backendType := repoconfig.GetBackendType(backupLocation.Spec.Provider, backupLocation.Spec.Config)
 
 	switch backendType {
 	case repoconfig.AWSBackend:
@@ -368,7 +368,7 @@ func getStorageCredentials(backupLocation *velerov1api.BackupStorageLocation, cr
 		return map[string]string{}, errors.New("invalid credentials interface")
 	}
 
-	backendType := repoconfig.GetBackendType(backupLocation.Spec.Provider)
+	backendType := repoconfig.GetBackendType(backupLocation.Spec.Provider, backupLocation.Spec.Config)
 	if !repoconfig.IsBackendTypeValid(backendType) {
 		return map[string]string{}, errors.New("invalid storage provider")
 	}
@@ -414,7 +414,7 @@ func getStorageCredentials(backupLocation *velerov1api.BackupStorageLocation, cr
 func getStorageVariables(backupLocation *velerov1api.BackupStorageLocation, repoBackend string, repoName string) (map[string]string, error) {
 	result := make(map[string]string)
 
-	backendType := repoconfig.GetBackendType(backupLocation.Spec.Provider)
+	backendType := repoconfig.GetBackendType(backupLocation.Spec.Provider, backupLocation.Spec.Config)
 	if !repoconfig.IsBackendTypeValid(backendType) {
 		return map[string]string{}, errors.New("invalid storage provider")
 	}

--- a/pkg/restic/common.go
+++ b/pkg/restic/common.go
@@ -92,7 +92,7 @@ func CmdEnv(backupLocation *velerov1api.BackupStorageLocation, credentialFileSto
 		config[repoconfig.CredentialsFileKey] = credsFile
 	}
 
-	backendType := repoconfig.GetBackendType(backupLocation.Spec.Provider)
+	backendType := repoconfig.GetBackendType(backupLocation.Spec.Provider, backupLocation.Spec.Config)
 
 	switch backendType {
 	case repoconfig.AWSBackend:


### PR DESCRIPTION
Issue fix 5477: create the common way to support S3 compatible object storages that work for both Restic and Kopia; Keep the `resticRepoPrefix` parameter for compatibility

fix issue #5477 