### PR TITLE
fix restic backup failure with self-signed certification backend storage

### DIFF
--- a/changelogs/unreleased/5526-qiuming-best
+++ b/changelogs/unreleased/5526-qiuming-best
@@ -1,0 +1,1 @@
+fix restic backup failure with self-signed certification backend storage

--- a/pkg/uploader/provider/restic.go
+++ b/pkg/uploader/provider/restic.go
@@ -147,7 +147,9 @@ func (rp *resticProvider) RunBackup(
 	snapshotIdCmd := restic.GetSnapshotCommand(rp.repoIdentifier, rp.credentialsFile, tags)
 	snapshotIdCmd.Env = rp.cmdEnv
 	snapshotIdCmd.CACertFile = rp.caCertFile
-
+	if len(rp.extraFlags) != 0 {
+		snapshotIdCmd.ExtraFlags = append(snapshotIdCmd.ExtraFlags, rp.extraFlags...)
+	}
 	snapshotID, err := restic.GetSnapshotID(snapshotIdCmd)
 	if err != nil {
 		return "", false, errors.WithStack(fmt.Errorf("error getting snapshot id with error: %v", err))


### PR DESCRIPTION
Signed-off-by: Ming <mqiu@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)
PodVolumeBackup failed with the self-signed certificate minio as the backup storage
https://github.com/vmware-tanzu/velero/issues/5502
# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
