### PR TITLE
upgrade and fix goreleaser issue

### DIFF
--- a/changelogs/unreleased/5899-anshulahuja98
+++ b/changelogs/unreleased/5899-anshulahuja98
@@ -1,0 +1,1 @@
+Fix goreleaser issue for resolving tags and updated it's version.

--- a/hack/release-tools/goreleaser.sh
+++ b/hack/release-tools/goreleaser.sh
@@ -46,12 +46,14 @@ fi
 if [[ "${PUBLISH:-}" != "TRUE" ]]; then
     echo "Not set to publish"
     goreleaser release \
-        --rm-dist \
+        --clean \
         --release-notes="${RELEASE_NOTES_FILE}" \
-        --skip-publish
+        --skip-publish \
+        --config goreleaser.yaml
 else
     echo "Getting ready to publish"
     goreleaser release \
-        --rm-dist \
+        --clean \
         --release-notes="${RELEASE_NOTES_FILE}"
+        --config goreleaser.yaml
 fi

--- a/hack/release-tools/goreleaser.yaml
+++ b/hack/release-tools/goreleaser.yaml
@@ -1,0 +1,6 @@
+git:
+  # What should be used to sort tags when gathering the current and previous
+  # tags if there are more than one tag in the same commit.
+  #
+  # Default: `-version:refname`
+  tag_sort: -version:creatordate


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

- Update goreleaser version to 1.15.2
- Replace deprecated --rm-dist flag with --clean
- Add goreleaser.yaml configfile which has logic to pick the latest tag on commit  (https://github.com/goreleaser/goreleaser/pull/3611/files)

# Does your change fix a particular issue?

Fixes #5646 

# Please indicate you've done the following:




- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
