### PR TITLE
[cherry-pick][release-1.9]Make E2E test adopt vSphere CSI version update

### DIFF
--- a/changelogs/CHANGELOG-0.9.md
+++ b/changelogs/CHANGELOG-0.9.md
@@ -154,7 +154,7 @@
   * Skip completed jobs and pods when restoring (#463, @nrb)
   * Set namespace correctly when syncing backups from object storage (#472, @skriss)
   * When building on macOS, bind-mount volumes with delegated config (#478, @skriss)
-  * Add replica sets and daemonsets to cohabitating resources so they're not backed up twice (#482 #485, @skriss)
+  * Add replica sets and daemonsets to cohabiting resources so they're not backed up twice (#482 #485, @skriss)
   * Shut down the Ark server gracefully on SIGINT/SIGTERM (#483, @skriss)
   * Only back up resources that support GET and DELETE in addition to LIST and CREATE (#486, @nrb)
   * Show a better error message when trying to get an incomplete restore's logs (#496, @nrb)

--- a/changelogs/CHANGELOG-1.8.md
+++ b/changelogs/CHANGELOG-1.8.md
@@ -103,7 +103,7 @@ Also added DownloadTargetKindBackupItemSnapshots for retrieving the signed URL t
 * Fix CVE-2020-29652 and CVE-2020-26160 (#4274, @ywk253100)
 * Refine tag-release.sh to align with change in release process (#4185, @reasonerjt)
 * Fix plugins incompatible issue in upgrade test (#4141, @danfengliu)
-* Verify group before treating resource as cohabitating (#4126, @sseago)
+* Verify group before treating resource as cohabiting (#4126, @sseago)
 * Added ItemSnapshotter plugin definition and plugin framework - addresses #3533.
   Part of the Upload Progress enhancement (#3533) (#4077, @dsmithuchida)
 * Add upgrade test in E2E test (#4058, @danfengliu)

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -1000,7 +1000,7 @@ func TestBackupResourceCohabitation(t *testing.T) {
 			},
 		},
 		{
-			name:   "when deployments exist that are not in the cohabitating groups those are backed up along with apps/deployments",
+			name:   "when deployments exist that are not in the cohabiting groups those are backed up along with apps/deployments",
 			backup: defaultBackup().Result(),
 			apiResources: []*test.APIResource{
 				test.VeleroDeployments(
@@ -1044,11 +1044,11 @@ func TestBackupResourceCohabitation(t *testing.T) {
 	}
 }
 
-// TestBackupUsesNewCohabitatingResourcesForEachBackup ensures that when two backups are
-// run that each include cohabitating resources, one copy of the relevant resources is
+// TestBackupUsesNewCohabitingResourcesForEachBackup ensures that when two backups are
+// run that each include cohabiting resources, one copy of the relevant resources is
 // backed up in each backup. Verification is done by looking at the contents of the backup
 // tarball. This covers a specific issue that was fixed by https://github.com/vmware-tanzu/velero/pull/485.
-func TestBackupUsesNewCohabitatingResourcesForEachBackup(t *testing.T) {
+func TestBackupUsesNewCohabitingResourcesForEachBackup(t *testing.T) {
 	h := newHarness(t)
 
 	// run and verify backup 1

--- a/test/e2e/util/k8s/secret.go
+++ b/test/e2e/util/k8s/secret.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-
 	"golang.org/x/net/context"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -72,26 +71,4 @@ func WaitForSecretsComplete(c clientset.Interface, ns, secretName string) error 
 
 func GetSecret(c clientset.Interface, ns, secretName string) (*v1.Secret, error) {
 	return c.CoreV1().Secrets(ns).Get(context.TODO(), secretName, metav1.GetOptions{})
-}
-
-//CreateVCCredentialSecret refer to https://github.com/vmware-tanzu/velero-plugin-for-vsphere/blob/v1.3.0/docs/vanilla.md
-func CreateVCCredentialSecret(c clientset.Interface, veleroNamespace string) error {
-	secret, err := GetSecret(c, "kube-system", "vsphere-config-secret")
-	if err != nil {
-		return err
-	}
-	vsphereCfg, exist := secret.Data["csi-vsphere.conf"]
-	if !exist {
-		return errors.New("failed to retrieve csi-vsphere config")
-	}
-	se := &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "velero-vsphere-config-secret",
-			Namespace: veleroNamespace,
-		},
-		Type: v1.SecretTypeOpaque,
-		Data: map[string][]byte{"csi-vsphere.conf": vsphereCfg},
-	}
-	_, err = c.CoreV1().Secrets(veleroNamespace).Create(context.TODO(), se, metav1.CreateOptions{})
-	return err
 }

--- a/test/e2e/util/velero/install.go
+++ b/test/e2e/util/velero/install.go
@@ -42,6 +42,11 @@ import (
 	. "github.com/vmware-tanzu/velero/test/e2e/util/k8s"
 )
 
+const (
+	KubeSystemNamespace           = "kube-system"
+	VSphereCSIControllerNamespace = "vmware-system-csi"
+)
+
 // we provide more install options other than the standard install.InstallOptions in E2E test
 type installOptions struct {
 	*install.InstallOptions
@@ -119,7 +124,7 @@ func configvSpherePlugin() error {
 	if err := CreateNamespace(context.Background(), cli, VeleroCfg.VeleroNamespace); err != nil {
 		return errors.WithMessagef(err, "Failed to create Velero %s namespace", VeleroCfg.VeleroNamespace)
 	}
-	if err := CreateVCCredentialSecret(cli.ClientGo, VeleroCfg.VeleroNamespace); err != nil {
+	if err := createVCCredentialSecret(cli.ClientGo, VeleroCfg.VeleroNamespace); err != nil {
 		return errors.WithMessagef(err, "Failed to create virtual center credential secret in %s namespace", VeleroCfg.VeleroNamespace)
 	}
 	if err := WaitForSecretsComplete(cli.ClientGo, VeleroCfg.VeleroNamespace, vsphereSecret); err != nil {
@@ -417,4 +422,38 @@ func VeleroUninstall(ctx context.Context, cli, namespace string) error {
 	}
 	fmt.Println("Velero uninstalled ⛵")
 	return nil
+}
+
+// createVCCredentialSecret refer to https://github.com/vmware-tanzu/velero-plugin-for-vsphere/blob/v1.3.0/docs/vanilla.md
+func createVCCredentialSecret(c clientset.Interface, veleroNamespace string) error {
+	secret, err := getVCCredentialSecret(c)
+	if err != nil {
+		return err
+	}
+	vsphereCfg, exist := secret.Data["csi-vsphere.conf"]
+	if !exist {
+		return errors.New("failed to retrieve csi-vsphere config")
+	}
+	se := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "velero-vsphere-config-secret",
+			Namespace: veleroNamespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{"csi-vsphere.conf": vsphereCfg},
+	}
+	_, err = c.CoreV1().Secrets(veleroNamespace).Create(context.TODO(), se, metav1.CreateOptions{})
+	return err
+}
+
+// Reference https://github.com/vmware-tanzu/velero-plugin-for-vsphere/blob/main/docs/vanilla.md#create-vc-credential-secret
+// Read secret from kube-system namespace first, if not found, try with vmware-system-csi.
+func getVCCredentialSecret(c clientset.Interface) (secret *corev1.Secret, err error) {
+	secret, err = GetSecret(c, KubeSystemNamespace, "vsphere-config-secret")
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			secret, err = GetSecret(c, VSphereCSIControllerNamespace, "vsphere-config-secret")
+		}
+	}
+	return
 }


### PR DESCRIPTION

Thank you for contributing to Velero!

# Please add a summary of your change
E2E test can read VC credential secret for vSphere plugin from namespace either kube-system or vmware-system-csi.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
