### PR TITLE
Fix concurrent repo ensure problem

### DIFF
--- a/pkg/exposer/csi_snapshot.go
+++ b/pkg/exposer/csi_snapshot.go
@@ -202,7 +202,7 @@ func (e *csiSnapshotExposer) GetExposed(ctx context.Context, ownerObject corev1.
 	}, pod)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			curLog.WithField("backup pod", backupPodName).Errorf("Backup pod is not running in the current node %s", exposeWaitParam.NodeName)
+			curLog.WithField("backup pod", backupPodName).Debugf("Backup pod is not running in the current node %s", exposeWaitParam.NodeName)
 			return nil, nil
 		} else {
 			return nil, errors.Wrapf(err, "error to get backup pod %s", backupPodName)

--- a/pkg/exposer/generic_restore.go
+++ b/pkg/exposer/generic_restore.go
@@ -123,7 +123,7 @@ func (e *genericRestoreExposer) GetExposed(ctx context.Context, ownerObject core
 	}, pod)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			curLog.WithField("backup pod", restorePodName).Error("Backup pod is not running in the current node")
+			curLog.WithField("backup pod", restorePodName).Debug("Backup pod is not running in the current node")
 			return nil, nil
 		} else {
 			return nil, errors.Wrapf(err, "error to get backup pod %s", restorePodName)

--- a/pkg/repository/ensurer_test.go
+++ b/pkg/repository/ensurer_test.go
@@ -30,13 +30,19 @@ import (
 )
 
 func TestEnsureRepo(t *testing.T) {
-	bkRepoObj := NewBackupRepository(velerov1.DefaultNamespace, BackupRepositoryKey{
+	bkRepoObjReady := NewBackupRepository(velerov1.DefaultNamespace, BackupRepositoryKey{
 		VolumeNamespace: "fake-ns",
 		BackupLocation:  "fake-bsl",
 		RepositoryType:  "fake-repo-type",
 	})
 
-	bkRepoObj.Status.Phase = velerov1.BackupRepositoryPhaseReady
+	bkRepoObjReady.Status.Phase = velerov1.BackupRepositoryPhaseReady
+
+	bkRepoObjNotReady := NewBackupRepository(velerov1.DefaultNamespace, BackupRepositoryKey{
+		VolumeNamespace: "fake-ns",
+		BackupLocation:  "fake-bsl",
+		RepositoryType:  "fake-repo-type",
+	})
 
 	scheme := runtime.NewScheme()
 	velerov1.AddToScheme(scheme)
@@ -82,10 +88,21 @@ func TestEnsureRepo(t *testing.T) {
 			bsl:            "fake-bsl",
 			repositoryType: "fake-repo-type",
 			kubeClientObj: []runtime.Object{
-				bkRepoObj,
+				bkRepoObjReady,
 			},
 			runtimeScheme: scheme,
-			expectedRepo:  bkRepoObj,
+			expectedRepo:  bkRepoObjReady,
+		},
+		{
+			name:           "wait existing repo fail",
+			namespace:      "fake-ns",
+			bsl:            "fake-bsl",
+			repositoryType: "fake-repo-type",
+			kubeClientObj: []runtime.Object{
+				bkRepoObjNotReady,
+			},
+			runtimeScheme: scheme,
+			err:           "failed to wait BackupRepository: timed out waiting for the condition",
 		},
 		{
 			name:           "create fail",


### PR DESCRIPTION
For concurrent data uploads for PVCs from the same source namespace, the one but first may fail due to a problem of EnsureRepo.
Inside `EnsureRepo`, it calls `GetBackupRepository` to check the existence of `BackupRepository` CR, if not found, it tries to create a new one.
However, the function `GetBackupRepository` could also return `errBackupRepoNotProvisioned` when the CR exist but not initialized, which should not be treated as an error.