### PR TITLE
Add server setting for resource timeouts

### DIFF
--- a/changelogs/unreleased/5926-eemcmullan
+++ b/changelogs/unreleased/5926-eemcmullan
@@ -1,0 +1,1 @@
+Add configurable server setting for default timeouts

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -84,6 +84,7 @@ type backupReconciler struct {
 	defaultVolumesToFsBackup    bool
 	defaultBackupTTL            time.Duration
 	defaultCSISnapshotTimeout   time.Duration
+	resourceTimeout             time.Duration
 	defaultItemOperationTimeout time.Duration
 	defaultSnapshotLocations    map[string]string
 	metrics                     *metrics.ServerMetrics
@@ -107,6 +108,7 @@ func NewBackupReconciler(
 	defaultVolumesToFsBackup bool,
 	defaultBackupTTL time.Duration,
 	defaultCSISnapshotTimeout time.Duration,
+	resourceTimeout time.Duration,
 	defaultItemOperationTimeout time.Duration,
 	defaultSnapshotLocations map[string]string,
 	metrics *metrics.ServerMetrics,
@@ -131,6 +133,7 @@ func NewBackupReconciler(
 		defaultVolumesToFsBackup:    defaultVolumesToFsBackup,
 		defaultBackupTTL:            defaultBackupTTL,
 		defaultCSISnapshotTimeout:   defaultCSISnapshotTimeout,
+		resourceTimeout:             resourceTimeout,
 		defaultItemOperationTimeout: defaultItemOperationTimeout,
 		defaultSnapshotLocations:    defaultSnapshotLocations,
 		metrics:                     metrics,
@@ -1057,7 +1060,7 @@ func (b *backupReconciler) deleteVolumeSnapshot(volumeSnapshots []snapshotv1api.
 // Set VolumeSnapshotRef's UID to nil will let the csi-controller finds out the related VS is gone, then
 // VSC can be deleted.
 func (b *backupReconciler) recreateVolumeSnapshotContent(vsc snapshotv1api.VolumeSnapshotContent) error {
-	timeout := 1 * time.Minute
+	timeout := b.resourceTimeout
 	interval := 1 * time.Second
 
 	err := b.kbClient.Delete(context.TODO(), &vsc)


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Added a server config setting to use for any default timeouts.

# Does your change fix a particular issue?

Fixes #(issue)
#5604 

# Please indicate you've done the following:

- [ x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x ] Updated the corresponding documentation in `site/content/docs/main`.
