### PR TITLE
Do not persist VolumeSnapshot and VolumeSnapshotContent for snapshot DataMover case

### DIFF
--- a/changelogs/unreleased/6366-blackpiglet
+++ b/changelogs/unreleased/6366-blackpiglet
@@ -1,0 +1,1 @@
+Do not persist VolumeSnapshot and VolumeSnapshotContent for snapshot DataMover case.

--- a/pkg/builder/persistent_volume_claim_builder.go
+++ b/pkg/builder/persistent_volume_claim_builder.go
@@ -67,3 +67,9 @@ func (b *PersistentVolumeClaimBuilder) StorageClass(name string) *PersistentVolu
 	b.object.Spec.StorageClassName = &name
 	return b
 }
+
+// Phase sets the PersistentVolumeClaim's status Phase.
+func (b *PersistentVolumeClaimBuilder) Phase(phase corev1api.PersistentVolumeClaimPhase) *PersistentVolumeClaimBuilder {
+	b.object.Status.Phase = phase
+	return b
+}

--- a/pkg/builder/storage_class_builder.go
+++ b/pkg/builder/storage_class_builder.go
@@ -81,3 +81,9 @@ func ForStorageClassSlice(names ...string) *StorageClassBuilder {
 func (b *StorageClassBuilder) SliceResult() []*storagev1api.StorageClass {
 	return b.objectSlice
 }
+
+// Provisioner sets StorageClass's provisioner.
+func (b *StorageClassBuilder) Provisioner(provisioner string) *StorageClassBuilder {
+	b.object.Provisioner = provisioner
+	return b
+}

--- a/pkg/builder/volume_snapshot_class_builder.go
+++ b/pkg/builder/volume_snapshot_class_builder.go
@@ -1,0 +1,62 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	snapshotv1api "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// VolumeSnapshotClassBuilder builds VolumeSnapshotClass objects.
+type VolumeSnapshotClassBuilder struct {
+	object *snapshotv1api.VolumeSnapshotClass
+}
+
+// ForVolumeSnapshotClass is the constructor of VolumeSnapshotClassBuilder.
+func (b *VolumeSnapshotClassBuilder) ForVolumeSnapshotClass(name string) *VolumeSnapshotClassBuilder {
+	return &VolumeSnapshotClassBuilder{
+		object: &snapshotv1api.VolumeSnapshotClass{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "VolumeSnapshotClass",
+				APIVersion: snapshotv1api.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		},
+	}
+}
+
+// Result returns the built VolumeSnapshotClass.
+func (b *VolumeSnapshotClassBuilder) Result() *snapshotv1api.VolumeSnapshotClass {
+	return b.object
+}
+
+// Driver sets the driver of built VolumeSnapshotClass.
+func (b *VolumeSnapshotClassBuilder) Driver(driver string) *VolumeSnapshotClassBuilder {
+	b.object.Driver = driver
+	return b
+}
+
+// ObjectMeta applies functional options to the VolumeSnapshotClass's ObjectMeta.
+func (b *VolumeSnapshotClassBuilder) ObjectMeta(opts ...ObjectMetaOpt) *VolumeSnapshotClassBuilder {
+	for _, opt := range opts {
+		opt(b.object)
+	}
+
+	return b
+}

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -648,7 +648,9 @@ func (b *backupReconciler) runBackup(backup *pkgbackup.Request) error {
 	var volumeSnapshots []snapshotv1api.VolumeSnapshot
 	var volumeSnapshotContents []snapshotv1api.VolumeSnapshotContent
 	var volumeSnapshotClasses []snapshotv1api.VolumeSnapshotClass
-	if features.IsEnabled(velerov1api.CSIFeatureFlag) {
+	if boolptr.IsSetToTrue(backup.Spec.SnapshotMoveData) {
+		backupLog.Info("backup SnapshotMoveData is set to true, skip VolumeSnapshot resource persistence.")
+	} else if features.IsEnabled(velerov1api.CSIFeatureFlag) {
 		selector := label.NewSelectorForBackup(backup.Name)
 		vscList := &snapshotv1api.VolumeSnapshotContentList{}
 

--- a/pkg/podvolume/restorer_test.go
+++ b/pkg/podvolume/restorer_test.go
@@ -460,7 +460,15 @@ func TestRestorePodVolumes(t *testing.T) {
 
 						assert.Equal(t, test.errs[i].err, errMsg)
 					} else {
-						assert.EqualError(t, errs[i], test.errs[i].err)
+						for i := 0; i < len(errs); i++ {
+							j := 0
+							for ; j < len(test.errs); j++ {
+								if errs[i].Error() == test.errs[j].err {
+									break
+								}
+							}
+							assert.Equal(t, true, j < len(test.errs))
+						}
 					}
 				}
 			}


### PR DESCRIPTION
1. Because VolumeSnapshot and VolumeSnapshotContent CRs are not kept after the backup is completed, don't persist them in the backup metadata.
2. Add some builder methods needed by the CSI plugin.

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #6118

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
