### PR TITLE
minor fixes for backup_operations_controller:

### DIFF
--- a/changelogs/unreleased/5996-sseago
+++ b/changelogs/unreleased/5996-sseago
@@ -1,0 +1,1 @@
+minor fixes for backup_operations_controller


### PR DESCRIPTION
1) default frequency 10s
2) per-reconcile log is now Debug not info
3) added predicate to reduce reconcile events


# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
