### PR TITLE
mark pvr failed when restore stuck in InProgress using restic.

### DIFF
--- a/pkg/controller/pod_volume_restore_controller_test.go
+++ b/pkg/controller/pod_volume_restore_controller_test.go
@@ -199,7 +199,7 @@ func TestShouldProcess(t *testing.T) {
 				clock:  &clocks.RealClock{},
 			}
 
-			shouldProcess, _, _ := c.shouldProcess(ctx, c.logger, ts.obj)
+			shouldProcess, _, _, _ := c.shouldProcess(ctx, c.logger, ts.obj)
 			require.Equal(t, ts.shouldProcessed, shouldProcess)
 		})
 	}


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
When restoring with restic, mark PVR as failed if pod is deleted

# Does your change fix a particular issue?
fix restore stuck in InProgress using restic.

Fixes #(issue)
5087
https://github.com/vmware-tanzu/velero/issues/5087
# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
