### PR TITLE
Add compile restic binary for CVE fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,6 @@ WORKDIR /go/src/github.com/vmware-tanzu/velero
 
 COPY . /go/src/github.com/vmware-tanzu/velero
 
-RUN apt-get update && apt-get install -y bzip2
-
 FROM --platform=$BUILDPLATFORM builder-env as builder
 
 ARG TARGETOS
@@ -45,7 +43,7 @@ ENV GOOS=${TARGETOS} \
     GOARM=${TARGETVARIANT}
 
 RUN mkdir -p /output/usr/bin && \
-    bash ./hack/download-restic.sh && \
+    bash ./hack/build-restic.sh && \
     export GOARM=$( echo "${GOARM}" | cut -c2-) && \
     go build -o /output/${BIN} \
     -ldflags "${LDFLAGS}" ${PKG}/cmd/${BIN}

--- a/changelogs/CHANGELOG-1.9.md
+++ b/changelogs/CHANGELOG-1.9.md
@@ -15,6 +15,7 @@ https://velero.io/docs/v1.9/upgrade-to-1.9/
 
 ### All changes
   * Fix controller problematic log output (#5570, @qiuming-best) 
+  * Add compile restic binary for CVE fix (#5564, @qiuming-best) 
   * Bump up golang version to 1.18.8 (#5558, @qiuming-best) 
   * Enhance the restore priorities list to support specifying the low prioritized resources that need to be restored in the last (#5529, @ywk253100)
   * Fix v1.9.3 CSI VolumeSnapshot status duplicate issue. (#5518, @blackpiglet)

--- a/hack/build-restic.sh
+++ b/hack/build-restic.sh
@@ -22,6 +22,7 @@ set -o pipefail
 # is the path expected by the Velero Dockerfile.
 output_dir=${OUTPUT_DIR:-/output/usr/bin}
 restic_bin=${output_dir}/restic
+build_path=$(dirname "$PWD")
 
 if [[ -z "${BIN}" ]]; then
     echo "BIN must be set"
@@ -46,8 +47,9 @@ if [[ -z "${RESTIC_VERSION}" ]]; then
     exit 1
 fi
 
-curl -s -L https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_${GOOS}_${GOARCH}.bz2 -O
-bunzip2 restic_${RESTIC_VERSION}_${GOOS}_${GOARCH}.bz2
-mv restic_${RESTIC_VERSION}_${GOOS}_${GOARCH} ${restic_bin}
-
+mkdir ${build_path}/restic
+git clone -b v${RESTIC_VERSION} https://github.com/restic/restic.git ${build_path}/restic
+pushd ${build_path}/restic
+go run build.go -o ${restic_bin}
 chmod +x ${restic_bin}
+popd


### PR DESCRIPTION
Signed-off-by: Ming <mqiu@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)
Fix CVE scanned from [TMC](https://osspi.eng.vmware.com/audit-reports/127860/vulnerabilities/all?limit=25&offset=0) by compiling `restic` binary using a higher version of golang

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
