### PR TITLE
data mover smoke testing 02

### DIFF
--- a/pkg/apis/velero/v1/labels_annotations.go
+++ b/pkg/apis/velero/v1/labels_annotations.go
@@ -75,4 +75,7 @@ const (
 	// ResourceTimeoutAnnotation is the annotation key used to carry the global resource
 	// timeout value for backup to plugins.
 	ResourceTimeoutAnnotation = "velero.io/resource-timeout"
+
+	// AsyncOperationIDLabel is the label key used to identify the async operation ID
+	AsyncOperationIDLabel = "velero.io/async-operation-id"
 )

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -102,7 +102,7 @@ const (
 	defaultBackupTTL = 30 * 24 * time.Hour
 
 	defaultCSISnapshotTimeout   = 10 * time.Minute
-	defaultItemOperationTimeout = 60 * time.Minute
+	defaultItemOperationTimeout = 4 * time.Hour
 
 	resourceTimeout = 10 * time.Minute
 
@@ -229,7 +229,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 	command.Flags().DurationVar(&config.itemOperationSyncFrequency, "item-operation-sync-frequency", config.itemOperationSyncFrequency, "How often to check status on backup/restore operations after backup/restore processing. Default is 10 seconds")
 	command.Flags().BoolVar(&config.defaultVolumesToFsBackup, "default-volumes-to-fs-backup", config.defaultVolumesToFsBackup, "Backup all volumes with pod volume file system backup by default.")
 	command.Flags().StringVar(&config.uploaderType, "uploader-type", config.uploaderType, "Type of uploader to handle the transfer of data of pod volumes")
-	command.Flags().DurationVar(&config.defaultItemOperationTimeout, "default-item-operation-timeout", config.defaultItemOperationTimeout, "How long to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. Default is 1 hour")
+	command.Flags().DurationVar(&config.defaultItemOperationTimeout, "default-item-operation-timeout", config.defaultItemOperationTimeout, "How long to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. Default is 4 hours")
 	command.Flags().DurationVar(&config.resourceTimeout, "resource-timeout", config.resourceTimeout, "How long to wait for resource processes which are not covered by other specific timeout parameters. Default is 10 minutes.")
 	command.Flags().IntVar(&config.maxConcurrentK8SConnections, "max-concurrent-k8s-connections", config.maxConcurrentK8SConnections, "Max concurrent connections number that Velero can create with kube-apiserver. Default is 30.")
 

--- a/pkg/datamover/util.go
+++ b/pkg/datamover/util.go
@@ -14,24 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package exposer
+package datamover
 
-import (
-	corev1 "k8s.io/api/core/v1"
-)
-
-const (
-	AccessModeFileSystem = "by-file-system"
-)
-
-// ExposeResult defines the result of expose.
-// Varying from the type of the expose, the result may be different.
-type ExposeResult struct {
-	ByPod ExposeByPod
-}
-
-// ExposeByPod defines the result for the expose method that a hosting pod is created
-type ExposeByPod struct {
-	HostingPod *corev1.Pod
-	PVC        string
+func GetUploaderType(dataMover string) string {
+	if dataMover == "" || dataMover == "velero" {
+		return "kopia"
+	} else {
+		return dataMover
+	}
 }

--- a/pkg/generated/clientset/versioned/typed/velero/v1/podvolumebackup.go
+++ b/pkg/generated/clientset/versioned/typed/velero/v1/podvolumebackup.go
@@ -36,7 +36,6 @@ type PodVolumeBackupsGetter interface {
 	PodVolumeBackups(namespace string) PodVolumeBackupInterface
 }
 
-//go:generate mockery --name PodVolumeBackupInterface
 // PodVolumeBackupInterface has methods to work with PodVolumeBackup resources.
 type PodVolumeBackupInterface interface {
 	Create(ctx context.Context, podVolumeBackup *v1.PodVolumeBackup, opts metav1.CreateOptions) (*v1.PodVolumeBackup, error)


### PR DESCRIPTION
Code changes during data mover smoke testing:

- Remove label selectors created by Velero for PVC during backup
- Change default `AsyncOperationTimeout` to `4 hour` in order to make it consistent with PVB
- Move `GetUploaderType` to `pkg/datamover` as it is irrelevant to exposer
- Remove `time.Sleep(2 * time.Second)` from `acceptDataUpload`, which is for debug purpose only
- Add `AsyncOperationIDLabel` to uploader tags so that it will be saved along with the snapshot in the repo
- Fix a problem that data mover backup is saved into the wrong place `BSL/kopia/velero` instead of `BSL/kopia/<source namespace>`