### PR TITLE
Clean "io/ioutil" .

### DIFF
--- a/cmd/velero-restore-helper/velero-restore-helper.go
+++ b/cmd/velero-restore-helper/velero-restore-helper.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -54,7 +53,7 @@ func main() {
 // within the .velero/ subdirectory whose name is equal to os.Args[1], or
 // false otherwise
 func done() bool {
-	children, err := ioutil.ReadDir("/restores")
+	children, err := os.ReadDir("/restores")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR reading /restores directory: %s\n", err)
 		return false
@@ -84,7 +83,7 @@ func done() bool {
 
 // remove .velero folder
 func removeFolder() error {
-	children, err := ioutil.ReadDir("/restores")
+	children, err := os.ReadDir("/restores")
 	if err != nil {
 		return err
 	}

--- a/hack/crd-gen/v1/main.go
+++ b/hack/crd-gen/v1/main.go
@@ -24,7 +24,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"text/template"
@@ -41,7 +40,7 @@ package crds
 import (
 	"bytes"
 	"compress/gzip"
-	"io/ioutil"
+	"io"
 
 	apiextinstall "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -65,7 +64,7 @@ func crds() []*apiextv1.CustomResourceDefinition {
 		if err != nil {
 			panic(err)
 		}
-		bytes, err := ioutil.ReadAll(gzr)
+		bytes, err := io.ReadAll(gzr)
 		if err != nil {
 			panic(err)
 		}
@@ -87,7 +86,7 @@ type templateData struct {
 }
 
 func main() {
-	headerBytes, err := ioutil.ReadFile(goHeaderFile)
+	headerBytes, err := os.ReadFile(goHeaderFile)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -97,7 +96,7 @@ func main() {
 	}
 
 	// This is relative to config/crd/crds
-	manifests, err := ioutil.ReadDir("../bases")
+	manifests, err := os.ReadDir("../bases")
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -252,7 +251,7 @@ func (kb *kubernetesBackupper) BackupWithResolvers(log logrus.FieldLogger,
 
 	// set up a temp dir for the itemCollector to use to temporarily
 	// store items as they're scraped from the API.
-	tempDir, err := ioutil.TempDir("", "")
+	tempDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return errors.Wrap(err, "error creating temp dir for backup")
 	}

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sort"
 	"strings"
 	"testing"
@@ -2868,7 +2867,7 @@ func assertTarballFileContents(t *testing.T, backupFile io.Reader, want map[stri
 		}
 		require.NoError(t, err)
 
-		bytes, err := ioutil.ReadAll(r)
+		bytes, err := io.ReadAll(r)
 		require.NoError(t, err)
 
 		items[hdr.Name] = bytes

--- a/pkg/backup/item_collector.go
+++ b/pkg/backup/item_collector.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 
@@ -368,7 +368,7 @@ func (r *itemCollector) getResourceItems(log logrus.FieldLogger, gv schema.Group
 }
 
 func (r *itemCollector) writeToFile(item *unstructured.Unstructured) (string, error) {
-	f, err := ioutil.TempFile(r.dir, "")
+	f, err := os.CreateTemp(r.dir, "")
 	if err != nil {
 		return "", errors.Wrap(err, "error creating temp file")
 	}

--- a/pkg/backup/remap_crd_version_action_test.go
+++ b/pkg/backup/remap_crd_version_action_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -174,7 +174,7 @@ func TestRemapCRDVersionActionData(t *testing.T) {
 		t.Run(tName, func(t *testing.T) {
 			// We don't need a Go struct of the v1 data, just an unstructured to pass into the plugin.
 			v1File := fmt.Sprintf("testdata/v1/%s.json", test.crd)
-			f, err := ioutil.ReadFile(v1File)
+			f, err := os.ReadFile(v1File)
 			require.NoError(t, err)
 
 			var obj unstructured.Unstructured
@@ -183,7 +183,7 @@ func TestRemapCRDVersionActionData(t *testing.T) {
 
 			// Load a v1beta1 struct into the beta client to be returned
 			v1beta1File := fmt.Sprintf("testdata/v1beta1/%s.json", test.crd)
-			f, err = ioutil.ReadFile(v1beta1File)
+			f, err = os.ReadFile(v1beta1File)
 			require.NoError(t, err)
 
 			var crd apiextv1beta1.CustomResourceDefinition

--- a/pkg/cmd/cli/backuplocation/create.go
+++ b/pkg/cmd/cli/backuplocation/create.go
@@ -19,7 +19,7 @@ package backuplocation
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -141,7 +141,7 @@ func (o *CreateOptions) BuildBackupStorageLocation(namespace string, setBackupSy
 		if err != nil {
 			return nil, err
 		}
-		caCertData, err = ioutil.ReadFile(realPath)
+		caCertData, err = os.ReadFile(realPath)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/cli/backuplocation/set.go
+++ b/pkg/cmd/cli/backuplocation/set.go
@@ -19,7 +19,7 @@ package backuplocation
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -98,7 +98,7 @@ func (o *SetOptions) Run(c *cobra.Command, f client.Factory) error {
 		if err != nil {
 			return err
 		}
-		caCertData, err = ioutil.ReadFile(realPath)
+		caCertData, err = os.ReadFile(realPath)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/cli/debug/debug.go
+++ b/pkg/cmd/cli/debug/debug.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -96,7 +95,7 @@ func (o *option) complete(f client.Factory, fs *pflag.FlagSet) error {
 		return fmt.Errorf("invalid output path: %v", err)
 	}
 	o.outputPath = absOutputPath
-	tmpDir, err := ioutil.TempDir("", "crashd")
+	tmpDir, err := os.MkdirTemp("", "crashd")
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/cli/install/install.go
+++ b/pkg/cmd/cli/install/install.go
@@ -18,7 +18,6 @@ package install
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -153,7 +152,7 @@ func (o *InstallOptions) AsVeleroOptions() (*install.VeleroOptions, error) {
 		if err != nil {
 			return nil, err
 		}
-		secretData, err = ioutil.ReadFile(realPath)
+		secretData, err = os.ReadFile(realPath)
 		if err != nil {
 			return nil, err
 		}
@@ -164,7 +163,7 @@ func (o *InstallOptions) AsVeleroOptions() (*install.VeleroOptions, error) {
 		if err != nil {
 			return nil, err
 		}
-		caCertData, err = ioutil.ReadFile(realPath)
+		caCertData, err = os.ReadFile(realPath)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/util/downloadrequest/downloadrequest.go
+++ b/pkg/cmd/util/downloadrequest/downloadrequest.go
@@ -23,9 +23,9 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/google/uuid"
@@ -91,7 +91,7 @@ func Stream(ctx context.Context, kbClient kbclient.Client, namespace, name strin
 
 	var caPool *x509.CertPool
 	if len(caCertFile) > 0 {
-		caCert, err := ioutil.ReadFile(caCertFile)
+		caCert, err := os.ReadFile(caCertFile)
 		if err != nil {
 			return errors.Wrapf(err, "couldn't open cacert")
 		}
@@ -140,7 +140,7 @@ func Stream(ctx context.Context, kbClient kbclient.Client, namespace, name strin
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return errors.Wrapf(err, "request failed: unable to decode response body")
 		}

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sync"
 	"time"
@@ -588,7 +587,7 @@ func (c *backupController) validateAndGetSnapshotLocations(backup *velerov1api.B
 func (c *backupController) runBackup(backup *pkgbackup.Request) error {
 	c.logger.WithField(Backup, kubeutil.NamespaceAndName(backup)).Info("Setting up backup log")
 
-	logFile, err := ioutil.TempFile("", "")
+	logFile, err := os.CreateTemp("", "")
 	if err != nil {
 		return errors.Wrap(err, "error creating temp file for backup log")
 	}
@@ -609,7 +608,7 @@ func (c *backupController) runBackup(backup *pkgbackup.Request) error {
 	backupLog := logger.WithField(Backup, kubeutil.NamespaceAndName(backup))
 
 	backupLog.Info("Setting up backup temp file")
-	backupFile, err := ioutil.TempFile("", "")
+	backupFile, err := os.CreateTemp("", "")
 	if err != nil {
 		return errors.Wrap(err, "error creating temp file for backup")
 	}

--- a/pkg/controller/backup_deletion_controller_test.go
+++ b/pkg/controller/backup_deletion_controller_test.go
@@ -19,11 +19,11 @@ package controller
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"sort"
 	"time"
 
 	"context"
-	"io/ioutil"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -322,7 +322,7 @@ func TestBackupDeletionControllerReconcile(t *testing.T) {
 		td.controller.newPluginManager = func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager }
 
 		td.backupStore.On("GetBackupVolumeSnapshots", input.Spec.BackupName).Return(snapshots, nil)
-		td.backupStore.On("GetBackupContents", input.Spec.BackupName).Return(ioutil.NopCloser(bytes.NewReader([]byte("hello world"))), nil)
+		td.backupStore.On("GetBackupContents", input.Spec.BackupName).Return(io.NopCloser(bytes.NewReader([]byte("hello world"))), nil)
 		td.backupStore.On("DeleteBackup", input.Spec.BackupName).Return(nil)
 		td.backupStore.On("DeleteRestore", "restore-1").Return(nil)
 		td.backupStore.On("DeleteRestore", "restore-2").Return(nil)
@@ -443,7 +443,7 @@ func TestBackupDeletionControllerReconcile(t *testing.T) {
 		td.controller.newPluginManager = func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager }
 
 		td.backupStore.On("GetBackupVolumeSnapshots", dbr.Spec.BackupName).Return(snapshots, nil)
-		td.backupStore.On("GetBackupContents", dbr.Spec.BackupName).Return(ioutil.NopCloser(bytes.NewReader([]byte("hello world"))), nil)
+		td.backupStore.On("GetBackupContents", dbr.Spec.BackupName).Return(io.NopCloser(bytes.NewReader([]byte("hello world"))), nil)
 		td.backupStore.On("DeleteBackup", dbr.Spec.BackupName).Return(nil)
 		td.backupStore.On("DeleteRestore", "restore-1").Return(nil)
 		td.backupStore.On("DeleteRestore", "restore-2").Return(nil)

--- a/pkg/controller/pod_volume_restore_controller.go
+++ b/pkg/controller/pod_volume_restore_controller.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -302,7 +301,7 @@ func (c *PodVolumeRestoreReconciler) processRestore(ctx context.Context, req *ve
 	// Write a done file with name=<restore-uid> into the just-created .velero dir
 	// within the volume. The velero init container on the pod is waiting
 	// for this file to exist in each restored volume before completing.
-	if err := ioutil.WriteFile(filepath.Join(volumePath, ".velero", string(restoreUID)), nil, 0644); err != nil { //nolint:gosec
+	if err := os.WriteFile(filepath.Join(volumePath, ".velero", string(restoreUID)), nil, 0644); err != nil { //nolint:gosec
 		return errors.Wrap(err, "error writing done file")
 	}
 

--- a/pkg/controller/restore_controller.go
+++ b/pkg/controller/restore_controller.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 	"time"
@@ -613,7 +612,7 @@ func downloadToTempFile(backupName string, backupStore persistence.BackupStore, 
 	}
 	defer readCloser.Close()
 
-	file, err := ioutil.TempFile("", backupName)
+	file, err := os.CreateTemp("", backupName)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating Backup temp file")
 	}
@@ -672,7 +671,7 @@ type restoreLogger struct {
 }
 
 func newRestoreLogger(restore *api.Restore, logLevel logrus.Level, logFormat logging.Format) (*restoreLogger, error) {
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating temp file")
 	}

--- a/pkg/controller/restore_controller_test.go
+++ b/pkg/controller/restore_controller_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -514,7 +514,7 @@ func TestProcessQueueItem(t *testing.T) {
 				errors.Velero = append(errors.Velero, "error uploading log file to object storage: "+test.putRestoreLogErr.Error())
 			}
 			if test.expectedRestorerCall != nil {
-				backupStore.On("GetBackupContents", test.backup.Name).Return(ioutil.NopCloser(bytes.NewReader([]byte("hello world"))), nil)
+				backupStore.On("GetBackupContents", test.backup.Name).Return(io.NopCloser(bytes.NewReader([]byte("hello world"))), nil)
 
 				restorer.On("RestoreWithResolvers", mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(warnings, errors)

--- a/pkg/persistence/in_memory_object_store.go
+++ b/pkg/persistence/in_memory_object_store.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"strings"
 	"time"
 )
@@ -62,7 +61,7 @@ func (o *inMemoryObjectStore) PutObject(bucket, key string, body io.Reader) erro
 		return errors.New("bucket not found")
 	}
 
-	obj, err := ioutil.ReadAll(body)
+	obj, err := io.ReadAll(body)
 	if err != nil {
 		return err
 	}
@@ -93,7 +92,7 @@ func (o *inMemoryObjectStore) GetObject(bucket, key string) (io.ReadCloser, erro
 		return nil, errors.New("key not found")
 	}
 
-	return ioutil.NopCloser(bytes.NewReader(obj)), nil
+	return io.NopCloser(bytes.NewReader(obj)), nil
 }
 
 func (o *inMemoryObjectStore) ListCommonPrefixes(bucket, prefix, delimiter string) ([]string, error) {

--- a/pkg/persistence/object_store.go
+++ b/pkg/persistence/object_store.go
@@ -20,7 +20,6 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"strings"
 	"time"
 
@@ -289,7 +288,7 @@ func (s *objectBackupStore) GetBackupMetadata(name string) (*velerov1api.Backup,
 	}
 	defer res.Close()
 
-	data, err := ioutil.ReadAll(res)
+	data, err := io.ReadAll(res)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/pkg/persistence/object_store_test.go
+++ b/pkg/persistence/object_store_test.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sort"
 	"strings"
 	"testing"
@@ -493,7 +492,7 @@ func TestGetBackupContents(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, rc)
 
-	data, err := ioutil.ReadAll(rc)
+	data, err := io.ReadAll(rc)
 	require.NoError(t, err)
 	assert.Equal(t, "foo", string(data))
 }

--- a/pkg/plugin/clientmgmt/restartable_object_store_test.go
+++ b/pkg/plugin/clientmgmt/restartable_object_store_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package clientmgmt
 
 import (
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -208,7 +208,7 @@ func TestRestartableObjectStoreDelegatedFunctions(t *testing.T) {
 			Function:                "GetObject",
 			Inputs:                  []interface{}{"bucket", "key"},
 			ExpectedErrorOutputs:    []interface{}{nil, errors.Errorf("reset error")},
-			ExpectedDelegateOutputs: []interface{}{ioutil.NopCloser(strings.NewReader("object")), errors.Errorf("delegate error")},
+			ExpectedDelegateOutputs: []interface{}{io.NopCloser(strings.NewReader("object")), errors.Errorf("delegate error")},
 		},
 		restartabletest.RestartableDelegateTest{
 			Function:                "ListCommonPrefixes",

--- a/pkg/plugin/framework/stream_reader_test.go
+++ b/pkg/plugin/framework/stream_reader_test.go
@@ -18,7 +18,7 @@ package framework
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,7 +59,7 @@ func TestStreamReader(t *testing.T) {
 		close:   rdr.CloseSend,
 	}
 
-	res, err := ioutil.ReadAll(sr)
+	res, err := io.ReadAll(sr)
 
 	require.Nil(t, err)
 	assert.Equal(t, s, string(res))

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -715,7 +715,7 @@ func getNamespace(logger logrus.FieldLogger, path, remappedName string) *v1.Name
 	var nsBytes []byte
 	var err error
 
-	if nsBytes, err = ioutil.ReadFile(path); err != nil {
+	if nsBytes, err = os.ReadFile(path); err != nil {
 		return &v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: remappedName,

--- a/pkg/test/test_logger.go
+++ b/pkg/test/test_logger.go
@@ -17,13 +17,13 @@ limitations under the License.
 package test
 
 import (
-	"io/ioutil"
+	"io"
 
 	"github.com/sirupsen/logrus"
 )
 
 func NewLogger() logrus.FieldLogger {
 	logger := logrus.New()
-	logger.Out = ioutil.Discard
+	logger.Out = io.Discard
 	return logrus.NewEntry(logger)
 }

--- a/pkg/uploader/kopia/snapshot.go
+++ b/pkg/uploader/kopia/snapshot.go
@@ -18,7 +18,6 @@ package kopia
 
 import (
 	"context"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -95,7 +94,7 @@ func Backup(ctx context.Context, fsUploader *snapshotfs.Uploader, repoWriter rep
 	}
 
 	// to be consistent with restic when backup empty dir returns one error for upper logic handle
-	dirs, err := ioutil.ReadDir(dir)
+	dirs, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, false, errors.Wrapf(err, "Unable to read dir in path %s", dir)
 	} else if len(dirs) == 0 {

--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -18,7 +18,7 @@ package exec
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os/exec"
 
 	"github.com/pkg/errors"
@@ -38,13 +38,13 @@ func RunCommand(cmd *exec.Cmd) (string, string, error) {
 
 	var stdout, stderr string
 
-	if res, readErr := ioutil.ReadAll(stdoutBuf); readErr != nil {
+	if res, readErr := io.ReadAll(stdoutBuf); readErr != nil {
 		stdout = errors.Wrap(readErr, "error reading command's stdout").Error()
 	} else {
 		stdout = string(res)
 	}
 
-	if res, readErr := ioutil.ReadAll(stderrBuf); readErr != nil {
+	if res, readErr := io.ReadAll(stderrBuf); readErr != nil {
 		stderr = errors.Wrap(readErr, "error reading command's stderr").Error()
 	} else {
 		stderr = string(res)

--- a/pkg/util/filesystem/file_system.go
+++ b/pkg/util/filesystem/file_system.go
@@ -18,7 +18,6 @@ package filesystem
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -31,7 +30,7 @@ type Interface interface {
 	Create(name string) (io.WriteCloser, error)
 	OpenFile(name string, flag int, perm os.FileMode) (io.WriteCloser, error)
 	RemoveAll(path string) error
-	ReadDir(dirname string) ([]os.FileInfo, error)
+	ReadDir(dirname string) ([]os.DirEntry, error)
 	ReadFile(filename string) ([]byte, error)
 	DirExists(path string) (bool, error)
 	TempFile(dir, prefix string) (NameWriteCloser, error)
@@ -56,7 +55,7 @@ func (fs *osFileSystem) Glob(path string) ([]string, error) {
 }
 
 func (fs *osFileSystem) TempDir(dir, prefix string) (string, error) {
-	return ioutil.TempDir(dir, prefix)
+	return os.MkdirTemp(dir, prefix)
 }
 
 func (fs *osFileSystem) MkdirAll(path string, perm os.FileMode) error {
@@ -75,12 +74,12 @@ func (fs *osFileSystem) RemoveAll(path string) error {
 	return os.RemoveAll(path)
 }
 
-func (fs *osFileSystem) ReadDir(dirname string) ([]os.FileInfo, error) {
-	return ioutil.ReadDir(dirname)
+func (fs *osFileSystem) ReadDir(dirname string) ([]os.DirEntry, error) {
+	return os.ReadDir(dirname)
 }
 
 func (fs *osFileSystem) ReadFile(filename string) ([]byte, error) {
-	return ioutil.ReadFile(filename)
+	return os.ReadFile(filename)
 }
 
 func (fs *osFileSystem) DirExists(path string) (bool, error) {
@@ -95,7 +94,7 @@ func (fs *osFileSystem) DirExists(path string) (bool, error) {
 }
 
 func (fs *osFileSystem) TempFile(dir, prefix string) (NameWriteCloser, error) {
-	return ioutil.TempFile(dir, prefix)
+	return os.CreateTemp(dir, prefix)
 }
 
 func (fs *osFileSystem) Stat(path string) (os.FileInfo, error) {

--- a/test/e2e/util/k8s/common.go
+++ b/test/e2e/util/k8s/common.go
@@ -18,7 +18,7 @@ package k8s
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"time"
 
@@ -43,7 +43,7 @@ func CreateSecretFromFiles(ctx context.Context, client TestClient, namespace str
 	data := make(map[string][]byte)
 
 	for key, filePath := range files {
-		contents, err := ioutil.ReadFile(filePath)
+		contents, err := os.ReadFile(filePath)
 		if err != nil {
 			return errors.WithMessagef(err, "Failed to read secret file %q", filePath)
 		}

--- a/test/e2e/util/k8s/serviceaccount.go
+++ b/test/e2e/util/k8s/serviceaccount.go
@@ -19,7 +19,7 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/pkg/errors"
@@ -47,7 +47,7 @@ func WaitUntilServiceAccountCreated(ctx context.Context, client TestClient, name
 }
 
 func PatchServiceAccountWithImagePullSecret(ctx context.Context, client TestClient, namespace, serviceAccount, dockerCredentialFile string) error {
-	credential, err := ioutil.ReadFile(dockerCredentialFile)
+	credential, err := os.ReadFile(dockerCredentialFile)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read the docker credential file %q", dockerCredentialFile)
 	}

--- a/test/e2e/util/providers/gcloud_utils.go
+++ b/test/e2e/util/providers/gcloud_utils.go
@@ -19,7 +19,7 @@ package providers
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"cloud.google.com/go/storage"
@@ -103,7 +103,7 @@ func (s GCSStorage) DeleteObjectsInBucket(cloudCredentialsFile, bslBucket, bslPr
 
 func (s GCSStorage) IsSnapshotExisted(cloudCredentialsFile, bslConfig, backupObject string, snapshotCheck SnapshotCheckPoint) error {
 	ctx := context.Background()
-	data, err := ioutil.ReadFile(cloudCredentialsFile)
+	data, err := os.ReadFile(cloudCredentialsFile)
 	if err != nil {
 		return errors.Wrapf(err, fmt.Sprintf("Failed reading gcloud credential file %s", cloudCredentialsFile))
 	}

--- a/test/e2e/util/velero/install.go
+++ b/test/e2e/util/velero/install.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -302,7 +301,7 @@ func createVelereResources(ctx context.Context, cli, namespace string, args []st
 func patchResources(ctx context.Context, resources *unstructured.UnstructuredList, namespace, registryCredentialFile, RestoreHelperImage string) error {
 	// apply the image pull secret to avoid the image pull limit of Docker Hub
 	if len(registryCredentialFile) > 0 {
-		credential, err := ioutil.ReadFile(registryCredentialFile)
+		credential, err := os.ReadFile(registryCredentialFile)
 		if err != nil {
 			return errors.Wrapf(err, "failed to read the registry credential file %s", registryCredentialFile)
 		}

--- a/test/e2e/util/velero/velero_utils.go
+++ b/test/e2e/util/velero/velero_utils.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -762,7 +761,7 @@ func InstallVeleroCLI(version string) (string, error) {
 		if err != nil {
 			return false, errors.WithMessagef(err, "failed to get Velero CLI tarball")
 		}
-		tempVeleroCliDir, err = ioutil.TempDir("", "velero-test")
+		tempVeleroCliDir, err = os.MkdirTemp("", "velero-test")
 		if err != nil {
 			return false, errors.WithMessagef(err, "failed to create temp dir for tarball extraction")
 		}
@@ -791,11 +790,11 @@ func getVeleroCliTarball(cliTarballUrl string) (*os.File, error) {
 	}
 	defer resp.Body.Close()
 
-	tarballBuf, err := ioutil.ReadAll(resp.Body)
+	tarballBuf, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "failed to read buffer for tarball %s.", tarball)
 	}
-	tmpfile, err := ioutil.TempFile("", tarball)
+	tmpfile, err := os.CreateTemp("", tarball)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "failed to create temp file for tarball %s locally.", tarball)
 	}


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

/kind cleanup

replaced io/ioutil with "os / io" package.

We should clean all io/util package according the url: [ioutil 1.16](https://go.dev/doc/go1.16#ioutil)