### PR TITLE
[cherry-pick]Restore finalizer and managedFields

### DIFF
--- a/changelogs/unreleased/5877-ywk253100
+++ b/changelogs/unreleased/5877-ywk253100
@@ -1,0 +1,1 @@
+Restore finalizer and managedFields of metadata during the restoration

--- a/pkg/builder/object_meta.go
+++ b/pkg/builder/object_meta.go
@@ -146,3 +146,10 @@ func WithGenerateName(val string) func(obj metav1.Object) {
 		obj.SetGenerateName(val)
 	}
 }
+
+// WithManagedFields is a functional option that applies the specified managed fields to an object.
+func WithManagedFields(val []metav1.ManagedFieldsEntry) func(obj metav1.Object) {
+	return func(obj metav1.Object) {
+		obj.SetManagedFields(val)
+	}
+}

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1421,6 +1421,24 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 		}
 	}
 
+	// restore the managedFields
+	withoutManagedFields := createdObj.DeepCopy()
+	createdObj.SetManagedFields(obj.GetManagedFields())
+	patchBytes, err := generatePatch(withoutManagedFields, createdObj)
+	if err != nil {
+		ctx.log.Errorf("error generating patch for managed fields %s: %v", kube.NamespaceAndName(obj), err)
+		errs.Add(namespace, err)
+		return warnings, errs
+	}
+	if patchBytes != nil {
+		if _, err = resourceClient.Patch(name, patchBytes); err != nil {
+			ctx.log.Errorf("error patch for managed fields %s: %v", kube.NamespaceAndName(obj), err)
+			errs.Add(namespace, err)
+			return warnings, errs
+		}
+		ctx.log.Infof("the managed fields for %s is patched", kube.NamespaceAndName(obj))
+	}
+
 	if groupResource == kuberesource.Pods {
 		pod := new(v1.Pod)
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), pod); err != nil {
@@ -1720,8 +1738,8 @@ func resetMetadata(obj *unstructured.Unstructured) (*unstructured.Unstructured, 
 
 	for k := range metadata {
 		switch k {
-		case "name", "namespace", "labels", "annotations":
-		default:
+		case "generateName", "selfLink", "uid", "resourceVersion", "generation", "creationTimestamp", "deletionTimestamp",
+			"deletionGracePeriodSeconds", "ownerReferences":
 			delete(metadata, k)
 		}
 	}

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -867,7 +867,7 @@ func TestRestoreItems(t *testing.T) {
 		want         []*test.APIResource
 	}{
 		{
-			name:    "metadata other than namespace/name/labels/annotations gets removed",
+			name:    "metadata uid/resourceVersion/etc. gets removed",
 			restore: defaultRestore().Result(),
 			backup:  defaultBackup().Result(),
 			tarball: test.NewTarWriter(t).
@@ -877,6 +877,7 @@ func TestRestoreItems(t *testing.T) {
 							builder.WithLabels("key-1", "val-1"),
 							builder.WithAnnotations("key-1", "val-1"),
 							builder.WithFinalizers("finalizer-1"),
+							builder.WithUID("uid"),
 						).
 						Result(),
 				).
@@ -890,6 +891,7 @@ func TestRestoreItems(t *testing.T) {
 						ObjectMeta(
 							builder.WithLabels("key-1", "val-1", "velero.io/backup-name", "backup-1", "velero.io/restore-name", "restore-1"),
 							builder.WithAnnotations("key-1", "val-1"),
+							builder.WithFinalizers("finalizer-1"),
 						).
 						Result(),
 				),
@@ -1105,6 +1107,53 @@ func TestRestoreItems(t *testing.T) {
 					Secrets:          []corev1api.ObjectReference{{Name: "secret-1"}},
 					ImagePullSecrets: []corev1api.LocalObjectReference{{Name: "pull-secret-1"}},
 				}),
+			},
+		},
+		{
+			name:    "metadata managedFields gets restored",
+			restore: defaultRestore().Result(),
+			backup:  defaultBackup().Result(),
+			tarball: test.NewTarWriter(t).
+				AddItems("pods",
+					builder.ForPod("ns-1", "pod-1").
+						ObjectMeta(
+							builder.WithManagedFields([]metav1.ManagedFieldsEntry{
+								{
+									Manager:    "kubectl",
+									Operation:  "Apply",
+									APIVersion: "v1",
+									FieldsType: "FieldsV1",
+									FieldsV1: &metav1.FieldsV1{
+										Raw: []byte(`{"f:data": {"f:key":{}}}`),
+									},
+								},
+							}),
+						).
+						Result(),
+				).
+				Done(),
+			apiResources: []*test.APIResource{
+				test.Pods(),
+			},
+			want: []*test.APIResource{
+				test.Pods(
+					builder.ForPod("ns-1", "pod-1").
+						ObjectMeta(
+							builder.WithLabels("velero.io/backup-name", "backup-1", "velero.io/restore-name", "restore-1"),
+							builder.WithManagedFields([]metav1.ManagedFieldsEntry{
+								{
+									Manager:    "kubectl",
+									Operation:  "Apply",
+									APIVersion: "v1",
+									FieldsType: "FieldsV1",
+									FieldsV1: &metav1.FieldsV1{
+										Raw: []byte(`{"f:data": {"f:key":{}}}`),
+									},
+								},
+							}),
+						).
+						Result(),
+				),
 			},
 		},
 	}
