### PR TITLE
Prevent nil panic on exec restore hooks

### DIFF
--- a/changelogs/unreleased/5674-dymurray
+++ b/changelogs/unreleased/5674-dymurray
@@ -1,0 +1,1 @@
+Prevent nil panic on exec restore hooks

--- a/pkg/controller/restore_controller.go
+++ b/pkg/controller/restore_controller.go
@@ -342,10 +342,12 @@ func (c *restoreController) validateAndComplete(restore *api.Restore, pluginMana
 	}
 	for _, resource := range restoreHooks {
 		for _, h := range resource.RestoreHooks {
-			for _, container := range h.Init.InitContainers {
-				err = hook.ValidateContainer(container.Raw)
-				if err != nil {
-					restore.Status.ValidationErrors = append(restore.Status.ValidationErrors, err.Error())
+			if h.Init != nil {
+				for _, container := range h.Init.InitContainers {
+					err = hook.ValidateContainer(container.Raw)
+					if err != nil {
+						restore.Status.ValidationErrors = append(restore.Status.ValidationErrors, err.Error())
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Dylan Murray <dymurray@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Adds a nil pointer check on initcontainer hook validation

# Does your change fix a particular issue?

Fixes #5674 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
