### PR TITLE
Adjust E2E test codes

### DIFF
--- a/test/e2e/backups/deletion.go
+++ b/test/e2e/backups/deletion.go
@@ -150,7 +150,7 @@ func runBackupDeletionTests(client TestClient, veleroCfg VeleroConfig, backupNam
 	}
 	var snapshotCheckPoint SnapshotCheckPoint
 	if useVolumeSnapshots {
-		snapshotCheckPoint, err = GetSnapshotCheckPoint(client, veleroCfg, 2, deletionTest, backupName, KibishiiPodNameList)
+		snapshotCheckPoint, err = GetSnapshotCheckPoint(client, veleroCfg, 2, deletionTest, backupName, KibishiiPVCNameList)
 		Expect(err).NotTo(HaveOccurred(), "Fail to get Azure CSI snapshot checkpoint")
 		err = SnapshotsShouldBeCreatedInCloud(veleroCfg.CloudProvider,
 			veleroCfg.CloudCredentialsFile, veleroCfg.BSLBucket, bslConfig,

--- a/test/e2e/backups/ttl.go
+++ b/test/e2e/backups/ttl.go
@@ -128,7 +128,7 @@ func TTLTest() {
 						test.testNS, 2)).To(Succeed())
 				})
 			}
-			snapshotCheckPoint, err = GetSnapshotCheckPoint(client, veleroCfg, 2, test.testNS, test.backupName, KibishiiPodNameList)
+			snapshotCheckPoint, err = GetSnapshotCheckPoint(client, veleroCfg, 2, test.testNS, test.backupName, KibishiiPVCNameList)
 			Expect(err).NotTo(HaveOccurred(), "Fail to get Azure CSI snapshot checkpoint")
 
 			Expect(SnapshotsShouldBeCreatedInCloud(veleroCfg.CloudProvider,

--- a/test/e2e/basic/api-group/enable_api_group_versions.go
+++ b/test/e2e/basic/api-group/enable_api_group_versions.go
@@ -100,7 +100,7 @@ func APIGropuVersionsTest() {
 				DeleteBackups(context.Background(), *veleroCfg.ClientToInstallVelero)
 			})
 			if veleroCfg.InstallVelero {
-				By("Uninstall Velero", func() {
+				By("Uninstall Velero in api group version case", func() {
 					Expect(VeleroUninstall(ctx, veleroCfg.VeleroCLI, veleroCfg.VeleroNamespace)).NotTo(HaveOccurred())
 				})
 			}

--- a/test/e2e/basic/nodeport.go
+++ b/test/e2e/basic/nodeport.go
@@ -3,6 +3,7 @@ package basic
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -20,40 +21,42 @@ import (
 
 type NodePort struct {
 	TestCase
-	replica              int32
 	labels               map[string]string
-	containers           *[]v1.Container
 	serviceName          string
-	serviceSpec          *v1.ServiceSpec
+	namespaceToCollision []string
 	nodePort             int32
-	namespaceToCollision string
-	namespace            string
 }
 
 const NodeportBaseName string = "nodeport-"
 
-var NodePortTest func() = TestFunc(&NodePort{namespace: NodeportBaseName + "1", TestCase: TestCase{NSBaseName: NodeportBaseName}})
+var NodePortTest func() = TestFunc(&NodePort{})
 
 func (n *NodePort) Init() error {
+	n.TestCase.Init()
+	n.CaseBaseName = NodeportBaseName + n.UUIDgen
+	n.BackupName = "backup-" + n.CaseBaseName
+	n.RestoreName = "restore-" + n.CaseBaseName
+	n.serviceName = "nginx-service-" + n.CaseBaseName
 	n.VeleroCfg = VeleroCfg
 	n.Client = *n.VeleroCfg.ClientToInstallVelero
-	n.NSBaseName = NodeportBaseName
+	n.NamespacesTotal = 1
 	n.TestMsg = &TestMSG{
-		Desc:      fmt.Sprintf("Nodeport preservation"),
+		Desc:      "Nodeport preservation",
 		FailedMSG: "Failed to restore with nodeport preservation",
-		Text:      fmt.Sprintf("Nodeport can be preserved or omit during restore"),
+		Text:      "Nodeport can be preserved or omit during restore",
 	}
-	n.BackupName = "backup-nodeport-" + UUIDgen.String()
-	n.RestoreName = "restore-" + UUIDgen.String()
-	n.serviceName = "nginx-service-" + UUIDgen.String()
-	n.labels = map[string]string{"app": "nginx"}
-	return nil
-}
 
-func (n *NodePort) StartRun() error {
+	n.labels = map[string]string{"app": "nginx"}
+	n.NSIncluded = &[]string{}
+	for nsNum := 0; nsNum < n.NamespacesTotal; nsNum++ {
+		createNSName := fmt.Sprintf("%s-%00000d", n.CaseBaseName, nsNum)
+		n.namespaceToCollision = append(n.namespaceToCollision, createNSName+"tmp")
+		*n.NSIncluded = append(*n.NSIncluded, createNSName)
+	}
+
 	n.BackupArgs = []string{
 		"create", "--namespace", VeleroCfg.VeleroNamespace, "backup", n.BackupName,
-		"--include-namespaces", n.namespace, "--wait",
+		"--include-namespaces", strings.Join(*n.NSIncluded, ","), "--wait",
 	}
 	n.RestoreArgs = []string{
 		"create", "--namespace", VeleroCfg.VeleroNamespace, "restore",
@@ -66,37 +69,40 @@ func (n *NodePort) CreateResources() error {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 60*time.Minute)
 	defer ctxCancel()
 
-	By(fmt.Sprintf("Creating service %s in namespaces %s ......\n", n.serviceName, n.namespace), func() {
-		Expect(CreateNamespace(ctx, n.Client, n.namespace)).To(Succeed(), fmt.Sprintf("Failed to create namespace %s", n.namespace))
-		Expect(createServiceWithNodeport(ctx, n.Client, n.namespace, n.serviceName, n.labels, 0)).To(Succeed(), fmt.Sprintf("Failed to create service %s", n.serviceName))
-		service, err := GetService(ctx, n.Client, n.namespace, n.serviceName)
-		Expect(err).To(Succeed())
-		Expect(len(service.Spec.Ports)).To(Equal(1))
-		n.nodePort = service.Spec.Ports[0].NodePort
-		_, err = GetAllService(ctx)
-		Expect(err).To(Succeed(), "fail to get service")
-	})
+	for _, ns := range *n.NSIncluded {
+		By(fmt.Sprintf("Creating service %s in namespaces %s ......\n", n.serviceName, ns), func() {
+			Expect(CreateNamespace(ctx, n.Client, ns)).To(Succeed(), fmt.Sprintf("Failed to create namespace %s", ns))
+			Expect(createServiceWithNodeport(ctx, n.Client, ns, n.serviceName, n.labels, 0)).To(Succeed(), fmt.Sprintf("Failed to create service %s", n.serviceName))
+			service, err := GetService(ctx, n.Client, ns, n.serviceName)
+			Expect(err).To(Succeed())
+			Expect(len(service.Spec.Ports)).To(Equal(1))
+			n.nodePort = service.Spec.Ports[0].NodePort
+			_, err = GetAllService(ctx)
+			Expect(err).To(Succeed(), "fail to get service")
+		})
+	}
 	return nil
 }
 
 func (n *NodePort) Destroy() error {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 60*time.Minute)
 	defer ctxCancel()
-	By(fmt.Sprintf("Start to destroy namespace %s......", n.NSBaseName), func() {
-		Expect(CleanupNamespacesWithPoll(ctx, n.Client, NodeportBaseName)).To(Succeed(),
-			fmt.Sprintf("Failed to delete namespace %s", n.NSBaseName))
-		Expect(WaitForServiceDelete(n.Client, n.namespace, n.serviceName, false)).To(Succeed(), "fail to delete service")
-		_, err := GetAllService(ctx)
-		Expect(err).To(Succeed(), "fail to get service")
-	})
+	for i, ns := range *n.NSIncluded {
+		By(fmt.Sprintf("Start to destroy namespace %s......", n.CaseBaseName), func() {
+			Expect(CleanupNamespacesWithPoll(ctx, n.Client, NodeportBaseName)).To(Succeed(),
+				fmt.Sprintf("Failed to delete namespace %s", n.CaseBaseName))
+			Expect(WaitForServiceDelete(n.Client, ns, n.serviceName, false)).To(Succeed(), "fail to delete service")
+			_, err := GetAllService(ctx)
+			Expect(err).To(Succeed(), "fail to get service")
+		})
 
-	n.namespaceToCollision = NodeportBaseName + "tmp"
-	By(fmt.Sprintf("Creating a new service which has the same nodeport as backed up service has in a new namespaces for nodeport collision ...%s\n", n.namespaceToCollision), func() {
-		Expect(CreateNamespace(ctx, n.Client, n.namespaceToCollision)).To(Succeed(), fmt.Sprintf("Failed to create namespace %s", n.namespaceToCollision))
-		Expect(createServiceWithNodeport(ctx, n.Client, n.namespaceToCollision, n.serviceName, n.labels, n.nodePort)).To(Succeed(), fmt.Sprintf("Failed to create service %s", n.serviceName))
-		_, err := GetAllService(ctx)
-		Expect(err).To(Succeed(), "fail to get service")
-	})
+		By(fmt.Sprintf("Creating a new service which has the same nodeport as backed up service has in a new namespaces for nodeport collision ...%s\n", n.namespaceToCollision[i]), func() {
+			Expect(CreateNamespace(ctx, n.Client, n.namespaceToCollision[i])).To(Succeed(), fmt.Sprintf("Failed to create namespace %s", n.namespaceToCollision[i]))
+			Expect(createServiceWithNodeport(ctx, n.Client, n.namespaceToCollision[i], n.serviceName, n.labels, n.nodePort)).To(Succeed(), fmt.Sprintf("Failed to create service %s", n.serviceName))
+			_, err := GetAllService(ctx)
+			Expect(err).To(Succeed(), "fail to get service")
+		})
+	}
 
 	return nil
 }
@@ -134,37 +140,38 @@ func (n *NodePort) Restore() error {
 		})
 	})
 
-	By(fmt.Sprintf("Delete service %s by deleting namespace %s", n.serviceName, n.namespace), func() {
-		service, err := GetService(ctx, n.Client, n.namespace, n.serviceName)
-		Expect(err).To(Succeed())
-		Expect(len(service.Spec.Ports)).To(Equal(1))
-		fmt.Println(service.Spec.Ports)
-		Expect(DeleteNamespace(ctx, n.Client, n.namespace, true)).To(Succeed())
-	})
-
-	By(fmt.Sprintf("Start to delete service %s in namespace %s ......", n.serviceName, n.namespaceToCollision), func() {
-		Expect(WaitForServiceDelete(n.Client, n.namespaceToCollision, n.serviceName, true)).To(Succeed(), "fail to delete service")
-		_, err := GetAllService(ctx)
-		Expect(err).To(Succeed(), "fail to get service")
-	})
-
-	args = n.RestoreArgs
-	args = append(args[:index], append([]string{restoreName2}, args[index:]...)...)
-	args = append(args, "--preserve-nodeports=true")
-	By(fmt.Sprintf("Start to restore %s with nodeports preservation ......", restoreName2), func() {
-		Expect(VeleroRestoreExec(ctx, n.VeleroCfg.VeleroCLI, n.VeleroCfg.VeleroNamespace,
-			restoreName2, args, velerov1api.RestorePhaseCompleted)).To(Succeed(), func() string {
-			RunDebug(context.Background(), n.VeleroCfg.VeleroCLI, n.VeleroCfg.VeleroNamespace, "", restoreName2)
-			return "Fail to restore workload"
+	for i, ns := range *n.NSIncluded {
+		By(fmt.Sprintf("Delete service %s by deleting namespace %s", n.serviceName, ns), func() {
+			service, err := GetService(ctx, n.Client, ns, n.serviceName)
+			Expect(err).To(Succeed())
+			Expect(len(service.Spec.Ports)).To(Equal(1))
+			fmt.Println(service.Spec.Ports)
+			Expect(DeleteNamespace(ctx, n.Client, ns, true)).To(Succeed())
 		})
-	})
 
-	By(fmt.Sprintf("Verify service %s was restore successfully with the origin nodeport.", n.namespace), func() {
-		service, err := GetService(ctx, n.Client, n.namespace, n.serviceName)
-		Expect(err).To(Succeed())
-		Expect(len(service.Spec.Ports)).To(Equal(1))
-		Expect(service.Spec.Ports[0].NodePort).To(Equal(n.nodePort))
-	})
+		By(fmt.Sprintf("Start to delete service %s in namespace %s ......", n.serviceName, n.namespaceToCollision[i]), func() {
+			Expect(WaitForServiceDelete(n.Client, n.namespaceToCollision[i], n.serviceName, true)).To(Succeed(), "fail to delete service")
+			_, err := GetAllService(ctx)
+			Expect(err).To(Succeed(), "fail to get service")
+		})
+		args = n.RestoreArgs
+		args = append(args[:index], append([]string{restoreName2}, args[index:]...)...)
+		args = append(args, "--preserve-nodeports=true")
+		By(fmt.Sprintf("Start to restore %s with nodeports preservation ......", restoreName2), func() {
+			Expect(VeleroRestoreExec(ctx, n.VeleroCfg.VeleroCLI, n.VeleroCfg.VeleroNamespace,
+				restoreName2, args, velerov1api.RestorePhaseCompleted)).To(Succeed(), func() string {
+				RunDebug(context.Background(), n.VeleroCfg.VeleroCLI, n.VeleroCfg.VeleroNamespace, "", restoreName2)
+				return "Fail to restore workload"
+			})
+		})
+
+		By(fmt.Sprintf("Verify service %s was restore successfully with the origin nodeport.", ns), func() {
+			service, err := GetService(ctx, n.Client, ns, n.serviceName)
+			Expect(err).To(Succeed())
+			Expect(len(service.Spec.Ports)).To(Equal(1))
+			Expect(service.Spec.Ports[0].NodePort).To(Equal(n.nodePort))
+		})
+	}
 
 	return nil
 }

--- a/test/e2e/basic/resources-check/namespaces.go
+++ b/test/e2e/basic/resources-check/namespaces.go
@@ -19,11 +19,9 @@ package basic
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -40,11 +38,11 @@ type MultiNSBackup struct {
 }
 
 func (m *MultiNSBackup) Init() error {
-	rand.Seed(time.Now().UnixNano())
-	UUIDgen, _ = uuid.NewRandom()
-	m.BackupName = "backup-" + UUIDgen.String()
-	m.RestoreName = "restore-" + UUIDgen.String()
-	m.NSBaseName = "nstest-" + UUIDgen.String()
+	m.TestCase.Init()
+	m.CaseBaseName = "nstest-" + m.UUIDgen
+	m.BackupName = "backup-" + m.CaseBaseName
+	m.RestoreName = "restore-" + m.CaseBaseName
+
 	m.VeleroCfg = VeleroCfg
 	m.Client = *m.VeleroCfg.ClientToInstallVelero
 	m.NSExcluded = &[]string{}
@@ -64,10 +62,7 @@ func (m *MultiNSBackup) Init() error {
 			FailedMSG: "Failed to successfully backup and restore multiple namespaces",
 		}
 	}
-	return nil
-}
 
-func (m *MultiNSBackup) StartRun() error {
 	// Currently it's hard to build a large list of namespaces to include and wildcards do not work so instead
 	// we will exclude all of the namespaces that existed prior to the test from the backup
 	namespaces, err := m.Client.ClientGo.CoreV1().Namespaces().List(context.Background(), v1.ListOptions{})
@@ -100,7 +95,7 @@ func (m *MultiNSBackup) CreateResources() error {
 		"ns-test": "true",
 	}
 	for nsNum := 0; nsNum < m.NamespacesTotal; nsNum++ {
-		createNSName := fmt.Sprintf("%s-%00000d", m.NSBaseName, nsNum)
+		createNSName := fmt.Sprintf("%s-%00000d", m.CaseBaseName, nsNum)
 		if err := CreateNamespaceWithLabel(ctx, m.Client, createNSName, labels); err != nil {
 			return errors.Wrapf(err, "Failed to create namespace %s", createNSName)
 		}
@@ -113,7 +108,7 @@ func (m *MultiNSBackup) Verify() error {
 	defer ctxCancel()
 	// Verify that we got back all of the namespaces we created
 	for nsNum := 0; nsNum < m.NamespacesTotal; nsNum++ {
-		checkNSName := fmt.Sprintf("%s-%00000d", m.NSBaseName, nsNum)
+		checkNSName := fmt.Sprintf("%s-%00000d", m.CaseBaseName, nsNum)
 		checkNS, err := GetNamespace(ctx, m.Client, checkNSName)
 		if err != nil {
 			return errors.Wrapf(err, "Could not retrieve test namespace %s", checkNSName)
@@ -127,7 +122,7 @@ func (m *MultiNSBackup) Verify() error {
 func (m *MultiNSBackup) Destroy() error {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 60*time.Minute)
 	defer ctxCancel()
-	err := CleanupNamespaces(ctx, m.Client, m.NSBaseName)
+	err := CleanupNamespaces(ctx, m.Client, m.CaseBaseName)
 	if err != nil {
 		return errors.Wrap(err, "Could cleanup retrieve namespaces")
 	}

--- a/test/e2e/basic/resources-check/namespaces_annotation.go
+++ b/test/e2e/basic/resources-check/namespaces_annotation.go
@@ -19,11 +19,9 @@ package basic
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 
 	. "github.com/vmware-tanzu/velero/test/e2e"
@@ -36,17 +34,17 @@ type NSAnnotationCase struct {
 }
 
 func (n *NSAnnotationCase) Init() error {
-	rand.Seed(time.Now().UnixNano())
-	UUIDgen, _ = uuid.NewRandom()
-	n.BackupName = "backup-namespace-annotations" + UUIDgen.String()
-	n.RestoreName = "restore-namespace-annotations" + UUIDgen.String()
-	n.NSBaseName = "namespace-annotations-" + UUIDgen.String()
+	n.TestCase.Init()
+	n.CaseBaseName = "namespace-annotations-" + n.UUIDgen
+	n.BackupName = "backup-" + n.CaseBaseName
+	n.RestoreName = "restore-" + n.CaseBaseName
+
 	n.NamespacesTotal = 1
 	n.NSIncluded = &[]string{}
 	n.VeleroCfg = VeleroCfg
 	n.Client = *n.VeleroCfg.ClientToInstallVelero
 	for nsNum := 0; nsNum < n.NamespacesTotal; nsNum++ {
-		createNSName := fmt.Sprintf("%s-%00000d", n.NSBaseName, nsNum)
+		createNSName := fmt.Sprintf("%s-%00000d", n.CaseBaseName, nsNum)
 		*n.NSIncluded = append(*n.NSIncluded, createNSName)
 	}
 	n.TestMsg = &TestMSG{
@@ -71,8 +69,8 @@ func (n *NSAnnotationCase) CreateResources() error {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 60*time.Minute)
 	defer ctxCancel()
 	for nsNum := 0; nsNum < n.NamespacesTotal; nsNum++ {
-		createNSName := fmt.Sprintf("%s-%00000d", n.NSBaseName, nsNum)
-		createAnnotationName := fmt.Sprintf("annotation-%s-%00000d", n.NSBaseName, nsNum)
+		createNSName := fmt.Sprintf("%s-%00000d", n.CaseBaseName, nsNum)
+		createAnnotationName := fmt.Sprintf("annotation-%s-%00000d", n.CaseBaseName, nsNum)
 		if err := CreateNamespaceWithAnnotation(ctx, n.Client, createNSName, map[string]string{"testAnnotation": createAnnotationName}); err != nil {
 			return errors.Wrapf(err, "Failed to create namespace %s", createNSName)
 		}
@@ -84,8 +82,8 @@ func (n *NSAnnotationCase) Verify() error {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 60*time.Minute)
 	defer ctxCancel()
 	for nsNum := 0; nsNum < n.NamespacesTotal; nsNum++ {
-		checkNSName := fmt.Sprintf("%s-%00000d", n.NSBaseName, nsNum)
-		checkAnnoName := fmt.Sprintf("annotation-%s-%00000d", n.NSBaseName, nsNum)
+		checkNSName := fmt.Sprintf("%s-%00000d", n.CaseBaseName, nsNum)
+		checkAnnoName := fmt.Sprintf("annotation-%s-%00000d", n.CaseBaseName, nsNum)
 		checkNS, err := GetNamespace(ctx, n.Client, checkNSName)
 
 		if err != nil {

--- a/test/e2e/basic/resources-check/resources_check.go
+++ b/test/e2e/basic/resources-check/resources_check.go
@@ -33,15 +33,14 @@ limitations under the License.
 package basic
 
 import (
-	. "github.com/vmware-tanzu/velero/test/e2e"
 	. "github.com/vmware-tanzu/velero/test/e2e/test"
 )
 
 func GetResourcesCheckTestCases() []VeleroBackupRestoreTest {
 	return []VeleroBackupRestoreTest{
-		&NSAnnotationCase{TestCase{VeleroCfg: VeleroCfg}},
-		&MultiNSBackup{IsScalTest: false, TestCase: TestCase{VeleroCfg: VeleroCfg}},
-		&RBACCase{TestCase{VeleroCfg: VeleroCfg}},
+		&NSAnnotationCase{},
+		&MultiNSBackup{IsScalTest: false},
+		&RBACCase{},
 	}
 }
 

--- a/test/e2e/basic/storage-class-changing.go
+++ b/test/e2e/basic/storage-class-changing.go
@@ -31,15 +31,17 @@ type StorageClasssChanging struct {
 
 const SCCBaseName string = "scc-"
 
-var StorageClasssChangingTest func() = TestFunc(&StorageClasssChanging{
-	namespace: SCCBaseName + "1", TestCase: TestCase{NSBaseName: SCCBaseName}})
+var StorageClasssChangingTest func() = TestFunc(&StorageClasssChanging{})
 
 func (s *StorageClasssChanging) Init() error {
+	s.TestCase.Init()
+	s.CaseBaseName = SCCBaseName + s.UUIDgen
+	s.namespace = s.CaseBaseName
+	s.BackupName = "backup-" + s.CaseBaseName
+	s.RestoreName = "restore-" + s.CaseBaseName
+	s.mappedNS = s.namespace + "-mapped"
 	s.VeleroCfg = VeleroCfg
 	s.Client = *s.VeleroCfg.ClientToInstallVelero
-	s.NSBaseName = SCCBaseName
-	s.namespace = s.NSBaseName + UUIDgen.String()
-	s.mappedNS = s.namespace + "-mapped"
 	s.TestMsg = &TestMSG{
 		Desc:      "Changing PV/PVC Storage Classes",
 		FailedMSG: "Failed to changing PV/PVC Storage Classes",
@@ -56,10 +58,7 @@ func (s *StorageClasssChanging) Init() error {
 	s.configmaptName = "change-storage-class-config"
 	s.volume = "volume-1"
 	s.podName = "pod-1"
-	return nil
-}
 
-func (s *StorageClasssChanging) StartRun() error {
 	s.BackupName = s.BackupName + "backup-" + UUIDgen.String()
 	s.RestoreName = s.RestoreName + "restore-" + UUIDgen.String()
 	s.BackupArgs = []string{
@@ -109,9 +108,9 @@ func (s *StorageClasssChanging) Destroy() error {
 			fmt.Sprintf("PV storage %s is not as expected %s", pv.Spec.StorageClassName, s.srcStorageClass))
 	})
 
-	By(fmt.Sprintf("Start to destroy namespace %s......", s.NSBaseName), func() {
-		Expect(CleanupNamespacesWithPoll(ctx, s.Client, s.NSBaseName)).To(Succeed(),
-			fmt.Sprintf("Failed to delete namespace %s", s.NSBaseName))
+	By(fmt.Sprintf("Start to destroy namespace %s......", s.CaseBaseName), func() {
+		Expect(CleanupNamespacesWithPoll(ctx, s.Client, s.CaseBaseName)).To(Succeed(),
+			fmt.Sprintf("Failed to delete namespace %s", s.CaseBaseName))
 	})
 	return nil
 }
@@ -145,5 +144,16 @@ func (s *StorageClasssChanging) Verify() error {
 		Expect(pv.Spec.StorageClassName).To(Equal(s.desStorageClass),
 			fmt.Sprintf("PV storage %s is not as expected %s", pv.Spec.StorageClassName, s.desStorageClass))
 	})
+	return nil
+}
+
+func (s *StorageClasssChanging) Clean() error {
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer ctxCancel()
+	if !s.VeleroCfg.Debug {
+		DeleteConfigmap(s.Client.ClientGo, s.VeleroCfg.VeleroNamespace, s.configmaptName)
+		DeleteStorageClass(ctx, s.Client, s.desStorageClass)
+		s.TestCase.Clean()
+	}
 	return nil
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -84,7 +84,7 @@ func init() {
 
 }
 
-var _ = Describe("[APIGroup][Common] Velero tests with various CRD API group versions", APIGropuVersionsTest)
+var _ = Describe("[APIGroup][APIVersion] Velero tests with various CRD API group versions", APIGropuVersionsTest)
 var _ = Describe("[APIGroup][APIExtensions] CRD of apiextentions v1beta1 should be B/R successfully from cluster(k8s version < 1.22) to cluster(k8s version >= 1.22)", APIExtensionsVersionsTest)
 
 // Test backup and restore of Kibishi using restic

--- a/test/e2e/migration/migration.go
+++ b/test/e2e/migration/migration.go
@@ -208,7 +208,7 @@ func MigrationTest(useVolumeSnapshots bool, veleroCLI2Version VeleroCLI2Version)
 				snapshotCheckPoint.NamespaceBackedUp = migrationNamespace
 				By("Snapshot should be created in cloud object store", func() {
 					snapshotCheckPoint, err := GetSnapshotCheckPoint(*veleroCfg.DefaultClient, veleroCfg, 2,
-						migrationNamespace, backupName, KibishiiPodNameList)
+						migrationNamespace, backupName, KibishiiPVCNameList)
 					Expect(err).NotTo(HaveOccurred(), "Fail to get snapshot checkpoint")
 					Expect(SnapshotsShouldBeCreatedInCloud(veleroCfg.CloudProvider,
 						veleroCfg.CloudCredentialsFile, veleroCfg.BSLBucket,

--- a/test/e2e/pv-backup/pv-backup-filter.go
+++ b/test/e2e/pv-backup/pv-backup-filter.go
@@ -31,30 +31,22 @@ var OptInPVBackupTest func() = TestFunc(&PVBackupFiltering{annotation: OPT_IN_AN
 var OptOutPVBackupTest func() = TestFunc(&PVBackupFiltering{annotation: OPT_OUT_ANN, id: "opt-out"})
 
 func (p *PVBackupFiltering) Init() error {
+	p.TestCase.Init()
+	p.CaseBaseName = "pv-filter-" + p.UUIDgen
+	p.BackupName = "backup-" + p.CaseBaseName + p.id
+	p.RestoreName = "restore-" + p.CaseBaseName + p.id
 	p.VeleroCfg = VeleroCfg
 	p.Client = *p.VeleroCfg.ClientToInstallVelero
 	p.VeleroCfg.UseVolumeSnapshots = false
 	p.VeleroCfg.UseNodeAgent = true
-	p.NSBaseName = "ns"
-	p.NSIncluded = &[]string{fmt.Sprintf("%s-%s-%d", p.NSBaseName, p.id, 1), fmt.Sprintf("%s-%s-%d", p.NSBaseName, p.id, 2)}
+	p.NSIncluded = &[]string{fmt.Sprintf("%s-%s-%d", p.CaseBaseName, p.id, 1), fmt.Sprintf("%s-%s-%d", p.CaseBaseName, p.id, 2)}
 
 	p.TestMsg = &TestMSG{
 		Desc:      "Backup PVs filtering by opt-in/opt-out annotation",
 		FailedMSG: "Failed to PVs filtering by opt-in/opt-out annotation",
 		Text:      fmt.Sprintf("Should backup PVs in namespace %s according to annotation %s", *p.NSIncluded, p.annotation),
 	}
-	return nil
-}
 
-func (p *PVBackupFiltering) StartRun() error {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Minute)
-	defer ctxCancel()
-	err := InstallStorageClass(ctx, fmt.Sprintf("testdata/storage-class/%s.yaml", VeleroCfg.CloudProvider))
-	if err != nil {
-		return err
-	}
-	p.BackupName = p.BackupName + "backup-" + p.id + "-" + UUIDgen.String()
-	p.RestoreName = p.RestoreName + "restore-" + p.id + "-" + UUIDgen.String()
 	p.BackupArgs = []string{
 		"create", "--namespace", VeleroCfg.VeleroNamespace, "backup", p.BackupName,
 		"--include-namespaces", strings.Join(*p.NSIncluded, ","),
@@ -72,9 +64,16 @@ func (p *PVBackupFiltering) StartRun() error {
 	}
 	return nil
 }
+
 func (p *PVBackupFiltering) CreateResources() error {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer ctxCancel()
+
+	err := InstallStorageClass(ctx, fmt.Sprintf("testdata/storage-class/%s.yaml", VeleroCfg.CloudProvider))
+	if err != nil {
+		return errors.Wrapf(err, "failed to install storage class for pv backup filtering test")
+	}
+
 	for _, ns := range *p.NSIncluded {
 		By(fmt.Sprintf("Create namespaces %s for workload\n", ns), func() {
 			Expect(CreateNamespace(ctx, p.Client, ns)).To(Succeed(), fmt.Sprintf("Failed to create namespace %s", ns))

--- a/test/e2e/resource-filtering/exclude_label.go
+++ b/test/e2e/resource-filtering/exclude_label.go
@@ -45,16 +45,17 @@ var ExcludeFromBackupTest func() = TestFunc(&ExcludeFromBackup{testInBackup})
 
 func (e *ExcludeFromBackup) Init() error {
 	e.FilteringCase.Init()
-	e.BackupName = "backup-exclude-from-backup-" + UUIDgen.String()
-	e.RestoreName = "restore-" + UUIDgen.String()
-	e.NSBaseName = "exclude-from-backup-" + UUIDgen.String()
+	e.CaseBaseName = "exclude-from-backup-" + e.UUIDgen
+	e.BackupName = "backup-" + e.CaseBaseName
+	e.RestoreName = "restore-" + e.CaseBaseName
+
 	e.TestMsg = &TestMSG{
 		Desc:      "Backup with the label velero.io/exclude-from-backup=true are not included test",
 		Text:      "Should not backup resources with the label velero.io/exclude-from-backup=true",
 		FailedMSG: "Failed to backup resources with the label velero.io/exclude-from-backup=true",
 	}
 	for nsNum := 0; nsNum < e.NamespacesTotal; nsNum++ {
-		createNSName := fmt.Sprintf("%s-%00000d", e.NSBaseName, nsNum)
+		createNSName := fmt.Sprintf("%s-%00000d", e.CaseBaseName, nsNum)
 		*e.NSIncluded = append(*e.NSIncluded, createNSName)
 	}
 	e.labels = map[string]string{
@@ -64,7 +65,7 @@ func (e *ExcludeFromBackup) Init() error {
 
 	e.BackupArgs = []string{
 		"create", "--namespace", VeleroCfg.VeleroNamespace, "backup", e.BackupName,
-		"--include-namespaces", e.NSBaseName,
+		"--include-namespaces", e.CaseBaseName,
 		"--default-volumes-to-fs-backup", "--wait",
 	}
 
@@ -78,7 +79,7 @@ func (e *ExcludeFromBackup) Init() error {
 func (e *ExcludeFromBackup) CreateResources() error {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer ctxCancel()
-	namespace := e.NSBaseName
+	namespace := e.CaseBaseName
 	// These 2 labels for resources to be included
 	label1 := map[string]string{
 		"meaningless-label-resource-to-include": "true",
@@ -90,18 +91,9 @@ func (e *ExcludeFromBackup) CreateResources() error {
 	if err := CreateNamespace(ctx, e.Client, namespace); err != nil {
 		return errors.Wrapf(err, "Failed to create namespace %s", namespace)
 	}
-	serviceAccountName := "default"
-	// wait until the service account is created before patch the image pull secret
-	if err := WaitUntilServiceAccountCreated(ctx, e.Client, namespace, serviceAccountName, 10*time.Minute); err != nil {
-		return errors.Wrapf(err, "failed to wait the service account %q created under the namespace %q", serviceAccountName, namespace)
-	}
-	// add the image pull secret to avoid the image pull limit issue of Docker Hub
-	if err := PatchServiceAccountWithImagePullSecret(ctx, e.Client, namespace, serviceAccountName, VeleroCfg.RegistryCredentialFile); err != nil {
-		return errors.Wrapf(err, "failed to patch the service account %q under the namespace %q", serviceAccountName, namespace)
-	}
 	//Create deployment: to be included
 	fmt.Printf("Creating deployment in namespaces ...%s\n", namespace)
-	deployment := NewDeployment(e.NSBaseName, namespace, e.replica, label2, nil).Result()
+	deployment := NewDeployment(e.CaseBaseName, namespace, e.replica, label2, nil).Result()
 	deployment, err := CreateDeployment(e.Client.ClientGo, namespace, deployment)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("failed to delete the namespace %q", namespace))
@@ -111,7 +103,7 @@ func (e *ExcludeFromBackup) CreateResources() error {
 		return errors.Wrap(err, fmt.Sprintf("failed to ensure job completion in namespace: %q", namespace))
 	}
 	//Create Secret
-	secretName := e.NSBaseName
+	secretName := e.CaseBaseName
 	fmt.Printf("Creating secret %s in namespaces ...%s\n", secretName, namespace)
 	_, err = CreateSecret(e.Client.ClientGo, namespace, secretName, e.labels)
 	if err != nil {
@@ -122,11 +114,11 @@ func (e *ExcludeFromBackup) CreateResources() error {
 		return errors.Wrap(err, fmt.Sprintf("failed to ensure secret completion in namespace: %q", namespace))
 	}
 	By(fmt.Sprintf("Checking secret %s should exists in namespaces ...%s\n", secretName, namespace), func() {
-		_, err = GetSecret(e.Client.ClientGo, namespace, e.NSBaseName)
+		_, err = GetSecret(e.Client.ClientGo, namespace, e.CaseBaseName)
 		Expect(err).ShouldNot(HaveOccurred(), fmt.Sprintf("failed to list deployment in namespace: %q", namespace))
 	})
 	//Create Configmap: to be included
-	configmaptName := e.NSBaseName
+	configmaptName := e.CaseBaseName
 	fmt.Printf("Creating configmap %s in namespaces ...%s\n", configmaptName, namespace)
 	_, err = CreateConfigMap(e.Client.ClientGo, namespace, configmaptName, label1, nil)
 	if err != nil {
@@ -142,7 +134,7 @@ func (e *ExcludeFromBackup) CreateResources() error {
 func (e *ExcludeFromBackup) Verify() error {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer ctxCancel()
-	namespace := e.NSBaseName
+	namespace := e.CaseBaseName
 	By(fmt.Sprintf("Checking resources in namespaces ...%s\n", namespace), func() {
 		//Check namespace
 		checkNS, err := GetNamespace(ctx, e.Client, namespace)
@@ -150,16 +142,16 @@ func (e *ExcludeFromBackup) Verify() error {
 		Expect(checkNS.Name == namespace).To(Equal(true), fmt.Sprintf("Retrieved namespace for %s has name %s instead", namespace, checkNS.Name))
 
 		//Check deployment: should be included
-		_, err = GetDeployment(e.Client.ClientGo, namespace, e.NSBaseName)
+		_, err = GetDeployment(e.Client.ClientGo, namespace, e.CaseBaseName)
 		Expect(err).ShouldNot(HaveOccurred(), fmt.Sprintf("failed to list deployment in namespace: %q", namespace))
 
 		//Check secrets: secrets should not be included
-		_, err = GetSecret(e.Client.ClientGo, namespace, e.NSBaseName)
+		_, err = GetSecret(e.Client.ClientGo, namespace, e.CaseBaseName)
 		Expect(err).Should(HaveOccurred(), fmt.Sprintf("failed to list deployment in namespace: %q", namespace))
 		Expect(apierrors.IsNotFound(err)).To(Equal(true))
 
 		//Check configmap: should be included
-		_, err = GetConfigmap(e.Client.ClientGo, namespace, e.NSBaseName)
+		_, err = GetConfigmap(e.Client.ClientGo, namespace, e.CaseBaseName)
 		Expect(err).ShouldNot(HaveOccurred(), fmt.Sprintf("failed to list configmap in namespace: %q", namespace))
 	})
 	return nil

--- a/test/e2e/resource-filtering/exclude_namespaces.go
+++ b/test/e2e/resource-filtering/exclude_namespaces.go
@@ -50,19 +50,20 @@ var RestoreWithExcludeNamespaces func() = TestFunc(&ExcludeNamespaces{FilteringC
 
 func (e *ExcludeNamespaces) Init() error {
 	e.FilteringCase.Init()
+	e.CaseBaseName = "exclude-namespaces-" + e.UUIDgen
 	e.namespacesExcluded = e.NamespacesTotal / 2
-	e.NSBaseName = "exclude-namespaces-" + UUIDgen.String()
+
 	if e.IsTestInBackup {
-		e.BackupName = "backup-exclude-namespaces-" + UUIDgen.String()
-		e.RestoreName = "restore-" + UUIDgen.String()
+		e.BackupName = "backup-" + e.CaseBaseName
+		e.RestoreName = "restore-" + e.UUIDgen
 		e.TestMsg = &TestMSG{
 			Desc:      "Backup resources with exclude namespace test",
 			FailedMSG: "Failed to backup and restore with namespace include",
 			Text:      fmt.Sprintf("should not backup %d namespaces of %d", e.namespacesExcluded, e.NamespacesTotal),
 		}
 	} else {
-		e.BackupName = "backup-" + UUIDgen.String()
-		e.RestoreName = "restore-exclude-namespaces-" + UUIDgen.String()
+		e.BackupName = "backup-" + e.UUIDgen
+		e.RestoreName = "restore-" + e.CaseBaseName
 		e.TestMsg = &TestMSG{
 			Desc:      "Restore resources with exclude namespace test",
 			FailedMSG: "Failed to restore with namespace exclude",
@@ -71,7 +72,7 @@ func (e *ExcludeNamespaces) Init() error {
 	}
 	e.nsExcluded = &[]string{}
 	for nsNum := 0; nsNum < e.NamespacesTotal; nsNum++ {
-		createNSName := fmt.Sprintf("%s-%00000d", e.NSBaseName, nsNum)
+		createNSName := fmt.Sprintf("%s-%00000d", e.CaseBaseName, nsNum)
 		if nsNum < e.namespacesExcluded {
 			*e.nsExcluded = append(*e.nsExcluded, createNSName)
 		} else {
@@ -112,7 +113,7 @@ func (e *ExcludeNamespaces) CreateResources() error {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer ctxCancel()
 	for nsNum := 0; nsNum < e.NamespacesTotal; nsNum++ {
-		createNSName := fmt.Sprintf("%s-%00000d", e.NSBaseName, nsNum)
+		createNSName := fmt.Sprintf("%s-%00000d", e.CaseBaseName, nsNum)
 		fmt.Printf("Creating namespaces ...%s\n", createNSName)
 		if err := CreateNamespace(ctx, e.Client, createNSName); err != nil {
 			return errors.Wrapf(err, "Failed to create namespace %s", createNSName)
@@ -126,7 +127,7 @@ func (e *ExcludeNamespaces) Verify() error {
 	defer ctxCancel()
 	// Verify that we got back all of the namespaces we created
 	for nsNum := 0; nsNum < e.namespacesExcluded; nsNum++ {
-		excludeNSName := fmt.Sprintf("%s-%00000d", e.NSBaseName, nsNum)
+		excludeNSName := fmt.Sprintf("%s-%00000d", e.CaseBaseName, nsNum)
 		_, err := GetNamespace(ctx, e.Client, excludeNSName)
 		if err == nil {
 			return errors.Wrapf(err, "Resource filtering with exclude namespace but exclude namespace %s exist", excludeNSName)
@@ -138,7 +139,7 @@ func (e *ExcludeNamespaces) Verify() error {
 	}
 
 	for nsNum := e.namespacesExcluded; nsNum < e.NamespacesTotal; nsNum++ {
-		checkNSName := fmt.Sprintf("%s-%00000d", e.NSBaseName, nsNum)
+		checkNSName := fmt.Sprintf("%s-%00000d", e.CaseBaseName, nsNum)
 		checkNS, err := GetNamespace(ctx, e.Client, checkNSName)
 		if err != nil {
 			return errors.Wrapf(err, "Could not retrieve test namespace %s", checkNSName)

--- a/test/e2e/resource-filtering/exclude_resources.go
+++ b/test/e2e/resource-filtering/exclude_resources.go
@@ -49,9 +49,9 @@ var RestoreWithExcludeResources func() = TestFunc(&ExcludeResources{testInRestor
 
 func (e *ExcludeResources) Init() error {
 	e.FilteringCase.Init()
-	e.NSBaseName = "exclude-resources-" + UUIDgen.String()
+	e.CaseBaseName = "exclude-resources-" + e.UUIDgen
 	for nsNum := 0; nsNum < e.NamespacesTotal; nsNum++ {
-		createNSName := fmt.Sprintf("%s-%00000d", e.NSBaseName, nsNum)
+		createNSName := fmt.Sprintf("%s-%00000d", e.CaseBaseName, nsNum)
 		*e.NSIncluded = append(*e.NSIncluded, createNSName)
 	}
 	if e.IsTestInBackup { // testing case backup with exclude-resources option
@@ -60,7 +60,7 @@ func (e *ExcludeResources) Init() error {
 			Text:      "Should not backup resources which is excluded others should be backup",
 			FailedMSG: "Failed to backup with resource exclude",
 		}
-		e.BackupName = "backup-exclude-resources-" + UUIDgen.String()
+		e.BackupName = "backup-" + e.CaseBaseName
 		e.RestoreName = "restore-" + UUIDgen.String()
 		e.BackupArgs = []string{
 			"create", "--namespace", VeleroCfg.VeleroNamespace, "backup", e.BackupName,
@@ -74,15 +74,13 @@ func (e *ExcludeResources) Init() error {
 			"--from-backup", e.BackupName, "--wait",
 		}
 	} else { // testing case restore with exclude-resources option
-		e.BackupName = "backup-" + UUIDgen.String()
-		e.RestoreName = "restore-exclude-resources-" + UUIDgen.String()
+		e.BackupName = "backup-" + e.UUIDgen
+		e.RestoreName = "restore-" + e.CaseBaseName
 		e.TestMsg = &TestMSG{
 			Desc:      "Restore resources with resources included test",
 			Text:      "Should not restore resources which is excluded others should be backup",
 			FailedMSG: "Failed to restore with resource exclude",
 		}
-		e.BackupName = "backup-exclude-resources-" + UUIDgen.String()
-		e.RestoreName = "restore-exclude-resources-" + UUIDgen.String()
 		e.BackupArgs = []string{
 			"create", "--namespace", VeleroCfg.VeleroNamespace, "backup", e.BackupName,
 			"--include-namespaces", strings.Join(*e.NSIncluded, ","),
@@ -99,10 +97,10 @@ func (e *ExcludeResources) Init() error {
 
 func (e *ExcludeResources) Verify() error {
 	for nsNum := 0; nsNum < e.NamespacesTotal; nsNum++ {
-		namespace := fmt.Sprintf("%s-%00000d", e.NSBaseName, nsNum)
+		namespace := fmt.Sprintf("%s-%00000d", e.CaseBaseName, nsNum)
 		fmt.Printf("Checking resources in namespaces ...%s\n", namespace)
 		//Check deployment
-		_, err := GetDeployment(e.Client.ClientGo, namespace, e.NSBaseName)
+		_, err := GetDeployment(e.Client.ClientGo, namespace, e.CaseBaseName)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("failed to list deployment in namespace: %q", namespace))
 		}

--- a/test/e2e/resource-filtering/include_namespaces.go
+++ b/test/e2e/resource-filtering/include_namespaces.go
@@ -51,11 +51,11 @@ var RestoreWithIncludeNamespaces func() = TestFunc(&IncludeNamespaces{FilteringC
 
 func (i *IncludeNamespaces) Init() error {
 	i.FilteringCase.Init()
+	i.CaseBaseName = "include-namespaces-" + i.UUIDgen
 	i.namespacesIncluded = i.NamespacesTotal / 2
 	i.allTestNamespaces = &[]string{}
-	i.NSBaseName = "include-namespaces-" + UUIDgen.String()
 	for nsNum := 0; nsNum < i.NamespacesTotal; nsNum++ {
-		createNSName := fmt.Sprintf("%s-%00000d", i.NSBaseName, nsNum)
+		createNSName := fmt.Sprintf("%s-%00000d", i.CaseBaseName, nsNum)
 		if nsNum < i.namespacesIncluded {
 			*i.NSIncluded = append(*i.NSIncluded, createNSName)
 		}
@@ -63,8 +63,8 @@ func (i *IncludeNamespaces) Init() error {
 	}
 
 	if i.IsTestInBackup {
-		i.BackupName = "backup-include-namespaces-" + UUIDgen.String()
-		i.RestoreName = "restore-" + UUIDgen.String()
+		i.BackupName = "backup-" + i.CaseBaseName
+		i.RestoreName = "restore-" + i.UUIDgen
 		i.TestMsg = &TestMSG{
 			Desc:      "Backup resources with include namespace test",
 			FailedMSG: "Failed to backup with namespace include",
@@ -82,8 +82,8 @@ func (i *IncludeNamespaces) Init() error {
 		}
 
 	} else {
-		i.BackupName = "backup-" + UUIDgen.String()
-		i.RestoreName = "restore-include-namespaces-" + UUIDgen.String()
+		i.BackupName = "backup-" + i.UUIDgen
+		i.RestoreName = "restore-" + i.CaseBaseName
 		i.TestMsg = &TestMSG{
 			Desc:      "Restore resources with include namespace test",
 			FailedMSG: "Failed to restore with namespace include",
@@ -108,7 +108,7 @@ func (i *IncludeNamespaces) CreateResources() error {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer ctxCancel()
 	for nsNum := 0; nsNum < i.NamespacesTotal; nsNum++ {
-		createNSName := fmt.Sprintf("%s-%00000d", i.NSBaseName, nsNum)
+		createNSName := fmt.Sprintf("%s-%00000d", i.CaseBaseName, nsNum)
 		fmt.Printf("Creating namespaces ...%s\n", createNSName)
 		if err := CreateNamespace(ctx, i.Client, createNSName); err != nil {
 			return errors.Wrapf(err, "Failed to create namespace %s", createNSName)
@@ -122,7 +122,7 @@ func (i *IncludeNamespaces) Verify() error {
 	defer ctxCancel()
 	// Verify that we got back all of the namespaces we created
 	for nsNum := 0; nsNum < i.namespacesIncluded; nsNum++ {
-		checkNSName := fmt.Sprintf("%s-%00000d", i.NSBaseName, nsNum)
+		checkNSName := fmt.Sprintf("%s-%00000d", i.CaseBaseName, nsNum)
 		checkNS, err := GetNamespace(ctx, i.Client, checkNSName)
 		if err != nil {
 			return errors.Wrapf(err, "Could not retrieve test namespace %s", checkNSName)
@@ -133,7 +133,7 @@ func (i *IncludeNamespaces) Verify() error {
 	}
 
 	for nsNum := i.namespacesIncluded; nsNum < i.NamespacesTotal; nsNum++ {
-		excludeNSName := fmt.Sprintf("%s-%00000d", i.NSBaseName, nsNum)
+		excludeNSName := fmt.Sprintf("%s-%00000d", i.CaseBaseName, nsNum)
 		_, err := GetNamespace(ctx, i.Client, excludeNSName)
 		if err == nil {
 			return errors.Wrapf(err, "Resource filtering with include namespace but exclude namespace %s exist", excludeNSName)

--- a/test/e2e/resource-filtering/include_resources.go
+++ b/test/e2e/resource-filtering/include_resources.go
@@ -47,9 +47,9 @@ var RestoreWithIncludeResources func() = TestFunc(&IncludeResources{testInRestor
 
 func (i *IncludeResources) Init() error {
 	i.FilteringCase.Init()
-	i.NSBaseName = "include-resources-" + UUIDgen.String()
+	i.CaseBaseName = "include-resources-" + i.UUIDgen
 	for nsNum := 0; nsNum < i.NamespacesTotal; nsNum++ {
-		createNSName := fmt.Sprintf("%s-%00000d", i.NSBaseName, nsNum)
+		createNSName := fmt.Sprintf("%s-%00000d", i.CaseBaseName, nsNum)
 		*i.NSIncluded = append(*i.NSIncluded, createNSName)
 	}
 	if i.IsTestInBackup { // testing case backup with include-resources option
@@ -58,8 +58,8 @@ func (i *IncludeResources) Init() error {
 			Text:      "Should backup resources which is included others should not be backup",
 			FailedMSG: "Failed to backup with resource include",
 		}
-		i.BackupName = "backup-include-resources-" + UUIDgen.String()
-		i.RestoreName = "restore-" + UUIDgen.String()
+		i.BackupName = "backup-" + i.CaseBaseName
+		i.RestoreName = "restore-" + i.UUIDgen
 		i.BackupArgs = []string{
 			"create", "--namespace", VeleroCfg.VeleroNamespace, "backup", i.BackupName,
 			"--include-resources", "deployments,configmaps",
@@ -76,8 +76,8 @@ func (i *IncludeResources) Init() error {
 			Text:      "Should restore resources which is included others should not be backup",
 			FailedMSG: "Failed to restore with resource include",
 		}
-		i.BackupName = "backup-" + UUIDgen.String()
-		i.RestoreName = "restore-include-resources-" + UUIDgen.String()
+		i.BackupName = "backup-" + i.UUIDgen
+		i.RestoreName = "restore-" + i.CaseBaseName
 		i.BackupArgs = []string{
 			"create", "--namespace", VeleroCfg.VeleroNamespace, "backup", i.BackupName,
 			"--include-namespaces", strings.Join(*i.NSIncluded, ","),
@@ -94,10 +94,10 @@ func (i *IncludeResources) Init() error {
 
 func (i *IncludeResources) Verify() error {
 	for nsNum := 0; nsNum < i.NamespacesTotal; nsNum++ {
-		namespace := fmt.Sprintf("%s-%00000d", i.NSBaseName, nsNum)
+		namespace := fmt.Sprintf("%s-%00000d", i.CaseBaseName, nsNum)
 		fmt.Printf("Checking resources in namespaces ...%s\n", namespace)
 		//Check deployment
-		_, err := GetDeployment(i.Client.ClientGo, namespace, i.NSBaseName)
+		_, err := GetDeployment(i.Client.ClientGo, namespace, i.CaseBaseName)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("failed to list deployment in namespace: %q", namespace))
 		}

--- a/test/e2e/scale/multiple_namespaces.go
+++ b/test/e2e/scale/multiple_namespaces.go
@@ -17,10 +17,8 @@ limitations under the License.
 package scale
 
 import (
-	"time"
-
 	basic "github.com/vmware-tanzu/velero/test/e2e/basic/resources-check"
 	. "github.com/vmware-tanzu/velero/test/e2e/test"
 )
 
-var MultiNSBackupRestore func() = TestFunc(&basic.MultiNSBackup{IsScalTest: true, TestCase: TestCase{Timeout: time.Hour}})
+var MultiNSBackupRestore func() = TestFunc(&basic.MultiNSBackup{IsScalTest: true})

--- a/test/e2e/schedule/ordered_resources.go
+++ b/test/e2e/schedule/ordered_resources.go
@@ -19,13 +19,10 @@ limitations under the License.
 //the ordered resources test related to https://github.com/vmware-tanzu/velero/issues/4561
 import (
 	"context"
-	"flag"
 	"fmt"
-	"math/rand"
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
@@ -39,6 +36,8 @@ import (
 	. "github.com/vmware-tanzu/velero/test/e2e/util/velero"
 )
 
+var ScheduleOrderedResources func() = TestFunc(&OrderedResources{})
+
 type OrderedResources struct {
 	Namespace    string
 	ScheduleName string
@@ -47,87 +46,23 @@ type OrderedResources struct {
 	TestCase
 }
 
-func ScheduleOrderedResources() {
-	veleroCfg := VeleroCfg
-	BeforeEach(func() {
-		flag.Parse()
-		if veleroCfg.InstallVelero {
-			veleroCfg.UseVolumeSnapshots = false
-			Expect(VeleroInstall(context.Background(), &veleroCfg)).To(Succeed())
-		}
-	})
-
-	AfterEach(func() {
-		if veleroCfg.InstallVelero && !veleroCfg.Debug {
-			Expect(VeleroUninstall(context.Background(), veleroCfg.VeleroCLI, veleroCfg.VeleroNamespace)).To(Succeed())
-		}
-	})
-
-	It("Create a schedule to backup resources in a specific order should be successful", func() {
-		ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Minute)
-		defer ctxCancel()
-		test := &OrderedResources{}
-		test.VeleroCfg = VeleroCfg
-		err := test.Init()
-		Expect(err).To(Succeed(), err)
-		defer func() {
-			Expect(DeleteNamespace(ctx, test.Client, test.Namespace, false)).To(Succeed(), fmt.Sprintf("Failed to delete the namespace %s", test.Namespace))
-			err = VeleroScheduleDelete(ctx, veleroCfg.VeleroCLI, veleroCfg.VeleroNamespace, test.ScheduleName)
-			Expect(err).To(Succeed(), fmt.Sprintf("Failed to delete schedule with err %v", err))
-			err = test.DeleteBackups()
-			Expect(err).To(Succeed(), fmt.Sprintf("Failed to delete backups with err %v", err))
-		}()
-
-		By(fmt.Sprintf("Prepare workload as target to backup in base namespace %s", test.Namespace), func() {
-			err = test.CreateResources()
-			Expect(err).To(Succeed(), fmt.Sprintf("Failed to create resources to backup with err %v", err))
-		})
-
-		By(fmt.Sprintf("Create schedule the workload in %s namespace", test.Namespace), func() {
-			err = VeleroScheduleCreate(ctx, veleroCfg.VeleroCLI, veleroCfg.VeleroNamespace, test.ScheduleName, test.ScheduleArgs)
-			Expect(err).To(Succeed(), fmt.Sprintf("Failed to create schedule %s  with err %v", test.ScheduleName, err))
-		})
-
-		By(fmt.Sprintf("Checking resource order in %s schedule cr", test.ScheduleName), func() {
-			err = CheckScheduleWithResourceOrder(ctx, veleroCfg.VeleroCLI, veleroCfg.VeleroNamespace, test.ScheduleName, test.OrderMap)
-			Expect(err).To(Succeed(), fmt.Sprintf("Failed to check schedule %s with err %v", test.ScheduleName, err))
-		})
-
-		By("Checking resource order in backup cr", func() {
-			backupList := new(velerov1api.BackupList)
-			err = waitutil.PollImmediate(10*time.Second, time.Minute*5, func() (bool, error) {
-				if err = test.Client.Kubebuilder.List(ctx, backupList, &kbclient.ListOptions{Namespace: veleroCfg.VeleroNamespace}); err != nil {
-					return false, fmt.Errorf("failed to list backup object in %s namespace with err %v", veleroCfg.VeleroNamespace, err)
-				}
-
-				for _, backup := range backupList.Items {
-					if err = CheckBackupWithResourceOrder(ctx, veleroCfg.VeleroCLI, veleroCfg.VeleroNamespace, backup.Name, test.OrderMap); err == nil {
-						return true, nil
-					}
-				}
-				fmt.Printf("still finding backup created by schedule %s ...\n", test.ScheduleName)
-				return false, nil
-			})
-			Expect(err).To(Succeed(), fmt.Sprintf("Failed to check schedule %s created backup with err %v", test.ScheduleName, err))
-		})
-
-	})
-}
-
 func (o *OrderedResources) Init() error {
-	rand.Seed(time.Now().UnixNano())
-	UUIDgen, _ = uuid.NewRandom()
+	o.TestCase.Init()
+	o.CaseBaseName = "ordered-resources-" + o.UUIDgen
+	o.ScheduleName = "schedule-" + o.CaseBaseName
+	o.Namespace = o.CaseBaseName + "-" + o.UUIDgen
 	o.VeleroCfg = VeleroCfg
 	o.Client = *o.VeleroCfg.ClientToInstallVelero
-	o.ScheduleName = "schedule-ordered-resources-" + UUIDgen.String()
-	o.NSBaseName = "schedule-ordered-resources"
-	o.Namespace = o.NSBaseName + "-" + UUIDgen.String()
 	o.OrderMap = map[string]string{
-		"deployments": fmt.Sprintf("deploy-%s", o.NSBaseName),
-		"secrets":     fmt.Sprintf("secret-%s", o.NSBaseName),
-		"configmaps":  fmt.Sprintf("configmap-%s", o.NSBaseName),
+		"deployments": fmt.Sprintf("deploy-%s", o.CaseBaseName),
+		"secrets":     fmt.Sprintf("secret-%s", o.CaseBaseName),
+		"configmaps":  fmt.Sprintf("configmap-%s", o.CaseBaseName),
 	}
-
+	o.TestMsg = &TestMSG{
+		Desc:      "Create a schedule to backup resources in a specific order should be successful",
+		FailedMSG: "Failed to verify schedule backup resources in a specific order",
+		Text:      "Create a schedule to backup resources in a specific order should be successful",
+	}
 	o.ScheduleArgs = []string{"--schedule", "@every 1m",
 		"--include-namespaces", o.Namespace, "--default-volumes-to-fs-backup", "--ordered-resources"}
 	var orderStr string
@@ -140,7 +75,6 @@ func (o *OrderedResources) Init() error {
 }
 
 func (o *OrderedResources) CreateResources() error {
-	veleroCfg := o.VeleroCfg
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer ctxCancel()
 	label := map[string]string{
@@ -150,17 +84,8 @@ func (o *OrderedResources) CreateResources() error {
 	if err := CreateNamespace(ctx, o.Client, o.Namespace); err != nil {
 		return errors.Wrapf(err, "failed to create namespace %s", o.Namespace)
 	}
-	serviceAccountName := "default"
-	// wait until the service account is created before patch the image pull secret
-	if err := WaitUntilServiceAccountCreated(ctx, o.Client, o.Namespace, serviceAccountName, 10*time.Minute); err != nil {
-		return errors.Wrapf(err, "failed to wait the service account %q created under the namespace %q", serviceAccountName, o.Namespace)
-	}
-	// add the image pull secret to avoid the image pull limit issue of Docker Hub
-	if err := PatchServiceAccountWithImagePullSecret(ctx, o.Client, o.Namespace, serviceAccountName, veleroCfg.RegistryCredentialFile); err != nil {
-		return errors.Wrapf(err, "failed to patch the service account %q under the namespace %q", serviceAccountName, o.Namespace)
-	}
 	//Create deployment
-	deploymentName := fmt.Sprintf("deploy-%s", o.NSBaseName)
+	deploymentName := fmt.Sprintf("deploy-%s", o.CaseBaseName)
 	fmt.Printf("Creating deployment %s in %s namespaces ...\n", deploymentName, o.Namespace)
 	deployment := NewDeployment(deploymentName, o.Namespace, 1, label, nil).Result()
 	deployment, err := CreateDeployment(o.Client.ClientGo, o.Namespace, deployment)
@@ -172,7 +97,7 @@ func (o *OrderedResources) CreateResources() error {
 		return errors.Wrap(err, fmt.Sprintf("failed to ensure job completion in namespace: %q", o.Namespace))
 	}
 	//Create Secret
-	secretName := fmt.Sprintf("secret-%s", o.NSBaseName)
+	secretName := fmt.Sprintf("secret-%s", o.CaseBaseName)
 	fmt.Printf("Creating secret %s in %s namespaces ...\n", secretName, o.Namespace)
 	_, err = CreateSecret(o.Client.ClientGo, o.Namespace, secretName, label)
 	if err != nil {
@@ -183,7 +108,7 @@ func (o *OrderedResources) CreateResources() error {
 		return errors.Wrap(err, fmt.Sprintf("failed to ensure secret completion in namespace: %q", o.Namespace))
 	}
 	//Create Configmap
-	configmapName := fmt.Sprintf("configmap-%s", o.NSBaseName)
+	configmapName := fmt.Sprintf("configmap-%s", o.CaseBaseName)
 	fmt.Printf("Creating configmap %s in %s namespaces ...\n", configmapName, o.Namespace)
 	_, err = CreateConfigMap(o.Client.ClientGo, o.Namespace, configmapName, label, nil)
 	if err != nil {
@@ -196,16 +121,63 @@ func (o *OrderedResources) CreateResources() error {
 	return nil
 }
 
+func (o *OrderedResources) Backup() error {
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer ctxCancel()
+	By(fmt.Sprintf("Create schedule the workload in %s namespace", o.Namespace), func() {
+		err := VeleroScheduleCreate(ctx, o.VeleroCfg.VeleroCLI, o.VeleroCfg.VeleroNamespace, o.ScheduleName, o.ScheduleArgs)
+		Expect(err).To(Succeed(), fmt.Sprintf("Failed to create schedule %s  with err %v", o.ScheduleName, err))
+	})
+	return nil
+}
+
+func (o *OrderedResources) Verify() error {
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer ctxCancel()
+	By(fmt.Sprintf("Checking resource order in %s schedule cr", o.ScheduleName), func() {
+		err := CheckScheduleWithResourceOrder(ctx, o.VeleroCfg.VeleroCLI, o.VeleroCfg.VeleroNamespace, o.ScheduleName, o.OrderMap)
+		Expect(err).To(Succeed(), fmt.Sprintf("Failed to check schedule %s with err %v", o.ScheduleName, err))
+	})
+
+	By("Checking resource order in backup cr", func() {
+		backupList := new(velerov1api.BackupList)
+		err := waitutil.PollImmediate(10*time.Second, time.Minute*5, func() (bool, error) {
+			if err := o.Client.Kubebuilder.List(ctx, backupList, &kbclient.ListOptions{Namespace: o.VeleroCfg.VeleroNamespace}); err != nil {
+				return false, fmt.Errorf("failed to list backup object in %s namespace with err %v", o.VeleroCfg.VeleroNamespace, err)
+			}
+
+			for _, backup := range backupList.Items {
+				if err := CheckBackupWithResourceOrder(ctx, o.VeleroCfg.VeleroCLI, o.VeleroCfg.VeleroNamespace, backup.Name, o.OrderMap); err == nil {
+					return true, nil
+				}
+			}
+			fmt.Printf("still finding backup created by schedule %s ...\n", o.ScheduleName)
+			return false, nil
+		})
+		Expect(err).To(Succeed(), fmt.Sprintf("Failed to check schedule %s created backup with err %v", o.ScheduleName, err))
+	})
+	return nil
+}
+
+func (o *OrderedResources) Clean() error {
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer ctxCancel()
+	if !o.VeleroCfg.Debug {
+		Expect(VeleroScheduleDelete(ctx, o.VeleroCfg.VeleroCLI, o.VeleroCfg.VeleroNamespace, o.ScheduleName)).To(Succeed())
+		Expect(o.TestCase.Clean()).To(Succeed())
+	}
+	return nil
+}
+
 func (o *OrderedResources) DeleteBackups() error {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer ctxCancel()
-	veleroCfg := o.VeleroCfg
 	backupList := new(velerov1api.BackupList)
-	if err := o.Client.Kubebuilder.List(ctx, backupList, &kbclient.ListOptions{Namespace: veleroCfg.VeleroNamespace}); err != nil {
-		return fmt.Errorf("failed to list backup object in %s namespace with err %v", veleroCfg.VeleroNamespace, err)
+	if err := o.Client.Kubebuilder.List(ctx, backupList, &kbclient.ListOptions{Namespace: o.VeleroCfg.VeleroNamespace}); err != nil {
+		return fmt.Errorf("failed to list backup object in %s namespace with err %v", o.VeleroCfg.VeleroNamespace, err)
 	}
 	for _, backup := range backupList.Items {
-		if err := VeleroBackupDelete(ctx, veleroCfg.VeleroCLI, veleroCfg.VeleroNamespace, backup.Name); err != nil {
+		if err := VeleroBackupDelete(ctx, o.VeleroCfg.VeleroCLI, o.VeleroCfg.VeleroNamespace, backup.Name); err != nil {
 			return err
 		}
 	}

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -181,7 +181,7 @@ func BackupUpgradeRestoreTest(useVolumeSnapshots bool, veleroCLI2Version VeleroC
 				snapshotCheckPoint.NamespaceBackedUp = upgradeNamespace
 				By("Snapshot should be created in cloud object store", func() {
 					snapshotCheckPoint, err := GetSnapshotCheckPoint(*veleroCfg.ClientToInstallVelero, veleroCfg, 2,
-						upgradeNamespace, backupName, KibishiiPodNameList)
+						upgradeNamespace, backupName, KibishiiPVCNameList)
 					Expect(err).NotTo(HaveOccurred(), "Fail to get snapshot checkpoint")
 					Expect(SnapshotsShouldBeCreatedInCloud(veleroCfg.CloudProvider,
 						veleroCfg.CloudCredentialsFile, veleroCfg.BSLBucket,

--- a/test/e2e/util/k8s/namespace.go
+++ b/test/e2e/util/k8s/namespace.go
@@ -89,14 +89,14 @@ func DeleteNamespace(ctx context.Context, client TestClient, namespace string, w
 		})
 }
 
-func CleanupNamespacesWithPoll(ctx context.Context, client TestClient, nsBaseName string) error {
+func CleanupNamespacesWithPoll(ctx context.Context, client TestClient, CaseBaseName string) error {
 	namespaces, err := client.ClientGo.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 
 	if err != nil {
 		return errors.Wrap(err, "Could not retrieve namespaces")
 	}
 	for _, checkNamespace := range namespaces.Items {
-		if strings.HasPrefix(checkNamespace.Name, nsBaseName) {
+		if strings.HasPrefix(checkNamespace.Name, CaseBaseName) {
 			err := DeleteNamespace(ctx, client, checkNamespace.Name, true)
 			if err != nil {
 				return errors.Wrapf(err, "Could not delete namespace %s", checkNamespace.Name)
@@ -107,13 +107,13 @@ func CleanupNamespacesWithPoll(ctx context.Context, client TestClient, nsBaseNam
 	return nil
 }
 
-func CleanupNamespaces(ctx context.Context, client TestClient, nsBaseName string) error {
+func CleanupNamespaces(ctx context.Context, client TestClient, CaseBaseName string) error {
 	namespaces, err := client.ClientGo.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return errors.Wrap(err, "Could not retrieve namespaces")
 	}
 	for _, checkNamespace := range namespaces.Items {
-		if strings.HasPrefix(checkNamespace.Name, nsBaseName) {
+		if strings.HasPrefix(checkNamespace.Name, CaseBaseName) {
 			err = client.ClientGo.CoreV1().Namespaces().Delete(ctx, checkNamespace.Name, metav1.DeleteOptions{})
 			if err != nil {
 				return errors.Wrapf(err, "Could not delete namespace %s", checkNamespace.Name)

--- a/test/e2e/util/k8s/rbac.go
+++ b/test/e2e/util/k8s/rbac.go
@@ -75,7 +75,7 @@ func GetClusterRoleBinding(ctx context.Context, client TestClient, rolebinding s
 	return client.ClientGo.RbacV1().ClusterRoleBindings().Get(ctx, rolebinding, metav1.GetOptions{})
 }
 
-func CleanupClusterRole(ctx context.Context, client TestClient, nsBaseName string) error {
+func CleanupClusterRole(ctx context.Context, client TestClient, CaseBaseName string) error {
 
 	clusterroles, err := client.ClientGo.RbacV1().ClusterRoles().List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -83,7 +83,7 @@ func CleanupClusterRole(ctx context.Context, client TestClient, nsBaseName strin
 	}
 
 	for _, checkClusterRole := range clusterroles.Items {
-		if strings.HasPrefix(checkClusterRole.Name, "clusterrole-"+nsBaseName) {
+		if strings.HasPrefix(checkClusterRole.Name, "clusterrole-"+CaseBaseName) {
 			fmt.Printf("Cleaning up clusterrole %s\n", checkClusterRole.Name)
 			err = client.ClientGo.RbacV1().ClusterRoles().Delete(ctx, checkClusterRole.Name, metav1.DeleteOptions{})
 			if err != nil {
@@ -94,7 +94,7 @@ func CleanupClusterRole(ctx context.Context, client TestClient, nsBaseName strin
 	return nil
 }
 
-func CleanupClusterRoleBinding(ctx context.Context, client TestClient, nsBaseName string) error {
+func CleanupClusterRoleBinding(ctx context.Context, client TestClient, CaseBaseName string) error {
 
 	clusterrolebindings, err := client.ClientGo.RbacV1().ClusterRoleBindings().List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -102,7 +102,7 @@ func CleanupClusterRoleBinding(ctx context.Context, client TestClient, nsBaseNam
 	}
 
 	for _, checkClusterRoleBinding := range clusterrolebindings.Items {
-		if strings.HasPrefix(checkClusterRoleBinding.Name, "clusterrolebinding-"+nsBaseName) {
+		if strings.HasPrefix(checkClusterRoleBinding.Name, "clusterrolebinding-"+CaseBaseName) {
 			fmt.Printf("Cleaning up clusterrolebinding %s\n", checkClusterRoleBinding.Name)
 			err = client.ClientGo.RbacV1().ClusterRoleBindings().Delete(ctx, checkClusterRoleBinding.Name, metav1.DeleteOptions{})
 			if err != nil {

--- a/test/e2e/util/kibishii/kibishii_utils.go
+++ b/test/e2e/util/kibishii/kibishii_utils.go
@@ -49,12 +49,12 @@ type KibishiiData struct {
 }
 
 var DefaultKibishiiData = &KibishiiData{2, 10, 10, 1024, 1024, 0, 2}
-var KibishiiPodNameList = []string{"kibishii-deployment-0", "kibishii-deployment-1"}
+var KibishiiPVCNameList = []string{"kibishii-data-kibishii-deployment-0", "kibishii-data-kibishii-deployment-1"}
 
 // RunKibishiiTests runs kibishii tests on the provider.
 func RunKibishiiTests(veleroCfg VeleroConfig, backupName, restoreName, backupLocation, kibishiiNamespace string,
 	useVolumeSnapshots, defaultVolumesToFsBackup bool) error {
-	pvCount := len(KibishiiPodNameList)
+	pvCount := len(KibishiiPVCNameList)
 	client := *veleroCfg.ClientToInstallVelero
 	oneHourTimeout, ctxCancel := context.WithTimeout(context.Background(), time.Minute*60)
 	defer ctxCancel()
@@ -80,12 +80,13 @@ func RunKibishiiTests(veleroCfg VeleroConfig, backupName, restoreName, backupLoc
 			}
 		}
 	}()
-
+	fmt.Printf("KibishiiPrepareBeforeBackup %s\n", time.Now().Format("2006-01-02 15:04:05"))
 	if err := KibishiiPrepareBeforeBackup(oneHourTimeout, client, providerName,
 		kibishiiNamespace, registryCredentialFile, veleroFeatures,
 		kibishiiDirectory, useVolumeSnapshots, DefaultKibishiiData); err != nil {
 		return errors.Wrapf(err, "Failed to install and prepare data for kibishii %s", kibishiiNamespace)
 	}
+	fmt.Printf("KibishiiPrepareBeforeBackup done %s\n", time.Now().Format("2006-01-02 15:04:05"))
 
 	var BackupCfg BackupConfig
 	BackupCfg.BackupName = backupName
@@ -95,20 +96,14 @@ func RunKibishiiTests(veleroCfg VeleroConfig, backupName, restoreName, backupLoc
 	BackupCfg.DefaultVolumesToFsBackup = defaultVolumesToFsBackup
 	BackupCfg.Selector = ""
 	BackupCfg.ProvideSnapshotsVolumeParam = veleroCfg.ProvideSnapshotsVolumeParam
+
+	fmt.Printf("VeleroBackupNamespace %s\n", time.Now().Format("2006-01-02 15:04:05"))
 	if err := VeleroBackupNamespace(oneHourTimeout, veleroCLI, veleroNamespace, BackupCfg); err != nil {
 		RunDebug(context.Background(), veleroCLI, veleroNamespace, backupName, "")
 		return errors.Wrapf(err, "Failed to backup kibishii namespace %s", kibishiiNamespace)
 	}
-	var snapshotCheckPoint SnapshotCheckPoint
-	var err error
-	pvbs, err := GetPVB(oneHourTimeout, veleroCfg.VeleroNamespace, kibishiiNamespace)
-	if err != nil {
-		return errors.Wrapf(err, "failed to get PVB for namespace %s", kibishiiNamespace)
-	}
+	fmt.Printf("VeleroBackupNamespace done %s\n", time.Now().Format("2006-01-02 15:04:05"))
 	if useVolumeSnapshots {
-		if len(pvbs) != 0 {
-			return errors.New(fmt.Sprintln("PVB count should be 0 in namespace %s", kibishiiNamespace))
-		}
 		if providerName == "vsphere" {
 			// Wait for uploads started by the Velero Plug-in for vSphere to complete
 			// TODO - remove after upload progress monitoring is implemented
@@ -117,7 +112,7 @@ func RunKibishiiTests(veleroCfg VeleroConfig, backupName, restoreName, backupLoc
 				return errors.Wrapf(err, "Error waiting for uploads to complete")
 			}
 		}
-		snapshotCheckPoint, err = GetSnapshotCheckPoint(client, veleroCfg, 2, kibishiiNamespace, backupName, KibishiiPodNameList)
+		snapshotCheckPoint, err := GetSnapshotCheckPoint(client, veleroCfg, 2, kibishiiNamespace, backupName, KibishiiPVCNameList)
 		if err != nil {
 			return errors.Wrap(err, "Fail to get snapshot checkpoint")
 		}
@@ -128,6 +123,10 @@ func RunKibishiiTests(veleroCfg VeleroConfig, backupName, restoreName, backupLoc
 			return errors.Wrap(err, "exceed waiting for snapshot created in cloud")
 		}
 	} else {
+		pvbs, err := GetPVB(oneHourTimeout, veleroCfg.VeleroNamespace, kibishiiNamespace)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get PVB for namespace %s", kibishiiNamespace)
+		}
 		if len(pvbs) != pvCount {
 			return errors.New(fmt.Sprintf("PVB count %d should be %d in namespace %s", len(pvbs), pvCount, kibishiiNamespace))
 		}
@@ -147,11 +146,14 @@ func RunKibishiiTests(veleroCfg VeleroConfig, backupName, restoreName, backupLoc
 			time.Sleep(5 * time.Minute)
 			if strings.EqualFold(veleroFeatures, "EnableCSI") {
 				_, err = GetSnapshotCheckPoint(*veleroCfg.ClientToInstallVelero, veleroCfg, 0,
-					kibishiiNamespace, backupName, KibishiiPodNameList)
+					kibishiiNamespace, backupName, KibishiiPVCNameList)
+				if err != nil {
+					return errors.Wrap(err, "failed to get snapshot checkPoint")
+				}
 			} else {
 				err = SnapshotsShouldNotExistInCloud(veleroCfg.CloudProvider,
 					veleroCfg.CloudCredentialsFile, veleroCfg.BSLBucket, veleroCfg.BSLConfig,
-					backupName, snapshotCheckPoint)
+					backupName, SnapshotCheckPoint{})
 				if err != nil {
 					return errors.Wrap(err, "exceed waiting for snapshot created in cloud")
 				}
@@ -159,7 +161,7 @@ func RunKibishiiTests(veleroCfg VeleroConfig, backupName, restoreName, backupLoc
 		}
 	}
 
-	fmt.Printf("Simulating a disaster by removing namespace %s\n", kibishiiNamespace)
+	fmt.Printf("Simulating a disaster by removing namespace %s %s\n", kibishiiNamespace, time.Now().Format("2006-01-02 15:04:05"))
 	if err := DeleteNamespace(oneHourTimeout, client, kibishiiNamespace, true); err != nil {
 		return errors.Wrapf(err, "failed to delete namespace %s", kibishiiNamespace)
 	}
@@ -172,6 +174,7 @@ func RunKibishiiTests(veleroCfg VeleroConfig, backupName, restoreName, backupLoc
 		time.Sleep(5 * time.Minute)
 	}
 
+	fmt.Printf("VeleroRestore %s\n", time.Now().Format("2006-01-02 15:04:05"))
 	if err := VeleroRestore(oneHourTimeout, veleroCLI, veleroNamespace, restoreName, backupName, ""); err != nil {
 		RunDebug(context.Background(), veleroCLI, veleroNamespace, "", restoreName)
 		return errors.Wrapf(err, "Restore %s failed from backup %s", restoreName, backupName)
@@ -184,11 +187,11 @@ func RunKibishiiTests(veleroCfg VeleroConfig, backupName, restoreName, backupLoc
 			return errors.New(fmt.Sprintf("PVR count %d is not as expected %d", len(pvrs), pvCount))
 		}
 	}
-
+	fmt.Printf("KibishiiVerifyAfterRestore %s\n", time.Now().Format("2006-01-02 15:04:05"))
 	if err := KibishiiVerifyAfterRestore(client, kibishiiNamespace, oneHourTimeout, DefaultKibishiiData); err != nil {
 		return errors.Wrapf(err, "Error verifying kibishii after restore")
 	}
-	fmt.Printf("kibishii test completed successfully\n")
+	fmt.Printf("kibishii test completed successfully %s\n", time.Now().Format("2006-01-02 15:04:05"))
 	return nil
 }
 
@@ -287,35 +290,25 @@ func waitForKibishiiPods(ctx context.Context, client TestClient, kibishiiNamespa
 func KibishiiPrepareBeforeBackup(oneHourTimeout context.Context, client TestClient,
 	providerName, kibishiiNamespace, registryCredentialFile, veleroFeatures,
 	kibishiiDirectory string, useVolumeSnapshots bool, kibishiiData *KibishiiData) error {
-	serviceAccountName := "default"
-
-	// wait until the service account is created before patch the image pull secret
-	if err := WaitUntilServiceAccountCreated(oneHourTimeout, client, kibishiiNamespace, serviceAccountName, 10*time.Minute); err != nil {
-		return errors.Wrapf(err, "failed to wait the service account %q created under the namespace %q", serviceAccountName, kibishiiNamespace)
-	}
-
-	// add the image pull secret to avoid the image pull limit issue of Docker Hub
-	if err := PatchServiceAccountWithImagePullSecret(oneHourTimeout, client, kibishiiNamespace, serviceAccountName, registryCredentialFile); err != nil {
-		return errors.Wrapf(err, "failed to patch the service account %q under the namespace %q", serviceAccountName, kibishiiNamespace)
-	}
-
+	fmt.Printf("installKibishii %s\n", time.Now().Format("2006-01-02 15:04:05"))
 	if err := installKibishii(oneHourTimeout, kibishiiNamespace, providerName, veleroFeatures,
 		kibishiiDirectory, useVolumeSnapshots); err != nil {
 		return errors.Wrap(err, "Failed to install Kibishii workload")
 	}
-
 	// wait for kibishii pod startup
 	// TODO - Fix kibishii so we can check that it is ready to go
-	fmt.Printf("Waiting for kibishii pods to be ready\n")
+	fmt.Printf("Waiting for kibishii pods to be ready %s\n", time.Now().Format("2006-01-02 15:04:05"))
 	if err := waitForKibishiiPods(oneHourTimeout, client, kibishiiNamespace); err != nil {
 		return errors.Wrapf(err, "Failed to wait for ready status of kibishii pods in %s", kibishiiNamespace)
 	}
 	if kibishiiData == nil {
 		kibishiiData = DefaultKibishiiData
 	}
+	fmt.Printf("generateData %s\n", time.Now().Format("2006-01-02 15:04:05"))
 	if err := generateData(oneHourTimeout, kibishiiNamespace, kibishiiData); err != nil {
 		return errors.Wrap(err, "Failed to generate data")
 	}
+	fmt.Printf("generateData done %s\n", time.Now().Format("2006-01-02 15:04:05"))
 	return nil
 }
 

--- a/test/e2e/util/velero/install.go
+++ b/test/e2e/util/velero/install.go
@@ -55,6 +55,7 @@ type installOptions struct {
 }
 
 func VeleroInstall(ctx context.Context, veleroCfg *VeleroConfig) error {
+	fmt.Printf("Velero install %s\n", time.Now().Format("2006-01-02 15:04:05"))
 	if veleroCfg.CloudProvider != "kind" {
 		fmt.Printf("For cloud platforms, object store plugin provider will be set as cloud provider")
 		veleroCfg.ObjectStoreProvider = veleroCfg.CloudProvider
@@ -109,7 +110,7 @@ func VeleroInstall(ctx context.Context, veleroCfg *VeleroConfig) error {
 		RunDebug(context.Background(), veleroCfg.VeleroCLI, veleroCfg.VeleroNamespace, "", "")
 		return errors.WithMessagef(err, "Failed to install Velero in the cluster")
 	}
-
+	fmt.Printf("Finish velero install %s\n", time.Now().Format("2006-01-02 15:04:05"))
 	return nil
 }
 

--- a/test/e2e/util/velero/velero_utils.go
+++ b/test/e2e/util/velero/velero_utils.go
@@ -627,7 +627,7 @@ func WaitForVSphereUploadCompletion(ctx context.Context, timeout time.Duration, 
 		actualCount := 0
 
 		for _, curLine := range lines {
-			fmt.Println(curLine)
+			fmt.Printf("%s %s\n", curLine, time.Now().Format("2006-01-02 15:04:05"))
 			comps := strings.Split(curLine, "=")
 			// SnapshotPhase represents the lifecycle phase of a Snapshot.
 			// New - No work yet, next phase is InProgress
@@ -668,7 +668,7 @@ func WaitForVSphereUploadCompletion(ctx context.Context, timeout time.Duration, 
 	return err
 }
 
-func GetVsphereSnapshotIDs(ctx context.Context, timeout time.Duration, namespace string, podNameList []string) ([]string, error) {
+func GetVsphereSnapshotIDs(ctx context.Context, timeout time.Duration, namespace string, pvcNameList []string) ([]string, error) {
 	checkSnapshotCmd := exec.CommandContext(ctx, "kubectl",
 		"get", "-n", namespace, "snapshots.backupdriver.cnsdp.vmware.com", "-o=jsonpath='{range .items[*]}{.spec.resourceHandle.name}{\"=\"}{.status.snapshotID}{\"\\n\"}{end}'")
 	fmt.Printf("checkSnapshotCmd cmd =%v\n", checkSnapshotCmd)
@@ -688,8 +688,8 @@ func GetVsphereSnapshotIDs(ctx context.Context, timeout time.Duration, namespace
 			continue
 		}
 		var Exist bool
-		for _, podName := range podNameList {
-			if podName != "" && strings.Contains(curLine, podName) {
+		for _, pvcName := range pvcNameList {
+			if pvcName != "" && strings.Contains(curLine, pvcName) {
 				Exist = true
 				break
 			}
@@ -1070,12 +1070,12 @@ func GetResticRepositories(ctx context.Context, veleroNamespace, targetNamespace
 	return common.GetListByCmdPipes(ctx, cmds)
 }
 
-func GetSnapshotCheckPoint(client TestClient, VeleroCfg VeleroConfig, expectCount int, namespaceBackedUp, backupName string, kibishiiPodNameList []string) (SnapshotCheckPoint, error) {
+func GetSnapshotCheckPoint(client TestClient, VeleroCfg VeleroConfig, expectCount int, namespaceBackedUp, backupName string, KibishiiPVCNameList []string) (SnapshotCheckPoint, error) {
 	var snapshotCheckPoint SnapshotCheckPoint
 	var err error
 	snapshotCheckPoint.ExpectCount = expectCount
 	snapshotCheckPoint.NamespaceBackedUp = namespaceBackedUp
-	snapshotCheckPoint.PodName = kibishiiPodNameList
+	snapshotCheckPoint.PodName = KibishiiPVCNameList
 	if VeleroCfg.CloudProvider == "azure" && strings.EqualFold(VeleroCfg.Features, "EnableCSI") {
 		snapshotCheckPoint.EnableCSI = true
 		if snapshotCheckPoint.SnapshotIDList, err = util.CheckVolumeSnapshotCR(client, backupName, expectCount); err != nil {


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
- Using random number instead of UUID for some cases failed with long UUID string
- Normalize the codes in E2E test, including names in each test case, respecting the test frame. removing StartRun function
- Deleting some undelete or useless resources, including pull image secrets, and delete resource after each case
- Adding timestamps for analysis time-consuming in some procedures
# Does your change fix a particular issue?

Fixes #(issue)
https://github.com/vmware-tanzu/velero/issues/6098
# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
