### PR TITLE
Refine the log message when BIA is skipped

### DIFF
--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -323,11 +323,11 @@ func (ib *itemBackupper) executeActions(
 			continue
 		}
 		log.Info("Executing custom action")
-
-		if act, err := ib.getMatchAction(obj, groupResource, action.Name()); err != nil {
+		actionName := action.Name()
+		if act, err := ib.getMatchAction(obj, groupResource, actionName); err != nil {
 			return nil, itemFiles, errors.WithStack(err)
 		} else if act != nil && act.Type == resourcepolicies.Skip {
-			log.Infof("skip snapshot of pvc %s/%s bound pv for the matched resource policies", namespace, name)
+			log.Infof("Skip executing Backup Item Action: %s of resource %s: %s/%s for the matched resource policies", actionName, groupResource, namespace, name)
 			continue
 		}
 


### PR DESCRIPTION
The log message should be clarified, otherwise when a user chooses to do the backup via podvolme there will be confusing logs, but actually it's just skipping the BIA for CSI plugin.

Thank you for contributing to Velero!

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
