### PR TITLE
fix: delete io/ioutil package.

### DIFF
--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -272,7 +271,7 @@ func (kb *kubernetesBackupper) BackupWithResolvers(log logrus.FieldLogger,
 
 	// set up a temp dir for the itemCollector to use to temporarily
 	// store items as they're scraped from the API.
-	tempDir, err := ioutil.TempDir("", "")
+	tempDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return errors.Wrap(err, "error creating temp dir for backup")
 	}
@@ -563,7 +562,7 @@ func (kb *kubernetesBackupper) FinalizeBackup(log logrus.FieldLogger,
 
 	// set up a temp dir for the itemCollector to use to temporarily
 	// store items as they're scraped from the API.
-	tempDir, err := ioutil.TempDir("", "")
+	tempDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return errors.Wrap(err, "error creating temp dir for backup")
 	}

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sort"
 	"strings"
 	"testing"
@@ -3190,7 +3189,7 @@ func assertTarballFileContents(t *testing.T, backupFile io.Reader, want map[stri
 		}
 		require.NoError(t, err)
 
-		bytes, err := ioutil.ReadAll(r)
+		bytes, err := io.ReadAll(r)
 		require.NoError(t, err)
 
 		items[hdr.Name] = bytes

--- a/pkg/backup/item_collector.go
+++ b/pkg/backup/item_collector.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 
@@ -415,7 +415,7 @@ func (r *itemCollector) getResourceItems(log logrus.FieldLogger, gv schema.Group
 }
 
 func (r *itemCollector) writeToFile(item *unstructured.Unstructured) (string, error) {
-	f, err := ioutil.TempFile(r.dir, "")
+	f, err := os.CreateTemp(r.dir, "")
 	if err != nil {
 		return "", errors.Wrap(err, "error creating temp file")
 	}

--- a/pkg/backup/remap_crd_version_action_test.go
+++ b/pkg/backup/remap_crd_version_action_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -174,7 +174,7 @@ func TestRemapCRDVersionActionData(t *testing.T) {
 		t.Run(tName, func(t *testing.T) {
 			// We don't need a Go struct of the v1 data, just an unstructured to pass into the plugin.
 			v1File := fmt.Sprintf("testdata/v1/%s.json", test.crd)
-			f, err := ioutil.ReadFile(v1File)
+			f, err := os.ReadFile(v1File)
 			require.NoError(t, err)
 
 			var obj unstructured.Unstructured
@@ -183,7 +183,7 @@ func TestRemapCRDVersionActionData(t *testing.T) {
 
 			// Load a v1beta1 struct into the beta client to be returned
 			v1beta1File := fmt.Sprintf("testdata/v1beta1/%s.json", test.crd)
-			f, err = ioutil.ReadFile(v1beta1File)
+			f, err = os.ReadFile(v1beta1File)
 			require.NoError(t, err)
 
 			var crd apiextv1beta1.CustomResourceDefinition

--- a/pkg/cmd/cli/backuplocation/create.go
+++ b/pkg/cmd/cli/backuplocation/create.go
@@ -19,7 +19,7 @@ package backuplocation
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -141,7 +141,7 @@ func (o *CreateOptions) BuildBackupStorageLocation(namespace string, setBackupSy
 		if err != nil {
 			return nil, err
 		}
-		caCertData, err = ioutil.ReadFile(realPath)
+		caCertData, err = os.ReadFile(realPath)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/cli/backuplocation/set.go
+++ b/pkg/cmd/cli/backuplocation/set.go
@@ -19,7 +19,7 @@ package backuplocation
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -98,7 +98,7 @@ func (o *SetOptions) Run(c *cobra.Command, f client.Factory) error {
 		if err != nil {
 			return err
 		}
-		caCertData, err = ioutil.ReadFile(realPath)
+		caCertData, err = os.ReadFile(realPath)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/cli/debug/debug.go
+++ b/pkg/cmd/cli/debug/debug.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -91,7 +90,7 @@ func (o *option) complete(f client.Factory, fs *pflag.FlagSet) error {
 		return fmt.Errorf("invalid output path: %v", err)
 	}
 	o.outputPath = absOutputPath
-	tmpDir, err := ioutil.TempDir("", "crashd")
+	tmpDir, err := os.MkdirTemp("", "crashd")
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/cli/install/install.go
+++ b/pkg/cmd/cli/install/install.go
@@ -18,7 +18,6 @@ package install
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -156,7 +155,7 @@ func (o *InstallOptions) AsVeleroOptions() (*install.VeleroOptions, error) {
 		if err != nil {
 			return nil, err
 		}
-		secretData, err = ioutil.ReadFile(realPath)
+		secretData, err = os.ReadFile(realPath)
 		if err != nil {
 			return nil, err
 		}
@@ -167,7 +166,7 @@ func (o *InstallOptions) AsVeleroOptions() (*install.VeleroOptions, error) {
 		if err != nil {
 			return nil, err
 		}
-		caCertData, err = ioutil.ReadFile(realPath)
+		caCertData, err = os.ReadFile(realPath)
 		if err != nil {
 			return nil, err
 		}
@@ -327,7 +326,7 @@ func (o *InstallOptions) Run(c *cobra.Command, f client.Factory) error {
 	return nil
 }
 
-//Complete completes options for a command.
+// Complete completes options for a command.
 func (o *InstallOptions) Complete(args []string, f client.Factory) error {
 	o.Namespace = f.Namespace()
 	return nil

--- a/pkg/cmd/util/downloadrequest/downloadrequest.go
+++ b/pkg/cmd/util/downloadrequest/downloadrequest.go
@@ -23,9 +23,9 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/google/uuid"
@@ -91,7 +91,7 @@ func Stream(ctx context.Context, kbClient kbclient.Client, namespace, name strin
 
 	var caPool *x509.CertPool
 	if len(caCertFile) > 0 {
-		caCert, err := ioutil.ReadFile(caCertFile)
+		caCert, err := os.ReadFile(caCertFile)
 		if err != nil {
 			return errors.Wrapf(err, "couldn't open cacert")
 		}
@@ -140,7 +140,7 @@ func Stream(ctx context.Context, kbClient kbclient.Client, namespace, name strin
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return errors.Wrapf(err, "request failed: unable to decode response body")
 		}

--- a/pkg/controller/backup_deletion_controller_test.go
+++ b/pkg/controller/backup_deletion_controller_test.go
@@ -19,11 +19,11 @@ package controller
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"sort"
 	"time"
 
 	"context"
-	"io/ioutil"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -320,7 +320,7 @@ func TestBackupDeletionControllerReconcile(t *testing.T) {
 		td.controller.newPluginManager = func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager }
 
 		td.backupStore.On("GetBackupVolumeSnapshots", input.Spec.BackupName).Return(snapshots, nil)
-		td.backupStore.On("GetBackupContents", input.Spec.BackupName).Return(ioutil.NopCloser(bytes.NewReader([]byte("hello world"))), nil)
+		td.backupStore.On("GetBackupContents", input.Spec.BackupName).Return(io.NopCloser(bytes.NewReader([]byte("hello world"))), nil)
 		td.backupStore.On("DeleteBackup", input.Spec.BackupName).Return(nil)
 		td.backupStore.On("DeleteRestore", "restore-1").Return(nil)
 		td.backupStore.On("DeleteRestore", "restore-2").Return(nil)
@@ -441,7 +441,7 @@ func TestBackupDeletionControllerReconcile(t *testing.T) {
 		td.controller.newPluginManager = func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager }
 
 		td.backupStore.On("GetBackupVolumeSnapshots", dbr.Spec.BackupName).Return(snapshots, nil)
-		td.backupStore.On("GetBackupContents", dbr.Spec.BackupName).Return(ioutil.NopCloser(bytes.NewReader([]byte("hello world"))), nil)
+		td.backupStore.On("GetBackupContents", dbr.Spec.BackupName).Return(io.NopCloser(bytes.NewReader([]byte("hello world"))), nil)
 		td.backupStore.On("DeleteBackup", dbr.Spec.BackupName).Return(nil)
 		td.backupStore.On("DeleteRestore", "restore-1").Return(nil)
 		td.backupStore.On("DeleteRestore", "restore-2").Return(nil)

--- a/pkg/controller/pod_volume_restore_controller.go
+++ b/pkg/controller/pod_volume_restore_controller.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -308,7 +307,7 @@ func (c *PodVolumeRestoreReconciler) processRestore(ctx context.Context, req *ve
 	// Write a done file with name=<restore-uid> into the just-created .velero dir
 	// within the volume. The velero init container on the pod is waiting
 	// for this file to exist in each restored volume before completing.
-	if err := ioutil.WriteFile(filepath.Join(volumePath, ".velero", string(restoreUID)), nil, 0644); err != nil { //nolint:gosec
+	if err := os.WriteFile(filepath.Join(volumePath, ".velero", string(restoreUID)), nil, 0644); err != nil { //nolint:gosec
 		return errors.Wrap(err, "error writing done file")
 	}
 

--- a/pkg/controller/restore_controller.go
+++ b/pkg/controller/restore_controller.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 	"time"
@@ -611,7 +610,7 @@ func downloadToTempFile(backupName string, backupStore persistence.BackupStore, 
 	}
 	defer readCloser.Close()
 
-	file, err := ioutil.TempFile("", backupName)
+	file, err := os.CreateTemp("", backupName)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating Backup temp file")
 	}

--- a/pkg/controller/restore_controller_test.go
+++ b/pkg/controller/restore_controller_test.go
@@ -19,7 +19,7 @@ package controller
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -444,7 +444,7 @@ func TestRestoreReconcile(t *testing.T) {
 				errors.Velero = append(errors.Velero, "error uploading log file to object storage: "+test.putRestoreLogErr.Error())
 			}
 			if test.expectedRestorerCall != nil {
-				backupStore.On("GetBackupContents", test.backup.Name).Return(ioutil.NopCloser(bytes.NewReader([]byte("hello world"))), nil)
+				backupStore.On("GetBackupContents", test.backup.Name).Return(io.NopCloser(bytes.NewReader([]byte("hello world"))), nil)
 
 				restorer.On("RestoreWithResolvers", mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(warnings, errors)

--- a/pkg/persistence/in_memory_object_store.go
+++ b/pkg/persistence/in_memory_object_store.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"strings"
 	"time"
 )
@@ -62,7 +61,7 @@ func (o *inMemoryObjectStore) PutObject(bucket, key string, body io.Reader) erro
 		return errors.New("bucket not found")
 	}
 
-	obj, err := ioutil.ReadAll(body)
+	obj, err := io.ReadAll(body)
 	if err != nil {
 		return err
 	}
@@ -93,7 +92,7 @@ func (o *inMemoryObjectStore) GetObject(bucket, key string) (io.ReadCloser, erro
 		return nil, errors.New("key not found")
 	}
 
-	return ioutil.NopCloser(bytes.NewReader(obj)), nil
+	return io.NopCloser(bytes.NewReader(obj)), nil
 }
 
 func (o *inMemoryObjectStore) ListCommonPrefixes(bucket, prefix, delimiter string) ([]string, error) {

--- a/pkg/persistence/object_store.go
+++ b/pkg/persistence/object_store.go
@@ -20,7 +20,6 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"strings"
 	"time"
 
@@ -298,7 +297,7 @@ func (s *objectBackupStore) GetBackupMetadata(name string) (*velerov1api.Backup,
 	}
 	defer res.Close()
 
-	data, err := ioutil.ReadAll(res)
+	data, err := io.ReadAll(res)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/pkg/persistence/object_store_test.go
+++ b/pkg/persistence/object_store_test.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sort"
 	"strings"
 	"testing"
@@ -503,7 +502,7 @@ func TestGetBackupContents(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, rc)
 
-	data, err := ioutil.ReadAll(rc)
+	data, err := io.ReadAll(rc)
 	require.NoError(t, err)
 	assert.Equal(t, "foo", string(data))
 }

--- a/pkg/plugin/clientmgmt/process/registry_test.go
+++ b/pkg/plugin/clientmgmt/process/registry_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,7 @@ limitations under the License.
 package process
 
 import (
+	"io/fs"
 	"os"
 	"sort"
 	"testing"
@@ -43,7 +44,7 @@ func TestNewRegistry(t *testing.T) {
 }
 
 type fakeFileInfo struct {
-	os.FileInfo
+	fs.FileInfo
 	mode os.FileMode
 }
 

--- a/pkg/plugin/clientmgmt/restartable_object_store_test.go
+++ b/pkg/plugin/clientmgmt/restartable_object_store_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package clientmgmt
 
 import (
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -208,7 +208,7 @@ func TestRestartableObjectStoreDelegatedFunctions(t *testing.T) {
 			Function:                "GetObject",
 			Inputs:                  []interface{}{"bucket", "key"},
 			ExpectedErrorOutputs:    []interface{}{nil, errors.Errorf("reset error")},
-			ExpectedDelegateOutputs: []interface{}{ioutil.NopCloser(strings.NewReader("object")), errors.Errorf("delegate error")},
+			ExpectedDelegateOutputs: []interface{}{io.NopCloser(strings.NewReader("object")), errors.Errorf("delegate error")},
 		},
 		restartabletest.RestartableDelegateTest{
 			Function:                "ListCommonPrefixes",

--- a/pkg/plugin/framework/stream_reader_test.go
+++ b/pkg/plugin/framework/stream_reader_test.go
@@ -18,7 +18,7 @@ package framework
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,7 +59,7 @@ func TestStreamReader(t *testing.T) {
 		close:   rdr.CloseSend,
 	}
 
-	res, err := ioutil.ReadAll(sr)
+	res, err := io.ReadAll(sr)
 
 	require.Nil(t, err)
 	assert.Equal(t, s, string(res))

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -697,7 +697,7 @@ func getNamespace(logger logrus.FieldLogger, path, remappedName string) *v1.Name
 	var nsBytes []byte
 	var err error
 
-	if nsBytes, err = ioutil.ReadFile(path); err != nil {
+	if nsBytes, err = os.ReadFile(path); err != nil {
 		return &v1.Namespace{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Namespace",

--- a/pkg/test/fake_file_system.go
+++ b/pkg/test/fake_file_system.go
@@ -18,6 +18,7 @@ package test
 
 import (
 	"io"
+	"io/fs"
 	"os"
 
 	"github.com/spf13/afero"
@@ -61,7 +62,7 @@ func (fs *FakeFileSystem) RemoveAll(path string) error {
 	return fs.fs.RemoveAll(path)
 }
 
-func (fs *FakeFileSystem) ReadDir(dirname string) ([]os.FileInfo, error) {
+func (fs *FakeFileSystem) ReadDir(dirname string) ([]fs.FileInfo, error) {
 	fs.ReadDirCalls = append(fs.ReadDirCalls, dirname)
 	return afero.ReadDir(fs.fs, dirname)
 }

--- a/pkg/test/test_logger.go
+++ b/pkg/test/test_logger.go
@@ -17,13 +17,13 @@ limitations under the License.
 package test
 
 import (
-	"io/ioutil"
+	"io"
 
 	"github.com/sirupsen/logrus"
 )
 
 func NewLogger() logrus.FieldLogger {
 	logger := logrus.New()
-	logger.Out = ioutil.Discard
+	logger.Out = io.Discard
 	return logrus.NewEntry(logger)
 }

--- a/pkg/uploader/kopia/snapshot.go
+++ b/pkg/uploader/kopia/snapshot.go
@@ -19,7 +19,6 @@ package kopia
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -44,14 +43,14 @@ import (
 	"github.com/pkg/errors"
 )
 
-//All function mainly used to make testing more convenient
+// All function mainly used to make testing more convenient
 var treeForSourceFunc = policy.TreeForSource
 var applyRetentionPolicyFunc = policy.ApplyRetentionPolicy
 var setPolicyFunc = policy.SetPolicy
 var saveSnapshotFunc = snapshot.SaveSnapshot
 var loadSnapshotFunc = snapshot.LoadSnapshot
 
-//SnapshotUploader which mainly used for UT test that could overwrite Upload interface
+// SnapshotUploader which mainly used for UT test that could overwrite Upload interface
 type SnapshotUploader interface {
 	Upload(
 		ctx context.Context,
@@ -72,7 +71,7 @@ func newOptionalBool(b bool) *policy.OptionalBool {
 	return &ob
 }
 
-//setupDefaultPolicy set default policy for kopia
+// setupDefaultPolicy set default policy for kopia
 func setupDefaultPolicy(ctx context.Context, rep repo.RepositoryWriter, sourceInfo snapshot.SourceInfo) error {
 	return setPolicyFunc(ctx, rep, sourceInfo, &policy.Policy{
 		RetentionPolicy: policy.RetentionPolicy{
@@ -93,7 +92,7 @@ func setupDefaultPolicy(ctx context.Context, rep repo.RepositoryWriter, sourceIn
 	})
 }
 
-//Backup backup specific sourcePath and update progress
+// Backup backup specific sourcePath and update progress
 func Backup(ctx context.Context, fsUploader *snapshotfs.Uploader, repoWriter repo.RepositoryWriter, sourcePath string,
 	parentSnapshot string, log logrus.FieldLogger) (*uploader.SnapshotInfo, bool, error) {
 	if fsUploader == nil {
@@ -105,7 +104,7 @@ func Backup(ctx context.Context, fsUploader *snapshotfs.Uploader, repoWriter rep
 	}
 
 	// to be consistent with restic when backup empty dir returns one error for upper logic handle
-	dirs, err := ioutil.ReadDir(dir)
+	dirs, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, false, errors.Wrapf(err, "Unable to read dir in path %s", dir)
 	} else if len(dirs) == 0 {
@@ -150,7 +149,7 @@ func getLocalFSEntry(path0 string) (fs.Entry, error) {
 	return e, nil
 }
 
-//resolveSymlink returns the path name after the evaluation of any symbolic links
+// resolveSymlink returns the path name after the evaluation of any symbolic links
 func resolveSymlink(path string) (string, error) {
 	st, err := os.Lstat(path)
 	if err != nil {
@@ -164,7 +163,7 @@ func resolveSymlink(path string) (string, error) {
 	return filepath.EvalSymlinks(path)
 }
 
-//SnapshotSource which setup policy for snapshot, upload snapshot, update progress
+// SnapshotSource which setup policy for snapshot, upload snapshot, update progress
 func SnapshotSource(
 	ctx context.Context,
 	rep repo.RepositoryWriter,
@@ -274,7 +273,7 @@ func findPreviousSnapshotManifest(ctx context.Context, rep repo.Repository, sour
 	return result, nil
 }
 
-//Restore restore specific sourcePath with given snapshotID and update progress
+// Restore restore specific sourcePath with given snapshotID and update progress
 func Restore(ctx context.Context, rep repo.RepositoryWriter, progress *KopiaProgress, snapshotID, dest string, log logrus.FieldLogger, cancleCh chan struct{}) (int64, int32, error) {
 	log.Info("Start to restore...")
 

--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -18,7 +18,7 @@ package exec
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os/exec"
 
 	"github.com/pkg/errors"
@@ -38,13 +38,13 @@ func RunCommand(cmd *exec.Cmd) (string, string, error) {
 
 	var stdout, stderr string
 
-	if res, readErr := ioutil.ReadAll(stdoutBuf); readErr != nil {
+	if res, readErr := io.ReadAll(stdoutBuf); readErr != nil {
 		stdout = errors.Wrap(readErr, "error reading command's stdout").Error()
 	} else {
 		stdout = string(res)
 	}
 
-	if res, readErr := ioutil.ReadAll(stderrBuf); readErr != nil {
+	if res, readErr := io.ReadAll(stderrBuf); readErr != nil {
 		stderr = errors.Wrap(readErr, "error reading command's stderr").Error()
 	} else {
 		stderr = string(res)

--- a/pkg/util/filesystem/file_system.go
+++ b/pkg/util/filesystem/file_system.go
@@ -18,7 +18,6 @@ package filesystem
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -56,7 +55,7 @@ func (fs *osFileSystem) Glob(path string) ([]string, error) {
 }
 
 func (fs *osFileSystem) TempDir(dir, prefix string) (string, error) {
-	return ioutil.TempDir(dir, prefix)
+	return os.MkdirTemp(dir, prefix)
 }
 
 func (fs *osFileSystem) MkdirAll(path string, perm os.FileMode) error {
@@ -76,11 +75,22 @@ func (fs *osFileSystem) RemoveAll(path string) error {
 }
 
 func (fs *osFileSystem) ReadDir(dirname string) ([]os.FileInfo, error) {
-	return ioutil.ReadDir(dirname)
+	var fileInfos []os.FileInfo
+	dirInfos, ise := os.ReadDir(dirname)
+	if ise != nil {
+		return fileInfos, ise
+	}
+	for _, dirInfo := range dirInfos {
+		fileInfo, ise := dirInfo.Info()
+		if ise == nil {
+			fileInfos = append(fileInfos, fileInfo)
+		}
+	}
+	return fileInfos, nil
 }
 
 func (fs *osFileSystem) ReadFile(filename string) ([]byte, error) {
-	return ioutil.ReadFile(filename)
+	return os.ReadFile(filename)
 }
 
 func (fs *osFileSystem) DirExists(path string) (bool, error) {
@@ -95,7 +105,7 @@ func (fs *osFileSystem) DirExists(path string) (bool, error) {
 }
 
 func (fs *osFileSystem) TempFile(dir, prefix string) (NameWriteCloser, error) {
-	return ioutil.TempFile(dir, prefix)
+	return os.CreateTemp(dir, prefix)
 }
 
 func (fs *osFileSystem) Stat(path string) (os.FileInfo, error) {

--- a/test/e2e/util/k8s/common.go
+++ b/test/e2e/util/k8s/common.go
@@ -18,7 +18,7 @@ package k8s
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"time"
 
@@ -43,7 +43,7 @@ func CreateSecretFromFiles(ctx context.Context, client TestClient, namespace str
 	data := make(map[string][]byte)
 
 	for key, filePath := range files {
-		contents, err := ioutil.ReadFile(filePath)
+		contents, err := os.ReadFile(filePath)
 		if err != nil {
 			return errors.WithMessagef(err, "Failed to read secret file %q", filePath)
 		}

--- a/test/e2e/util/k8s/serviceaccount.go
+++ b/test/e2e/util/k8s/serviceaccount.go
@@ -19,7 +19,7 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/pkg/errors"
@@ -47,7 +47,7 @@ func WaitUntilServiceAccountCreated(ctx context.Context, client TestClient, name
 }
 
 func PatchServiceAccountWithImagePullSecret(ctx context.Context, client TestClient, namespace, serviceAccount, dockerCredentialFile string) error {
-	credential, err := ioutil.ReadFile(dockerCredentialFile)
+	credential, err := os.ReadFile(dockerCredentialFile)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read the docker credential file %q", dockerCredentialFile)
 	}

--- a/test/e2e/util/providers/gcloud_utils.go
+++ b/test/e2e/util/providers/gcloud_utils.go
@@ -19,7 +19,7 @@ package providers
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"cloud.google.com/go/storage"
@@ -103,7 +103,7 @@ func (s GCSStorage) DeleteObjectsInBucket(cloudCredentialsFile, bslBucket, bslPr
 
 func (s GCSStorage) IsSnapshotExisted(cloudCredentialsFile, bslConfig, backupObject string, snapshotCheck SnapshotCheckPoint) error {
 	ctx := context.Background()
-	data, err := ioutil.ReadFile(cloudCredentialsFile)
+	data, err := os.ReadFile(cloudCredentialsFile)
 	if err != nil {
 		return errors.Wrapf(err, fmt.Sprintf("Failed reading gcloud credential file %s", cloudCredentialsFile))
 	}

--- a/test/e2e/util/velero/install.go
+++ b/test/e2e/util/velero/install.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -109,7 +108,7 @@ func VeleroInstall(ctx context.Context, veleroCfg *VeleroConfig) error {
 	return nil
 }
 
-//configvSpherePlugin refers to https://github.com/vmware-tanzu/velero-plugin-for-vsphere/blob/v1.3.0/docs/vanilla.md
+// configvSpherePlugin refers to https://github.com/vmware-tanzu/velero-plugin-for-vsphere/blob/v1.3.0/docs/vanilla.md
 func configvSpherePlugin(cli TestClient) error {
 	var err error
 	vsphereSecret := "velero-vsphere-config-secret"
@@ -311,11 +310,10 @@ func patchResources(ctx context.Context, resources *unstructured.UnstructuredLis
 		// apply the image pull secret to avoid the image pull limit of Docker Hub
 		if len(options.RegistryCredentialFile) > 0 && resource.GetKind() == "ServiceAccount" &&
 			resource.GetName() == "velero" {
-			credential, err := ioutil.ReadFile(options.RegistryCredentialFile)
+			credential, err := os.ReadFile(options.RegistryCredentialFile)
 			if err != nil {
 				return errors.Wrapf(err, "failed to read the registry credential file %s", options.RegistryCredentialFile)
 			}
-
 			imagePullSecret = corev1.Secret{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Secret",

--- a/test/e2e/util/velero/velero_utils.go
+++ b/test/e2e/util/velero/velero_utils.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -772,7 +771,7 @@ func InstallVeleroCLI(version string) (string, error) {
 		if err != nil {
 			return false, errors.WithMessagef(err, "failed to get Velero CLI tarball")
 		}
-		tempVeleroCliDir, err = ioutil.TempDir("", "velero-test")
+		tempVeleroCliDir, err = os.MkdirTemp("", "velero-test")
 		if err != nil {
 			return false, errors.WithMessagef(err, "failed to create temp dir for tarball extraction")
 		}
@@ -801,11 +800,11 @@ func getVeleroCliTarball(cliTarballUrl string) (*os.File, error) {
 	}
 	defer resp.Body.Close()
 
-	tarballBuf, err := ioutil.ReadAll(resp.Body)
+	tarballBuf, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "failed to read buffer for tarball %s.", tarball)
 	}
-	tmpfile, err := ioutil.TempFile("", tarball)
+	tmpfile, err := os.CreateTemp("", tarball)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "failed to create temp file for tarball %s locally.", tarball)
 	}


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

Deprecated: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code.See the specific function documentation for details.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
