### PR TITLE
add prometheus metrics to record warning total and last status of backups

### DIFF
--- a/changelogs/unreleased/5779-allenxu404
+++ b/changelogs/unreleased/5779-allenxu404
@@ -1,0 +1,3 @@
+Add File system backup related matrics to Grafana dashboard
+Add metrics backup_warning_total for record of total warnings
+Add metrics backup_last_status for record of last status of the backup 


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
- add metrics backup_warning_total for record of total warnings
- add metrics backup_last_status for record of last status of the backup

# Does your change fix a particular issue?

Fixes #5380 #5398

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
