### PR TITLE
Cherry pick 5388 to v1.9.3

### DIFF
--- a/changelogs/unreleased/5482-blackpiglet
+++ b/changelogs/unreleased/5482-blackpiglet
@@ -1,0 +1,1 @@
+Add some corner cases checking for CSI snapshot in backup controller.


### PR DESCRIPTION
Although this PR is titled as cherry-pick, because v1.9 doesn't contain some changes in v1.10, I didn't use cherry-pick, instead I pick the needed code manually, as a result, this PR's change looks different from #5388.

Signed-off-by: Xun Jiang <blackpiglet@gmail.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #5463 

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
