### PR TITLE
BIA/RIAv2 -- distinguish between New and InProgress operations

### DIFF
--- a/changelogs/unreleased/6012-sseago
+++ b/changelogs/unreleased/6012-sseago
@@ -1,0 +1,1 @@
+distinguish between New and InProgress operations

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -2478,7 +2478,7 @@ func TestBackupWithAsyncOperations(t *testing.T) {
 						OperationID: "pod-1-1",
 					},
 					Status: itemoperation.OperationStatus{
-						Phase: "InProgress",
+						Phase: "New",
 					},
 				},
 			},
@@ -2507,7 +2507,7 @@ func TestBackupWithAsyncOperations(t *testing.T) {
 						OperationID: "pod-2-1",
 					},
 					Status: itemoperation.OperationStatus{
-						Phase: "InProgress",
+						Phase: "New",
 					},
 				},
 			},

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -367,7 +367,7 @@ func (ib *itemBackupper) executeActions(
 					OperationID:        operationID,
 				},
 				Status: itemoperation.OperationStatus{
-					Phase:   itemoperation.OperationPhaseInProgress,
+					Phase:   itemoperation.OperationPhaseNew,
 					Created: &now,
 				},
 			}

--- a/pkg/controller/backup_operations_controller_test.go
+++ b/pkg/controller/backup_operations_controller_test.go
@@ -106,7 +106,7 @@ func TestBackupOperationsReconcile(t *testing.T) {
 						OperationID: "operation-11",
 					},
 					Status: itemoperation.OperationStatus{
-						Phase:   itemoperation.OperationPhaseInProgress,
+						Phase:   itemoperation.OperationPhaseNew,
 						Created: &metav1Now,
 					},
 				},
@@ -136,7 +136,7 @@ func TestBackupOperationsReconcile(t *testing.T) {
 						OperationID: "operation-12",
 					},
 					Status: itemoperation.OperationStatus{
-						Phase:   itemoperation.OperationPhaseInProgress,
+						Phase:   itemoperation.OperationPhaseNew,
 						Created: &metav1Now,
 					},
 				},
@@ -167,7 +167,7 @@ func TestBackupOperationsReconcile(t *testing.T) {
 						OperationID: "operation-13",
 					},
 					Status: itemoperation.OperationStatus{
-						Phase:   itemoperation.OperationPhaseInProgress,
+						Phase:   itemoperation.OperationPhaseNew,
 						Created: &metav1Now,
 					},
 				},
@@ -197,7 +197,7 @@ func TestBackupOperationsReconcile(t *testing.T) {
 						OperationID: "operation-14",
 					},
 					Status: itemoperation.OperationStatus{
-						Phase:   itemoperation.OperationPhaseInProgress,
+						Phase:   itemoperation.OperationPhaseNew,
 						Created: &metav1Now,
 					},
 				},
@@ -227,7 +227,7 @@ func TestBackupOperationsReconcile(t *testing.T) {
 						OperationID: "operation-15",
 					},
 					Status: itemoperation.OperationStatus{
-						Phase:   itemoperation.OperationPhaseInProgress,
+						Phase:   itemoperation.OperationPhaseNew,
 						Created: &metav1Now,
 					},
 				},
@@ -258,7 +258,7 @@ func TestBackupOperationsReconcile(t *testing.T) {
 						OperationID: "operation-16",
 					},
 					Status: itemoperation.OperationStatus{
-						Phase:   itemoperation.OperationPhaseInProgress,
+						Phase:   itemoperation.OperationPhaseNew,
 						Created: &metav1Now,
 					},
 				},

--- a/pkg/itemoperation/shared.go
+++ b/pkg/itemoperation/shared.go
@@ -86,7 +86,11 @@ func (in *OperationStatus) DeepCopyInto(out *OperationStatus) {
 }
 
 const (
-	// OperationPhaseNew means the item operation has been created and started
+	// OperationPhaseNew means the item operation has been created but not started
+	// by the plugin
+	OperationPhaseNew OperationPhase = "New"
+
+	// OperationPhaseInProgress means the item operation has been created and started
 	// by the plugin
 	OperationPhaseInProgress OperationPhase = "InProgress"
 

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1221,7 +1221,7 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 					OperationID:        executeOutput.OperationID,
 				},
 				Status: itemoperation.OperationStatus{
-					Phase:   itemoperation.OperationPhaseInProgress,
+					Phase:   itemoperation.OperationPhaseNew,
 					Created: &now,
 				},
 			}

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -1707,7 +1707,7 @@ func TestRestoreWithAsyncOperations(t *testing.T) {
 						OperationID: "pod-1-1",
 					},
 					Status: itemoperation.OperationStatus{
-						Phase: "InProgress",
+						Phase: "New",
 					},
 				},
 			},
@@ -1732,7 +1732,7 @@ func TestRestoreWithAsyncOperations(t *testing.T) {
 						OperationID: "pod-2-1",
 					},
 					Status: itemoperation.OperationStatus{
-						Phase: "InProgress",
+						Phase: "New",
 					},
 				},
 			},


### PR DESCRIPTION
Add a new OperationPhase to distinguish between New and InProgress operations.



Fixes #(issue)

# Please indicate you've done the following:

- [ x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
