### PR TITLE
Use errors.Is to check for a specific error

### DIFF
--- a/pkg/archive/extractor.go
+++ b/pkg/archive/extractor.go
@@ -19,6 +19,7 @@ package archive
 import (
 	"archive/tar"
 	"compress/gzip"
+	"errors"
 	"io"
 	"path/filepath"
 
@@ -76,7 +77,7 @@ func (e *Extractor) readBackup(tarRdr *tar.Reader) (string, error) {
 	for {
 		header, err := tarRdr.Next()
 
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -2832,7 +2832,7 @@ func assertTarballContents(t *testing.T, backupFile io.Reader, items ...string) 
 	var files []string
 	for {
 		hdr, err := r.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		require.NoError(t, err)
@@ -2863,7 +2863,7 @@ func assertTarballFileContents(t *testing.T, backupFile io.Reader, want map[stri
 
 	for {
 		hdr, err := r.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		require.NoError(t, err)
@@ -2911,7 +2911,7 @@ func assertTarballOrdering(t *testing.T, backupFile io.Reader, orderedResources 
 
 	for {
 		hdr, err := r.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		require.NoError(t, err)

--- a/pkg/plugin/framework/object_store_client.go
+++ b/pkg/plugin/framework/object_store_client.go
@@ -80,7 +80,7 @@ func (c *ObjectStoreGRPCClient) PutObject(bucket, key string, body io.Reader) er
 	chunk := make([]byte, byteChunkSize)
 	for {
 		n, err := body.Read(chunk)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			if _, resErr := stream.CloseAndRecv(); resErr != nil {
 				return common.FromGRPCError(resErr)
 			}
@@ -129,7 +129,7 @@ func (c *ObjectStoreGRPCClient) GetObject(bucket, key string) (io.ReadCloser, er
 
 	receive := func() ([]byte, error) {
 		data, err := stream.Recv()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			// we need to return io.EOF errors unwrapped so that
 			// calling code sees them as io.EOF and knows to stop
 			// reading.

--- a/pkg/plugin/framework/object_store_server.go
+++ b/pkg/plugin/framework/object_store_server.go
@@ -102,7 +102,7 @@ func (s *ObjectStoreGRPCServer) PutObject(stream proto.ObjectStore_PutObjectServ
 		}
 
 		data, err := stream.Recv()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			// we need to return io.EOF errors unwrapped so that
 			// calling code sees them as io.EOF and knows to stop
 			// reading.

--- a/pkg/plugin/framework/stream_reader.go
+++ b/pkg/plugin/framework/stream_reader.go
@@ -18,6 +18,7 @@ package framework
 
 import (
 	"bytes"
+	"errors"
 	"io"
 )
 
@@ -57,7 +58,7 @@ func (s *StreamReadCloser) Read(p []byte) (n int, err error) {
 		// buffer; else, write the new data to the buffer and
 		// try another read.
 		data, err := s.receive()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return s.buf.Read(p)
 		}
 		if err != nil {


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

Comparing with ==  will fail on wrapped errors. Use errors.Is to check for a specific error

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
