### PR TITLE
Update tilt ubuntu image to avoid glibc error

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -110,7 +110,7 @@ local_resource(
 
 # Note: we need a distro with a bash shell to exec into the Velero container
 tilt_dockerfile_header = """
-FROM ubuntu:focal as tilt
+FROM ubuntu:22.04 as tilt
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y ca-certificates tzdata && rm -rf /var/lib/apt/lists/*
 
@@ -218,7 +218,7 @@ def enable_provider(provider):
 
     # Note: we need a distro with a shell to do a copy of the plugin binary
     tilt_dockerfile_header = """
-    FROM ubuntu:focal as tilt
+    FROM ubuntu:22.04 as tilt
     WORKDIR /
     COPY --from=tilt-helper /start.sh .
     COPY --from=tilt-helper /restart.sh .


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Ubuntu: focal operates on slightly older versions. It has glibc version 2.31 as compared to newer OS use 2.35.

This leads to issues in the pod coming up, the pod keeps crashing with error message cribbing that the appropriate glibc version was not found.


# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
