### PR TITLE
[cherry-pick][release-1.10]Add labels for velero installed namespace to support PSA

### DIFF
--- a/changelogs/unreleased/5888-blackpiglet
+++ b/changelogs/unreleased/5888-blackpiglet
@@ -1,0 +1,1 @@
+Add labels for velero installed namespace to support PSA.

--- a/pkg/install/resources.go
+++ b/pkg/install/resources.go
@@ -136,13 +136,18 @@ func ClusterRoleBinding(namespace string) *rbacv1.ClusterRoleBinding {
 }
 
 func Namespace(namespace string) *corev1.Namespace {
-	return &corev1.Namespace{
+	ns := &corev1.Namespace{
 		ObjectMeta: objectMeta("", namespace),
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Namespace",
 			APIVersion: corev1.SchemeGroupVersion.String(),
 		},
 	}
+
+	ns.Labels["pod-security.kubernetes.io/enforce"] = "privileged"
+	ns.Labels["pod-security.kubernetes.io/enforce-version"] = "latest"
+
+	return ns
 }
 
 func BackupStorageLocation(namespace, provider, bucket, prefix string, config map[string]string, caCert []byte) *velerov1api.BackupStorageLocation {

--- a/pkg/install/resources_test.go
+++ b/pkg/install/resources_test.go
@@ -40,6 +40,11 @@ func TestResources(t *testing.T) {
 	ns := Namespace("velero")
 
 	assert.Equal(t, "velero", ns.Name)
+	// For k8s version v1.25 and later, need to add the following labels to make
+	// velero installation namespace has privileged version to work with
+	// PSA(Pod Security Admission) and PSS(Pod Security Standards).
+	assert.Equal(t, ns.Labels["pod-security.kubernetes.io/enforce"], "privileged")
+	assert.Equal(t, ns.Labels["pod-security.kubernetes.io/enforce-version"], "latest")
 
 	crb := ClusterRoleBinding(DefaultVeleroNamespace)
 	// The CRB is a cluster-scoped resource


### PR DESCRIPTION
Add labels for created namespace during the Velero installation to adopt k8s v1.25's PSS and PSA.

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
