### PR TITLE
add missing CompletionTimestamp and metrics when restore moved into terminal phase

### DIFF
--- a/changelogs/unreleased/6397-Nutrymaco
+++ b/changelogs/unreleased/6397-Nutrymaco
@@ -1,0 +1,1 @@
+Add missing CompletionTimestamp and metrics when restore moved into terminal phase in restoreOperationsReconciler


### PR DESCRIPTION
# Please add a summary of your change
As i understood when we move Restore into terminal phase (Completed, PartiallyFailure, Failure) we should set CompletionTimestamp and register metrics. But if we wait async operations we do not do this.

# Please indicate you've done the following:

- [x ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
