### PR TITLE
[cherry-pick]Enhance the restore priorities list to support specifying the low prioritized resources that need to be restored in the last

### DIFF
--- a/changelogs/unreleased/5535-ywk253100
+++ b/changelogs/unreleased/5535-ywk253100
@@ -1,0 +1,1 @@
+Enhance the restore priorities list to support specifying the low prioritized resources that need to be restored in the last

--- a/pkg/restore/priority.go
+++ b/pkg/restore/priority.go
@@ -1,0 +1,92 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restore
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	prioritySeparator = "-"
+)
+
+// Priorities defines the desired order of resource operations:
+//   Resources in the HighPriorities list will be handled first
+//   Resources in the LowPriorities list will be handled last
+//   Other resources will be handled alphabetically after the high prioritized resources and before the low prioritized resources
+type Priorities struct {
+	HighPriorities []string
+	LowPriorities  []string
+}
+
+// String returns a string representation of Priority.
+func (p *Priorities) String() string {
+	priorities := p.HighPriorities
+	if len(p.LowPriorities) > 0 {
+		priorities = append(priorities, prioritySeparator)
+		priorities = append(priorities, p.LowPriorities...)
+	}
+	return strings.Join(priorities, ",")
+}
+
+// Set parses the provided string to the priority object
+func (p *Priorities) Set(s string) error {
+	if len(s) == 0 {
+		return nil
+	}
+	strs := strings.Split(s, ",")
+	separatorIndex := -1
+	for i, str := range strs {
+		if str == prioritySeparator {
+			if separatorIndex > -1 {
+				return fmt.Errorf("multiple priority separator %q found", prioritySeparator)
+			}
+			separatorIndex = i
+		}
+	}
+	// has no separator
+	if separatorIndex == -1 {
+		p.HighPriorities = strs
+		return nil
+	}
+	// start with separator
+	if separatorIndex == 0 {
+		// contain only separator
+		if len(strs) == 1 {
+			return nil
+		}
+		p.LowPriorities = strs[1:]
+		return nil
+	}
+	// end with separator
+	if separatorIndex == len(strs)-1 {
+		p.HighPriorities = strs[:len(strs)-1]
+		return nil
+	}
+
+	// separator in the middle
+	p.HighPriorities = strs[:separatorIndex]
+	p.LowPriorities = strs[separatorIndex+1:]
+
+	return nil
+}
+
+// Type specifies the flag type
+func (p *Priorities) Type() string {
+	return "stringArray"
+}

--- a/pkg/restore/priority_test.go
+++ b/pkg/restore/priority_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringOfPriorities(t *testing.T) {
+	priority := Priorities{
+		HighPriorities: []string{"high"},
+	}
+	assert.Equal(t, "high", priority.String())
+
+	priority = Priorities{
+		HighPriorities: []string{"high"},
+		LowPriorities:  []string{"low"},
+	}
+	assert.Equal(t, "high,-,low", priority.String())
+}
+
+func TestSetOfPriority(t *testing.T) {
+	cases := []struct {
+		name       string
+		input      string
+		priorities Priorities
+		hasErr     bool
+	}{
+		{
+			name:       "empty input",
+			input:      "",
+			priorities: Priorities{},
+			hasErr:     false,
+		},
+		{
+			name:  "only high priorities",
+			input: "p0",
+			priorities: Priorities{
+				HighPriorities: []string{"p0"},
+			},
+			hasErr: false,
+		},
+		{
+			name:  "only low priorities",
+			input: "-,p9",
+			priorities: Priorities{
+				LowPriorities: []string{"p9"},
+			},
+			hasErr: false,
+		},
+		{
+			name:       "only separator",
+			input:      "-",
+			priorities: Priorities{},
+			hasErr:     false,
+		},
+		{
+			name:       "multiple separators",
+			input:      "-,-",
+			priorities: Priorities{},
+			hasErr:     true,
+		},
+		{
+			name:  "contain both high and low priorities",
+			input: "p0,p1,p2,-,p9",
+			priorities: Priorities{
+				HighPriorities: []string{"p0", "p1", "p2"},
+				LowPriorities:  []string{"p9"},
+			},
+			hasErr: false,
+		},
+		{
+			name:  "end with separator",
+			input: "p0,-",
+			priorities: Priorities{
+				HighPriorities: []string{"p0"},
+			},
+			hasErr: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p := Priorities{}
+			err := p.Set(c.input)
+			if c.hasErr {
+				require.NotNil(t, err)
+			} else {
+				require.Nil(t, err)
+			}
+			assert.Equal(t, c.priorities, p)
+		})
+	}
+}

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -681,7 +681,7 @@ func TestRestoreResourcePriorities(t *testing.T) {
 		backup             *velerov1api.Backup
 		apiResources       []*test.APIResource
 		tarball            io.Reader
-		resourcePriorities []string
+		resourcePriorities Priorities
 	}{
 		{
 			name:    "resources are restored according to the specified resource priorities",
@@ -715,7 +715,10 @@ func TestRestoreResourcePriorities(t *testing.T) {
 				test.Deployments(),
 				test.ServiceAccounts(),
 			},
-			resourcePriorities: []string{"persistentvolumes", "serviceaccounts", "pods", "deployments.apps"},
+			resourcePriorities: Priorities{
+				HighPriorities: []string{"persistentvolumes", "persistentvolumeclaims", "serviceaccounts"},
+				LowPriorities:  []string{"deployments.apps"},
+			},
 		},
 	}
 
