### PR TITLE
Add option "--service-account-name" to install cmd

### DIFF
--- a/changelogs/unreleased/5802-reasonerjt
+++ b/changelogs/unreleased/5802-reasonerjt
@@ -1,0 +1,1 @@
+Add option "--service-account-name" to install cmd

--- a/pkg/cmd/cli/install/install.go
+++ b/pkg/cmd/cli/install/install.go
@@ -51,6 +51,7 @@ type InstallOptions struct {
 	PodAnnotations            flag.Map
 	PodLabels                 flag.Map
 	ServiceAccountAnnotations flag.Map
+	ServiceAccountName        string
 	VeleroPodCPURequest       string
 	VeleroPodMemRequest       string
 	VeleroPodCPULimit         string
@@ -93,6 +94,7 @@ func (o *InstallOptions) BindFlags(flags *pflag.FlagSet) {
 	flags.Var(&o.PodAnnotations, "pod-annotations", "Annotations to add to the Velero and node agent pods. Optional. Format is key1=value1,key2=value2")
 	flags.Var(&o.PodLabels, "pod-labels", "Labels to add to the Velero and node agent pods. Optional. Format is key1=value1,key2=value2")
 	flags.Var(&o.ServiceAccountAnnotations, "sa-annotations", "Annotations to add to the Velero ServiceAccount. Add iam.gke.io/gcp-service-account=[GSA_NAME]@[PROJECT_NAME].iam.gserviceaccount.com for workload identity. Optional. Format is key1=value1,key2=value2")
+	flags.StringVar(&o.ServiceAccountName, "service-account-name", o.ServiceAccountName, "ServiceAccountName to be set to the Velero and node agent pods, it should be created before the installation.  Optional, if this attribute is set, the default service account 'velero' will not be created, and the flag --sa-annotations will be disregarded.")
 	flags.StringVar(&o.VeleroPodCPURequest, "velero-pod-cpu-request", o.VeleroPodCPURequest, `CPU request for Velero pod. A value of "0" is treated as unbounded. Optional.`)
 	flags.StringVar(&o.VeleroPodMemRequest, "velero-pod-mem-request", o.VeleroPodMemRequest, `Memory request for Velero pod. A value of "0" is treated as unbounded. Optional.`)
 	flags.StringVar(&o.VeleroPodCPULimit, "velero-pod-cpu-limit", o.VeleroPodCPULimit, `CPU limit for Velero pod. A value of "0" is treated as unbounded. Optional.`)
@@ -187,6 +189,7 @@ func (o *InstallOptions) AsVeleroOptions() (*install.VeleroOptions, error) {
 		PodAnnotations:                  o.PodAnnotations.Data(),
 		PodLabels:                       o.PodLabels.Data(),
 		ServiceAccountAnnotations:       o.ServiceAccountAnnotations.Data(),
+		ServiceAccountName:              o.ServiceAccountName,
 		VeleroPodResources:              veleroPodResources,
 		NodeAgentPodResources:           nodeAgentPodResources,
 		SecretData:                      secretData,

--- a/pkg/install/daemonset.go
+++ b/pkg/install/daemonset.go
@@ -74,7 +74,7 @@ func DaemonSet(namespace string, opts ...podTemplateOption) *appsv1.DaemonSet {
 					Annotations: c.annotations,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: "velero",
+					ServiceAccountName: c.serviceAccountName,
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsUser: &userID,
 					},

--- a/pkg/install/daemonset_test.go
+++ b/pkg/install/daemonset_test.go
@@ -40,4 +40,7 @@ func TestDaemonSet(t *testing.T) {
 	ds = DaemonSet("velero", WithFeatures([]string{"foo,bar,baz"}))
 	assert.Len(t, ds.Spec.Template.Spec.Containers[0].Args, 3)
 	assert.Equal(t, "--features=foo,bar,baz", ds.Spec.Template.Spec.Containers[0].Args[2])
+
+	ds = DaemonSet("velero", WithServiceAccountName("test-sa"))
+	assert.Equal(t, "test-sa", ds.Spec.Template.Spec.ServiceAccountName)
 }

--- a/pkg/install/deployment.go
+++ b/pkg/install/deployment.go
@@ -44,6 +44,7 @@ type podTemplateConfig struct {
 	plugins                         []string
 	features                        []string
 	defaultVolumesToFsBackup        bool
+	serviceAccountName              string
 	uploaderType                    string
 }
 
@@ -135,6 +136,12 @@ func WithDefaultVolumesToFsBackup() podTemplateOption {
 	}
 }
 
+func WithServiceAccountName(sa string) podTemplateOption {
+	return func(c *podTemplateConfig) {
+		c.serviceAccountName = sa
+	}
+}
+
 func Deployment(namespace string, opts ...podTemplateOption) *appsv1.Deployment {
 	// TODO: Add support for server args
 	c := &podTemplateConfig{
@@ -180,7 +187,7 @@ func Deployment(namespace string, opts ...podTemplateOption) *appsv1.Deployment 
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyAlways,
-					ServiceAccountName: "velero",
+					ServiceAccountName: c.serviceAccountName,
 					Containers: []corev1.Container{
 						{
 							Name:            "velero",

--- a/pkg/install/deployment_test.go
+++ b/pkg/install/deployment_test.go
@@ -61,4 +61,7 @@ func TestDeployment(t *testing.T) {
 	deploy = Deployment("velero", WithUploaderType("kopia"))
 	assert.Len(t, deploy.Spec.Template.Spec.Containers[0].Args, 2)
 	assert.Equal(t, "--uploader-type=kopia", deploy.Spec.Template.Spec.Containers[0].Args[1])
+
+	deploy = Deployment("velero", WithServiceAccountName("test-sa"))
+	assert.Equal(t, "test-sa", deploy.Spec.Template.Spec.ServiceAccountName)
 }

--- a/pkg/install/resources.go
+++ b/pkg/install/resources.go
@@ -30,6 +30,8 @@ import (
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 )
 
+const defaultServiceAccountName = "velero"
+
 var (
 	DefaultVeleroPodCPURequest    = "500m"
 	DefaultVeleroPodMemRequest    = "128Mi"
@@ -96,7 +98,7 @@ func objectMeta(namespace, name string) metav1.ObjectMeta {
 }
 
 func ServiceAccount(namespace string, annotations map[string]string) *corev1.ServiceAccount {
-	objMeta := objectMeta(namespace, "velero")
+	objMeta := objectMeta(namespace, defaultServiceAccountName)
 	objMeta.Annotations = annotations
 	return &corev1.ServiceAccount{
 		ObjectMeta: objMeta,
@@ -217,6 +219,7 @@ type VeleroOptions struct {
 	PodAnnotations                  map[string]string
 	PodLabels                       map[string]string
 	ServiceAccountAnnotations       map[string]string
+	ServiceAccountName              string
 	VeleroPodResources              corev1.ResourceRequirements
 	NodeAgentPodResources           corev1.ResourceRequirements
 	SecretData                      []byte
@@ -258,9 +261,13 @@ func AllResources(o *VeleroOptions) *unstructured.UnstructuredList {
 
 	crb := ClusterRoleBinding(o.Namespace)
 	appendUnstructured(resources, crb)
-
-	sa := ServiceAccount(o.Namespace, o.ServiceAccountAnnotations)
-	appendUnstructured(resources, sa)
+	serviceAccountName := defaultServiceAccountName
+	if o.ServiceAccountName == "" {
+		sa := ServiceAccount(o.Namespace, o.ServiceAccountAnnotations)
+		appendUnstructured(resources, sa)
+	} else {
+		serviceAccountName = o.ServiceAccountName
+	}
 
 	if o.SecretData != nil {
 		sec := Secret(o.Namespace, o.SecretData)
@@ -287,6 +294,7 @@ func AllResources(o *VeleroOptions) *unstructured.UnstructuredList {
 		WithResources(o.VeleroPodResources),
 		WithSecret(secretPresent),
 		WithDefaultRepoMaintenanceFrequency(o.DefaultRepoMaintenanceFrequency),
+		WithServiceAccountName(serviceAccountName),
 		WithGarbageCollectionFrequency(o.GarbageCollectionFrequency),
 		WithUploaderType(o.UploaderType),
 	}
@@ -318,6 +326,7 @@ func AllResources(o *VeleroOptions) *unstructured.UnstructuredList {
 			WithImage(o.Image),
 			WithResources(o.NodeAgentPodResources),
 			WithSecret(secretPresent),
+			WithServiceAccountName(serviceAccountName),
 		}
 		if len(o.Features) > 0 {
 			dsOpts = append(dsOpts, WithFeatures(o.Features))


### PR DESCRIPTION
The option "--service-account-name" is to be added to that user can use an existing service account for velero and node-agent pods.  This is helpful for users who wanna use IRSA.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>

Thank you for contributing to Velero!

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
