### PR TITLE
Add snapshotvolumes default behavior E2E test

### DIFF
--- a/test/e2e/backups/sync_backups.go
+++ b/test/e2e/backups/sync_backups.go
@@ -59,7 +59,9 @@ func BackupsSyncTest() {
 	BeforeEach(func() {
 		flag.Parse()
 		if VeleroCfg.InstallVelero {
-			Expect(VeleroInstall(context.Background(), &VeleroCfg, false)).To(Succeed())
+			veleroCfg := VeleroCfg
+			veleroCfg.UseVolumeSnapshots = false
+			Expect(VeleroInstall(context.Background(), &VeleroCfg)).To(Succeed())
 		}
 	})
 
@@ -105,8 +107,9 @@ func BackupsSyncTest() {
 		})
 
 		By("Install velero", func() {
-			VeleroCfg.ObjectStoreProvider = ""
-			Expect(VeleroInstall(test.ctx, &VeleroCfg, false)).To(Succeed())
+			veleroCfg := VeleroCfg
+			veleroCfg.UseVolumeSnapshots = false
+			Expect(VeleroInstall(test.ctx, &VeleroCfg)).To(Succeed())
 		})
 
 		By("Check all backups in object storage are synced to Velero", func() {

--- a/test/e2e/backups/ttl.go
+++ b/test/e2e/backups/ttl.go
@@ -59,29 +59,33 @@ func (b *TTL) Init() {
 
 func TTLTest() {
 	var err error
+	var veleroCfg VeleroConfig
 	useVolumeSnapshots := true
 	test := new(TTL)
-	client := *VeleroCfg.ClientToInstallVelero
+	veleroCfg = VeleroCfg
+	client := *veleroCfg.ClientToInstallVelero
 
 	//Expect(err).To(Succeed(), "Failed to instantiate cluster client for backup tests")
 
 	BeforeEach(func() {
 		flag.Parse()
-		if VeleroCfg.InstallVelero {
+		veleroCfg = VeleroCfg
+		if veleroCfg.InstallVelero {
 			// Make sure GCFrequency is shorter than backup TTL
-			VeleroCfg.GCFrequency = "4m0s"
-			Expect(VeleroInstall(context.Background(), &VeleroCfg, useVolumeSnapshots)).To(Succeed())
+			veleroCfg.GCFrequency = "4m0s"
+			veleroCfg.UseVolumeSnapshots = useVolumeSnapshots
+			Expect(VeleroInstall(context.Background(), &veleroCfg)).To(Succeed())
 		}
 	})
 
 	AfterEach(func() {
-		VeleroCfg.GCFrequency = ""
-		if !VeleroCfg.Debug {
+		veleroCfg.GCFrequency = ""
+		if !veleroCfg.Debug {
 			By("Clean backups after test", func() {
-				DeleteBackups(context.Background(), *VeleroCfg.ClientToInstallVelero)
+				DeleteBackups(context.Background(), *veleroCfg.ClientToInstallVelero)
 			})
-			if VeleroCfg.InstallVelero {
-				Expect(VeleroUninstall(context.Background(), VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace)).To(Succeed())
+			if veleroCfg.InstallVelero {
+				Expect(VeleroUninstall(context.Background(), veleroCfg.VeleroCLI, veleroCfg.VeleroNamespace)).To(Succeed())
 			}
 			Expect(DeleteNamespace(test.ctx, client, test.testNS, false)).To(Succeed(), fmt.Sprintf("Failed to delete the namespace %s", test.testNS))
 		}
@@ -95,9 +99,9 @@ func TTLTest() {
 		})
 
 		By("Deploy sample workload of Kibishii", func() {
-			Expect(KibishiiPrepareBeforeBackup(test.ctx, client, VeleroCfg.CloudProvider,
-				test.testNS, VeleroCfg.RegistryCredentialFile, VeleroCfg.Features,
-				VeleroCfg.KibishiiDirectory, useVolumeSnapshots, DefaultKibishiiData)).To(Succeed())
+			Expect(KibishiiPrepareBeforeBackup(test.ctx, client, veleroCfg.CloudProvider,
+				test.testNS, veleroCfg.RegistryCredentialFile, veleroCfg.Features,
+				veleroCfg.KibishiiDirectory, useVolumeSnapshots, DefaultKibishiiData)).To(Succeed())
 		})
 
 		var BackupCfg BackupConfig
@@ -109,26 +113,26 @@ func TTLTest() {
 		BackupCfg.TTL = test.ttl
 
 		By(fmt.Sprintf("Backup the workload in %s namespace", test.testNS), func() {
-			Expect(VeleroBackupNamespace(test.ctx, VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace, BackupCfg)).To(Succeed(), func() string {
-				RunDebug(context.Background(), VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace, test.backupName, "")
+			Expect(VeleroBackupNamespace(test.ctx, veleroCfg.VeleroCLI, veleroCfg.VeleroNamespace, BackupCfg)).To(Succeed(), func() string {
+				RunDebug(context.Background(), veleroCfg.VeleroCLI, veleroCfg.VeleroNamespace, test.backupName, "")
 				return "Fail to backup workload"
 			})
 		})
 
 		var snapshotCheckPoint SnapshotCheckPoint
 		if useVolumeSnapshots {
-			if VeleroCfg.CloudProvider == "vsphere" {
+			if veleroCfg.CloudProvider == "vsphere" {
 				// TODO - remove after upload progress monitoring is implemented
 				By("Waiting for vSphere uploads to complete", func() {
 					Expect(WaitForVSphereUploadCompletion(test.ctx, time.Hour,
-						test.testNS)).To(Succeed())
+						test.testNS, 2)).To(Succeed())
 				})
 			}
-			snapshotCheckPoint, err = GetSnapshotCheckPoint(client, VeleroCfg, 2, test.testNS, test.backupName, KibishiiPodNameList)
+			snapshotCheckPoint, err = GetSnapshotCheckPoint(client, veleroCfg, 2, test.testNS, test.backupName, KibishiiPodNameList)
 			Expect(err).NotTo(HaveOccurred(), "Fail to get Azure CSI snapshot checkpoint")
 
-			Expect(SnapshotsShouldBeCreatedInCloud(VeleroCfg.CloudProvider,
-				VeleroCfg.CloudCredentialsFile, VeleroCfg.BSLBucket, VeleroCfg.BSLConfig,
+			Expect(SnapshotsShouldBeCreatedInCloud(veleroCfg.CloudProvider,
+				veleroCfg.CloudCredentialsFile, veleroCfg.BSLBucket, veleroCfg.BSLConfig,
 				test.backupName, snapshotCheckPoint)).NotTo(HaveOccurred(), "Fail to get Azure CSI snapshot checkpoint")
 		}
 
@@ -137,30 +141,30 @@ func TTLTest() {
 				fmt.Sprintf("Failed to delete namespace %s", BackupCfg.BackupName))
 		})
 
-		if VeleroCfg.CloudProvider == "aws" && useVolumeSnapshots {
+		if veleroCfg.CloudProvider == "aws" && useVolumeSnapshots {
 			fmt.Println("Waiting 7 minutes to make sure the snapshots are ready...")
 			time.Sleep(7 * time.Minute)
 		}
 
 		By(fmt.Sprintf("Restore %s", test.testNS), func() {
-			Expect(VeleroRestore(test.ctx, VeleroCfg.VeleroCLI,
-				VeleroCfg.VeleroNamespace, test.restoreName, test.backupName, "")).To(Succeed(), func() string {
-				RunDebug(test.ctx, VeleroCfg.VeleroCLI,
-					VeleroCfg.VeleroNamespace, "", test.restoreName)
+			Expect(VeleroRestore(test.ctx, veleroCfg.VeleroCLI,
+				veleroCfg.VeleroNamespace, test.restoreName, test.backupName, "")).To(Succeed(), func() string {
+				RunDebug(test.ctx, veleroCfg.VeleroCLI,
+					veleroCfg.VeleroNamespace, "", test.restoreName)
 				return "Fail to restore workload"
 			})
 		})
 
 		By("Associated Restores should be created", func() {
-			Expect(ObjectsShouldBeInBucket(VeleroCfg.CloudProvider,
-				VeleroCfg.CloudCredentialsFile, VeleroCfg.BSLBucket,
-				VeleroCfg.BSLPrefix, VeleroCfg.BSLConfig, test.restoreName,
+			Expect(ObjectsShouldBeInBucket(veleroCfg.CloudProvider,
+				veleroCfg.CloudCredentialsFile, veleroCfg.BSLBucket,
+				veleroCfg.BSLPrefix, veleroCfg.BSLConfig, test.restoreName,
 				RestoreObjectsPrefix)).NotTo(HaveOccurred(), "Fail to get restore object")
 
 		})
 
 		By("Check TTL was set correctly", func() {
-			ttl, err := GetBackupTTL(test.ctx, VeleroCfg.VeleroNamespace, test.backupName)
+			ttl, err := GetBackupTTL(test.ctx, veleroCfg.VeleroNamespace, test.backupName)
 			Expect(err).NotTo(HaveOccurred(), "Fail to get Azure CSI snapshot checkpoint")
 			t, _ := time.ParseDuration(strings.ReplaceAll(ttl, "'", ""))
 			fmt.Println(t.Round(time.Minute).String())
@@ -172,28 +176,28 @@ func TTLTest() {
 		})
 
 		By("Check if backups are deleted by GC", func() {
-			Expect(WaitBackupDeleted(test.ctx, VeleroCfg.VeleroCLI, test.backupName, time.Minute*10)).To(Succeed(), fmt.Sprintf("Backup %s was not deleted by GC", test.backupName))
+			Expect(WaitBackupDeleted(test.ctx, veleroCfg.VeleroCLI, test.backupName, time.Minute*10)).To(Succeed(), fmt.Sprintf("Backup %s was not deleted by GC", test.backupName))
 		})
 
 		By("Backup file from cloud object storage should be deleted", func() {
-			Expect(ObjectsShouldNotBeInBucket(VeleroCfg.CloudProvider,
-				VeleroCfg.CloudCredentialsFile, VeleroCfg.BSLBucket,
-				VeleroCfg.BSLPrefix, VeleroCfg.BSLConfig, test.backupName,
+			Expect(ObjectsShouldNotBeInBucket(veleroCfg.CloudProvider,
+				veleroCfg.CloudCredentialsFile, veleroCfg.BSLBucket,
+				veleroCfg.BSLPrefix, veleroCfg.BSLConfig, test.backupName,
 				BackupObjectsPrefix, 5)).NotTo(HaveOccurred(), "Fail to get Azure CSI snapshot checkpoint")
 		})
 
 		By("PersistentVolume snapshots should be deleted", func() {
 			if useVolumeSnapshots {
-				Expect(SnapshotsShouldNotExistInCloud(VeleroCfg.CloudProvider,
-					VeleroCfg.CloudCredentialsFile, VeleroCfg.BSLBucket, VeleroCfg.BSLConfig,
+				Expect(SnapshotsShouldNotExistInCloud(veleroCfg.CloudProvider,
+					veleroCfg.CloudCredentialsFile, veleroCfg.BSLBucket, veleroCfg.BSLConfig,
 					test.backupName, snapshotCheckPoint)).NotTo(HaveOccurred(), "Fail to get Azure CSI snapshot checkpoint")
 			}
 		})
 
 		By("Associated Restores should be deleted", func() {
-			Expect(ObjectsShouldNotBeInBucket(VeleroCfg.CloudProvider,
-				VeleroCfg.CloudCredentialsFile, VeleroCfg.BSLBucket,
-				VeleroCfg.BSLPrefix, VeleroCfg.BSLConfig, test.restoreName,
+			Expect(ObjectsShouldNotBeInBucket(veleroCfg.CloudProvider,
+				veleroCfg.CloudCredentialsFile, veleroCfg.BSLBucket,
+				veleroCfg.BSLPrefix, veleroCfg.BSLConfig, test.restoreName,
 				RestoreObjectsPrefix, 5)).NotTo(HaveOccurred(), "Fail to get restore object")
 
 		})

--- a/test/e2e/basic/namespace-mapping.go
+++ b/test/e2e/basic/namespace-mapping.go
@@ -29,7 +29,11 @@ var OneNamespaceMappingSnapshotTest func() = TestFunc(&NamespaceMapping{TestCase
 var MultiNamespacesMappingSnapshotTest func() = TestFunc(&NamespaceMapping{TestCase: TestCase{NSBaseName: NamespaceBaseName, NSIncluded: &[]string{NamespaceBaseName + "1", NamespaceBaseName + "2"}, UseVolumeSnapshots: true}})
 
 func (n *NamespaceMapping) Init() error {
-	n.Client = TestClientInstance
+	//n.Client = TestClientInstance
+	n.VeleroCfg = VeleroCfg
+	n.Client = *n.VeleroCfg.ClientToInstallVelero
+	n.VeleroCfg.UseVolumeSnapshots = n.UseVolumeSnapshots
+	n.VeleroCfg.UseNodeAgent = !n.UseVolumeSnapshots
 	n.kibishiiData = &KibishiiData{2, 10, 10, 1024, 1024, 0, 2}
 	backupType := "restic"
 	if n.UseVolumeSnapshots {

--- a/test/e2e/basic/nodeport.go
+++ b/test/e2e/basic/nodeport.go
@@ -1,0 +1,182 @@
+package basic
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+
+	. "github.com/vmware-tanzu/velero/test/e2e"
+	. "github.com/vmware-tanzu/velero/test/e2e/test"
+	. "github.com/vmware-tanzu/velero/test/e2e/util/k8s"
+	. "github.com/vmware-tanzu/velero/test/e2e/util/velero"
+)
+
+type NodePort struct {
+	TestCase
+	replica              int32
+	labels               map[string]string
+	containers           *[]v1.Container
+	serviceName          string
+	serviceSpec          *v1.ServiceSpec
+	nodePort             int32
+	namespaceToCollision string
+	namespace            string
+}
+
+const NodeportBaseName string = "nodeport-"
+
+var NodePortTest func() = TestFunc(&NodePort{namespace: NodeportBaseName + "1", TestCase: TestCase{NSBaseName: NodeportBaseName}})
+
+func (n *NodePort) Init() error {
+	n.VeleroCfg = VeleroCfg
+	n.Client = *n.VeleroCfg.ClientToInstallVelero
+	n.NSBaseName = NodeportBaseName
+	n.NamespacesTotal = 1
+	n.TestMsg = &TestMSG{
+		Desc:      fmt.Sprintf("Nodeport preservation"),
+		FailedMSG: "Failed to restore with nodeport preservation",
+		Text:      fmt.Sprintf("Nodeport can be preserved or omit during restore"),
+	}
+	n.BackupName = "backup-label-selector-" + UUIDgen.String()
+	n.RestoreName = "restore-" + UUIDgen.String()
+	n.serviceName = "nginx-service-" + UUIDgen.String()
+	n.labels = map[string]string{"app": "nginx"}
+	return nil
+}
+
+func (n *NodePort) StartRun() error {
+	n.BackupArgs = []string{
+		"create", "--namespace", VeleroCfg.VeleroNamespace, "backup", n.BackupName,
+		"--include-namespaces", n.namespace, "--wait",
+	}
+	n.RestoreArgs = []string{
+		"create", "--namespace", VeleroCfg.VeleroNamespace, "restore",
+		"--from-backup", n.BackupName,
+		"--wait",
+	}
+	return nil
+}
+func (n *NodePort) CreateResources() error {
+	n.Ctx, _ = context.WithTimeout(context.Background(), 60*time.Minute)
+
+	By(fmt.Sprintf("Creating service %s in namespaces %s ......\n", n.serviceName, n.namespace), func() {
+		Expect(CreateNamespace(n.Ctx, n.Client, n.namespace)).To(Succeed(), fmt.Sprintf("Failed to create namespace %s", n.namespace))
+		Expect(createServiceWithNodeport(n.Ctx, n.Client, n.namespace, n.serviceName, n.labels, 0)).To(Succeed(), fmt.Sprintf("Failed to create service %s", n.serviceName))
+		service, err := GetService(n.Ctx, n.Client, n.namespace, n.serviceName)
+		Expect(err).To(Succeed())
+		Expect(len(service.Spec.Ports)).To(Equal(1))
+		n.nodePort = service.Spec.Ports[0].NodePort
+		_, err = GetAllService(n.Ctx)
+		Expect(err).To(Succeed(), "fail to get service")
+	})
+	return nil
+}
+
+func (n *NodePort) Destroy() error {
+	By(fmt.Sprintf("Start to destroy namespace %s......", n.NSBaseName), func() {
+		Expect(CleanupNamespacesWithPoll(n.Ctx, n.Client, NodeportBaseName)).To(Succeed(),
+			fmt.Sprintf("Failed to delete namespace %s", n.NSBaseName))
+		Expect(WaitForServiceDelete(n.Client, n.namespace, n.serviceName, false)).To(Succeed(), "fail to delete service")
+		_, err := GetAllService(n.Ctx)
+		Expect(err).To(Succeed(), "fail to get service")
+	})
+
+	n.namespaceToCollision = NodeportBaseName + "tmp"
+	By(fmt.Sprintf("Creating a new service which has the same nodeport as backed up service has in a new namespaces for nodeport collision ...%s\n", n.namespaceToCollision), func() {
+		Expect(CreateNamespace(n.Ctx, n.Client, n.namespaceToCollision)).To(Succeed(), fmt.Sprintf("Failed to create namespace %s", n.namespaceToCollision))
+		Expect(createServiceWithNodeport(n.Ctx, n.Client, n.namespaceToCollision, n.serviceName, n.labels, n.nodePort)).To(Succeed(), fmt.Sprintf("Failed to create service %s", n.serviceName))
+		_, err := GetAllService(n.Ctx)
+		Expect(err).To(Succeed(), "fail to get service")
+	})
+
+	return nil
+}
+
+func (n *NodePort) Restore() error {
+	index := 4
+	restoreName1 := n.RestoreName + "-1"
+	restoreName2 := restoreName1 + "-1"
+
+	args := n.RestoreArgs
+	args = append(args[:index], append([]string{n.RestoreName}, args[index:]...)...)
+	args = append(args, "--preserve-nodeports=true")
+	By(fmt.Sprintf("Start to restore %s with nodeports preservation when port %d is already occupied by other service", n.RestoreName, n.nodePort), func() {
+		Expect(VeleroRestoreExec(n.Ctx, n.VeleroCfg.VeleroCLI,
+			n.VeleroCfg.VeleroNamespace, n.RestoreName,
+			args, velerov1api.RestorePhasePartiallyFailed)).To(
+			Succeed(),
+			func() string {
+				RunDebug(context.Background(), n.VeleroCfg.VeleroCLI,
+					n.VeleroCfg.VeleroNamespace, "", n.RestoreName)
+				return "Fail to restore workload"
+			})
+	})
+
+	args = n.RestoreArgs
+	args = append(args[:index], append([]string{restoreName1}, args[index:]...)...)
+	args = append(args, "--preserve-nodeports=false")
+	By(fmt.Sprintf("Start to restore %s without nodeports preservation ......", restoreName1), func() {
+		Expect(VeleroRestoreExec(n.Ctx, n.VeleroCfg.VeleroCLI, n.VeleroCfg.VeleroNamespace,
+			restoreName1, args, velerov1api.RestorePhaseCompleted)).To(Succeed(), func() string {
+			RunDebug(context.Background(), n.VeleroCfg.VeleroCLI, n.VeleroCfg.VeleroNamespace, "", restoreName1)
+			return "Fail to restore workload"
+		})
+	})
+
+	By(fmt.Sprintf("Delete service %s by deleting namespace %s", n.serviceName, n.namespace), func() {
+		service, err := GetService(n.Ctx, n.Client, n.namespace, n.serviceName)
+		Expect(err).To(Succeed())
+		Expect(len(service.Spec.Ports)).To(Equal(1))
+		fmt.Println(service.Spec.Ports)
+		Expect(DeleteNamespace(n.Ctx, n.Client, n.namespace, true)).To(Succeed())
+	})
+
+	By(fmt.Sprintf("Start to delete service %s in namespace %s ......", n.serviceName, n.namespaceToCollision), func() {
+		Expect(WaitForServiceDelete(n.Client, n.namespaceToCollision, n.serviceName, true)).To(Succeed(), "fail to delete service")
+		_, err := GetAllService(n.Ctx)
+		Expect(err).To(Succeed(), "fail to get service")
+	})
+
+	args = n.RestoreArgs
+	args = append(args[:index], append([]string{restoreName2}, args[index:]...)...)
+	args = append(args, "--preserve-nodeports=true")
+	By(fmt.Sprintf("Start to restore %s with nodeports preservation ......", restoreName2), func() {
+		Expect(VeleroRestoreExec(n.Ctx, n.VeleroCfg.VeleroCLI, n.VeleroCfg.VeleroNamespace,
+			restoreName2, args, velerov1api.RestorePhaseCompleted)).To(Succeed(), func() string {
+			RunDebug(context.Background(), n.VeleroCfg.VeleroCLI, n.VeleroCfg.VeleroNamespace, "", restoreName2)
+			return "Fail to restore workload"
+		})
+	})
+
+	By(fmt.Sprintf("Verify service %s was restore successfully with the origin nodeport.", n.namespace), func() {
+		service, err := GetService(n.Ctx, n.Client, n.namespace, n.serviceName)
+		Expect(err).To(Succeed())
+		Expect(len(service.Spec.Ports)).To(Equal(1))
+		Expect(service.Spec.Ports[0].NodePort).To(Equal(n.nodePort))
+	})
+
+	return nil
+}
+
+func createServiceWithNodeport(ctx context.Context, client TestClient, namespace string,
+	service string, labels map[string]string, nodePort int32) error {
+	serviceSpec := &v1.ServiceSpec{
+		Ports: []v1.ServicePort{
+			{
+				Port:       80,
+				TargetPort: intstr.IntOrString{IntVal: 80},
+				NodePort:   nodePort,
+			},
+		},
+		Selector: nil,
+		Type:     v1.ServiceTypeLoadBalancer,
+	}
+	return CreateService(ctx, client, namespace, service, labels, serviceSpec)
+}

--- a/test/e2e/basic/resources-check/namespaces.go
+++ b/test/e2e/basic/resources-check/namespaces.go
@@ -45,7 +45,8 @@ func (m *MultiNSBackup) Init() error {
 	m.BackupName = "backup-" + UUIDgen.String()
 	m.RestoreName = "restore-" + UUIDgen.String()
 	m.NSBaseName = "nstest-" + UUIDgen.String()
-	m.Client = TestClientInstance
+	m.VeleroCfg = VeleroCfg
+	m.Client = *m.VeleroCfg.ClientToInstallVelero
 	m.NSExcluded = &[]string{}
 
 	if m.IsScalTest {
@@ -79,13 +80,13 @@ func (m *MultiNSBackup) StartRun() error {
 	}
 
 	m.BackupArgs = []string{
-		"create", "--namespace", VeleroCfg.VeleroNamespace, "backup", m.BackupName,
+		"create", "--namespace", m.VeleroCfg.VeleroNamespace, "backup", m.BackupName,
 		"--exclude-namespaces", strings.Join(*m.NSExcluded, ","),
 		"--default-volumes-to-fs-backup", "--wait",
 	}
 
 	m.RestoreArgs = []string{
-		"create", "--namespace", VeleroCfg.VeleroNamespace, "restore", m.RestoreName,
+		"create", "--namespace", m.VeleroCfg.VeleroNamespace, "restore", m.RestoreName,
 		"--from-backup", m.BackupName, "--wait",
 	}
 	return nil

--- a/test/e2e/basic/resources-check/namespaces_annotation.go
+++ b/test/e2e/basic/resources-check/namespaces_annotation.go
@@ -43,7 +43,8 @@ func (n *NSAnnotationCase) Init() error {
 	n.NSBaseName = "namespace-annotations-" + UUIDgen.String()
 	n.NamespacesTotal = 1
 	n.NSIncluded = &[]string{}
-	n.Client = TestClientInstance
+	n.VeleroCfg = VeleroCfg
+	n.Client = *n.VeleroCfg.ClientToInstallVelero
 	for nsNum := 0; nsNum < n.NamespacesTotal; nsNum++ {
 		createNSName := fmt.Sprintf("%s-%00000d", n.NSBaseName, nsNum)
 		*n.NSIncluded = append(*n.NSIncluded, createNSName)

--- a/test/e2e/basic/resources-check/rbac.go
+++ b/test/e2e/basic/resources-check/rbac.go
@@ -78,7 +78,8 @@ func (r *RBACCase) Init() error {
 		"create", "--namespace", VeleroCfg.VeleroNamespace, "restore", r.RestoreName,
 		"--from-backup", r.BackupName, "--wait",
 	}
-	r.Client = TestClientInstance
+	r.VeleroCfg = VeleroCfg
+	r.Client = *r.VeleroCfg.ClientToInstallVelero
 	return nil
 }
 

--- a/test/e2e/basic/resources-check/resources_check.go
+++ b/test/e2e/basic/resources-check/resources_check.go
@@ -32,13 +32,16 @@ limitations under the License.
 
 package basic
 
-import . "github.com/vmware-tanzu/velero/test/e2e/test"
+import (
+	. "github.com/vmware-tanzu/velero/test/e2e"
+	. "github.com/vmware-tanzu/velero/test/e2e/test"
+)
 
 func GetResourcesCheckTestCases() []VeleroBackupRestoreTest {
 	return []VeleroBackupRestoreTest{
-		&NSAnnotationCase{},
-		&MultiNSBackup{IsScalTest: false},
-		&RBACCase{},
+		&NSAnnotationCase{TestCase{VeleroCfg: VeleroCfg}},
+		&MultiNSBackup{IsScalTest: false, TestCase: TestCase{VeleroCfg: VeleroCfg}},
+		&RBACCase{TestCase{VeleroCfg: VeleroCfg}},
 	}
 }
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -90,7 +90,7 @@ var _ = Describe("[Basic][Snapshot] Velero tests on cluster using the plugin pro
 
 var _ = Describe("[Basic][ClusterResource] Backup/restore of cluster resources", ResourcesCheckTest)
 
-var _ = Describe("[Scale] Backup/restore of 2500 namespaces", MultiNSBackupRestore)
+var _ = Describe("[Scale][LongTime] Backup/restore of 2500 namespaces", MultiNSBackupRestore)
 
 // Upgrade test by Kibishi using restic
 var _ = Describe("[Upgrade][Restic] Velero upgrade tests on cluster using the plugin provider for object storage and Restic for volume backups", BackupUpgradeRestoreWithRestic)
@@ -110,10 +110,10 @@ var _ = Describe("[ResourceFiltering][LabelSelector] Velero test on backup inclu
 
 var _ = Describe("[Backups][Deletion][Restic] Velero tests of Restic backup deletion", BackupDeletionWithRestic)
 var _ = Describe("[Backups][Deletion][Snapshot] Velero tests of snapshot backup deletion", BackupDeletionWithSnapshots)
-var _ = Describe("[Backups][TTL] Local backups and restic repos will be deleted once the corresponding backup storage location is deleted", TTLTest)
+var _ = Describe("[Backups][TTL][LongTime] Local backups and restic repos will be deleted once the corresponding backup storage location is deleted", TTLTest)
 var _ = Describe("[Backups][BackupsSync] Backups in object storage are synced to a new Velero and deleted backups in object storage are synced to be deleted in Velero", BackupsSyncTest)
 
-var _ = Describe("[Schedule][BR][Pause] Backup will be created periodly by schedule defined by a Cron expression", ScheduleBackupTest)
+var _ = Describe("[Schedule][BR][Pause][LongTime] Backup will be created periodly by schedule defined by a Cron expression", ScheduleBackupTest)
 var _ = Describe("[Schedule][OrederedResources] Backup resources should follow the specific order in schedule", ScheduleOrderedResources)
 
 var _ = Describe("[PrivilegesMgmt][SSR] Velero test on ssr object when controller namespace mix-ups", SSRTest)
@@ -121,17 +121,18 @@ var _ = Describe("[PrivilegesMgmt][SSR] Velero test on ssr object when controlle
 var _ = Describe("[BSL][Deletion][Snapshot] Local backups will be deleted once the corresponding backup storage location is deleted", BslDeletionWithSnapshots)
 var _ = Describe("[BSL][Deletion][Restic] Local backups and restic repos will be deleted once the corresponding backup storage location is deleted", BslDeletionWithRestic)
 
-var _ = Describe("[Migration][Restic]", MigrationWithRestic)
-
-var _ = Describe("[Migration][Snapshot]", MigrationWithSnapshots)
+var _ = Describe("[Migration][Restic] Migrate resources between clusters by Restic", MigrationWithRestic)
+var _ = Describe("[Migration][Snapshot] Migrate resources between clusters by snapshot", MigrationWithSnapshots)
 
 var _ = Describe("[NamespaceMapping][Single][Restic] Backup resources should follow the specific order in schedule", OneNamespaceMappingResticTest)
-var _ = Describe("[NamespaceMapping][Multiple][Restic]  Backup resources should follow the specific order in schedule", MultiNamespacesMappingResticTest)
-var _ = Describe("[NamespaceMapping][Single][Snapshot]  Backup resources should follow the specific order in schedule", OneNamespaceMappingSnapshotTest)
-var _ = Describe("[NamespaceMapping][Multiple][Snapshot]  Backup resources should follow the specific order in schedule", MultiNamespacesMappingSnapshotTest)
+var _ = Describe("[NamespaceMapping][Multiple][Restic] Backup resources should follow the specific order in schedule", MultiNamespacesMappingResticTest)
+var _ = Describe("[NamespaceMapping][Single][Snapshot] Backup resources should follow the specific order in schedule", OneNamespaceMappingSnapshotTest)
+var _ = Describe("[NamespaceMapping][Multiple][Snapshot] Backup resources should follow the specific order in schedule", MultiNamespacesMappingSnapshotTest)
 
 var _ = Describe("[pv-backup][Opt-In] Backup resources should follow the specific order in schedule", OptInPVBackupTest)
 var _ = Describe("[pv-backup][Opt-Out] Backup resources should follow the specific order in schedule", OptOutPVBackupTest)
+
+var _ = Describe("[Basic][Nodeport] Service nodeport reservation during restore is configurable", NodePortTest)
 
 func GetKubeconfigContext() error {
 	var err error

--- a/test/e2e/privilegesmgmt/ssr.go
+++ b/test/e2e/privilegesmgmt/ssr.go
@@ -39,65 +39,66 @@ func SSRTest() {
 	var (
 		err error
 	)
-
+	veleroCfg := VeleroCfg
 	BeforeEach(func() {
 		flag.Parse()
-		if VeleroCfg.InstallVelero {
-			Expect(VeleroInstall(context.Background(), &VeleroCfg, false)).To(Succeed())
+		veleroCfg.UseVolumeSnapshots = false
+		if veleroCfg.InstallVelero {
+			Expect(VeleroInstall(context.Background(), &veleroCfg)).To(Succeed())
 		}
 	})
 
 	AfterEach(func() {
-		if VeleroCfg.InstallVelero {
-			if !VeleroCfg.Debug {
-				Expect(VeleroUninstall(context.Background(), VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace)).To(Succeed())
+		if veleroCfg.InstallVelero {
+			if !veleroCfg.Debug {
+				Expect(VeleroUninstall(context.Background(), veleroCfg.VeleroCLI, veleroCfg.VeleroNamespace)).To(Succeed())
 			}
 		}
 	})
 
-	It(fmt.Sprintf("Should create an ssr object in the %s namespace and later removed by controller", VeleroCfg.VeleroNamespace), func() {
-		defer DeleteNamespace(context.TODO(), *VeleroCfg.ClientToInstallVelero, testNS, false)
-		ctx, _ := context.WithTimeout(context.Background(), time.Minute*10)
+	It(fmt.Sprintf("Should create an ssr object in the %s namespace and later removed by controller", veleroCfg.VeleroNamespace), func() {
+		defer DeleteNamespace(context.TODO(), *veleroCfg.ClientToInstallVelero, testNS, false)
+		ctx, _ := context.WithTimeout(context.Background(), time.Duration(time.Minute*10))
 		By(fmt.Sprintf("Create %s namespace", testNS))
-		Expect(CreateNamespace(ctx, *VeleroCfg.ClientToInstallVelero, testNS)).To(Succeed(),
+		Expect(CreateNamespace(ctx, *veleroCfg.ClientToInstallVelero, testNS)).To(Succeed(),
 			fmt.Sprintf("Failed to create %s namespace", testNS))
 
 		By(fmt.Sprintf("Get version in %s namespace", testNS), func() {
-			Expect(VeleroVersion(context.Background(), VeleroCfg.VeleroCLI, testNS)).To(Succeed(),
+			Expect(VeleroVersion(context.Background(), veleroCfg.VeleroCLI, testNS)).To(Succeed(),
 				fmt.Sprintf("Failed to create an ssr object in the %s namespace", testNS))
 		})
-		By(fmt.Sprintf("Get version in %s namespace", VeleroCfg.VeleroNamespace), func() {
-			Expect(VeleroVersion(context.Background(), VeleroCfg.VeleroCLI, VeleroCfg.VeleroNamespace)).To(Succeed(),
-				fmt.Sprintf("Failed to create an ssr object in %s namespace", VeleroCfg.VeleroNamespace))
+		By(fmt.Sprintf("Get version in %s namespace", veleroCfg.VeleroNamespace), func() {
+			Expect(VeleroVersion(context.Background(), veleroCfg.VeleroCLI, veleroCfg.VeleroNamespace)).To(Succeed(),
+				fmt.Sprintf("Failed to create an ssr object in %s namespace", veleroCfg.VeleroNamespace))
 		})
 		ssrListResp := new(v1.ServerStatusRequestList)
-		By(fmt.Sprintf("Check ssr object in %s namespace", VeleroCfg.VeleroNamespace))
+		By(fmt.Sprintf("Check ssr object in %s namespace", veleroCfg.VeleroNamespace))
 		err = waitutil.PollImmediate(5*time.Second, time.Minute,
 			func() (bool, error) {
-				if err = VeleroCfg.ClientToInstallVelero.Kubebuilder.List(ctx, ssrListResp, &kbclient.ListOptions{Namespace: VeleroCfg.VeleroNamespace}); err != nil {
-					return false, fmt.Errorf("failed to list ssr object in %s namespace with err %v", VeleroCfg.VeleroNamespace, err)
+				if err = veleroCfg.ClientToInstallVelero.Kubebuilder.List(ctx, ssrListResp, &kbclient.ListOptions{Namespace: veleroCfg.VeleroNamespace}); err != nil {
+					return false, fmt.Errorf("failed to list ssr object in %s namespace with err %v", veleroCfg.VeleroNamespace, err)
 				}
 				if len(ssrListResp.Items) != 1 {
-					return false, fmt.Errorf("count of ssr object in %s namespace is not 1", VeleroCfg.VeleroNamespace)
+					return false, fmt.Errorf("count of ssr object in %s namespace is not 1", veleroCfg.VeleroNamespace)
 				}
 
 				if ssrListResp.Items[0].Status.ServerVersion == "" {
-					fmt.Printf("ServerVersion of ssr object in %s namespace should not empty, current response result %v\n", VeleroCfg.VeleroNamespace, ssrListResp)
+					fmt.Printf("ServerVersion of ssr object in %s namespace should not empty, current response result %v\n", veleroCfg.VeleroNamespace, ssrListResp)
 					return false, nil
 				}
 
 				if ssrListResp.Items[0].Status.Phase != "Processed" {
-					return false, fmt.Errorf("phase of ssr object in %s namespace should be Processed but got phase %s", VeleroCfg.VeleroNamespace, ssrListResp.Items[0].Status.Phase)
+					return false, fmt.Errorf("phase of ssr object in %s namespace should be Processed but got phase %s", veleroCfg.VeleroNamespace, ssrListResp.Items[0].Status.Phase)
 				}
 				return true, nil
 			})
 		if err == waitutil.ErrWaitTimeout {
-			fmt.Printf("exceed test case deadline and failed to check ssr object in %s namespace", VeleroCfg.VeleroNamespace)
+			fmt.Printf("exceed test case deadline and failed to check ssr object in %s namespace", veleroCfg.VeleroNamespace)
 		}
-		Expect(err).To(Succeed(), fmt.Sprintf("Failed to check ssr object in %s namespace", VeleroCfg.VeleroNamespace))
+		Expect(err).To(Succeed(), fmt.Sprintf("Failed to check ssr object in %s namespace", veleroCfg.VeleroNamespace))
 
 		By(fmt.Sprintf("Check ssr object in %s namespace", testNS))
-		Expect(VeleroCfg.ClientToInstallVelero.Kubebuilder.List(ctx, ssrListResp, &kbclient.ListOptions{Namespace: testNS})).To(Succeed(),
+		Expect(veleroCfg.ClientToInstallVelero.Kubebuilder.List(ctx, ssrListResp, &kbclient.ListOptions{Namespace: testNS})).To(Succeed(),
 			fmt.Sprintf("Failed to list ssr object in %s namespace", testNS))
 		Expect(len(ssrListResp.Items)).To(BeNumerically("==", 1),
 			fmt.Sprintf("Count of ssr object in %s namespace is not 1", testNS))
@@ -106,10 +107,10 @@ func SSRTest() {
 		Expect(ssrListResp.Items[0].Status.ServerVersion).To(BeEmpty(),
 			fmt.Sprintf("ServerVersion of ssr object in %s namespace should be empty", testNS))
 
-		By(fmt.Sprintf("Waiting ssr object in %s namespace deleted", VeleroCfg.VeleroNamespace))
+		By(fmt.Sprintf("Waiting ssr object in %s namespace deleted", veleroCfg.VeleroNamespace))
 		err = waitutil.PollImmediateInfinite(5*time.Second,
 			func() (bool, error) {
-				if err = VeleroCfg.ClientToInstallVelero.Kubebuilder.List(ctx, ssrListResp, &kbclient.ListOptions{Namespace: VeleroCfg.VeleroNamespace}); err != nil {
+				if err = veleroCfg.ClientToInstallVelero.Kubebuilder.List(ctx, ssrListResp, &kbclient.ListOptions{Namespace: veleroCfg.VeleroNamespace}); err != nil {
 					if apierrors.IsNotFound(err) {
 						return true, nil
 					}
@@ -121,6 +122,6 @@ func SSRTest() {
 				return true, nil
 			})
 
-		Expect(err).To(Succeed(), fmt.Sprintf("ssr object in %s namespace is not been deleted by controller", VeleroCfg.VeleroNamespace))
+		Expect(err).To(Succeed(), fmt.Sprintf("ssr object in %s namespace is not been deleted by controller", veleroCfg.VeleroNamespace))
 	})
 }

--- a/test/e2e/pv-backup/pv-backup-filter.go
+++ b/test/e2e/pv-backup/pv-backup-filter.go
@@ -32,7 +32,10 @@ var OptOutPVBackupTest func() = TestFunc(&PVBackupFiltering{annotation: OPT_OUT_
 
 func (p *PVBackupFiltering) Init() error {
 	p.Ctx, _ = context.WithTimeout(context.Background(), 60*time.Minute)
-	p.Client = TestClientInstance
+	p.VeleroCfg = VeleroCfg
+	p.Client = *p.VeleroCfg.ClientToInstallVelero
+	p.VeleroCfg.UseVolumeSnapshots = false
+	p.VeleroCfg.UseNodeAgent = true
 	p.NSBaseName = "ns"
 	p.NSIncluded = &[]string{fmt.Sprintf("%s-%s-%d", p.NSBaseName, p.id, 1), fmt.Sprintf("%s-%s-%d", p.NSBaseName, p.id, 2)}
 

--- a/test/e2e/resource-filtering/base.go
+++ b/test/e2e/resource-filtering/base.go
@@ -48,8 +48,9 @@ func (f *FilteringCase) Init() error {
 	f.replica = int32(2)
 	f.labels = map[string]string{"resourcefiltering": "true"}
 	f.labelSelector = "resourcefiltering"
-	f.Client = TestClientInstance
-
+	//f.Client = TestClientInstance
+	f.VeleroCfg = VeleroCfg
+	f.Client = *f.VeleroCfg.ClientToInstallVelero
 	f.NamespacesTotal = 3
 	f.BackupArgs = []string{
 		"create", "--namespace", VeleroCfg.VeleroNamespace, "backup", f.BackupName,
@@ -84,7 +85,7 @@ func (f *FilteringCase) CreateResources() error {
 		}
 		//Create deployment
 		fmt.Printf("Creating deployment in namespaces ...%s\n", namespace)
-		deployment := NewDeployment(f.NSBaseName, namespace, f.replica, f.labels)
+		deployment := NewDeployment(f.NSBaseName, namespace, f.replica, f.labels, nil)
 		deployment, err := CreateDeployment(f.Client.ClientGo, namespace, deployment)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("failed to delete the namespace %q", namespace))

--- a/test/e2e/resource-filtering/exclude_label.go
+++ b/test/e2e/resource-filtering/exclude_label.go
@@ -100,7 +100,7 @@ func (e *ExcludeFromBackup) CreateResources() error {
 	}
 	//Create deployment: to be included
 	fmt.Printf("Creating deployment in namespaces ...%s\n", namespace)
-	deployment := NewDeployment(e.NSBaseName, namespace, e.replica, label2)
+	deployment := NewDeployment(e.NSBaseName, namespace, e.replica, label2, nil)
 	deployment, err := CreateDeployment(e.Client.ClientGo, namespace, deployment)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("failed to delete the namespace %q", namespace))

--- a/test/e2e/resource-filtering/label_selector.go
+++ b/test/e2e/resource-filtering/label_selector.go
@@ -101,7 +101,7 @@ func (l *LabelSelector) CreateResources() error {
 		//Create deployment
 		fmt.Printf("Creating deployment in namespaces ...%s\n", namespace)
 
-		deployment := NewDeployment(l.NSBaseName, namespace, l.replica, labels)
+		deployment := NewDeployment(l.NSBaseName, namespace, l.replica, labels, nil)
 		deployment, err := CreateDeployment(l.Client.ClientGo, namespace, deployment)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("failed to delete the namespace %q", namespace))

--- a/test/e2e/schedule/schedule.go
+++ b/test/e2e/schedule/schedule.go
@@ -28,7 +28,9 @@ type ScheduleBackup struct {
 var ScheduleBackupTest func() = TestFunc(&ScheduleBackup{TestCase: TestCase{NSBaseName: "schedule-test"}})
 
 func (n *ScheduleBackup) Init() error {
-	n.Client = TestClientInstance
+	//n.Client = TestClientInstance
+	n.VeleroCfg = VeleroCfg
+	n.Client = *n.VeleroCfg.ClientToInstallVelero
 	n.Period = 3      // Unit is minute
 	n.verifyTimes = 5 // More verify times more confidence
 	n.TestMsg = &TestMSG{

--- a/test/e2e/types.go
+++ b/test/e2e/types.go
@@ -29,43 +29,46 @@ var UUIDgen uuid.UUID
 var VeleroCfg VeleroConfig
 
 type VeleroConfig struct {
-	VeleroCLI                string
-	VeleroImage              string
-	VeleroVersion            string
-	CloudCredentialsFile     string
-	BSLConfig                string
-	BSLBucket                string
-	BSLPrefix                string
-	VSLConfig                string
-	CloudProvider            string
-	ObjectStoreProvider      string
-	VeleroNamespace          string
-	AdditionalBSLProvider    string
-	AdditionalBSLBucket      string
-	AdditionalBSLPrefix      string
-	AdditionalBSLConfig      string
-	AdditionalBSLCredentials string
-	RegistryCredentialFile   string
-	RestoreHelperImage       string
-	UpgradeFromVeleroVersion string
-	UpgradeFromVeleroCLI     string
-	MigrateFromVeleroVersion string
-	MigrateFromVeleroCLI     string
-	Plugins                  string
-	AddBSLPlugins            string
-	InstallVelero            bool
-	KibishiiDirectory        string
-	Features                 string
-	Debug                    bool
-	GCFrequency              string
-	DefaultCluster           string
-	StandbyCluster           string
-	ClientToInstallVelero    *TestClient
-	DefaultClient            *TestClient
-	StandbyClient            *TestClient
-	UploaderType             string
-	UseNodeAgent             bool
-	UseRestic                bool
+	VeleroCLI                   string
+	VeleroImage                 string
+	VeleroVersion               string
+	CloudCredentialsFile        string
+	BSLConfig                   string
+	BSLBucket                   string
+	BSLPrefix                   string
+	VSLConfig                   string
+	CloudProvider               string
+	ObjectStoreProvider         string
+	VeleroNamespace             string
+	AdditionalBSLProvider       string
+	AdditionalBSLBucket         string
+	AdditionalBSLPrefix         string
+	AdditionalBSLConfig         string
+	AdditionalBSLCredentials    string
+	RegistryCredentialFile      string
+	RestoreHelperImage          string
+	UpgradeFromVeleroVersion    string
+	UpgradeFromVeleroCLI        string
+	MigrateFromVeleroVersion    string
+	MigrateFromVeleroCLI        string
+	Plugins                     string
+	AddBSLPlugins               string
+	InstallVelero               bool
+	KibishiiDirectory           string
+	Features                    string
+	Debug                       bool
+	GCFrequency                 string
+	DefaultCluster              string
+	StandbyCluster              string
+	ClientToInstallVelero       *TestClient
+	DefaultClient               *TestClient
+	StandbyClient               *TestClient
+	UploaderType                string
+	UseNodeAgent                bool
+	UseRestic                   bool
+	ProvideSnapshotsVolumeParam bool
+	DefaultVolumesToFsBackup    bool
+	UseVolumeSnapshots          bool
 }
 
 type SnapshotCheckPoint struct {
@@ -79,17 +82,19 @@ type SnapshotCheckPoint struct {
 }
 
 type BackupConfig struct {
-	BackupName              string
-	Namespace               string
-	BackupLocation          string
-	UseVolumeSnapshots      bool
-	Selector                string
-	TTL                     time.Duration
-	IncludeResources        string
-	ExcludeResources        string
-	IncludeClusterResources bool
-	OrderedResources        string
-	UseResticIfFSBackup     bool
+	BackupName                  string
+	Namespace                   string
+	BackupLocation              string
+	UseVolumeSnapshots          bool
+	ProvideSnapshotsVolumeParam bool
+	Selector                    string
+	TTL                         time.Duration
+	IncludeResources            string
+	ExcludeResources            string
+	IncludeClusterResources     bool
+	OrderedResources            string
+	UseResticIfFSBackup         bool
+	DefaultVolumesToFsBackup    bool
 }
 
 type VeleroCLI2Version struct {

--- a/test/e2e/util/csi/common.go
+++ b/test/e2e/util/csi/common.go
@@ -129,12 +129,13 @@ func GetVolumeSnapshotContentNameByPod(client TestClient, podName, namespace, ba
 	return "", errors.New(fmt.Sprintf("Fail to get VolumeSnapshotContentName for pod %s under namespace %s", podName, namespace))
 }
 
-func CheckVolumeSnapshotCR(client TestClient, backupName string, expectedCount int) error {
+func CheckVolumeSnapshotCR(client TestClient, backupName string, expectedCount int) ([]string, error) {
 	var err error
 	var snapshotContentNameList []string
-	if snapshotContentNameList, err = GetCsiSnapshotHandle(client, backupName); err != nil || len(snapshotContentNameList) != expectedCount {
-		return errors.Wrap(err, "Fail to get Azure CSI snapshot content")
+	if snapshotContentNameList, err = GetCsiSnapshotHandle(client, backupName); err != nil ||
+		len(snapshotContentNameList) != expectedCount {
+		return nil, errors.Wrap(err, "Fail to get Azure CSI snapshot content")
 	}
 	fmt.Println(snapshotContentNameList)
-	return nil
+	return snapshotContentNameList, nil
 }

--- a/test/e2e/util/k8s/common.go
+++ b/test/e2e/util/k8s/common.go
@@ -341,3 +341,17 @@ func WaitForCRDEstablished(crdName string) error {
 	}
 	return nil
 }
+
+func GetAllService(ctx context.Context) (string, error) {
+	args := []string{"get", "service", "-A"}
+	cmd := exec.CommandContext(context.Background(), "kubectl", args...)
+	fmt.Printf("Kubectl exec cmd =%v\n", cmd)
+	stdout, stderr, err := veleroexec.RunCommand(cmd)
+	fmt.Println(stdout)
+	if err != nil {
+		fmt.Println(stderr)
+		fmt.Println(err)
+		return "", err
+	}
+	return stdout, nil
+}

--- a/test/e2e/util/k8s/namespace.go
+++ b/test/e2e/util/k8s/namespace.go
@@ -100,7 +100,7 @@ func CleanupNamespacesWithPoll(ctx context.Context, client TestClient, nsBaseNam
 			if err != nil {
 				return errors.Wrapf(err, "Could not delete namespace %s", checkNamespace.Name)
 			}
-			fmt.Printf("Delete namespace %s\n", checkNamespace.Name)
+			fmt.Printf("Namespace %s was deleted\n", checkNamespace.Name)
 		}
 	}
 	return nil

--- a/test/e2e/util/k8s/service.go
+++ b/test/e2e/util/k8s/service.go
@@ -1,0 +1,75 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	waitutil "k8s.io/apimachinery/pkg/util/wait"
+)
+
+func CreateService(ctx context.Context, client TestClient, namespace string,
+	service string, labels map[string]string, serviceSpec *corev1.ServiceSpec) error {
+	se := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      service,
+			Labels:    labels,
+			Namespace: namespace,
+		},
+		Spec: *serviceSpec,
+	}
+	_, err = client.ClientGo.CoreV1().Services(namespace).Create(ctx, se, metav1.CreateOptions{})
+
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+func GetService(ctx context.Context, client TestClient, namespace string, service string) (*corev1.Service, error) {
+	return client.ClientGo.CoreV1().Services(namespace).Get(ctx, service, metav1.GetOptions{})
+}
+
+func WaitForServiceDelete(client TestClient, ns, name string, deleteFirst bool) error {
+	if deleteFirst {
+		if err := client.ClientGo.CoreV1().Services(ns).Delete(context.TODO(), name, metav1.DeleteOptions{}); err != nil {
+			return errors.Wrap(err, fmt.Sprintf("failed to delete  secret in namespace %q", ns))
+		}
+	}
+	return waitutil.PollImmediateInfinite(5*time.Second,
+		func() (bool, error) {
+			if _, err := client.ClientGo.CoreV1().Services(ns).Get(context.TODO(), ns, metav1.GetOptions{}); err != nil {
+				if apierrors.IsNotFound(err) {
+					return true, nil
+				}
+				return false, err
+			}
+			logrus.Debugf("service %q in namespace %q is still being deleted...", name, ns)
+			return false, nil
+		})
+}

--- a/test/e2e/util/kibishii/kibishii_utils.go
+++ b/test/e2e/util/kibishii/kibishii_utils.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	veleroexec "github.com/vmware-tanzu/velero/pkg/util/exec"
 	. "github.com/vmware-tanzu/velero/test/e2e"
@@ -51,15 +52,16 @@ var DefaultKibishiiData = &KibishiiData{2, 10, 10, 1024, 1024, 0, 2}
 var KibishiiPodNameList = []string{"kibishii-deployment-0", "kibishii-deployment-1"}
 
 // RunKibishiiTests runs kibishii tests on the provider.
-func RunKibishiiTests(client TestClient, veleroCfg VeleroConfig, backupName, restoreName, backupLocation, kibishiiNamespace string,
-	useVolumeSnapshots bool) error {
+func RunKibishiiTests(veleroCfg VeleroConfig, backupName, restoreName, backupLocation, kibishiiNamespace string,
+	useVolumeSnapshots, defaultVolumesToFsBackup bool) error {
+	client := *veleroCfg.ClientToInstallVelero
 	oneHourTimeout, _ := context.WithTimeout(context.Background(), time.Minute*60)
-	veleroCLI := VeleroCfg.VeleroCLI
-	providerName := VeleroCfg.CloudProvider
-	veleroNamespace := VeleroCfg.VeleroNamespace
-	registryCredentialFile := VeleroCfg.RegistryCredentialFile
-	veleroFeatures := VeleroCfg.Features
-	kibishiiDirectory := VeleroCfg.KibishiiDirectory
+	veleroCLI := veleroCfg.VeleroCLI
+	providerName := veleroCfg.CloudProvider
+	veleroNamespace := veleroCfg.VeleroNamespace
+	registryCredentialFile := veleroCfg.RegistryCredentialFile
+	veleroFeatures := veleroCfg.Features
+	kibishiiDirectory := veleroCfg.KibishiiDirectory
 	if _, err := GetNamespace(context.Background(), client, kibishiiNamespace); err == nil {
 		fmt.Printf("Workload namespace %s exists, delete it first.\n", kibishiiNamespace)
 		if err = DeleteNamespace(context.Background(), client, kibishiiNamespace, true); err != nil {
@@ -88,31 +90,65 @@ func RunKibishiiTests(client TestClient, veleroCfg VeleroConfig, backupName, res
 	BackupCfg.Namespace = kibishiiNamespace
 	BackupCfg.BackupLocation = backupLocation
 	BackupCfg.UseVolumeSnapshots = useVolumeSnapshots
+	BackupCfg.DefaultVolumesToFsBackup = defaultVolumesToFsBackup
 	BackupCfg.Selector = ""
+	BackupCfg.ProvideSnapshotsVolumeParam = veleroCfg.ProvideSnapshotsVolumeParam
 	if err := VeleroBackupNamespace(oneHourTimeout, veleroCLI, veleroNamespace, BackupCfg); err != nil {
 		RunDebug(context.Background(), veleroCLI, veleroNamespace, backupName, "")
 		return errors.Wrapf(err, "Failed to backup kibishii namespace %s", kibishiiNamespace)
 	}
 	var snapshotCheckPoint SnapshotCheckPoint
 	var err error
+	pvbs, err := GetPVB(oneHourTimeout, veleroCfg.VeleroNamespace, kibishiiNamespace)
 	if useVolumeSnapshots {
+		if err != nil || len(pvbs) != 0 {
+			return errors.Wrapf(err, "failed to get PVB for namespace %s", kibishiiNamespace)
+		}
 		if providerName == "vsphere" {
 			// Wait for uploads started by the Velero Plug-in for vSphere to complete
 			// TODO - remove after upload progress monitoring is implemented
 			fmt.Println("Waiting for vSphere uploads to complete")
-			if err := WaitForVSphereUploadCompletion(oneHourTimeout, time.Hour, kibishiiNamespace); err != nil {
+			if err := WaitForVSphereUploadCompletion(oneHourTimeout, time.Hour, kibishiiNamespace, 2); err != nil {
 				return errors.Wrapf(err, "Error waiting for uploads to complete")
 			}
 		}
-		snapshotCheckPoint, err = GetSnapshotCheckPoint(client, VeleroCfg, 2, kibishiiNamespace, backupName, KibishiiPodNameList)
+		snapshotCheckPoint, err = GetSnapshotCheckPoint(client, veleroCfg, 2, kibishiiNamespace, backupName, KibishiiPodNameList)
 		if err != nil {
 			return errors.Wrap(err, "Fail to get snapshot checkpoint")
 		}
-		err = SnapshotsShouldBeCreatedInCloud(VeleroCfg.CloudProvider,
-			VeleroCfg.CloudCredentialsFile, VeleroCfg.BSLBucket, veleroCfg.BSLConfig,
+		err = SnapshotsShouldBeCreatedInCloud(veleroCfg.CloudProvider,
+			veleroCfg.CloudCredentialsFile, veleroCfg.BSLBucket, veleroCfg.BSLConfig,
 			backupName, snapshotCheckPoint)
 		if err != nil {
 			return errors.Wrap(err, "exceed waiting for snapshot created in cloud")
+		}
+	} else {
+		if err != nil || len(pvbs) != 2 {
+			return errors.Wrapf(err, "failed to get PVB for namespace %s", kibishiiNamespace)
+		}
+		if providerName == "vsphere" {
+			// Wait for uploads started by the Velero Plug-in for vSphere to complete
+			// TODO - remove after upload progress monitoring is implemented
+
+			// TODO[High] - uncomment code block below when vSphere plugin PR #500 is included in release version.
+			//   https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/500/
+
+			// fmt.Println("Make sure no vSphere snapshot uploads created")
+			// if err := WaitForVSphereUploadCompletion(oneHourTimeout, time.Hour, kibishiiNamespace, 0); err != nil {
+			// 	return errors.Wrapf(err, "Error get vSphere snapshot uploads")
+			// }
+		} else {
+			if strings.EqualFold(veleroFeatures, "EnableCSI") {
+				_, err = GetSnapshotCheckPoint(*veleroCfg.ClientToInstallVelero, veleroCfg, 0,
+					kibishiiNamespace, backupName, KibishiiPodNameList)
+			} else {
+				err = SnapshotsShouldNotExistInCloud(veleroCfg.CloudProvider,
+					veleroCfg.CloudCredentialsFile, veleroCfg.BSLBucket, veleroCfg.BSLConfig,
+					backupName, snapshotCheckPoint)
+				if err != nil {
+					return errors.Wrap(err, "exceed waiting for snapshot created in cloud")
+				}
+			}
 		}
 	}
 
@@ -132,6 +168,12 @@ func RunKibishiiTests(client TestClient, veleroCfg VeleroConfig, backupName, res
 	if err := VeleroRestore(oneHourTimeout, veleroCLI, veleroNamespace, restoreName, backupName, ""); err != nil {
 		RunDebug(context.Background(), veleroCLI, veleroNamespace, "", restoreName)
 		return errors.Wrapf(err, "Restore %s failed from backup %s", restoreName, backupName)
+	}
+	if !useVolumeSnapshots {
+		pvrs, err := GetPVR(oneHourTimeout, veleroCfg.VeleroNamespace, kibishiiNamespace)
+		if err != nil || len(pvrs) != 2 {
+			return errors.Wrapf(err, "failed to get PVB for namespace %s", kibishiiNamespace)
+		}
 	}
 
 	if err := KibishiiVerifyAfterRestore(client, kibishiiNamespace, oneHourTimeout, DefaultKibishiiData); err != nil {
@@ -174,33 +216,55 @@ func installKibishii(ctx context.Context, namespace string, cloudPlatform, veler
 }
 
 func generateData(ctx context.Context, namespace string, kibishiiData *KibishiiData) error {
-	timeout, _ := context.WithTimeout(context.Background(), time.Minute*20)
-	kibishiiGenerateCmd := exec.CommandContext(timeout, "kubectl", "exec", "-n", namespace, "jump-pad", "--",
-		"/usr/local/bin/generate.sh", strconv.Itoa(kibishiiData.Levels), strconv.Itoa(kibishiiData.DirsPerLevel),
-		strconv.Itoa(kibishiiData.FilesPerLevel), strconv.Itoa(kibishiiData.FileLength),
-		strconv.Itoa(kibishiiData.BlockSize), strconv.Itoa(kibishiiData.PassNum), strconv.Itoa(kibishiiData.ExpectedNodes))
-	fmt.Printf("kibishiiGenerateCmd cmd =%v\n", kibishiiGenerateCmd)
+	timeout := 30 * time.Minute
+	interval := 1 * time.Second
+	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+		timeout, _ := context.WithTimeout(context.Background(), time.Minute*20)
+		kibishiiGenerateCmd := exec.CommandContext(timeout, "kubectl", "exec", "-n", namespace, "jump-pad", "--",
+			"/usr/local/bin/generate.sh", strconv.Itoa(kibishiiData.Levels), strconv.Itoa(kibishiiData.DirsPerLevel),
+			strconv.Itoa(kibishiiData.FilesPerLevel), strconv.Itoa(kibishiiData.FileLength),
+			strconv.Itoa(kibishiiData.BlockSize), strconv.Itoa(kibishiiData.PassNum), strconv.Itoa(kibishiiData.ExpectedNodes))
+		fmt.Printf("kibishiiGenerateCmd cmd =%v\n", kibishiiGenerateCmd)
 
-	_, stderr, err := veleroexec.RunCommand(kibishiiGenerateCmd)
+		stdout, stderr, err := veleroexec.RunCommand(kibishiiGenerateCmd)
+		if err != nil || strings.Contains(stderr, "Timeout occurred") || strings.Contains(stderr, "dialing backend") {
+			fmt.Printf("Kibishi generate stdout Timeout occurred: %s stderr: %s err: %s", stdout, stderr, err)
+			return false, nil
+		}
+		return true, nil
+	})
+
 	if err != nil {
-		return errors.Wrapf(err, "failed to generate, stderr=%s", stderr)
+		return errors.Wrapf(err, fmt.Sprintf("Failed to wait generate data in namespace %s", namespace))
 	}
-
 	return nil
 }
 
 func verifyData(ctx context.Context, namespace string, kibishiiData *KibishiiData) error {
-	timeout, _ := context.WithTimeout(context.Background(), time.Minute*10)
-	kibishiiVerifyCmd := exec.CommandContext(timeout, "kubectl", "exec", "-n", namespace, "jump-pad", "--",
-		"/usr/local/bin/verify.sh", strconv.Itoa(kibishiiData.Levels), strconv.Itoa(kibishiiData.DirsPerLevel),
-		strconv.Itoa(kibishiiData.FilesPerLevel), strconv.Itoa(kibishiiData.FileLength),
-		strconv.Itoa(kibishiiData.BlockSize), strconv.Itoa(kibishiiData.PassNum),
-		strconv.Itoa(kibishiiData.ExpectedNodes))
-	fmt.Printf("kibishiiVerifyCmd cmd =%v\n", kibishiiVerifyCmd)
+	timeout := 10 * time.Minute
+	interval := 5 * time.Second
+	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+		timeout, _ := context.WithTimeout(context.Background(), time.Minute*20)
+		kibishiiVerifyCmd := exec.CommandContext(timeout, "kubectl", "exec", "-n", namespace, "jump-pad", "--",
+			"/usr/local/bin/verify.sh", strconv.Itoa(kibishiiData.Levels), strconv.Itoa(kibishiiData.DirsPerLevel),
+			strconv.Itoa(kibishiiData.FilesPerLevel), strconv.Itoa(kibishiiData.FileLength),
+			strconv.Itoa(kibishiiData.BlockSize), strconv.Itoa(kibishiiData.PassNum),
+			strconv.Itoa(kibishiiData.ExpectedNodes))
+		fmt.Printf("kibishiiVerifyCmd cmd =%v\n", kibishiiVerifyCmd)
 
-	stdout, stderr, err := veleroexec.RunCommand(kibishiiVerifyCmd)
+		stdout, stderr, err := veleroexec.RunCommand(kibishiiVerifyCmd)
+		if strings.Contains(stderr, "Timeout occurred") {
+			return false, nil
+		}
+		if err != nil {
+			fmt.Printf("Kibishi verify stdout Timeout occurred: %s stderr: %s err: %s", stdout, stderr, err)
+			return false, nil
+		}
+		return true, nil
+	})
+
 	if err != nil {
-		return errors.Wrapf(err, "failed to verify, stderr=%s, stdout=%s", stderr, stdout)
+		return errors.Wrapf(err, fmt.Sprintf("Failed to wait generate data in namespace %s", namespace))
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: danfengl <danfengl@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

Volume snapshot:
Case 1: 
    velero install  --use-node-agent --default-volumes-to-fs-backup --use-volume-snapshots
    velero create backup 
Case 2: 
    velero install  --use-volume-snapshots
    velero create backup --snapshot-volumes 

FS backup:
Case 3: 
    velero install --use-node-agent --default-volumes-to-fs-backup 
    velero create backup 

Case 4: 
    velero install --use-node-agent --use-volume-snapshots 
    velero create backup --default-volumes-to-fs-backup --snapshot-volumes=false

# Does your change fix a particular issue?

Fixes #5688,#5689

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
