### PR TITLE
Switch the base image to distroless/base-nossl-debian11 to reduce the CVE triage efforts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN mkdir -p /output/usr/bin && \
     /go/src/github.com/vmware-tanzu/velero/hack/build-restic.sh
 
 # Velero image packing section
-FROM gcr.io/distroless/base-debian11@sha256:99133cb0878bb1f84d1753957c6fd4b84f006f2798535de22ebf7ba170bbf434
+FROM gcr.io/distroless/base-nossl-debian11:nonroot
 
 LABEL maintainer="Nolan Brubaker <brubakern@vmware.com>"
 

--- a/changelogs/unreleased/5939-ywk253100
+++ b/changelogs/unreleased/5939-ywk253100
@@ -1,0 +1,1 @@
+Switch the base image to distroless/base-nossl-debian11 to reduce the CVE triage efforts


### PR DESCRIPTION
Switch the base image to distroless/base-nossl-debian11 to reduce the CVE triage efforts

Fixes #5902

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
