### PR TITLE
Delete the expired deletebackuprequests that are stuck in "InProgress"

### DIFF
--- a/changelogs/unreleased/6476-reasonerjt
+++ b/changelogs/unreleased/6476-reasonerjt
@@ -1,0 +1,1 @@
+Delete the expired deletebackuprequests that are stuck in "InProgress"


### PR DESCRIPTION
state

This PR should fix #6042
But I couldn't reproduce the problem to make the dbr stuck in `InProgress` status, still waiting for the author to clarify.

More details please refer to the discussion under #6042 

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
