### PR TITLE
Fix Dockerfile issue.

### DIFF
--- a/changelogs/unreleased/5761-blackpiglet
+++ b/changelogs/unreleased/5761-blackpiglet
@@ -1,0 +1,1 @@
+Fix Dockerfile issue.


### PR DESCRIPTION
#5685 introduced Restic builder in the Velero Dockerfile.
It supposes to use Golang v1.19 as the built environment, but due to Dockerfile's bug, Golang v1.18 is used instead.
This PR is used to address that.

Signed-off-by: Xun Jiang <blackpiglet@gmail.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
