### PR TITLE
[cherry-pick]Set Kopia IgnoreUnknownTypes in ErrorHandlingPolicy to True for ignoring backup unknown file type

### DIFF
--- a/changelogs/unreleased/5890-qiuiming-best
+++ b/changelogs/unreleased/5890-qiuiming-best
@@ -1,0 +1,1 @@
+Set Kopia IgnoreUnknownTypes in ErrorHandlingPolicy to True for ignoring backup unknown file type

--- a/pkg/uploader/provider/kopia.go
+++ b/pkg/uploader/provider/kopia.go
@@ -119,10 +119,11 @@ func (kp *kopiaProvider) RunBackup(
 	})
 	repoWriter := kopia.NewShimRepo(kp.bkRepo)
 	kpUploader := snapshotfs.NewUploader(repoWriter)
-	prorgess := new(kopia.KopiaProgress)
-	prorgess.InitThrottle(backupProgressCheckInterval)
-	prorgess.Updater = updater
-	kpUploader.Progress = prorgess
+	progress := new(kopia.KopiaProgress)
+	progress.InitThrottle(backupProgressCheckInterval)
+	progress.Updater = updater
+	progress.Log = log
+	kpUploader.Progress = progress
 	quit := make(chan struct{})
 	log.Info("Starting backup")
 	go kp.CheckContext(ctx, quit, nil, kpUploader)


### PR DESCRIPTION
Set Kopia IgnoreUnknownTypes in ErrorHandlingPolicy to True for ignoring backup unknown file type

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
