### PR TITLE
Gather list of volumes to pvb backup after execute actions

### DIFF
--- a/changelogs/unreleased/6243-kaovilai
+++ b/changelogs/unreleased/6243-kaovilai
@@ -1,0 +1,1 @@
+Gather list of volumes to pvb backup after execute actions so plugin can affect which volumes are in the backup


### PR DESCRIPTION
Gather list of volumes to pvb backup after execute actions so plugin can affect which volumes are in the backup

Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
