### PR TITLE
[Main]fix main CI no space problem

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -99,4 +99,7 @@ jobs:
     - name: Publish container image to GCR
       if: github.repository == 'vmware-tanzu/velero'
       run: |
+        sudo swapoff -a
+        sudo rm -f /mnt/swapfile
+        docker image prune -a --force
         REGISTRY=gcr.io/velero-gcp ./hack/docker-push.sh


### PR DESCRIPTION
The Main CI frequently fail with error "System.IO.IOException: No space left on device". Clean swap file and docker image cache to free space