### PR TITLE
Exclude endpointslice from restore list

### DIFF
--- a/pkg/controller/restore_controller.go
+++ b/pkg/controller/restore_controller.go
@@ -60,6 +60,11 @@ var nonRestorableResources = []string{
 	"events",
 	"events.events.k8s.io",
 
+	// The restored endpointslices are removed immediately and that causes the following patch operation for managedFields failed
+	// The control plane automatically creates EndpointSlices for any Kubernetes Service that has a selector specified.
+	// So don't need to restore it
+	"endpointslices",
+
 	// Don't ever restore backups - if appropriate, they'll be synced in from object storage.
 	// https://github.com/vmware-tanzu/velero/issues/622
 	"backups.velero.io",


### PR DESCRIPTION
The restored endpointslices are removed immediately and that causes the following patch operation for managedFields failed. The control plane automatically creates EndpointSlices for any Kubernetes Service that has a selector specified. So don't need to restore it

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
