### PR TITLE
examples: Label the deployment to get it backed up

### DIFF
--- a/examples/nginx-app/base.yaml
+++ b/examples/nginx-app/base.yaml
@@ -26,6 +26,8 @@ kind: Deployment
 metadata:
   name: nginx-deployment
   namespace: nginx-example
+  labels:
+    app: nginx
 spec:
   replicas: 2
   selector:


### PR DESCRIPTION
Following the examples instructions[1], the nginx-deployment is not backed up or restored. Add a label to the deployment so it will be backed up and restored.

Similar change is needed for `examples/nginx-app/with-pv.yaml` but I did not try that example.

[1] https://velero.io/docs/v1.11/contributions/minio/

Fixes #6347

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
  No changelog required
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
  Docs need no change
