### PR TITLE
Fix hook filter display issue for backup describer

### DIFF
--- a/changelogs/unreleased/6434-allenxu404
+++ b/changelogs/unreleased/6434-allenxu404
@@ -1,0 +1,1 @@
+Fix hook filter display issue for backup describer

--- a/pkg/cmd/util/output/backup_describer.go
+++ b/pkg/cmd/util/output/backup_describer.go
@@ -231,31 +231,31 @@ func DescribeBackupSpec(d *Describer, spec velerov1api.BackupSpec) {
 			d.Printf("\t\t%s:\n", backupResourceHookSpec.Name)
 			d.Printf("\t\t\tNamespaces:\n")
 			var s string
-			if len(spec.IncludedNamespaces) == 0 {
+			if len(backupResourceHookSpec.IncludedNamespaces) == 0 {
 				s = "*"
 			} else {
-				s = strings.Join(spec.IncludedNamespaces, ", ")
+				s = strings.Join(backupResourceHookSpec.IncludedNamespaces, ", ")
 			}
 			d.Printf("\t\t\t\tIncluded:\t%s\n", s)
-			if len(spec.ExcludedNamespaces) == 0 {
+			if len(backupResourceHookSpec.ExcludedNamespaces) == 0 {
 				s = emptyDisplay
 			} else {
-				s = strings.Join(spec.ExcludedNamespaces, ", ")
+				s = strings.Join(backupResourceHookSpec.ExcludedNamespaces, ", ")
 			}
 			d.Printf("\t\t\t\tExcluded:\t%s\n", s)
 
 			d.Println()
 			d.Printf("\t\t\tResources:\n")
-			if len(spec.IncludedResources) == 0 {
+			if len(backupResourceHookSpec.IncludedResources) == 0 {
 				s = "*"
 			} else {
-				s = strings.Join(spec.IncludedResources, ", ")
+				s = strings.Join(backupResourceHookSpec.IncludedResources, ", ")
 			}
 			d.Printf("\t\t\t\tIncluded:\t%s\n", s)
-			if len(spec.ExcludedResources) == 0 {
+			if len(backupResourceHookSpec.ExcludedResources) == 0 {
 				s = emptyDisplay
 			} else {
-				s = strings.Join(spec.ExcludedResources, ", ")
+				s = strings.Join(backupResourceHookSpec.ExcludedResources, ", ")
 			}
 			d.Printf("\t\t\t\tExcluded:\t%s\n", s)
 

--- a/pkg/cmd/util/output/backup_describer_test.go
+++ b/pkg/cmd/util/output/backup_describer_test.go
@@ -72,6 +72,10 @@ func TestDescribeBackupSpec(t *testing.T) {
 							},
 						},
 					},
+					IncludedNamespaces: []string{"hook-inc-ns-1", "hook-inc-ns-2"},
+					ExcludedNamespaces: []string{"hook-exc-ns-1", "hook-exc-ns-2"},
+					IncludedResources:  []string{"hook-inc-res-1", "hook-inc-res-2"},
+					ExcludedResources:  []string{"hook-exc-res-1", "hook-exc-res-2"},
 				},
 			},
 		}).Result().Spec
@@ -102,12 +106,12 @@ Hooks:
   Resources:
     hook-1:
       Namespaces:
-        Included:  inc-ns-1, inc-ns-2
-        Excluded:  exc-ns-1, exc-ns-2
+        Included:  hook-inc-ns-1, hook-inc-ns-2
+        Excluded:  hook-exc-ns-1, hook-exc-ns-2
 
       Resources:
-        Included:  inc-res-1, inc-res-2
-        Excluded:  exc-res-1, exc-res-2
+        Included:  hook-inc-res-1, hook-inc-res-2
+        Excluded:  hook-exc-res-1, hook-exc-res-2
 
       Label selector:  <none>
 

