### PR TITLE
[cherry-pick][v1.10] Remove container-builder-env section and add pr-containers action

### DIFF
--- a/.github/workflows/pr-containers.yml
+++ b/.github/workflows/pr-containers.yml
@@ -1,0 +1,37 @@
+name: build Velero containers on Dockerfile change
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+      - 'release-**'
+    paths:
+      - 'Dockerfile'
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      name: Checkout
+
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: all
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+      with:
+        version: latest
+
+    # Although this action also calls docker-push.sh, it is not triggered
+    # by push, so BRANCH and TAG are empty by default. docker-push.sh will
+    # only build Velero image without pushing.
+    - name: Make Velero container without pushing to registry.
+      if: github.repository == 'vmware-tanzu/velero'
+      run: |
+        ./hack/docker-push.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,8 @@ env CGO_ENABLED=0 \
 COPY . /go/src/github.com/vmware-tanzu/velero
 
 RUN mkdir -p /output/usr/bin && \
-    bash /go/src/github.com/vmware-tanzu/velero/hack/build-restic.sh
+    export GOARM=$(echo "${GOARM}" | cut -c2-) && \
+    /go/src/github.com/vmware-tanzu/velero/hack/build-restic.sh
 
 # Velero image packing section
 FROM gcr.io/distroless/base-debian11@sha256:99133cb0878bb1f84d1753957c6fd4b84f006f2798535de22ebf7ba170bbf434

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ build-%:
 
 all-build: $(addprefix build-, $(CLI_PLATFORMS))
 
-all-containers: container-builder-env
+all-containers:
 	@$(MAKE) --no-print-directory container
 	@$(MAKE) --no-print-directory container BIN=velero-restore-helper
 
@@ -178,20 +178,6 @@ shell: build-dirs build-env
 		$(BUILDER_IMAGE) \
 		/bin/sh $(CMD)
 
-container-builder-env:
-ifneq ($(BUILDX_ENABLED), true)
-	$(error $(BUILDX_ERROR))
-endif
-	@docker buildx build \
-	--target=builder-env \
-	--build-arg=GOPROXY=$(GOPROXY) \
-	--build-arg=PKG=$(PKG) \
-	--build-arg=VERSION=$(VERSION) \
-	--build-arg=GIT_SHA=$(GIT_SHA) \
-	--build-arg=GIT_TREE_STATE=$(GIT_TREE_STATE) \
-	--build-arg=REGISTRY=$(REGISTRY) \
-	-f $(VELERO_DOCKERFILE) .
-
 container:
 ifneq ($(BUILDX_ENABLED), true)
 	$(error $(BUILDX_ERROR))
@@ -200,6 +186,7 @@ endif
 	--output=type=$(BUILDX_OUTPUT_TYPE) \
 	--platform $(BUILDX_PLATFORMS) \
 	$(addprefix -t , $(IMAGE_TAGS)) \
+	--build-arg=GOPROXY=$(GOPROXY) \
 	--build-arg=PKG=$(PKG) \
 	--build-arg=BIN=$(BIN) \
 	--build-arg=VERSION=$(VERSION) \

--- a/changelogs/unreleased/5770-blackpiglet
+++ b/changelogs/unreleased/5770-blackpiglet
@@ -1,0 +1,1 @@
+Add PR container build action, which will not push image. Add GOARM parameter. Remove container-builder-env section.


### PR DESCRIPTION
* Add PR container build action, which will not push the Velero image.
* Add GOARM parameter in Restic docker builder section in Dockerfile.
* Remove the `container-builder-env` section from Makefile.

Signed-off-by: Xun Jiang <blackpiglet@gmail.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
