### PR TITLE
Speedup update-1fmt.sh by removing xargs, printf.

### DIFF
--- a/hack/update-1fmt.sh
+++ b/hack/update-1fmt.sh
@@ -35,7 +35,7 @@ fi
 
 files="$(find . -type f -name '*.go' -not -path './.go/*' -not -path './vendor/*' -not -path './site/*' -not -path '*/generated/*' -not -name 'zz_generated*' -not -path '*/mocks/*')"
 echo "${ACTION} gofmt"
-output=$(printf '%s\n' "${files}" | xargs gofmt "${MODE}" -s)
+output=$(gofmt "${MODE}" -s ${files})
 if [[ -n "${output}" ]]; then
   VERIFY_FMT_FAILED=1
   echo "${output}"
@@ -47,7 +47,7 @@ else
 fi
 
 echo "${ACTION} goimports"
-output=$(printf '%s\n' "${files}" | xargs goimports "${MODE}" -local github.com/vmware-tanzu/velero)
+output=$(goimports "${MODE}" -local github.com/vmware-tanzu/velero ${files})
 if [[ -n "${output}" ]]; then
   VERIFY_IMPORTS_FAILED=1
   echo "${output}"

--- a/pkg/backup/backup_pv_action.go
+++ b/pkg/backup/backup_pv_action.go
@@ -76,5 +76,4 @@ func (a *PVCAction) Execute(item runtime.Unstructured, backup *v1.Backup) (runti
 	}
 
 	return &unstructured.Unstructured{Object: pvcMap}, []velero.ResourceIdentifier{pv}, nil
-
 }


### PR DESCRIPTION


Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
```
❯ hack/update-1fmt.sh 
Updating gofmt
Updating gofmt - done!
Updating goimports
Updating goimports - done!

~/git/velero remotes/upstream/HEAD 32s <-- before
❯ hack/update-1fmt.sh 
Updating gofmt
Updating gofmt - done!
Updating goimports
Updating goimports - done!

~/git/velero remotes/upstream/HEAD* 24s <-- after
```


# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
