### PR TITLE
Make E2E test adopt vSphere CSI version update

### DIFF
--- a/test/e2e/util/k8s/secret.go
+++ b/test/e2e/util/k8s/secret.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-
 	"golang.org/x/net/context"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -72,26 +71,4 @@ func WaitForSecretsComplete(c clientset.Interface, ns, secretName string) error 
 
 func GetSecret(c clientset.Interface, ns, secretName string) (*v1.Secret, error) {
 	return c.CoreV1().Secrets(ns).Get(context.TODO(), secretName, metav1.GetOptions{})
-}
-
-//CreateVCCredentialSecret refer to https://github.com/vmware-tanzu/velero-plugin-for-vsphere/blob/v1.3.0/docs/vanilla.md
-func CreateVCCredentialSecret(c clientset.Interface, veleroNamespace string) error {
-	secret, err := GetSecret(c, "kube-system", "vsphere-config-secret")
-	if err != nil {
-		return err
-	}
-	vsphereCfg, exist := secret.Data["csi-vsphere.conf"]
-	if !exist {
-		return errors.New("failed to retrieve csi-vsphere config")
-	}
-	se := &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "velero-vsphere-config-secret",
-			Namespace: veleroNamespace,
-		},
-		Type: v1.SecretTypeOpaque,
-		Data: map[string][]byte{"csi-vsphere.conf": vsphereCfg},
-	}
-	_, err = c.CoreV1().Secrets(veleroNamespace).Create(context.TODO(), se, metav1.CreateOptions{})
-	return err
 }


### PR DESCRIPTION

Thank you for contributing to Velero!

# Please add a summary of your change
E2E test can read VC credential secret according to the vSphere CSI driver version.
This fix is needed to run E2E test on TKG environment.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
