### PR TITLE
Fix data path concurrent

### DIFF
--- a/pkg/controller/data_download_controller_test.go
+++ b/pkg/controller/data_download_controller_test.go
@@ -192,7 +192,12 @@ func TestDataDownloadReconcile(t *testing.T) {
 				},
 			})
 
-			require.Nil(t, err)
+			if test.isGetExposeErr {
+				assert.Contains(t, err.Error(), test.expectedStatusMsg)
+			} else {
+				require.Nil(t, err)
+			}
+
 			require.NotNil(t, actualResult)
 
 			dd := velerov2alpha1api.DataDownload{}

--- a/pkg/controller/data_upload_controller_test.go
+++ b/pkg/controller/data_upload_controller_test.go
@@ -291,8 +291,8 @@ func TestReconcile(t *testing.T) {
 			expectedProcessed: true,
 			expected:          dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseFailed).Result(),
 			expectedRequeue:   ctrl.Result{},
-		},
-		{
+			expectedErrMsg:    "unknown type type of snapshot exposer is not exist",
+		}, {
 			name:              "Dataupload should be accepted",
 			du:                dataUploadBuilder().Result(),
 			pod:               builder.ForPod(velerov1api.DefaultNamespace, dataUploadName).Volumes(&corev1.Volume{Name: "dataupload-1"}).Result(),
@@ -336,7 +336,7 @@ func TestReconcile(t *testing.T) {
 			pod:               builder.ForPod(velerov1api.DefaultNamespace, dataUploadName).Volumes(&corev1.Volume{Name: "dataupload-1"}).Result(),
 			du:                dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).SnapshotType(fakeSnapshotType).Cancel(true).Result(),
 			expectedProcessed: false,
-			expected:          dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseInProgress).Result(),
+			expected:          dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).Result(),
 			expectedRequeue:   ctrl.Result{Requeue: true, RequeueAfter: time.Minute},
 		},
 	}
@@ -400,7 +400,7 @@ func TestReconcile(t *testing.T) {
 			if test.expectedErrMsg == "" {
 				require.NoError(t, err)
 			} else {
-				assert.Equal(t, err.Error(), test.expectedErrMsg)
+				assert.Contains(t, err.Error(), test.expectedErrMsg)
 			}
 
 			du := velerov2alpha1api.DataUpload{}


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)
Two Datauploads are committed to a node, they are executed sequentially. However, when executing the second one but the first one is still in processing,  the second dataupload will get stuck in process.
# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
