### PR TITLE
Skip updating status when CRDs are restored

### DIFF
--- a/changelogs/unreleased/6325-reasonerjt
+++ b/changelogs/unreleased/6325-reasonerjt
@@ -1,0 +1,1 @@
+Skip updating status when CRDs are restored


### PR DESCRIPTION
This commit skips updating the restore progress, in the first loop for restoration when CRDs are handled, so that the misleading "totalItem" will not appear in the CR.
Fixes #5990


- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
