### PR TITLE
Fix v1.9.3 CSI VolumeSnapshot status duplicate issue.

### DIFF
--- a/changelogs/unreleased/5518-blackpiglet
+++ b/changelogs/unreleased/5518-blackpiglet
@@ -1,0 +1,1 @@
+Fix v1.9.3 CSI VolumeSnapshot status duplicate issue.

--- a/pkg/backup/request.go
+++ b/pkg/backup/request.go
@@ -50,7 +50,7 @@ type Request struct {
 	VolumeSnapshots           []*volume.Snapshot
 	PodVolumeBackups          []*velerov1api.PodVolumeBackup
 	BackedUpItems             map[itemKey]struct{}
-	CSISnapshots              []*snapshotv1api.VolumeSnapshot
+	CSISnapshots              []snapshotv1api.VolumeSnapshot
 }
 
 // BackupResourceList returns the list of backed up resources grouped by the API

--- a/pkg/builder/volume_snapshot_builder.go
+++ b/pkg/builder/volume_snapshot_builder.go
@@ -1,0 +1,66 @@
+/*
+Copyright the Velero contributors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	snapshotv1api "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// VolumeSnapshotBuilder builds VolumeSnapshot objects.
+type VolumeSnapshotBuilder struct {
+	object *snapshotv1api.VolumeSnapshot
+}
+
+// ForVolumeSnapshot is the constructor for VolumeSnapshotBuilder.
+func ForVolumeSnapshot(ns, name string) *VolumeSnapshotBuilder {
+	return &VolumeSnapshotBuilder{
+		object: &snapshotv1api.VolumeSnapshot{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: snapshotv1api.SchemeGroupVersion.String(),
+				Kind:       "VolumeSnapshot",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+			},
+		},
+	}
+}
+
+// ObjectMeta applies functional options to the VolumeSnapshot's ObjectMeta.
+func (v *VolumeSnapshotBuilder) ObjectMeta(opts ...ObjectMetaOpt) *VolumeSnapshotBuilder {
+	for _, opt := range opts {
+		opt(v.object)
+	}
+
+	return v
+}
+
+// Result return the built VolumeSnapshot.
+func (v *VolumeSnapshotBuilder) Result() *snapshotv1api.VolumeSnapshot {
+	return v.object
+}
+
+// Status init the built VolumeSnapshot's status.
+func (v *VolumeSnapshotBuilder) Status() *VolumeSnapshotBuilder {
+	v.object.Status = &snapshotv1api.VolumeSnapshotStatus{}
+	return v
+}
+
+// BoundVolumeSnapshotContentName set built VolumeSnapshot's status BoundVolumeSnapshotContentName field.
+func (v *VolumeSnapshotBuilder) BoundVolumeSnapshotContentName(vscName string) *VolumeSnapshotBuilder {
+	v.object.Status.BoundVolumeSnapshotContentName = &vscName
+	return v
+}

--- a/pkg/builder/volume_snapshot_content_builder.go
+++ b/pkg/builder/volume_snapshot_content_builder.go
@@ -1,0 +1,67 @@
+/*
+Copyright the Velero contributors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	snapshotv1api "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// VolumeSnapshotContentBuilder builds VolumeSnapshotContent object.
+type VolumeSnapshotContentBuilder struct {
+	object *snapshotv1api.VolumeSnapshotContent
+}
+
+// ForVolumeSnapshotContent is the constructor of VolumeSnapshotContentBuilder.
+func ForVolumeSnapshotContent(name string) *VolumeSnapshotContentBuilder {
+	return &VolumeSnapshotContentBuilder{
+		object: &snapshotv1api.VolumeSnapshotContent{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: snapshotv1api.SchemeGroupVersion.String(),
+				Kind:       "VolumeSnapshotContent",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		},
+	}
+}
+
+// Result returns the built VolumeSnapshotContent.
+func (v *VolumeSnapshotContentBuilder) Result() *snapshotv1api.VolumeSnapshotContent {
+	return v.object
+}
+
+// Status initiates VolumeSnapshotContent's status.
+func (v *VolumeSnapshotContentBuilder) Status() *VolumeSnapshotContentBuilder {
+	v.object.Status = &snapshotv1api.VolumeSnapshotContentStatus{}
+	return v
+}
+
+// DeletionPolicy sets built VolumeSnapshotContent's spec.DeletionPolicy value.
+func (v *VolumeSnapshotContentBuilder) DeletionPolicy(policy snapshotv1api.DeletionPolicy) *VolumeSnapshotContentBuilder {
+	v.object.Spec.DeletionPolicy = policy
+	return v
+}
+
+func (v *VolumeSnapshotContentBuilder) VolumeSnapshotRef(namespace, name string) *VolumeSnapshotContentBuilder {
+	v.object.Spec.VolumeSnapshotRef = v1.ObjectReference{
+		APIVersion: "snapshot.storage.k8s.io/v1",
+		Kind:       "VolumeSnapshot",
+		Namespace:  namespace,
+		Name:       name,
+	}
+	return v
+}

--- a/pkg/test/fake_controller_runtime_client.go
+++ b/pkg/test/fake_controller_runtime_client.go
@@ -19,6 +19,7 @@ package test
 import (
 	"testing"
 
+	snapshotv1api "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	"github.com/stretchr/testify/require"
 	corev1api "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,6 +35,8 @@ func NewFakeControllerRuntimeClientBuilder(t *testing.T) *k8sfake.ClientBuilder 
 	require.NoError(t, err)
 	err = corev1api.AddToScheme(scheme)
 	require.NoError(t, err)
+	err = snapshotv1api.AddToScheme(scheme)
+	require.NoError(t, err)
 	return k8sfake.NewClientBuilder().WithScheme(scheme)
 }
 
@@ -42,6 +45,8 @@ func NewFakeControllerRuntimeClient(t *testing.T, initObjs ...runtime.Object) cl
 	err := velerov1api.AddToScheme(scheme)
 	require.NoError(t, err)
 	err = corev1api.AddToScheme(scheme)
+	require.NoError(t, err)
+	err = snapshotv1api.AddToScheme(scheme)
 	require.NoError(t, err)
 	return k8sfake.NewFakeClientWithScheme(scheme, initObjs...)
 }


### PR DESCRIPTION
Signed-off-by: Xun Jiang <blackpiglet@gmail.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Add UT for function deleteVolumeSnapshot.
Fix v1.9.3 CSI pipeline failure, which is caused by VolumeSnapshot' status is duplicated, when there are multiple VolumeSnapshots in one backup.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
