### PR TITLE
Add credential file store in the backup deletion controller.

### DIFF
--- a/changelogs/unreleased/5521-blackpiglet
+++ b/changelogs/unreleased/5521-blackpiglet
@@ -1,0 +1,1 @@
+Add credential store in backup deletion controller to support VSL credential.

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	k8s.io/client-go v0.24.1
 	k8s.io/klog/v2 v2.60.1
 	k8s.io/kube-aggregator v0.19.12
+	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	sigs.k8s.io/controller-runtime v0.12.1
 	sigs.k8s.io/yaml v1.3.0
 )
@@ -147,7 +148,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/component-base v0.24.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220614142933-1062c7ade5f8 // indirect
-	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/json v0.0.0-20220525155127-227cbc7cc124 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 )

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -805,6 +805,7 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 			s.discoveryHelper,
 			newPluginManager,
 			backupStoreGetter,
+			s.credentialFileStore,
 		).SetupWithManager(s.mgr); err != nil {
 			s.logger.Fatal(err, "unable to create controller", "controller", controller.BackupDeletion)
 		}

--- a/pkg/controller/backup_deletion_controller_test.go
+++ b/pkg/controller/backup_deletion_controller_test.go
@@ -96,6 +96,7 @@ func setupBackupDeletionControllerTest(t *testing.T, req *velerov1api.DeleteBack
 			nil, // discovery helper
 			func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager },
 			NewFakeSingleObjectBackupStoreGetter(backupStore),
+			velerotest.NewFakeCredentialsFileStore("", nil),
 		),
 		req: ctrl.Request{NamespacedName: types.NamespacedName{Namespace: req.Namespace, Name: req.Name}},
 	}


### PR DESCRIPTION
Signed-off-by: Xun Jiang <blackpiglet@gmail.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Add credential store in backup deletion controller to support VSL credential.

I followed these steps of v1.10 Velero manual test to verify VSL credential feature.
* Prepare workload as target to backup;
* Modify the default credential cloud-credentials to wrong value.
* Backup should fail.
* Create a new secret with correct credentials, and patch BSL and VSL to use it.
``` bash
# Handle VSL credential
kubectl create secret generic -n velero --from-file=/Users/jxun/Documents/credentials-velero-gcp vsl-credential
 
kubectl -n velero patch VolumeSnapshotLocation default -p '{"spec":{"credential":{"name":"vsl-credential", "key":"credentials-velero-gcp"}}}' --type=merge

# Handel BSL credential
kubectl create secret generic -n velero --from-file=/Users/jxun/Documents/credentials-velero-gcp bsl-credential
 
kubectl -n velero patch BackupStorageLocation default -p '{"spec":{"credential":{"name":"bsl-credential", "key":"credentials-velero-gcp"}}}' --type=merge
```

After BSL and VSL's credential modification, backup can be created successfully, but backup deletion would fail with something similar to "unable to read credential from environment variable GOOGLE_APPLICATION_CREDENTIALS".

This is caused by BackupDeletionController didn't have the secret credetial store to read secret. I didn't trigger this error during GCP supporting VSL credential PR, because BSL's credential is not modified during verification.

# Does your change fix a particular issue?

Fixes #4862 

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