--- a/pkg/cmd/util/output/backup_structured_describer.go
+++ b/pkg/cmd/util/output/backup_structured_describer.go
@@ -160,31 +160,31 @@ func DescribeBackupSpecInSF(d *StructuredDescriber, spec velerov1api.BackupSpec)
 		ResourceDetails := make(map[string]interface{})
 		var s string
 		namespaceInfo := make(map[string]string)
-		if len(spec.IncludedNamespaces) == 0 {
+		if len(backupResourceHookSpec.IncludedNamespaces) == 0 {
 			s = "*"
 		} else {
-			s = strings.Join(spec.IncludedNamespaces, ", ")
+			s = strings.Join(backupResourceHookSpec.IncludedNamespaces, ", ")
 		}
 		namespaceInfo["included"] = s
-		if len(spec.ExcludedNamespaces) == 0 {
+		if len(backupResourceHookSpec.ExcludedNamespaces) == 0 {
 			s = emptyDisplay
 		} else {
-			s = strings.Join(spec.ExcludedNamespaces, ", ")
+			s = strings.Join(backupResourceHookSpec.ExcludedNamespaces, ", ")
 		}
 		namespaceInfo["excluded"] = s
 		ResourceDetails["namespaces"] = namespaceInfo
 
 		resourcesInfo := make(map[string]string)
-		if len(spec.IncludedResources) == 0 {
+		if len(backupResourceHookSpec.IncludedResources) == 0 {
 			s = "*"
 		} else {
-			s = strings.Join(spec.IncludedResources, ", ")
+			s = strings.Join(backupResourceHookSpec.IncludedResources, ", ")
 		}
 		resourcesInfo["included"] = s
-		if len(spec.ExcludedResources) == 0 {
+		if len(backupResourceHookSpec.ExcludedResources) == 0 {
 			s = emptyDisplay
 		} else {
-			s = strings.Join(spec.ExcludedResources, ", ")
+			s = strings.Join(backupResourceHookSpec.ExcludedResources, ", ")
 		}
 		resourcesInfo["excluded"] = s
 		ResourceDetails["resources"] = resourcesInfo

--- a/pkg/cmd/util/output/backup_structured_describer_test.go
+++ b/pkg/cmd/util/output/backup_structured_describer_test.go
@@ -56,6 +56,10 @@ func TestDescribeBackupInSF(t *testing.T) {
 							},
 						},
 					},
+					IncludedNamespaces: []string{"hook-inc-ns-1", "hook-inc-ns-2"},
+					ExcludedNamespaces: []string{"hook-exc-ns-1", "hook-exc-ns-2"},
+					IncludedResources:  []string{"hook-inc-res-1", "hook-inc-res-2"},
+					ExcludedResources:  []string{"hook-exc-res-1", "hook-exc-res-2"},
 				},
 			},
 		})
@@ -83,8 +87,8 @@ func TestDescribeBackupInSF(t *testing.T) {
 					"hook-1": map[string]interface{}{
 						"labelSelector": emptyDisplay,
 						"namespaces": map[string]string{
-							"included": "inc-ns-1, inc-ns-2",
-							"excluded": "exc-ns-1, exc-ns-2",
+							"included": "hook-inc-ns-1, hook-inc-ns-2",
+							"excluded": "hook-exc-ns-1, hook-exc-ns-2",
 						},
 						"preExecHook": []map[string]interface{}{
 							{
@@ -103,8 +107,8 @@ func TestDescribeBackupInSF(t *testing.T) {
 							},
 						},
 						"resources": map[string]string{
-							"included": "inc-res-1, inc-res-2",
-							"excluded": "exc-res-1, exc-res-2",
+							"included": "hook-inc-res-1, hook-inc-res-2",
+							"excluded": "hook-exc-res-1, hook-exc-res-2",
 						},
 					},
 				},


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
 Backup describer displays hook filter specified in backup hook spec rather than backup spec  

# Does your change fix a particular issue?

Fixes #6043

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
