### PR TITLE
Enhance code for issue 6297

### DIFF
--- a/changelogs/unreleased/6326-Lyndon-Li
+++ b/changelogs/unreleased/6326-Lyndon-Li
@@ -1,0 +1,1 @@
+Enhance the code because of #6297, the return value of GetBucketRegion is not recorded, as a result, when it fails, we have no way to get the cause

--- a/pkg/repository/config/aws.go
+++ b/pkg/repository/config/aws.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"os"
 
+	goerr "errors"
+
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -80,16 +82,20 @@ func GetS3Credentials(config map[string]string) (*credentials.Value, error) {
 // GetAWSBucketRegion returns the AWS region that a bucket is in, or an error
 // if the region cannot be determined.
 func GetAWSBucketRegion(bucket string) (string, error) {
-	var region string
-
 	sess, err := session.NewSession()
 	if err != nil {
 		return "", errors.WithStack(err)
 	}
 
+	var region string
+	var requestErrs []error
+
 	for _, partition := range endpoints.DefaultPartitions() {
 		for regionHint := range partition.Regions() {
-			region, _ = s3manager.GetBucketRegion(context.Background(), sess, bucket, regionHint)
+			region, err = s3manager.GetBucketRegion(context.Background(), sess, bucket, regionHint)
+			if err != nil {
+				requestErrs = append(requestErrs, errors.Wrapf(err, "error to get region with hint %s", regionHint))
+			}
 
 			// we only need to try a single region hint per partition, so break after the first
 			break
@@ -100,5 +106,9 @@ func GetAWSBucketRegion(bucket string) (string, error) {
 		}
 	}
 
-	return "", errors.New("unable to determine bucket's region")
+	if requestErrs == nil {
+		return "", errors.Errorf("unable to determine region by bucket %s", bucket)
+	} else {
+		return "", errors.Wrapf(goerr.Join(requestErrs...), "error to get region by bucket %s", bucket)
+	}
 }


### PR DESCRIPTION
Enhance the code because of #6297, the return value of `GetBucketRegion` is not recorded, as a result, when it fails, we have no way to get the cause.