@@ -2823,10 +2872,16 @@ func TestResetMetadata(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			name:        "keep name, namespace, labels, annotations only",
-			obj:         NewTestUnstructured().WithMetadata("name", "blah", "namespace", "labels", "annotations", "foo").Unstructured,
+			name:        "keep name, namespace, labels, annotations, managedFields, finalizers",
+			obj:         NewTestUnstructured().WithMetadata("name", "namespace", "labels", "annotations", "managedFields", "finalizers").Unstructured,
 			expectedErr: false,
-			expectedRes: NewTestUnstructured().WithMetadata("name", "namespace", "labels", "annotations").Unstructured,
+			expectedRes: NewTestUnstructured().WithMetadata("name", "namespace", "labels", "annotations", "managedFields", "finalizers").Unstructured,
+		},
+		{
+			name:        "remove uid, ownerReferences",
+			obj:         NewTestUnstructured().WithMetadata("name", "namespace", "uid", "ownerReferences").Unstructured,
+			expectedErr: false,
+			expectedRes: NewTestUnstructured().WithMetadata("name", "namespace").Unstructured,
 		},
 		{
 			name:        "keep status",

--- a/pkg/restore/service_action_test.go
+++ b/pkg/restore/service_action_test.go
@@ -368,6 +368,124 @@ func TestServiceActionExecute(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "nodePort should be delete when not specified in managedFields",
+			obj: corev1api.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "svc-1",
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{
+							FieldsV1: &metav1.FieldsV1{
+								Raw: []byte(`{"f:spec":{"f:ports":{"k:{\"port\":443,\"protocol\":\"TCP\"}":{".":{},"f:name":{},"f:port":{}},"k:{\"port\":80,\"protocol\":\"TCP\"}":{".":{},"f:name":{},"f:port":{}}},"f:selector":{},"f:type":{}}}`),
+							},
+						},
+					},
+				},
+				Spec: corev1api.ServiceSpec{
+					Ports: []corev1api.ServicePort{
+						{
+							Name:     "http",
+							Port:     80,
+							Protocol: "TCP",
+						},
+						{
+							Name:     "https",
+							Port:     443,
+							Protocol: "TCP",
+						},
+					},
+				},
+			},
+			restore: builder.ForRestore(api.DefaultNamespace, "").Result(),
+			expectedRes: corev1api.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "svc-1",
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{
+							FieldsV1: &metav1.FieldsV1{
+								Raw: []byte(`{"f:spec":{"f:ports":{"k:{\"port\":443,\"protocol\":\"TCP\"}":{".":{},"f:name":{},"f:port":{}},"k:{\"port\":80,\"protocol\":\"TCP\"}":{".":{},"f:name":{},"f:port":{}}},"f:selector":{},"f:type":{}}}`),
+							},
+						},
+					},
+				},
+				Spec: corev1api.ServiceSpec{
+					Ports: []corev1api.ServicePort{
+						{
+							Name:     "http",
+							Port:     80,
+							NodePort: 0,
+							Protocol: "TCP",
+						},
+						{
+							Name:     "https",
+							Port:     443,
+							NodePort: 0,
+							Protocol: "TCP",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "nodePort should be preserved when specified in managedFields",
+			obj: corev1api.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "svc-1",
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{
+							FieldsV1: &metav1.FieldsV1{
+								Raw: []byte(`{"f:spec":{"f:ports":{"k:{\"port\":443,\"protocol\":\"TCP\"}":{".":{},"f:name":{},"f:nodePort":{},"f:port":{}},"k:{\"port\":80,\"protocol\":\"TCP\"}":{".":{},"f:name":{},"f:nodePort":{},"f:port":{}}},"f:selector":{},"f:type":{}}}`),
+							},
+						},
+					},
+				},
+				Spec: corev1api.ServiceSpec{
+					Ports: []corev1api.ServicePort{
+						{
+							Name:     "http",
+							Port:     80,
+							NodePort: 30000,
+							Protocol: "TCP",
+						},
+						{
+							Name:     "https",
+							Port:     443,
+							NodePort: 30002,
+							Protocol: "TCP",
+						},
+					},
+				},
+			},
+			restore: builder.ForRestore(api.DefaultNamespace, "").Result(),
+			expectedRes: corev1api.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "svc-1",
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{
+							FieldsV1: &metav1.FieldsV1{
+								Raw: []byte(`{"f:spec":{"f:ports":{"k:{\"port\":443,\"protocol\":\"TCP\"}":{".":{},"f:name":{},"f:nodePort":{},"f:port":{}},"k:{\"port\":80,\"protocol\":\"TCP\"}":{".":{},"f:name":{},"f:nodePort":{},"f:port":{}}},"f:selector":{},"f:type":{}}}`),
+							},
+						},
+					},
+				},
+				Spec: corev1api.ServiceSpec{
+					Ports: []corev1api.ServicePort{
+						{
+							Name:     "http",
+							Port:     80,
+							NodePort: 30000,
+							Protocol: "TCP",
+						},
+						{
+							Name:     "https",
+							Port:     443,
+							NodePort: 30002,
+							Protocol: "TCP",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Restore finalizer and managedFields of metadata during the restoration

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
