### PR TITLE
Wait for additional items to be ready before restoring current item

### DIFF
--- a/changelogs/unreleased/5933-sseago
+++ b/changelogs/unreleased/5933-sseago
@@ -1,0 +1,1 @@
+Wait for additional items to be ready before restoring current item

--- a/pkg/restore/request.go
+++ b/pkg/restore/request.go
@@ -54,19 +54,24 @@ type Request struct {
 	PodVolumeBackups []*velerov1api.PodVolumeBackup
 	VolumeSnapshots  []*volume.Snapshot
 	BackupReader     io.Reader
-	RestoredItems    map[itemKey]string
+	RestoredItems    map[itemKey]restoredItemStatus
+}
+
+type restoredItemStatus struct {
+	action     string
+	itemExists bool
 }
 
 // RestoredResourceList returns the list of restored resources grouped by the API
 // Version and Kind
 func (r *Request) RestoredResourceList() map[string][]string {
 	resources := map[string][]string{}
-	for i, action := range r.RestoredItems {
+	for i, item := range r.RestoredItems {
 		entry := i.name
 		if i.namespace != "" {
 			entry = fmt.Sprintf("%s/%s", i.namespace, i.name)
 		}
-		entry = fmt.Sprintf("%s(%s)", entry, action)
+		entry = fmt.Sprintf("%s(%s)", entry, item.action)
 		resources[i.resource] = append(resources[i.resource], entry)
 	}
 

--- a/pkg/restore/request_test.go
+++ b/pkg/restore/request_test.go
@@ -44,17 +44,17 @@ func TestResourceKey(t *testing.T) {
 
 func TestRestoredResourceList(t *testing.T) {
 	request := &Request{
-		RestoredItems: map[itemKey]string{
+		RestoredItems: map[itemKey]restoredItemStatus{
 			{
 				resource:  "v1/Namespace",
 				namespace: "",
 				name:      "default",
-			}: "created",
+			}: {action: "created"},
 			{
 				resource:  "v1/ConfigMap",
 				namespace: "default",
 				name:      "cm",
-			}: "skipped",
+			}: {action: "skipped"},
 		},
 	}
 

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -862,7 +862,7 @@ func TestRestoreItems(t *testing.T) {
 		apiResources         []*test.APIResource
 		tarball              io.Reader
 		want                 []*test.APIResource
-		expectedRestoreItems map[itemKey]string
+		expectedRestoreItems map[itemKey]restoredItemStatus
 	}{
 		{
 			name:    "metadata uid/resourceVersion/etc. gets removed",
@@ -894,9 +894,9 @@ func TestRestoreItems(t *testing.T) {
 						Result(),
 				),
 			},
-			expectedRestoreItems: map[itemKey]string{
-				{resource: "v1/Namespace", namespace: "", name: "ns-1"}: "created",
-				{resource: "v1/Pod", namespace: "ns-1", name: "pod-1"}:  "created",
+			expectedRestoreItems: map[itemKey]restoredItemStatus{
+				{resource: "v1/Namespace", namespace: "", name: "ns-1"}: {action: "created", itemExists: true},
+				{resource: "v1/Pod", namespace: "ns-1", name: "pod-1"}:  {action: "created", itemExists: true},
 			},
 		},
 		{
@@ -1004,9 +1004,9 @@ func TestRestoreItems(t *testing.T) {
 			want: []*test.APIResource{
 				test.ServiceAccounts(builder.ForServiceAccount("ns-1", "sa-1").Result()),
 			},
-			expectedRestoreItems: map[itemKey]string{
-				{resource: "v1/Namespace", namespace: "", name: "ns-1"}:          "created",
-				{resource: "v1/ServiceAccount", namespace: "ns-1", name: "sa-1"}: "skipped",
+			expectedRestoreItems: map[itemKey]restoredItemStatus{
+				{resource: "v1/Namespace", namespace: "", name: "ns-1"}:          {action: "created", itemExists: true},
+				{resource: "v1/ServiceAccount", namespace: "ns-1", name: "sa-1"}: {action: "skipped", itemExists: true},
 			},
 		},
 		{
@@ -1022,9 +1022,9 @@ func TestRestoreItems(t *testing.T) {
 			want: []*test.APIResource{
 				test.Secrets(builder.ForSecret("ns-1", "sa-1").ObjectMeta(builder.WithLabels("velero.io/backup-name", "backup-1", "velero.io/restore-name", "restore-1")).Data(map[string][]byte{"key-1": []byte("value-1")}).Result()),
 			},
-			expectedRestoreItems: map[itemKey]string{
-				{resource: "v1/Namespace", namespace: "", name: "ns-1"}:  "created",
-				{resource: "v1/Secret", namespace: "ns-1", name: "sa-1"}: "updated",
+			expectedRestoreItems: map[itemKey]restoredItemStatus{
+				{resource: "v1/Namespace", namespace: "", name: "ns-1"}:  {action: "created", itemExists: true},
+				{resource: "v1/Secret", namespace: "ns-1", name: "sa-1"}: {action: "updated", itemExists: true},
 			},
 		},
 		{
@@ -1183,7 +1183,7 @@ func TestRestoreItems(t *testing.T) {
 				PodVolumeBackups: nil,
 				VolumeSnapshots:  nil,
 				BackupReader:     tc.tarball,
-				RestoredItems:    map[itemKey]string{},
+				RestoredItems:    map[itemKey]restoredItemStatus{},
 			}
 			warnings, errs := h.restorer.Restore(
 				data,


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Waits for additional items to be ready before restoring current item. This is needed to resolve a known race condition in restoring OpenShift ImageStreamTag resources.

# Does your change fix a particular issue?

Fixes #1350

The design is already approved for this feature (https://github.com/vmware-tanzu/velero/pull/2867 ), and the required Plugin API changes have already been merged. This just includes the necessary controller changes. 

# Please indicate you've done the following:

- [ x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
