### PR TITLE
add VSL credentials documentation.

### DIFF
--- a/site/content/docs/main/locations.md
+++ b/site/content/docs/main/locations.md
@@ -205,7 +205,7 @@ kubectl create secret generic -n velero credentials --from-file=bsl=</path/to/cr
 
 This will create a secret named `credentials` with a single key (`bsl`) which contains the contents of your credentials file.
 Next, create a `BackupStorageLocation` that uses this Secret by passing the Secret name and key in the `--credential` flag.
-When interacting with this `BackupStroageLocation` in the future, Velero will fetch the data from the key within the Secret you provide.
+When interacting with this `BackupStorageLocation` in the future, Velero will fetch the data from the key within the Secret you provide.
 
 For example, a new `BackupStorageLocation` with a Secret would be configured as follows:
 
@@ -241,6 +241,58 @@ Once you have created the Secret, or have an existing Secret which contains the 
 
 ```bash
 velero backup-location set <bsl-name> \
+  --credential=<secret-name>=<key-within-secret>
+```
+
+### Create a volume snapshot location that uses unique credentials
+
+It is possible to create additional `VolumeSnapshotLocations` that use their own credentials.
+This may be necessary if you already have default credentials which don't match the account used by the cloud volumes being backed up.
+
+If you create additional `VolumeSnapshotLocations` without specifying the credentials to use, Velero will use the credentials provided at install time and stored in the `cloud-credentials` secret.
+
+#### Prerequisites
+- This feature requires support from the [volume snapshotter plugin][5] you wish to use.
+  All plugins maintained by the Velero team support this feature.
+  If you are using a plugin from another provider, please check their documentation to determine if this is supported.
+- The [plugin for the volume snapshotter provider][5] you wish to use must be [installed][6].
+- You must create a file with the object storage credentials. Follow the instructions provided by your object storage provider plugin to create this file.
+
+Once you have installed the necessary plugin and created the credentials file, create a [Kubernetes Secret][7] in the Velero namespace that contains these credentials:
+
+```shell
+kubectl create secret generic -n velero credentials --from-file=vsl=</path/to/credentialsfile>
+```
+
+This will create a secret named `credentials` with a single key (`vsl`) which contains the contents of your credentials file.
+Next, create a `VolumeSnapshotLocation` that uses this Secret by passing the Secret name and key in the `--credential` flag.
+When interacting with this `VolumeSnapshotLocation` in the future, Velero will fetch the data from the key within the Secret you provide.
+
+For example, a new `VolumeSnapshotLocation` with a Secret would be configured as follows:
+
+```bash
+velero snapshot-location create <vsl-name> \
+  --provider <provider> \
+  --config region=<region> \
+  --credential=<secret-name>=<key-within-secret>
+```
+
+To use this new `VolumeSnapshotLocation` when performing a backup, use the flag `--volume-snapshot-locations <vsl-name>[,<vsl-name...]` when running `velero backup create`, supplying at most one VSL per provider.
+
+### Modify the credentials used by an existing volume snapshot location
+
+By default, `VolumeSnapshotLocations` will use the credentials provided at install time and stored in the `cloud-credentials` secret in the Velero namespace.
+You can modify these existing credentials by [editing the `cloud-credentials` secret][10], however, these changes will apply to all locations using this secret.
+This may be the desired outcome, for example, in the case where you wish to rotate the credentials used for a particular account.
+
+You can also opt to modify an existing `VolumeSnapshotLocation` such that it uses its own credentials by using the `snapshot-location set` command.
+
+If you have a credentials file that you wish to use for a `VolumeSnapshotLocation`, follow the instructions above to create the Secret with that file in the Velero namespace.
+
+Once you have created the Secret, or have an existing Secret which contains the credentials you wish to use for your `VolumeSnapshotLocation`, set the credential to use as follows:
+
+```bash
+velero snapshot-location set <vsl-name> \
   --credential=<secret-name>=<key-within-secret>
 ```
 


### PR DESCRIPTION
Signed-off-by: Scott Seago <sseago@redhat.com>

Thank you for contributing to Velero!

This adds documentation around how to manage per-VSL credentials.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x ] Updated the corresponding documentation in `site/content/docs/main`.
