### PR TITLE
log volumes to backup to help debug why `IsPodRunning` is called.

### DIFF
--- a/changelogs/unreleased/6232-kaovilai
+++ b/changelogs/unreleased/6232-kaovilai
@@ -1,0 +1,1 @@
+log volumes to backup to help debug why `IsPodRunning` is called.

--- a/pkg/podvolume/backupper.go
+++ b/pkg/podvolume/backupper.go
@@ -131,7 +131,7 @@ func (b *backupper) BackupPodVolumes(backup *velerov1api.Backup, pod *corev1api.
 	if len(volumesToBackup) == 0 {
 		return nil, nil
 	}
-
+	log.Infof("pod %s/%s has volumes to backup: %v", pod.Namespace, pod.Name, volumesToBackup)
 	err := kube.IsPodRunning(pod)
 	if err != nil {
 		for _, volumeName := range volumesToBackup {


### PR DESCRIPTION
This change help users debug when trying to backup pods without triggering volume backups by using volume exclude annotations. This log will help user identify volumes that need to be annotated for exclusion.

image to test at `ghcr.io/kaovilai/velero:logpvb`

Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
