### PR TITLE
add restore finalizer to clean up external resources

### DIFF
--- a/changelogs/unreleased/6479-allenxu404
+++ b/changelogs/unreleased/6479-allenxu404
@@ -1,0 +1,1 @@
+Add restore finalizer to clean up external resources


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
- Add restore finalizer to clean up external resources when restore is being deleted
# Does your change fix a particular issue?

Fixes #2697

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
