### PR TITLE
Rollback goreleaser upgrade

### DIFF
--- a/hack/build-image/Dockerfile
+++ b/hack/build-image/Dockerfile
@@ -52,7 +52,7 @@ RUN wget --quiet https://github.com/protocolbuffers/protobuf/releases/download/v
 RUN go install github.com/golang/protobuf/protoc-gen-go@v1.4.3
 
 # get goreleaser
-RUN wget --quiet https://github.com/goreleaser/goreleaser/releases/download/v1.12.3/goreleaser_Linux_x86_64.tar.gz && \
+RUN wget --quiet https://github.com/goreleaser/goreleaser/releases/download/v0.120.8/goreleaser_Linux_x86_64.tar.gz && \
     tar xvf goreleaser_Linux_x86_64.tar.gz && \
     mv goreleaser /usr/bin/goreleaser && \
     chmod +x /usr/bin/goreleaser


### PR DESCRIPTION
Rollback goreleaser upgrade due to a goreleaser regression issue introduced by goreleaser [PR 2377](https://github.com/goreleaser/goreleaser/pull/2377)