### PR TITLE
[Cherry-Pick]Fix error with Restic backup empty volumes

### DIFF
--- a/changelogs/unreleased/5713-qiuming-best
+++ b/changelogs/unreleased/5713-qiuming-best
@@ -1,0 +1,1 @@
+Fix error with Restic backup empty volumes

--- a/pkg/uploader/provider/restic.go
+++ b/pkg/uploader/provider/restic.go
@@ -137,7 +137,7 @@ func (rp *resticProvider) RunBackup(
 
 	summary, stderrBuf, err := restic.RunBackup(backupCmd, log, updater)
 	if err != nil {
-		if strings.Contains(err.Error(), "snapshot is empty") {
+		if strings.Contains(stderrBuf, "snapshot is empty") {
 			log.Debugf("Restic backup got empty dir with %s path", path)
 			return "", true, nil
 		}


### PR DESCRIPTION
Signed-off-by: Ming <mqiu@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)
#5678
Fix error with Restic backup empty volumes

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
