### PR TITLE
Include namespace resource needed by namespaced-scope resource in backup

### DIFF
--- a/changelogs/unreleased/6320-blackpiglet
+++ b/changelogs/unreleased/6320-blackpiglet
@@ -1,0 +1,1 @@
+Include namespaces needed by namespaced-scope resources in backup.


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
For some use cases, namespaced-scope resources are inluded into backup, but the namespaces are not included due to filters setting. To do this, removing label selector filter from namespace resource. Namespace resource only honor namespace exclude/include filters.

# Does your change fix a particular issue?

Fixes #6302 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
