### PR TITLE
[cherry-pick][release-1.10]Make the E2E testing pods obey the restricted pod security standard.

### DIFF
--- a/test/e2e/util/k8s/namespace.go
+++ b/test/e2e/util/k8s/namespace.go
@@ -35,6 +35,11 @@ import (
 
 func CreateNamespace(ctx context.Context, client TestClient, namespace string) error {
 	ns := builder.ForNamespace(namespace).Result()
+	// Add label to avoid PSA check.
+	ns.Labels = map[string]string{
+		"pod-security.kubernetes.io/enforce":         "baseline",
+		"pod-security.kubernetes.io/enforce-version": "latest",
+	}
 	_, err := client.ClientGo.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 	if apierrors.IsAlreadyExists(err) {
 		return nil
@@ -45,6 +50,9 @@ func CreateNamespace(ctx context.Context, client TestClient, namespace string) e
 func CreateNamespaceWithLabel(ctx context.Context, client TestClient, namespace string, label map[string]string) error {
 	ns := builder.ForNamespace(namespace).Result()
 	ns.Labels = label
+	// Add label to avoid PSA check.
+	ns.Labels["pod-security.kubernetes.io/enforce"] = "baseline"
+	ns.Labels["pod-security.kubernetes.io/enforce-version"] = "latest"
 	_, err := client.ClientGo.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 	if apierrors.IsAlreadyExists(err) {
 		return nil
@@ -54,6 +62,11 @@ func CreateNamespaceWithLabel(ctx context.Context, client TestClient, namespace 
 
 func CreateNamespaceWithAnnotation(ctx context.Context, client TestClient, namespace string, annotation map[string]string) error {
 	ns := builder.ForNamespace(namespace).Result()
+	// Add label to avoid PSA check.
+	ns.Labels = map[string]string{
+		"pod-security.kubernetes.io/enforce":         "baseline",
+		"pod-security.kubernetes.io/enforce-version": "latest",
+	}
 	ns.ObjectMeta.Annotations = annotation
 	_, err := client.ClientGo.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 	if apierrors.IsAlreadyExists(err) {

--- a/test/e2e/util/kibishii/kibishii_utils.go
+++ b/test/e2e/util/kibishii/kibishii_utils.go
@@ -156,6 +156,13 @@ func installKibishii(ctx context.Context, namespace string, cloudPlatform, veler
 		return errors.Wrapf(err, "failed to install kibishii, stderr=%s", stderr)
 	}
 
+	labelNamespaceCmd := exec.CommandContext(ctx, "kubectl", "label", "namespace", namespace, "pod-security.kubernetes.io/enforce=baseline", "pod-security.kubernetes.io/enforce-version=latest", "--overwrite=true")
+	_, stderr, err = veleroexec.RunCommand(labelNamespaceCmd)
+	fmt.Printf("Label namespace with PSA policy: %s\n", labelNamespaceCmd)
+	if err != nil {
+		return errors.Wrapf(err, "failed to label namespace with PSA policy, stderr=%s", stderr)
+	}
+
 	kibishiiSetWaitCmd := exec.CommandContext(ctx, "kubectl", "rollout", "status", "statefulset.apps/kibishii-deployment",
 		"-n", namespace, "-w", "--timeout=30m")
 	_, stderr, err = veleroexec.RunCommand(kibishiiSetWaitCmd)


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
