### PR TITLE
Fix GCP StorageClass used for E2E testing's YAML syntax error.

### DIFF
--- a/test/e2e/testdata/storage-class/gcp.yaml
+++ b/test/e2e/testdata/storage-class/gcp.yaml
@@ -9,5 +9,5 @@ parameters:
   type: pd-standard
 provisioner: kubernetes.io/gce-pd
 reclaimPolicy: Delete
-volumeBindingMode: volumeBindingMode: WaitForFirstConsumer
+volumeBindingMode: WaitForFirstConsumer
 


### PR DESCRIPTION
Signed-off-by: Xun Jiang <blackpiglet@gmail.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
