### PR TITLE
Restore Services before Clusters

### DIFF
--- a/changelogs/unreleased/6057-ywk253100
+++ b/changelogs/unreleased/6057-ywk253100
@@ -1,0 +1,1 @@
+Restore Services before Clusters

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -513,6 +513,9 @@ func (s *server) veleroResourcesExist() error {
 //   - Replica sets go before deployments/other controllers so they can be explicitly
 //     restored and be adopted by controllers.
 //   - CAPI ClusterClasses go before Clusters.
+//   - Services go before Clusters so they can be adopted by AKO-operator and no new Services will be created
+//     for the same clusters
+
 //
 // Low priorities:
 //   - Tanzu ClusterBootstraps go last as it can reference any other kind of resources.
@@ -541,6 +544,7 @@ var defaultRestorePriorities = restore.Priorities{
 		// in the backup.
 		"replicasets.apps",
 		"clusterclasses.cluster.x-k8s.io",
+		"services",
 	},
 	LowPriorities: []string{
 		"clusterbootstraps.run.tanzu.vmware.com",


### PR DESCRIPTION
Restore Services before Clusters so they can be adopted by AKO-operator and no new Services will be created for the same clusters

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
