### PR TITLE
Read TZ from Env and respect it

### DIFF
--- a/changelogs/unreleased/5977-kaovilai
+++ b/changelogs/unreleased/5977-kaovilai
@@ -1,0 +1,1 @@
+Read timezone information from TZ Environment variable so logs and schedule generated backup names are in local time expected.

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -168,6 +168,20 @@ func NewCommand(f client.Factory) *cobra.Command {
 		Long:   "Run the velero server",
 		Hidden: true,
 		Run: func(c *cobra.Command, args []string) {
+			// load time zone information from the system so logs are timestamped with local time
+			// rather than UTC
+			tzEnv := os.Getenv("TZ")
+			// if TZ is not set, respect system default
+			if tzEnv == "" {
+				// do nothing
+			} else {
+				loc, err := time.LoadLocation(tzEnv)
+				if err != nil {
+					logrus.WithError(err).WithField("TZ", tzEnv).Fatal("Error loading time zone")
+				}
+				time.Local = loc
+			}
+
 			// go-plugin uses log.Println to log when it's waiting for all plugin processes to complete so we need to
 			// set its output to stdout.
 			log.SetOutput(os.Stdout)


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #5976 
With TZ env set to `America/New_York` the following log is seen with local timestamp.
```
time="2023-03-10T13:34:09-05:00" level=info msg="setting log-level to DEBUG" logSource="pkg/cmd/server/server.go:198"
```

Schedule generated backup name also lines up with the TZ set. Note `08:35` matches `0835` in backup name.
```
time="2023-03-10T14:08:35-05:00" level=info msg="No Schedule.template.metadata.labels set - using Schedule.labels for backup object" backup=openshift-adp/schedule-20230310140835 labels="map[]"
```
Prior to this change, logs are always in UTC regardless of TZ env.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
