### PR TITLE
Limit label "velero.io/pvc-namespace-name" length to 63.

### DIFF
--- a/pkg/apis/velero/v1/labels_annotations.go
+++ b/pkg/apis/velero/v1/labels_annotations.go
@@ -83,9 +83,6 @@ const (
 	// The format is <namespace>/<name>.
 	PVCNamespaceNameLabel = "velero.io/pvc-namespace-name"
 
-	// DynamicPVRestoreLabel is the label key for dynamic PV restore
-	DynamicPVRestoreLabel = "velero.io/dynamic-pv-restore"
-
 	// ResourceUsageLabel is the label key to explain the Velero resource usage.
 	ResourceUsageLabel = "velero.io/resource-usage"
 )

--- a/pkg/restore/dataupload_retrieve_action.go
+++ b/pkg/restore/dataupload_retrieve_action.go
@@ -84,8 +84,8 @@ func (d *DataUploadRetrieveAction) Execute(input *velero.RestoreItemActionExecut
 			Namespace:    dataUpload.Namespace,
 			Labels: map[string]string{
 				velerov1api.RestoreUIDLabel:       label.GetValidName(string(input.Restore.UID)),
-				velerov1api.PVCNamespaceNameLabel: dataUpload.Spec.SourceNamespace + "." + dataUpload.Spec.SourcePVC,
-				velerov1api.ResourceUsageLabel:    string(velerov1api.VeleroResourceUsageDataUploadResult),
+				velerov1api.PVCNamespaceNameLabel: label.GetValidName(dataUpload.Spec.SourceNamespace + "." + dataUpload.Spec.SourcePVC),
+				velerov1api.ResourceUsageLabel:    label.GetValidName(string(velerov1api.VeleroResourceUsageDataUploadResult)),
 			},
 		},
 		Data: map[string]string{


### PR DESCRIPTION
1. Limit label length.
2. Modify UT accordingly.
3. Remove unnecessary const variable.

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
