### PR TITLE
Add display of resource policies name in describe backup output

### DIFF
--- a/pkg/cmd/util/output/backup_describer.go
+++ b/pkg/cmd/util/output/backup_describer.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strings"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	snapshotv1api "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
@@ -83,6 +84,11 @@ func DescribeBackup(
 
 		d.Printf("Phase:\t%s%s\n", phaseString, logsNote)
 
+		if backup.Spec.ResourcePolicy != nil {
+			d.Println()
+			DescribeResourcePolicies(d, backup.Spec.ResourcePolicy)
+		}
+
 		status := backup.Status
 		if len(status.ValidationErrors) > 0 {
 			d.Println()
@@ -116,6 +122,13 @@ func DescribeBackup(
 			DescribePodVolumeBackups(d, podVolumeBackups, details)
 		}
 	})
+}
+
+// DescribeResourcePolicies describes resource policiesin human-readable format
+func DescribeResourcePolicies(d *Describer, resPolicies *v1.TypedLocalObjectReference) {
+	d.Printf("Resource policies:\n")
+	d.Printf("\tType:\t%s\n", resPolicies.Kind)
+	d.Printf("\tName:\t%s\n", resPolicies.Name)
 }
 
 // DescribeBackupSpec describes a backup spec in human-readable format.

--- a/pkg/cmd/util/output/backup_structured_describer.go
+++ b/pkg/cmd/util/output/backup_structured_describer.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"strings"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	snapshotv1api "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
@@ -55,6 +56,10 @@ func DescribeBackupInSF(
 		d.DescribeMetadata(backup.ObjectMeta)
 
 		d.Describe("phase", backup.Status.Phase)
+
+		if backup.Spec.ResourcePolicy != nil {
+			DescribeResourcePoliciesInSF(d, backup.Spec.ResourcePolicy)
+		}
 
 		status := backup.Status
 		if len(status.ValidationErrors) > 0 {
@@ -501,6 +506,14 @@ func DescribeBackupResultsInSF(ctx context.Context, kbClient kbclient.Client, d 
 	if backup.Status.Errors > 0 {
 		describeResultInSF(errors, resultMap["errors"])
 	}
+}
+
+// DescribeResourcePoliciesInSF describes resource policies in structured format.
+func DescribeResourcePoliciesInSF(d *StructuredDescriber, resPolicies *v1.TypedLocalObjectReference) {
+	policiesInfo := make(map[string]interface{})
+	policiesInfo["type"] = resPolicies.Kind
+	policiesInfo["name"] = resPolicies.Name
+	d.Describe("resourcePolicies", policiesInfo)
 }
 
 func describeResultInSF(m map[string]interface{}, result results.Result) {

--- a/pkg/cmd/util/output/schedule_describer.go
+++ b/pkg/cmd/util/output/schedule_describer.go
@@ -43,6 +43,11 @@ func DescribeSchedule(schedule *v1.Schedule) string {
 		}
 		d.Printf("Phase:\t%s\n", phaseString)
 
+		if schedule.Spec.Template.ResourcePolicy != nil {
+			d.Println()
+			DescribeResourcePolicies(d, schedule.Spec.Template.ResourcePolicy)
+		}
+
 		status := schedule.Status
 		if len(status.ValidationErrors) > 0 {
 			d.Println()


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)
https://github.com/vmware-tanzu/velero/issues/6066
# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
