### PR TITLE
Optimize string contrast judgment

### DIFF
--- a/pkg/repository/config/azure.go
+++ b/pkg/repository/config/azure.go
@@ -112,9 +112,8 @@ func getStorageAccountKey(config map[string]string) (string, error) {
 
 	var storageKey string
 	for _, key := range *res.Keys {
-		// uppercase both strings for comparison because the ListKeys call returns e.g. "FULL" but
-		// the storagemgmt.Full constant in the SDK is defined as "Full".
-		if strings.ToUpper(string(key.Permissions)) == strings.ToUpper(string(storagemgmt.Full)) {
+		// The ListKeys call returns e.g. "FULL" but the storagemgmt.Full constant in the SDK is defined as "Full".
+		if strings.EqualFold(string(key.Permissions), string(storagemgmt.Full)) {
 			storageKey = *key.Value
 			break
 		}

--- a/test/e2e/util/velero/velero_utils.go
+++ b/test/e2e/util/velero/velero_utils.go
@@ -462,9 +462,9 @@ func VeleroScheduleCreate(ctx context.Context, veleroCLI string, veleroNamespace
 
 func VeleroSchedulePause(ctx context.Context, veleroCLI string, veleroNamespace string, scheduleName string) error {
 	var args []string
-	args = append([]string{
+	args = []string{
 		"--namespace", veleroNamespace, "schedule", "pause", scheduleName,
-	})
+	}
 	if err := VeleroCmdExec(ctx, veleroCLI, args); err != nil {
 		return err
 	}
@@ -473,9 +473,9 @@ func VeleroSchedulePause(ctx context.Context, veleroCLI string, veleroNamespace 
 
 func VeleroScheduleUnpause(ctx context.Context, veleroCLI string, veleroNamespace string, scheduleName string) error {
 	var args []string
-	args = append([]string{
+	args = []string{
 		"--namespace", veleroNamespace, "schedule", "unpause", scheduleName,
-	})
+	}
 	if err := VeleroCmdExec(ctx, veleroCLI, args); err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Fish-pro <zechun.chen@daocloud.io>

Thank you for contributing to Velero!

# Please add a summary of your change

`strings.ToUpper(string(key.Permissions)) == strings.ToUpper(string(storagemgmt.Full))` should use `strings.EqualFold` instead

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
