### PR TITLE
Add exit code log and possible memory shortage warning log for Restic command failure

### DIFF
--- a/changelogs/unreleased/6459-blackpiglet
+++ b/changelogs/unreleased/6459-blackpiglet
@@ -1,0 +1,1 @@
+Add exit code log and possible memory shortage warning log for Restic command failure.

--- a/pkg/repository/restic/repository.go
+++ b/pkg/repository/restic/repository.go
@@ -112,7 +112,7 @@ func (r *RepositoryService) exec(cmd *restic.Command, bsl *velerov1api.BackupSto
 		cmd.ExtraFlags = append(cmd.ExtraFlags, skipTLSRet)
 	}
 
-	stdout, stderr, err := veleroexec.RunCommand(cmd.Cmd())
+	stdout, stderr, err := veleroexec.RunCommandWithLog(cmd.Cmd(), r.log)
 	r.log.WithFields(logrus.Fields{
 		"repository": cmd.RepoName(),
 		"command":    cmd.String(),

--- a/pkg/restic/exec_commands.go
+++ b/pkg/restic/exec_commands.go
@@ -86,6 +86,7 @@ func RunBackup(backupCmd *Command, log logrus.FieldLogger, updater uploader.Prog
 
 	err := cmd.Start()
 	if err != nil {
+		exec.LogErrorAsExitCode(err, log)
 		return stdoutBuf.String(), stderrBuf.String(), err
 	}
 
@@ -119,6 +120,7 @@ func RunBackup(backupCmd *Command, log logrus.FieldLogger, updater uploader.Prog
 
 	err = cmd.Wait()
 	if err != nil {
+		exec.LogErrorAsExitCode(err, log)
 		return stdoutBuf.String(), stderrBuf.String(), err
 	}
 	quit <- struct{}{}
@@ -229,7 +231,7 @@ func RunRestore(restoreCmd *Command, log logrus.FieldLogger, updater uploader.Pr
 		}
 	}()
 
-	stdout, stderr, err := exec.RunCommand(restoreCmd.Cmd())
+	stdout, stderr, err := exec.RunCommandWithLog(restoreCmd.Cmd(), log)
 	quit <- struct{}{}
 
 	// update progress to 100%

--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // RunCommand runs a command and returns its stdout, stderr, and its returned
@@ -51,4 +52,26 @@ func RunCommand(cmd *exec.Cmd) (string, string, error) {
 	}
 
 	return stdout, stderr, runErr
+}
+
+func RunCommandWithLog(cmd *exec.Cmd, log logrus.FieldLogger) (string, string, error) {
+	stdout, stderr, err := RunCommand(cmd)
+	LogErrorAsExitCode(err, log)
+	return stdout, stderr, err
+}
+
+func LogErrorAsExitCode(err error, log logrus.FieldLogger) {
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			log.Errorf("Restic command fail with ExitCode: %d. Process ID is %d, Exit error is: %s", exitError.ExitCode(), exitError.Pid(), exitError.String())
+			// Golang's os.exec -1 ExitCode means signal kill. Usually this is caused
+			// by CGroup's OOM. Log a warning to notice user.
+			// https://github.com/golang/go/blob/master/src/os/exec_posix.go#L128-L136
+			if exitError.ExitCode() == -1 {
+				log.Warnf("The ExitCode is -1, which means the process is terminated by signal. Usually this is caused by CGroup kill due to out of memory. Please check whether there is such information in the work nodes' dmesg log.")
+			}
+		} else {
+			log.WithError(err).Info("Error cannot be convert to ExitError format.")
+		}
+	}
 }


### PR DESCRIPTION


Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #6001 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
