### PR TITLE
Add mapped selected-node existence check.

### DIFF
--- a/changelogs/unreleased/5806-blackpiglet
+++ b/changelogs/unreleased/5806-blackpiglet
@@ -1,0 +1,1 @@
+Add mapped selected-node existence check

--- a/pkg/restore/change_pvc_node_selector.go
+++ b/pkg/restore/change_pvc_node_selector.go
@@ -100,6 +100,15 @@ func (p *ChangePVCNodeSelectorAction) Execute(input *velero.RestoreItemActionExe
 	}
 
 	if len(newNode) != 0 {
+		// Check whether the mapped node exists first.
+		exists, err := isNodeExist(p.nodeClient, newNode)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error checking %s's mapped node %s existence", node, newNode)
+		}
+		if !exists {
+			log.Warnf("Selected-node's mapped node doesn't exist: source: %s, dest: %s. Please check the ConfigMap with label velero.io/change-pvc-node-selector.", node, newNode)
+		}
+
 		// set node selector
 		// We assume that node exist for node-mapping
 		annotations["volume.kubernetes.io/selected-node"] = newNode


### PR DESCRIPTION
Signed-off-by: Xun Jiang <blackpiglet@gmail.com>

Thank you for contributing to Velero!

# Please add a summary of your change
When the change-pvc-node-selector action got the mapped node, but the mapped node doesn't exist in the cluster, print a warning log to notify the user.

# Does your change fix a particular issue?

Fixes #5631 

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
