### PR TITLE
Test pinning to an old version of buildx

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'main'
       - 'release-**'
+      - 'buildx-version-**'
     tags:
       - '*'
 
@@ -45,7 +46,7 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@v1
       with:
-        version: latest
+        version: v0.9.1
 
     - name: Build
       run: make local


### PR DESCRIPTION
Pin to v0.9.1 to see if it pushes a docker v2 manifest list

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
