### PR TITLE
[1.9] Remove old kubernetes versions from kind CI

### DIFF
--- a/.github/workflows/crds-verify-kind.yaml
+++ b/.github/workflows/crds-verify-kind.yaml
@@ -57,9 +57,6 @@ jobs:
       matrix:
         # Latest k8s versions. There's no series-based tag, nor is there a latest tag.
         k8s:
-          - 1.16.15
-          - 1.17.17
-          - 1.18.15
           - 1.19.7
           - 1.20.2
           - 1.21.1

--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -60,11 +60,6 @@ jobs:
     strategy:
       matrix:
         k8s:
-          # doesn't cover 1.15 as 1.15 doesn't support "apiextensions.k8s.io/v1" that is needed for the case
-          #- 1.15.12
-          - 1.16.15
-          - 1.17.17
-          - 1.18.20
           - 1.19.16
           - 1.20.15
           - 1.21.12


### PR DESCRIPTION
Remove old kubernetes versions from kind CI matrix, as kind has some problem to create clusters of old versions