### PR TITLE
Add GOARM in Restic builder.

### DIFF
--- a/.github/workflows/pr-containers.yml
+++ b/.github/workflows/pr-containers.yml
@@ -1,0 +1,37 @@
+name: build Velero containers on Dockerfile change
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+      - 'release-**'
+    paths:
+      - 'Dockerfile'
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      name: Checkout
+
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: all
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+      with:
+        version: latest
+
+    # Although this action also calls docker-push.sh, it is not triggered
+    # by push, so BRANCH and TAG are empty by default. docker-push.sh will
+    # only build Velero image without pushing.
+    - name: Make Velero container without pushing to registry.
+      if: github.repository == 'vmware-tanzu/velero'
+      run: |
+        ./hack/docker-push.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,8 @@ env CGO_ENABLED=0 \
 COPY . /go/src/github.com/vmware-tanzu/velero
 
 RUN mkdir -p /output/usr/bin && \
-    bash /go/src/github.com/vmware-tanzu/velero/hack/build-restic.sh
+    export GOARM=$(echo "${GOARM}" | cut -c2-) && \
+    /go/src/github.com/vmware-tanzu/velero/hack/build-restic.sh
 
 # Velero image packing section
 FROM gcr.io/distroless/base-debian11@sha256:99133cb0878bb1f84d1753957c6fd4b84f006f2798535de22ebf7ba170bbf434

--- a/changelogs/unreleased/5771-blackpiglet
+++ b/changelogs/unreleased/5771-blackpiglet
@@ -1,0 +1,1 @@
+Add PR container build action, which will not push image. Add GOARM parameter.


### PR DESCRIPTION
Sorry for another PR for Dockerfile change.
I didn't meet this problem on my own build environment. `make all-containers` is only triggered by PR merged, so PR creation actions cannot trigger this too.
I made some hack verification on my testing repository. It should work now. 
https://github.com/blackpiglet/velero-test/actions/runs/3931617334/jobs/6723109746

Missed GOARM environment parameter in Restic builder section.

Signed-off-by: Xun Jiang <blackpiglet@gmail.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
