### PR TITLE
Bump goreleaser to v1.12.3

### DIFF
--- a/hack/build-image/Dockerfile
+++ b/hack/build-image/Dockerfile
@@ -52,7 +52,7 @@ RUN wget --quiet https://github.com/protocolbuffers/protobuf/releases/download/v
 RUN go install github.com/golang/protobuf/protoc-gen-go@v1.4.3
 
 # get goreleaser
-RUN wget --quiet https://github.com/goreleaser/goreleaser/releases/download/v0.120.8/goreleaser_Linux_x86_64.tar.gz && \
+RUN wget --quiet https://github.com/goreleaser/goreleaser/releases/download/v1.12.3/goreleaser_Linux_x86_64.tar.gz && \
     tar xvf goreleaser_Linux_x86_64.tar.gz && \
     mv goreleaser /usr/bin/goreleaser && \
     chmod +x /usr/bin/goreleaser


### PR DESCRIPTION
# Please add a summary of your change
Bump gorelease to v1.12.2

# Does your change fix a particular issue?

Velero did not release the darwin arm64 binary.
I hope that bumps the gorelease version will make the darwin arm64 binary available.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] ~Updated the corresponding documentation in `site/content/docs/main`.~
