### PR TITLE
Clarify the deletion frequency for gc controller

### DIFF
--- a/changelogs/unreleased/6414-allenxu404
+++ b/changelogs/unreleased/6414-allenxu404
@@ -1,0 +1,1 @@
+Clarify the deletion frequency for gc controller

--- a/site/content/docs/main/how-velero-works.md
+++ b/site/content/docs/main/how-velero-works.md
@@ -88,6 +88,9 @@ When you create a backup, you can specify a TTL (time to live) by adding the fla
 
 The TTL flag allows the user to specify the backup retention period with the value specified in hours, minutes and seconds in the form `--ttl 24h0m0s`. If not specified, a default TTL value of 30 days will be applied.
 
+The effects of expiration are not applied immediately, they are applied when the gc-controller runs its reconciliation loop every hour by default. If needed, you can adjust the frequency of the reconciliation loop using the `--garbage-collection-frequency
+<DURATION>` flag.
+
 If backup fails to delete, a label `velero.io/gc-failure=<Reason>` will be added to the backup custom resource.
 
 You can use this label to filter and select backups that failed to delete.

--- a/site/content/docs/v1.10/how-velero-works.md
+++ b/site/content/docs/v1.10/how-velero-works.md
@@ -88,6 +88,9 @@ When you create a backup, you can specify a TTL (time to live) by adding the fla
 
 The TTL flag allows the user to specify the backup retention period with the value specified in hours, minutes and seconds in the form `--ttl 24h0m0s`. If not specified, a default TTL value of 30 days will be applied.
 
+The effects of expiration are not applied immediately, they are applied when the gc-controller runs its reconciliation loop every hour by default. If needed, you can adjust the frequency of the reconciliation loop using the `--garbage-collection-frequency
+<DURATION>` flag.
+
 If backup fails to delete, a label `velero.io/gc-failure=<Reason>` will be added to the backup custom resource.
 
 You can use this label to filter and select backups that failed to delete.

--- a/site/content/docs/v1.11/how-velero-works.md
+++ b/site/content/docs/v1.11/how-velero-works.md
@@ -88,6 +88,9 @@ When you create a backup, you can specify a TTL (time to live) by adding the fla
 
 The TTL flag allows the user to specify the backup retention period with the value specified in hours, minutes and seconds in the form `--ttl 24h0m0s`. If not specified, a default TTL value of 30 days will be applied.
 
+The effects of expiration are not applied immediately, they are applied when the gc-controller runs its reconciliation loop every hour by default. If needed, you can adjust the frequency of the reconciliation loop using the `--garbage-collection-frequency
+<DURATION>` flag.
+
 If backup fails to delete, a label `velero.io/gc-failure=<Reason>` will be added to the backup custom resource.
 
 You can use this label to filter and select backups that failed to delete.


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Clarify there is the deletion frequency for gc controller so the effects of expiration are not applied immediately.
# Does your change fix a particular issue?

Fixes #6245

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
