### PR TITLE
Restore ClusterBootstrap before Cluster

### DIFF
--- a/changelogs/unreleased/5615-ywk253100
+++ b/changelogs/unreleased/5615-ywk253100
@@ -1,0 +1,1 @@
+Restore ClusterBootstrap before Cluster otherwise a new default ClusterBootstrap object is create for the cluster

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -487,12 +487,13 @@ func (s *server) veleroResourcesExist() error {
 // - Replica sets go before deployments/other controllers so they can be explicitly
 //	 restored and be adopted by controllers.
 // - CAPI ClusterClasses go before Clusters.
+//
+// Low priorities:
+// - Tanzu ClusterBootstraps go last as it can reference any other kind of resources.
+//   ClusterBootstraps go before CAPI Clusters otherwise a new default ClusterBootstrap object is created for the cluster
 // - CAPI Clusters come before ClusterResourceSets because failing to do so means the CAPI controller-manager will panic.
 //	 Both Clusters and ClusterResourceSets need to come before ClusterResourceSetBinding in order to properly restore workload clusters.
 //   See https://github.com/kubernetes-sigs/cluster-api/issues/4105
-//
-// Low priorities:
-// - Tanzu ClusterBootstrap go last as it can reference any other kind of resources
 var defaultRestorePriorities = restore.Priorities{
 	HighPriorities: []string{
 		"customresourcedefinitions",
@@ -514,11 +515,11 @@ var defaultRestorePriorities = restore.Priorities{
 		// in the backup.
 		"replicasets.apps",
 		"clusterclasses.cluster.x-k8s.io",
-		"clusters.cluster.x-k8s.io",
-		"clusterresourcesets.addons.cluster.x-k8s.io",
 	},
 	LowPriorities: []string{
 		"clusterbootstraps.run.tanzu.vmware.com",
+		"clusters.cluster.x-k8s.io",
+		"clusterresourcesets.addons.cluster.x-k8s.io",
 	},
 }
 


### PR DESCRIPTION
Restore ClusterBootstrap before Cluster otherwise a new default ClusterBootstrap object is create for the cluster

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
