### PR TITLE
Add Restic builder in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,47 +11,58 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM --platform=$BUILDPLATFORM golang:1.18.8 as builder-env
+
+# Setup build environment
+ARG GOLANG_VERSION=1.18.8
+FROM --platform=$BUILDPLATFORM golang:${GOLANG_VERSION} as builder-env
 
 ARG GOPROXY
+ARG BIN
 ARG PKG
 ARG VERSION
+ARG REGISTRY
 ARG GIT_SHA
 ARG GIT_TREE_STATE
-ARG REGISTRY
+ARG RESTIC_VERSION
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
 
 ENV CGO_ENABLED=0 \
     GO111MODULE=on \
     GOPROXY=${GOPROXY} \
+    GOOS=${TARGETOS} \
+    GOARCH=${TARGETARCH} \
+    GOARM=${TARGETVARIANT} \
     LDFLAGS="-X ${PKG}/pkg/buildinfo.Version=${VERSION} -X ${PKG}/pkg/buildinfo.GitSHA=${GIT_SHA} -X ${PKG}/pkg/buildinfo.GitTreeState=${GIT_TREE_STATE} -X ${PKG}/pkg/buildinfo.ImageRegistry=${REGISTRY}"
 
 WORKDIR /go/src/github.com/vmware-tanzu/velero
 
 COPY . /go/src/github.com/vmware-tanzu/velero
 
+# Velero binary build section
+ARG GOLANG_VERSION=1.18.8
 FROM --platform=$BUILDPLATFORM builder-env as builder
-
-ARG TARGETOS
-ARG TARGETARCH
-ARG TARGETVARIANT
-ARG PKG
-ARG BIN
-ARG RESTIC_VERSION
-
-ENV GOOS=${TARGETOS} \
-    GOARCH=${TARGETARCH} \
-    GOARM=${TARGETVARIANT}
 
 RUN mkdir -p /output/usr/bin && \
     export GOARM=$( echo "${GOARM}" | cut -c2-) && \
-    bash ./hack/build-restic.sh && \
     go build -o /output/${BIN} \
     -ldflags "${LDFLAGS}" ${PKG}/cmd/${BIN}
 
+# Restic binary build section
+ARG GOLANG_VERSION=1.19.4-bullseye
+FROM --platform=$BUILDPLATFORM builder-env as restic-builder
+
+RUN mkdir -p /output/usr/bin && \
+    bash /go/src/github.com/vmware-tanzu/velero/hack/build-restic.sh
+
+# Velero image packing section
 FROM gcr.io/distroless/base-debian11@sha256:99133cb0878bb1f84d1753957c6fd4b84f006f2798535de22ebf7ba170bbf434
 
 LABEL maintainer="Nolan Brubaker <brubakern@vmware.com>"
 
 COPY --from=builder /output /
+
+COPY --from=restic-builder /output /
 
 USER nonroot:nonroot

--- a/changelogs/unreleased/5685-blackpiglet
+++ b/changelogs/unreleased/5685-blackpiglet
@@ -1,0 +1,1 @@
+Add Restic builder in Dockerfile, and keep the used built Golang image version in accordance with upstream Restic.

--- a/hack/build-restic.sh
+++ b/hack/build-restic.sh
@@ -50,6 +50,7 @@ fi
 mkdir ${build_path}/restic
 git clone -b v${RESTIC_VERSION} https://github.com/restic/restic.git ${build_path}/restic
 pushd ${build_path}/restic
+git apply /go/src/github.com/vmware-tanzu/velero/hack/modify_acces_denied_code.txt
 go run build.go --goos "${GOOS}" --goarch "${GOARCH}" --goarm "${GOARM}" -o ${restic_bin}
 chmod +x ${restic_bin}
 popd

--- a/hack/modify_acces_denied_code.txt
+++ b/hack/modify_acces_denied_code.txt
@@ -1,0 +1,13 @@
+diff --git a/internal/backend/s3/s3.go b/internal/backend/s3/s3.go
+index 0b3816c06..eec10f9c7 100644
+--- a/internal/backend/s3/s3.go
++++ b/internal/backend/s3/s3.go
+@@ -164,7 +164,7 @@ func isAccessDenied(err error) bool {
+ 	debug.Log("isAccessDenied(%T, %#v)", err, err)
+ 
+ 	var e minio.ErrorResponse
+-	return errors.As(err, &e) && e.Code == "Access Denied"
++	return errors.As(err, &e) && e.Code == "AccessDenied"
+ }
+ 
+ // IsNotExist returns true if the error is caused by a not existing file.


### PR DESCRIPTION
Signed-off-by: Xun Jiang <blackpiglet@gmail.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)
This PR fix Velero v1.9.4 backup failure in AWS restricted permission setting environment.
Velero would fail during checking whether bucket exists with `Access Denied`, when creating the ResticRepository.

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
