### PR TITLE
Add required footer links and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ _testmain.go
 # Hugo compiled data
 site/public
 site/resources
+site/.hugo_build.lock
 
 .vs
 

--- a/site/layouts/_default/footer.html
+++ b/site/layouts/_default/footer.html
@@ -43,7 +43,12 @@
                 &copy; {{ now.Format "2006" }} {{ .Site.Params.Author }}.
                 <a href="{{ .Site.Params.footer.vm_link }}" class="vm-logo">A VMware-backed project. <img
                             src="/img/{{ .Site.Params.vm_logo }}" alt="VMware logo"/></a>
-                <br/>This Website Does Not Use Cookies or Other Tracking Technology
+                <br/>This Website Does Not Use Cookies or Other Tracking Technology<br/><br/>
+                <span>
+                    <a target="_blank" rel="noopener" href='https://www.vmware.com/help/legal.html'>Terms of Use</a> |
+                    <a target="_blank" rel="noopener" href='https://www.vmware.com/help/privacy.html'>Privacy Policy</a> |
+                    <a target="_blank" rel="noopener" href='https://www.vmware.com/help/privacy/california-privacy-rights.html'>Your California Privacy Rights</a>
+                </span>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Minor change on the footer to include links to VMware's privacy information, required for all VMware-owned websites.

# Does your change fix a particular issue?
No

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
