### PR TITLE
Fix main CI out of space problem

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -64,6 +64,10 @@ jobs:
     - name: Publish container image
       if: github.repository == 'vmware-tanzu/velero'
       run: |
+        sudo swapoff -a
+        sudo rm -f /mnt/swapfile
+        docker image prune -a --force
+              
         # Build and push Velero image to docker registry
         docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
         VERSION=$(./hack/docker-push.sh | grep 'VERSION:' | awk -F: '{print $2}' | xargs)


### PR DESCRIPTION
The Main CI frequently fails with error "System.IO.IOException: No space left on device" during Publish container image step. Clean swap file and docker image cache to free space