### PR TITLE
Update Velero and k8s version compatibility matrix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ The following is a list of the supported Kubernetes versions for each Velero ver
 
 | Velero version | Expected Kubernetes version compatibility| Tested on Kubernetes version|
 |----------------|--------------------|--------------------|
-| 1.10           | 1.16-latest        |  1.22.5, 1.23.8, 1.24.6 and 1.25.1 |
-| 1.9            | 1.16-latest        |  1.20.5, 1.21.2, 1.22.5, 1.23, and 1.24 |
-| 1.8            | 1.16-latest        |  |
+| 1.10           | 1.18-latest        |  1.22.5, 1.23.8, 1.24.6 and 1.25.1 |
+| 1.9            | 1.18-latest        |  1.20.5, 1.21.2, 1.22.5, 1.23, and 1.24 |
+| 1.8            | 1.18-latest        |  |
 | 1.6.3-1.7.1    | 1.12-latest        ||
 | 1.60-1.6.2     | 1.12-1.21          ||
 | 1.5            | 1.12-1.21          ||


### PR DESCRIPTION
Due to CSIDriver is checked for Restic volume mounting path, and CSIDriver is GA and moved to storage v1 group in k8s v1.18, so update Velero v1.8, v1.9 and v1.10 compatible k8s version to 1.18-latest.

Signed-off-by: Xun Jiang <blackpiglet@gmail.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
