### PR TITLE
Make Velero not exits when EnableCSI is on and CSI snapshot not installed

### DIFF
--- a/changelogs/unreleased/6062-blackpiglet
+++ b/changelogs/unreleased/6062-blackpiglet
@@ -1,0 +1,1 @@
+Make Velero not exits when EnableCSI is on and CSI snapshot not installed

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -585,6 +585,7 @@ func (s *server) getCSIVolumeSnapshotListers() (vsLister snapshotv1listers.Volum
 	case apierrors.IsNotFound(err):
 		// CSI is enabled, but the required CRDs aren't installed, so halt.
 		s.logger.Warnf("The '%s' feature flag was specified, but CSI API group [%s] was not found.", velerov1api.CSIFeatureFlag, snapshotv1api.SchemeGroupVersion.String())
+		err = nil
 	case err == nil:
 		wrapper := NewCSIInformerFactoryWrapper(s.csiSnapshotClient)
 


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Make the Velero server continue to work when the CSI feature is enabled and the Snapshot CRD group is missing.

# Does your change fix a particular issue?

Fixes #5862 

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
