### PR TITLE
Update Golang to v1.20 for main branch.

### DIFF
--- a/.github/workflows/crds-verify-kind.yaml
+++ b/.github/workflows/crds-verify-kind.yaml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: '1.20'
         id: go
       # Look for a CLI that's made for this PR
       - name: Fetch built CLI

--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: '1.20'
         id: go
       # Look for a CLI that's made for this PR
       - name: Fetch built CLI
@@ -70,9 +70,9 @@ jobs:
       fail-fast: false
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: '1.20'
         id: go
       - name: Check out the code
         uses: actions/checkout@v2

--- a/.github/workflows/pr-ci-check.yml
+++ b/.github/workflows/pr-ci-check.yml
@@ -8,9 +8,9 @@ jobs:
       fail-fast: false
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: '1.20'
         id: go
       - name: Check out the code
         uses: actions/checkout@v2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,9 +16,9 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: 1.19
+        go-version: '1.20'
       id: go
 
     - uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Velero binary build section
-FROM --platform=$BUILDPLATFORM golang:1.19-bullseye as velero-builder
+FROM --platform=$BUILDPLATFORM golang:1.20-bullseye as velero-builder
 
 ARG GOPROXY
 ARG BIN
@@ -44,7 +44,7 @@ RUN mkdir -p /output/usr/bin && \
     -ldflags "${LDFLAGS}" ${PKG}/cmd/${BIN}
 
 # Restic binary build section
-FROM --platform=$BUILDPLATFORM golang:1.19-bullseye as restic-builder
+FROM --platform=$BUILDPLATFORM golang:1.20-bullseye as restic-builder
 
 ARG BIN
 ARG TARGETOS

--- a/Tiltfile
+++ b/Tiltfile
@@ -50,7 +50,7 @@ git_sha = str(local("git rev-parse HEAD", quiet = True, echo_off = True)).strip(
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.19 as tilt-helper
+FROM golang:1.20 as tilt-helper
 
 # Support live reloading with Tilt
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \
@@ -62,7 +62,7 @@ additional_docker_helper_commands = """
 # Install delve to allow debugging
 RUN go get github.com/go-delve/delve/cmd/dlv
 
-RUN wget -qO- https://dl.k8s.io/v1.19.2/kubernetes-client-linux-amd64.tar.gz | tar xvz
+RUN wget -qO- https://dl.k8s.io/v1.25.2/kubernetes-client-linux-amd64.tar.gz | tar xvz
 RUN wget -qO- https://get.docker.com | sh
 """
 

--- a/changelogs/unreleased/6158-blackpiglet
+++ b/changelogs/unreleased/6158-blackpiglet
@@ -1,0 +1,1 @@
+Update Golang to v1.20 for main.

--- a/hack/build-image/Dockerfile
+++ b/hack/build-image/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=linux/amd64 golang:1.19-bullseye
+FROM --platform=linux/amd64 golang:1.20-bullseye
 
 ARG GOPROXY
 


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

Due to `actions/setup-python`'s limitation, golang's version `1.20` is parsed into `1.2`. Need to use `'1.20'` instead.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
