### PR TITLE
Fix context issues for several E2E tests

### DIFF
--- a/test/e2e/backups/sync_backups.go
+++ b/test/e2e/backups/sync_backups.go
@@ -50,8 +50,6 @@ func (b *SyncBackups) Init() {
 
 func BackupsSyncTest() {
 	test := new(SyncBackups)
-	ctx, ctxCancel := context.WithCancel(context.Background())
-	defer ctxCancel()
 	var (
 		err error
 	)
@@ -79,7 +77,8 @@ func BackupsSyncTest() {
 
 	It("Backups in object storage should be synced to a new Velero successfully", func() {
 		test.Init()
-
+		ctx, ctxCancel := context.WithTimeout(context.Background(), 30*time.Minute)
+		defer ctxCancel()
 		By(fmt.Sprintf("Prepare workload as target to backup by creating namespace %s namespace", test.testNS))
 		Expect(CreateNamespace(ctx, *VeleroCfg.ClientToInstallVelero, test.testNS)).To(Succeed(),
 			fmt.Sprintf("Failed to create %s namespace", test.testNS))
@@ -114,12 +113,13 @@ func BackupsSyncTest() {
 		})
 
 		By("Check all backups in object storage are synced to Velero", func() {
-			Expect(test.IsBackupsSynced()).To(Succeed(), fmt.Sprintf("Failed to sync backup %s from object storage", test.backupName))
+			Expect(test.IsBackupsSynced(ctx, ctxCancel)).To(Succeed(), fmt.Sprintf("Failed to sync backup %s from object storage", test.backupName))
 		})
 	})
 
 	It("Deleted backups in object storage are synced to be deleted in Velero", func() {
 		test.Init()
+		ctx, ctxCancel := context.WithTimeout(context.Background(), 30*time.Minute)
 		defer ctxCancel()
 		By(fmt.Sprintf("Prepare workload as target to backup by creating namespace in %s namespace", test.testNS), func() {
 			Expect(CreateNamespace(ctx, *VeleroCfg.ClientToInstallVelero, test.testNS)).To(Succeed(),
@@ -163,8 +163,7 @@ func BackupsSyncTest() {
 	})
 }
 
-func (b *SyncBackups) IsBackupsSynced() error {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Minute)
+func (b *SyncBackups) IsBackupsSynced(ctx context.Context, ctxCancel context.CancelFunc) error {
 	defer ctxCancel()
 	return WaitForBackupToBeCreated(ctx, VeleroCfg.VeleroCLI, b.backupName, 10*time.Minute)
 }

--- a/test/e2e/backups/ttl.go
+++ b/test/e2e/backups/ttl.go
@@ -56,16 +56,12 @@ func (b *TTL) Init() {
 }
 
 func TTLTest() {
-	ctx, contextCancel := context.WithCancel(context.Background())
-	defer contextCancel()
 	var err error
 	var veleroCfg VeleroConfig
 	useVolumeSnapshots := true
 	test := new(TTL)
 	veleroCfg = VeleroCfg
 	client := *veleroCfg.ClientToInstallVelero
-
-	//Expect(err).To(Succeed(), "Failed to instantiate cluster client for backup tests")
 
 	BeforeEach(func() {
 		flag.Parse()
@@ -87,12 +83,16 @@ func TTLTest() {
 			if veleroCfg.InstallVelero {
 				Expect(VeleroUninstall(context.Background(), veleroCfg.VeleroCLI, veleroCfg.VeleroNamespace)).To(Succeed())
 			}
+			ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer ctxCancel()
 			Expect(DeleteNamespace(ctx, client, test.testNS, false)).To(Succeed(), fmt.Sprintf("Failed to delete the namespace %s", test.testNS))
 		}
 	})
 
 	It("Backups in object storage should be synced to a new Velero successfully", func() {
 		test.Init()
+		ctx, ctxCancel := context.WithTimeout(context.Background(), 1*time.Hour)
+		defer ctxCancel()
 		By(fmt.Sprintf("Prepare workload as target to backup by creating namespace %s namespace", test.testNS), func() {
 			Expect(CreateNamespace(ctx, client, test.testNS)).To(Succeed(),
 				fmt.Sprintf("Failed to create %s namespace", test.testNS))

--- a/test/e2e/basic/namespace-mapping.go
+++ b/test/e2e/basic/namespace-mapping.go
@@ -24,9 +24,9 @@ type NamespaceMapping struct {
 const NamespaceBaseName string = "ns-mp-"
 
 var OneNamespaceMappingResticTest func() = TestFunc(&NamespaceMapping{TestCase: TestCase{NSBaseName: NamespaceBaseName, NSIncluded: &[]string{NamespaceBaseName + "1"}, UseVolumeSnapshots: false}})
-var MultiNamespacesMappingResticTest func() = TestFunc(&NamespaceMapping{TestCase: TestCase{NSBaseName: NamespaceBaseName, NSIncluded: &[]string{NamespaceBaseName + "1", NamespaceBaseName + "2"}, UseVolumeSnapshots: false}})
-var OneNamespaceMappingSnapshotTest func() = TestFunc(&NamespaceMapping{TestCase: TestCase{NSBaseName: NamespaceBaseName, NSIncluded: &[]string{NamespaceBaseName + "1"}, UseVolumeSnapshots: true}})
-var MultiNamespacesMappingSnapshotTest func() = TestFunc(&NamespaceMapping{TestCase: TestCase{NSBaseName: NamespaceBaseName, NSIncluded: &[]string{NamespaceBaseName + "1", NamespaceBaseName + "2"}, UseVolumeSnapshots: true}})
+var MultiNamespacesMappingResticTest func() = TestFunc(&NamespaceMapping{TestCase: TestCase{NSBaseName: NamespaceBaseName, NSIncluded: &[]string{NamespaceBaseName + "2", NamespaceBaseName + "3"}, UseVolumeSnapshots: false}})
+var OneNamespaceMappingSnapshotTest func() = TestFunc(&NamespaceMapping{TestCase: TestCase{NSBaseName: NamespaceBaseName, NSIncluded: &[]string{NamespaceBaseName + "4"}, UseVolumeSnapshots: true}})
+var MultiNamespacesMappingSnapshotTest func() = TestFunc(&NamespaceMapping{TestCase: TestCase{NSBaseName: NamespaceBaseName, NSIncluded: &[]string{NamespaceBaseName + "5", NamespaceBaseName + "6"}, UseVolumeSnapshots: true}})
 
 func (n *NamespaceMapping) Init() error {
 	n.VeleroCfg = VeleroCfg

--- a/test/e2e/basic/storage-class-changing.go
+++ b/test/e2e/basic/storage-class-changing.go
@@ -49,7 +49,7 @@ func (s *StorageClasssChanging) Init() error {
 	s.BackupName = "backup-sc-" + UUIDgen.String()
 	s.RestoreName = "restore-" + UUIDgen.String()
 	s.srcStorageClass = "default"
-	s.desStorageClass = "e2e-storage-class"
+	s.desStorageClass = StorageClassName
 	s.labels = map[string]string{"velero.io/change-storage-class": "RestoreItemAction",
 		"velero.io/plugin-config": ""}
 	s.data = map[string]string{s.srcStorageClass: s.desStorageClass}

--- a/test/e2e/pv-backup/pv-backup-filter.go
+++ b/test/e2e/pv-backup/pv-backup-filter.go
@@ -99,7 +99,7 @@ func (p *PVBackupFiltering) CreateResources() error {
 				podName := fmt.Sprintf("pod-%d", i)
 				pods = append(pods, podName)
 				By(fmt.Sprintf("Create pod %s in namespace %s", podName, ns), func() {
-					pod, err := CreatePod(p.Client, ns, podName, "e2e-storage-class", "", volumes, nil, nil)
+					pod, err := CreatePod(p.Client, ns, podName, StorageClassName, "", volumes, nil, nil)
 					Expect(err).To(Succeed())
 					ann := map[string]string{
 						p.annotation: volumesToAnnotation,

--- a/test/e2e/scale/multiple_namespaces.go
+++ b/test/e2e/scale/multiple_namespaces.go
@@ -17,8 +17,10 @@ limitations under the License.
 package scale
 
 import (
+	"time"
+
 	basic "github.com/vmware-tanzu/velero/test/e2e/basic/resources-check"
 	. "github.com/vmware-tanzu/velero/test/e2e/test"
 )
 
-var MultiNSBackupRestore func() = TestFunc(&basic.MultiNSBackup{IsScalTest: true})
+var MultiNSBackupRestore func() = TestFunc(&basic.MultiNSBackup{IsScalTest: true, TestCase: TestCase{Timeout: time.Hour}})

--- a/test/e2e/schedule/schedule.go
+++ b/test/e2e/schedule/schedule.go
@@ -92,7 +92,7 @@ func (n *ScheduleBackup) Backup() error {
 	return nil
 }
 func (n *ScheduleBackup) Destroy() error {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 60*time.Minute)
 	defer ctxCancel()
 	By(fmt.Sprintf("Schedule %s is created without any delay\n", n.ScheduleName), func() {
 		creationTimestamp, err := GetSchedule(context.Background(), VeleroCfg.VeleroNamespace, n.ScheduleName)

--- a/test/e2e/types.go
+++ b/test/e2e/types.go
@@ -24,6 +24,8 @@ import (
 	. "github.com/vmware-tanzu/velero/test/e2e/util/k8s"
 )
 
+const StorageClassName = "e2e-storage-class"
+
 var UUIDgen uuid.UUID
 
 var VeleroCfg VeleroConfig

--- a/test/e2e/util/velero/velero_utils.go
+++ b/test/e2e/util/velero/velero_utils.go
@@ -336,6 +336,20 @@ func VeleroBackupNamespace(ctx context.Context, veleroCLI, veleroNamespace strin
 		if backupCfg.ProvideSnapshotsVolumeParam && !backupCfg.UseVolumeSnapshots {
 			args = append(args, "--snapshot-volumes=false")
 		} // if "--snapshot-volumes" is not provide, snapshot should be taken as default behavior.
+	} else { // DefaultVolumesToFsBackup is false
+		// Althrough DefaultVolumesToFsBackup is false, but probably DefaultVolumesToFsBackup
+		// was set to true in installation CLI in snapshot volume test, so set DefaultVolumesToFsBackup
+		// to false specifically to make sure volume snapshot was taken
+		if backupCfg.UseVolumeSnapshots {
+			if backupCfg.UseResticIfFSBackup {
+				args = append(args, "--default-volumes-to-restic=false")
+			} else {
+				args = append(args, "--default-volumes-to-fs-backup=false")
+			}
+		}
+		// Also Althrough DefaultVolumesToFsBackup is false, but probably DefaultVolumesToFsBackup
+		// was set to true in installation CLI in FS volume backup test, so do nothing here, no DefaultVolumesToFsBackup
+		// appear in backup CLI
 	}
 	if backupCfg.BackupLocation != "" {
 		args = append(args, "--storage-location", backupCfg.BackupLocation)


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

1. Fix context issues produced by previous PR, increase timeout or add case scpoed global timeout param to make  backup/restore command timeout configurable.
2. Add global param for storage class name using by test cases;
3. Fix param DefaultVolumesToFsBackup usage issue: set DefaultVolumesToFsBackup to false in backup CLI  in case it was set to true in install CLI.
4. Make namespace names of each namespace mapping test unique from being interfered by each other.



# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
