### PR TITLE
Make GetPluginConfig accessible from other packages.

### DIFF
--- a/changelogs/unreleased/6151-tkaovila
+++ b/changelogs/unreleased/6151-tkaovila
@@ -1,0 +1,1 @@
+Make GetPluginConfig accessible from other packages.

--- a/pkg/plugin/framework/common/plugin_config.go
+++ b/pkg/plugin/framework/common/plugin_config.go
@@ -1,0 +1,58 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+func PluginConfigLabelSelector(kind PluginKind, name string) string {
+	return fmt.Sprintf("velero.io/plugin-config=true,%s=%s", name, kind)
+}
+
+func GetPluginConfig(kind PluginKind, name string, client corev1client.ConfigMapInterface) (*corev1.ConfigMap, error) {
+	opts := metav1.ListOptions{
+		// velero.io/plugin-config: true
+		// velero.io/pod-volume-restore: RestoreItemAction
+		LabelSelector: PluginConfigLabelSelector(kind, name),
+	}
+
+	list, err := client.List(context.Background(), opts)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	if len(list.Items) == 0 {
+		return nil, nil
+	}
+
+	if len(list.Items) > 1 {
+		var items []string
+		for _, item := range list.Items {
+			items = append(items, item.Name)
+		}
+		return nil, errors.Errorf("found more than one ConfigMap matching label selector %q: %v", opts.LabelSelector, items)
+	}
+
+	return &list.Items[0], nil
+}

--- a/pkg/plugin/framework/common/plugin_config_test.go
+++ b/pkg/plugin/framework/common/plugin_config_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+)
+
+func TestGetPluginConfig(t *testing.T) {
+	type args struct {
+		kind    PluginKind
+		name    string
+		objects []runtime.Object
+	}
+	pluginLabelsSet, _ := labels.ConvertSelectorToLabelsMap(PluginConfigLabelSelector(PluginKindRestoreItemAction, "foo"))
+	testConfigMap := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo-config",
+			Namespace: velerov1.DefaultNamespace,
+			Labels:    pluginLabelsSet,
+		},
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *corev1.ConfigMap
+		wantErr bool
+	}{
+		{
+			name: "should return nil if no config map found",
+			args: args{
+				kind:    PluginKindRestoreItemAction,
+				name:    "foo",
+				objects: []runtime.Object{},
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "should return error if more than one config map found",
+			args: args{
+				kind: PluginKindRestoreItemAction,
+				name: "foo",
+				objects: []runtime.Object{
+					&corev1.ConfigMap{
+						TypeMeta: metav1.TypeMeta{
+							Kind: "ConfigMap",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo-config",
+							Namespace: velerov1.DefaultNamespace,
+							Labels:    pluginLabelsSet,
+						},
+					},
+					&corev1.ConfigMap{
+						TypeMeta: metav1.TypeMeta{
+							Kind: "ConfigMap",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo-config-duplicate",
+							Namespace: velerov1.DefaultNamespace,
+							Labels:    pluginLabelsSet,
+						},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "should return pointer to configmap if only one config map with label found",
+			args: args{
+				kind: PluginKindRestoreItemAction,
+				name: "foo",
+				objects: []runtime.Object{
+					testConfigMap,
+				},
+			},
+			want:    testConfigMap,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewSimpleClientset(tt.args.objects...)
+			got, err := GetPluginConfig(tt.args.kind, tt.args.name, fakeClient.CoreV1().ConfigMaps(velerov1.DefaultNamespace))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetPluginConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetPluginConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/restore/change_pvc_node_selector.go
+++ b/pkg/restore/change_pvc_node_selector.go
@@ -140,7 +140,7 @@ func (p *ChangePVCNodeSelectorAction) Execute(input *velero.RestoreItemActionExe
 
 func getNewNodeFromConfigMap(client corev1client.ConfigMapInterface, node string) (string, error) {
 	// fetch node mapping from configMap
-	config, err := getPluginConfig(common.PluginKindRestoreItemAction, "velero.io/change-pvc-node-selector", client)
+	config, err := common.GetPluginConfig(common.PluginKindRestoreItemAction, "velero.io/change-pvc-node-selector", client)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/restore/change_storageclass_action.go
+++ b/pkg/restore/change_storageclass_action.go
@@ -69,7 +69,7 @@ func (a *ChangeStorageClassAction) Execute(input *velero.RestoreItemActionExecut
 	defer a.logger.Info("Done executing ChangeStorageClassAction")
 
 	a.logger.Debug("Getting plugin config")
-	config, err := getPluginConfig(common.PluginKindRestoreItemAction, "velero.io/change-storage-class", a.configMapClient)
+	config, err := common.GetPluginConfig(common.PluginKindRestoreItemAction, "velero.io/change-storage-class", a.configMapClient)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
…n/framework/common/plugin_config.go/GetPluginConfig

Fixes #4865 Expose GetPluginConfig

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
