### PR TITLE
Add velero_backup_active_total metric

### DIFF
--- a/changelogs/unreleased/5703-mrnold
+++ b/changelogs/unreleased/5703-mrnold
@@ -1,0 +1,1 @@
+Add velero_backup_active_total metric

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -269,10 +269,12 @@ func (b *backupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	original = request.Backup.DeepCopy()
 
 	b.backupTracker.Add(request.Namespace, request.Name)
+	b.metrics.IncrementActiveBackupTotal()
 	defer func() {
 		switch request.Status.Phase {
 		case velerov1api.BackupPhaseCompleted, velerov1api.BackupPhasePartiallyFailed, velerov1api.BackupPhaseFailed, velerov1api.BackupPhaseFailedValidation:
 			b.backupTracker.Delete(request.Namespace, request.Name)
+			b.metrics.DecrementActiveBackupTotal()
 		}
 	}()
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 the Velero contributors.
+Copyright the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ const (
 	//Velero metrics
 	backupTarballSizeBytesGauge   = "backup_tarball_size_bytes"
 	backupTotal                   = "backup_total"
+	backupActiveTotal             = "backup_active_total"
 	backupAttemptTotal            = "backup_attempt_total"
 	backupSuccessTotal            = "backup_success_total"
 	backupPartialFailureTotal     = "backup_partial_failure_total"
@@ -111,6 +112,13 @@ func NewServerMetrics() *ServerMetrics {
 					Namespace: metricNamespace,
 					Name:      backupTotal,
 					Help:      "Current number of existent backups",
+				},
+			),
+			backupActiveTotal: prometheus.NewGauge(
+				prometheus.GaugeOpts{
+					Namespace: metricNamespace,
+					Name:      backupActiveTotal,
+					Help:      "Number of backups currently in progress",
 				},
 			),
 			backupAttemptTotal: prometheus.NewCounterVec(
@@ -703,6 +711,20 @@ func (m *ServerMetrics) SetBackupLastSuccessfulTimestamp(backupSchedule string, 
 func (m *ServerMetrics) SetBackupTotal(numberOfBackups int64) {
 	if g, ok := m.metrics[backupTotal].(prometheus.Gauge); ok {
 		g.Set(float64(numberOfBackups))
+	}
+}
+
+// IncrementActiveBackupTotal increments the number of in-progress backups
+func (m *ServerMetrics) IncrementActiveBackupTotal() {
+	if g, ok := m.metrics[backupActiveTotal].(prometheus.Gauge); ok {
+		g.Inc()
+	}
+}
+
+// DecrementActiveBackupTotal decrements the number of in-progress backups
+func (m *ServerMetrics) DecrementActiveBackupTotal() {
+	if g, ok := m.metrics[backupActiveTotal].(prometheus.Gauge); ok {
+		g.Dec()
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Matthew Arnold <marnold@redhat.com>

# Please add a summary of your change

Add a backup_active_total metric, as requested in #2254. This metric counts the number of backups in progress.

# Does your change fix a particular issue?

Fixes #2254 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
