### PR TITLE
Fix: Lastest release link in website

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,7 +344,7 @@ serve-docs: build-image-hugo
 	-v "$$(pwd)/site:/srv/hugo" \
 	-it -p 1313:1313 \
 	$(HUGO_IMAGE) \
-	hugo server --bind=0.0.0.0 --enableGitInfo=false
+	server --bind=0.0.0.0 --enableGitInfo=false
 # gen-docs generates a new versioned docs directory under site/content/docs.
 # Please read the documentation in the script for instructions on how to use it.
 gen-docs:

--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -1,9 +1,5 @@
-FROM ubuntu:20.04
-
-RUN apt update
-RUN apt install -y hugo
+FROM klakegg/hugo:0.73.0-ext-ubuntu
 
 WORKDIR /srv/hugo
 
 EXPOSE 1313
-

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -10,7 +10,7 @@ hero:
   content: Velero is an open source tool to safely backup and restore, perform disaster recovery, and migrate Kubernetes cluster resources and persistent volumes.
   cta_link1:
     text: Latest Release Information
-    url: /blog/velero-1.6-bring-all-your-credentials/
+    url: /blog/Velero-1.11/
   cta_link2:
     text:  Download Velero
     url: https://github.com/vmware-tanzu/velero/releases/latest

--- a/site/content/docs/main/release-instructions.md
+++ b/site/content/docs/main/release-instructions.md
@@ -159,7 +159,7 @@ What to include in a release blog:
 
 Release blog post PR:
 * Prepare a PR containing the release blog post. Read the [website guidelines][2] for more information on creating a blog post. It's usually easiest to make a copy of the most recent existing post, then replace the content as appropriate.
-* You also need to update `site/index.html` to have "Latest Release Information" contain a link to the new post.
+* You also need to update `site/content/_index.md` to have "Latest Release Information" contain a link to the new post.
 * Plan to publish the blog post the same day as the release.
 
 ## Announce a release


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

[The Velero website](https://velero.io/) LATEST RELEASE INFORMATION button points to wrong version (1.6 instead of 1.11). This PR fixes this.

# Does your change fix a particular issue?

No.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
