### PR TITLE
run gofmt goimports for every files in parallel

### DIFF
--- a/hack/update-1fmt.sh
+++ b/hack/update-1fmt.sh
@@ -35,13 +35,11 @@ fi
 
 files="$(find . -type f -name '*.go' -not -path './.go/*' -not -path './vendor/*' -not -path './site/*' -not -path '*/generated/*' -not -name 'zz_generated*' -not -path '*/mocks/*')"
 echo "${ACTION} gofmt"
-for file in ${files}; do
-  output=$(gofmt "${MODE}" -s "${file}")
-  if [[ -n "${output}" ]]; then
-    VERIFY_FMT_FAILED=1
-    echo "${output}"
-  fi
-done
+output=$(printf '%s\n' "${files}" | xargs gofmt "${MODE}" -s)
+if [[ -n "${output}" ]]; then
+  VERIFY_FMT_FAILED=1
+  echo "${output}"
+fi
 if [[ -n "${VERIFY_FMT_FAILED:-}" ]]; then
   echo "${ACTION} gofmt - failed! Please run 'make update'."
 else
@@ -49,13 +47,11 @@ else
 fi
 
 echo "${ACTION} goimports"
-for file in ${files}; do
-  output=$(goimports "${MODE}" -local github.com/vmware-tanzu/velero "${file}")
-  if [[ -n "${output}" ]]; then
-    VERIFY_IMPORTS_FAILED=1
-    echo "${output}"
-  fi
-done
+output=$(printf '%s\n' "${files}" | xargs goimports "${MODE}" -local github.com/vmware-tanzu/velero)
+if [[ -n "${output}" ]]; then
+  VERIFY_IMPORTS_FAILED=1
+  echo "${output}"
+fi
 if [[ -n "${VERIFY_IMPORTS_FAILED:-}" ]]; then
   echo "${ACTION} goimports - failed! Please run 'make update'."
 else


### PR DESCRIPTION
This cut down update fmt runtime down to 25 seconds
```
❯ hack/update-1fmt.sh 
Updating gofmt
Updating gofmt - done!
Updating goimports
Updating goimports - done!

~/git/velero * 25s
```

`make ci` run time from _[9m 14s](https://github.com/vmware-tanzu/velero/actions/runs/4896081321/jobs/8742443706?pr=6232#step:5:1)_ to _[7m 57s](https://github.com/vmware-tanzu/velero/actions/runs/4896200359/jobs/8742725334?pr=6234#step:5:1)_

Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
