### PR TITLE
Fix restic file not build output right location

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -103,7 +103,7 @@ local_resource(
 
 local_resource(
     "restic_binary",
-    cmd = 'cd ' + '.' + ';mkdir -p _tiltbuild/restic; BIN=velero GOOS=linux GOARCH=amd64 RESTIC_VERSION=0.13.1 OUTPUT_DIR=_tiltbuild/restic ./hack/download-restic.sh',
+    cmd = 'cd ' + '.' + ';rm -rf ../restic; BIN=velero GOOS=linux GOARCH=amd64 GOARM="" RESTIC_VERSION=0.13.1 OUTPUT_DIR=../velero/_tiltbuild/restic ./hack/build-restic.sh',
 )
 
 # Note: we need a distro with a bash shell to exec into the Velero container


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Unfortunately, I find the tiltfile is broken by the change https://github.com/vmware-tanzu/velero/tree/fc0c4703950452f035788b0831ca2c2fd4968a59, and I find that I should update again in this commit, for fixing the tilefile. But I don't know if have a better way to build restic files by my changes. Welcome any suggestions.

```bash
    cmd = 'cd ' + '.' + ';rm -rf ../restic; BIN=velero GOOS=linux GOARCH=amd64 GOARM="" RESTIC_VERSION=0.13.1 OUTPUT_DIR=../velero/_tiltbuild/restic ./hack/build-restic.sh',
```
# Does your change fix a particular issue?

Fixes #5948

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
