### PR TITLE
Add file system group setting for deployment and pod used in E2E test.

### DIFF
--- a/pkg/backup/backup_pv_action.go
+++ b/pkg/backup/backup_pv_action.go
@@ -76,5 +76,4 @@ func (a *PVCAction) Execute(item runtime.Unstructured, backup *v1.Backup) (runti
 	}
 
 	return &unstructured.Unstructured{Object: pvcMap}, []velero.ResourceIdentifier{pv}, nil
-
 }

--- a/test/e2e/util/k8s/deployment.go
+++ b/test/e2e/util/k8s/deployment.go
@@ -93,6 +93,10 @@ func NewDeployment(name, ns string, replicas int32, labels map[string]string, co
 						Labels: labels,
 					},
 					Spec: v1.PodSpec{
+						SecurityContext: &v1.PodSecurityContext{
+							FSGroup:             func(i int64) *int64 { return &i }(65534),
+							FSGroupChangePolicy: func(policy v1.PodFSGroupChangePolicy) *v1.PodFSGroupChangePolicy { return &policy }(v1.FSGroupChangeAlways),
+						},
 						Containers: containers,
 					},
 				},

--- a/test/e2e/util/k8s/pod.go
+++ b/test/e2e/util/k8s/pod.go
@@ -70,6 +70,10 @@ func CreatePod(client TestClient, ns, name, sc, pvcName string, volumeNameList [
 			Annotations: ann,
 		},
 		Spec: corev1.PodSpec{
+			SecurityContext: &v1.PodSecurityContext{
+				FSGroup:             func(i int64) *int64 { return &i }(65534),
+				FSGroupChangePolicy: func(policy v1.PodFSGroupChangePolicy) *v1.PodFSGroupChangePolicy { return &policy }(v1.FSGroupChangeAlways),
+			},
 			Containers: []corev1.Container{
 				{
 					Name:         name,


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Add file system group setting for deployment and pod used in E2E test.
After #6279, pods and deployments created during backup conform to the k8s `restricted` PSA, which includes setting the pod running as `nobody`, but the volumes mounted owner setting is unchanged.

Add the `fsGoup` and `fsGroupChangePolicy` setting in the deployment's pod spec and pod spec to fix the error.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
