### PR TITLE
Update the Valero channel hash-name for Kubernetes Slack.

### DIFF
--- a/site/content/community/_index.md
+++ b/site/content/community/_index.md
@@ -12,7 +12,7 @@ If you are ready to jump in and test, add code, or help with documentation, foll
 You can follow the work we do, see our milestones, and our backlog on our [GitHub project boards](https://github.com/vmware-tanzu/velero/projects).
 
 * Follow us on Twitter at [@projectvelero](https://twitter.com/projectvelero)
-* Join our Kubernetes Slack channel and talk to over 800 other community members: [#velero](https://kubernetes.slack.com/messages/velero)
+* Join our Kubernetes Slack channel and talk to over 800 other community members: [#velero-users](https://kubernetes.slack.com/messages/velero-users)
 * Join our [Google Group](https://groups.google.com/forum/#!forum/projectvelero) to get updates on the project and invites to community meetings.
 * Join the Velero community meetings  - [Zoom link](https://VMware.zoom.us/j/94501971662?pwd=aUxVbWVEWHZSbDh4ZGdGU1cxYUFoZz09)  
 Bi-weekly  community meeting alternating every week between Beijing Friendly timezone and EST/Europe Friendly Timezone  

--- a/site/content/docs/main/_index.md
+++ b/site/content/docs/main/_index.md
@@ -29,7 +29,7 @@ Please use the version selector at the top of the site to ensure you are using t
 
 ## Troubleshooting
 
-If you encounter issues, review the [troubleshooting docs][30], [file an issue][4], or talk to us on the [#velero channel][25] on the Kubernetes Slack server.
+If you encounter issues, review the [troubleshooting docs][30], [file an issue][4], or talk to us on the [#velero-users channel][25] on the Kubernetes Slack server.
 
 ## Contributing
 
@@ -51,7 +51,7 @@ See [the list of releases][6] to find out about feature changes.
 [12]: https://github.com/kubernetes/kubernetes/blob/main/cluster/addons/dns/README.md
 [14]: https://github.com/kubernetes/kubernetes
 [24]: https://groups.google.com/forum/#!forum/projectvelero
-[25]: https://kubernetes.slack.com/messages/velero
+[25]: https://kubernetes.slack.com/messages/velero-users
 
 [30]: troubleshooting.md
 


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Corrected Valero channel hash-name for Kubernetes Slack with the Slack URL. 
# Does your change fix a particular issue?

Fixes #5607

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
