### PR TITLE
Fix file rename: hack/download-restic.sh -> hack/build-restic.sh

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -103,7 +103,7 @@ local_resource(
 
 local_resource(
     "restic_binary",
-    cmd = 'cd ' + '.' + ';mkdir -p _tiltbuild/restic; BIN=velero GOOS=linux GOARCH=amd64 RESTIC_VERSION=0.13.1 OUTPUT_DIR=_tiltbuild/restic ./hack/build-restic.sh',
+    cmd = 'cd ' + '.' + ';mkdir -p _tiltbuild/restic; BIN=velero GOOS=linux GOARCH=amd64 GOARM="" RESTIC_VERSION=0.13.1 OUTPUT_DIR=_tiltbuild/restic ./hack/build-restic.sh',
 )
 
 # Note: we need a distro with a bash shell to exec into the Velero container

--- a/Tiltfile
+++ b/Tiltfile
@@ -103,7 +103,7 @@ local_resource(
 
 local_resource(
     "restic_binary",
-    cmd = 'cd ' + '.' + ';mkdir -p _tiltbuild/restic; BIN=velero GOOS=linux GOARCH=amd64 RESTIC_VERSION=0.13.1 OUTPUT_DIR=_tiltbuild/restic ./hack/download-restic.sh',
+    cmd = 'cd ' + '.' + ';mkdir -p _tiltbuild/restic; BIN=velero GOOS=linux GOARCH=amd64 RESTIC_VERSION=0.13.1 OUTPUT_DIR=_tiltbuild/restic ./hack/build-restic.sh',
 )
 
 # Note: we need a distro with a bash shell to exec into the Velero container


### PR DESCRIPTION
In https://github.com/vmware-tanzu/velero/commits/fc0c4703950452f035788b0831ca2c2fd4968a59 rename the file. But not sync the update in tiltfile

Thank you for contributing to Velero!

# Please add a summary of your change
fix file rename: hack/download-restic.sh -> hack/build-restic.sh.
Tilt call wrong filename cause the `tilt up` failed

# Does your change fix a particular issue?

Fixes #5941

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
