### PR TITLE
Fix tilt up: missing ${GOARM}" parameter in build-restic.sh

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -103,7 +103,7 @@ local_resource(
 
 local_resource(
     "restic_binary",
-    cmd = 'cd ' + '.' + ';mkdir -p _tiltbuild/restic; BIN=velero GOOS=linux GOARCH=amd64 RESTIC_VERSION=0.13.1 OUTPUT_DIR=_tiltbuild/restic ./hack/download-restic.sh',
+    cmd = 'cd ' + '.' + ';mkdir -p _tiltbuild/restic; BIN=velero GOOS=linux GOARCH=amd64 GOARM="" RESTIC_VERSION=0.13.1 OUTPUT_DIR=_tiltbuild/restic ./hack/download-restic.sh',
 )
 
 # Note: we need a distro with a bash shell to exec into the Velero container

--- a/hack/build-restic.sh
+++ b/hack/build-restic.sh
@@ -50,10 +50,6 @@ fi
 mkdir ${build_path}/restic
 git clone -b v${RESTIC_VERSION} https://github.com/restic/restic.git ${build_path}/restic
 pushd ${build_path}/restic
-if [ -z "${GOARM}" ]; then
-    go run build.go --goos "${GOOS}" --goarch "${GOARCH}" -o ${restic_bin}
-else
-    go run build.go --goos "${GOOS}" --goarch "${GOARCH}" --goarm "${GOARM}" -o ${restic_bin}
-fi
+go run build.go --goos "${GOOS}" --goarch "${GOARCH}" --goarm "${GOARM}" -o ${restic_bin}
 chmod +x ${restic_bin}
 popd

--- a/hack/build-restic.sh
+++ b/hack/build-restic.sh
@@ -50,6 +50,10 @@ fi
 mkdir ${build_path}/restic
 git clone -b v${RESTIC_VERSION} https://github.com/restic/restic.git ${build_path}/restic
 pushd ${build_path}/restic
-go run build.go --goos "${GOOS}" --goarch "${GOARCH}" --goarm "${GOARM}" -o ${restic_bin}
+if [ -z "${GOARM}" ]; then
+    go run build.go --goos "${GOOS}" --goarch "${GOARCH}" -o ${restic_bin}
+else
+    go run build.go --goos "${GOOS}" --goarch "${GOARCH}" --goarm "${GOARM}" -o ${restic_bin}
+fi
 chmod +x ${restic_bin}
 popd


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Fix missing ${GOARM}" parameter in build-restic.sh

# Does your change fix a particular issue?

Fixes #5943

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