@@ -747,7 +750,7 @@ func TestRestoreResourcePriorities(t *testing.T) {
 		)
 
 		assertEmptyResults(t, warnings, errs)
-		assertResourceCreationOrder(t, tc.resourcePriorities, recorder.resources)
+		assertResourceCreationOrder(t, []string{"persistentvolumes", "persistentvolumeclaims", "serviceaccounts", "pods", "deployments.apps"}, recorder.resources)
 	}
 }
 
@@ -2624,7 +2627,7 @@ func TestRestorePersistentVolumes(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			h := newHarness(t)
-			h.restorer.resourcePriorities = []string{"persistentvolumes", "persistentvolumeclaims"}
+			h.restorer.resourcePriorities = Priorities{HighPriorities: []string{"persistentvolumes", "persistentvolumeclaims"}}
 			h.restorer.pvRenamer = func(oldName string) (string, error) {
 				renamed := "renamed-" + oldName
 				return renamed, nil
@@ -2942,19 +2945,19 @@ func TestIsCompleted(t *testing.T) {
 func Test_getOrderedResources(t *testing.T) {
 	tests := []struct {
 		name               string
-		resourcePriorities []string
+		resourcePriorities Priorities
 		backupResources    map[string]*archive.ResourceItems
 		want               []string
 	}{
 		{
 			name:               "when only priorities are specified, they're returned in order",
-			resourcePriorities: []string{"prio-3", "prio-2", "prio-1"},
+			resourcePriorities: Priorities{HighPriorities: []string{"prio-3", "prio-2", "prio-1"}},
 			backupResources:    nil,
 			want:               []string{"prio-3", "prio-2", "prio-1"},
 		},
 		{
 			name:               "when only backup resources are specified, they're returned in alphabetical order",
-			resourcePriorities: nil,
+			resourcePriorities: Priorities{},
 			backupResources: map[string]*archive.ResourceItems{
 				"backup-resource-3": nil,
 				"backup-resource-2": nil,
@@ -2964,14 +2967,26 @@ func Test_getOrderedResources(t *testing.T) {
 		},
 		{
 			name:               "when priorities and backup resources are specified, they're returned in the correct order",
-			resourcePriorities: []string{"prio-3", "prio-2", "prio-1"},
+			resourcePriorities: Priorities{HighPriorities: []string{"prio-3", "prio-2", "prio-1"}},
 			backupResources: map[string]*archive.ResourceItems{
 				"prio-3":            nil,
 				"backup-resource-3": nil,
 				"backup-resource-2": nil,
 				"backup-resource-1": nil,
 			},
-			want: []string{"prio-3", "prio-2", "prio-1", "backup-resource-1", "backup-resource-2", "backup-resource-3", "prio-3"},
+			want: []string{"prio-3", "prio-2", "prio-1", "backup-resource-1", "backup-resource-2", "backup-resource-3"},
+		},
+		{
+			name:               "when priorities and backup resources are specified, they're returned in the correct order",
+			resourcePriorities: Priorities{HighPriorities: []string{"prio-3", "prio-2", "prio-1"}, LowPriorities: []string{"prio-0"}},
+			backupResources: map[string]*archive.ResourceItems{
+				"prio-3":            nil,
+				"prio-0":            nil,
+				"backup-resource-3": nil,
+				"backup-resource-2": nil,
+				"backup-resource-1": nil,
+			},
+			want: []string{"prio-3", "prio-2", "prio-1", "backup-resource-1", "backup-resource-2", "backup-resource-3", "prio-0"},
 		},
 	}
 


### PR DESCRIPTION
Enhance the restore priorities list to support specifying the low prioritized resources that need to be restored in the last

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
