### PR TITLE
Fix issue 5972

### DIFF
--- a/changelogs/unreleased/6028-Lyndon-Li
+++ b/changelogs/unreleased/6028-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix issue #5972, don't assume errorField as error type when dealing with logger.WithError

--- a/pkg/util/logging/log_counter_hook.go
+++ b/pkg/util/logging/log_counter_hook.go
@@ -71,7 +71,7 @@ func (h *LogHook) Fire(entry *logrus.Entry) error {
 		entryMessage = fmt.Sprintf("%s name: /%s", entryMessage, nameField.(string))
 	}
 	if isErrorFieldPresent {
-		entryMessage = fmt.Sprintf("%s error: /%s", entryMessage, errorField.(error).Error())
+		entryMessage = fmt.Sprintf("%s error: /%v", entryMessage, errorField)
 	}
 
 	if isNamespacePresent {


### PR DESCRIPTION
Fix issue #5972, don't assume `errorField` as error type when dealing with `logger.WithError`