### PR TITLE
Move kopia logging from util/logging to remove indirect dependency in velero plugins

### DIFF
--- a/changelogs/unreleased/6484-kaovilai
+++ b/changelogs/unreleased/6484-kaovilai
@@ -1,0 +1,1 @@
+Velero Plugins no longer need kopia indirect dependency in their go.mod

--- a/pkg/kopia/kopia_log.go
+++ b/pkg/kopia/kopia_log.go
@@ -1,3 +1,5 @@
+package kopia
+
 /*
 Copyright the Velero contributors.
 
@@ -13,8 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-package logging
 
 import (
 	"context"

--- a/pkg/kopia/kopia_log_test.go
+++ b/pkg/kopia/kopia_log_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package logging
+package kopia
 
 import (
 	"testing"

--- a/pkg/repository/udmrepo/kopialib/lib_repo.go
+++ b/pkg/repository/udmrepo/kopialib/lib_repo.go
@@ -33,8 +33,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	"github.com/vmware-tanzu/velero/pkg/kopia"
 	"github.com/vmware-tanzu/velero/pkg/repository/udmrepo"
-	"github.com/vmware-tanzu/velero/pkg/util/logging"
 )
 
 type kopiaRepoService struct {
@@ -91,7 +91,7 @@ func NewKopiaRepoService(logger logrus.FieldLogger) udmrepo.BackupRepoService {
 }
 
 func (ks *kopiaRepoService) Init(ctx context.Context, repoOption udmrepo.RepoOptions, createNew bool) error {
-	repoCtx := logging.SetupKopiaLog(ctx, ks.logger)
+	repoCtx := kopia.SetupKopiaLog(ctx, ks.logger)
 
 	if createNew {
 		if err := CreateBackupRepo(repoCtx, repoOption); err != nil {
@@ -113,7 +113,7 @@ func (ks *kopiaRepoService) Open(ctx context.Context, repoOption udmrepo.RepoOpt
 		return nil, errors.Wrapf(err, "repo config %s doesn't exist", repoConfig)
 	}
 
-	repoCtx := logging.SetupKopiaLog(ctx, ks.logger)
+	repoCtx := kopia.SetupKopiaLog(ctx, ks.logger)
 
 	r, err := openKopiaRepo(repoCtx, repoConfig, repoOption.RepoPassword)
 	if err != nil {
@@ -156,7 +156,7 @@ func (ks *kopiaRepoService) Maintain(ctx context.Context, repoOption udmrepo.Rep
 		return errors.Wrapf(err, "repo config %s doesn't exist", repoConfig)
 	}
 
-	repoCtx := logging.SetupKopiaLog(ctx, ks.logger)
+	repoCtx := kopia.SetupKopiaLog(ctx, ks.logger)
 
 	r, err := openKopiaRepo(repoCtx, repoConfig, repoOption.RepoPassword)
 	if err != nil {
@@ -206,7 +206,7 @@ func (ks *kopiaRepoService) DefaultMaintenanceFrequency() time.Duration {
 }
 
 func (km *kopiaMaintenance) runMaintenance(ctx context.Context, rep repo.DirectRepositoryWriter) error {
-	err := snapshotmaintenance.Run(logging.SetupKopiaLog(ctx, km.logger), rep, km.mode, false, maintenance.SafetyFull)
+	err := snapshotmaintenance.Run(kopia.SetupKopiaLog(ctx, km.logger), rep, km.mode, false, maintenance.SafetyFull)
 	if err != nil {
 		return errors.Wrapf(err, "error to run maintenance under mode %s", km.mode)
 	}
@@ -238,7 +238,7 @@ func (kr *kopiaRepository) OpenObject(ctx context.Context, id udmrepo.ID) (udmre
 		return nil, errors.Wrapf(err, "error to parse object ID from %v", id)
 	}
 
-	reader, err := kr.rawRepo.OpenObject(logging.SetupKopiaLog(ctx, kr.logger), objID)
+	reader, err := kr.rawRepo.OpenObject(kopia.SetupKopiaLog(ctx, kr.logger), objID)
 	if err != nil {
 		return nil, errors.Wrap(err, "error to open object")
 	}
@@ -253,7 +253,7 @@ func (kr *kopiaRepository) GetManifest(ctx context.Context, id udmrepo.ID, mani 
 		return errors.New("repo is closed or not open")
 	}
 
-	metadata, err := kr.rawRepo.GetManifest(logging.SetupKopiaLog(ctx, kr.logger), manifest.ID(id), mani.Payload)
+	metadata, err := kr.rawRepo.GetManifest(kopia.SetupKopiaLog(ctx, kr.logger), manifest.ID(id), mani.Payload)
 	if err != nil {
 		return errors.Wrap(err, "error to get manifest")
 	}
@@ -268,7 +268,7 @@ func (kr *kopiaRepository) FindManifests(ctx context.Context, filter udmrepo.Man
 		return nil, errors.New("repo is closed or not open")
 	}
 
-	metadata, err := kr.rawRepo.FindManifests(logging.SetupKopiaLog(ctx, kr.logger), filter.Labels)
+	metadata, err := kr.rawRepo.FindManifests(kopia.SetupKopiaLog(ctx, kr.logger), filter.Labels)
 	if err != nil {
 		return nil, errors.Wrap(err, "error to find manifests")
 	}
@@ -286,7 +286,7 @@ func (kr *kopiaRepository) Time() time.Time {
 
 func (kr *kopiaRepository) Close(ctx context.Context) error {
 	if kr.rawWriter != nil {
-		err := kr.rawWriter.Close(logging.SetupKopiaLog(ctx, kr.logger))
+		err := kr.rawWriter.Close(kopia.SetupKopiaLog(ctx, kr.logger))
 		if err != nil {
 			return errors.Wrap(err, "error to close repo writer")
 		}
@@ -295,7 +295,7 @@ func (kr *kopiaRepository) Close(ctx context.Context) error {
 	}
 
 	if kr.rawRepo != nil {
-		err := kr.rawRepo.Close(logging.SetupKopiaLog(ctx, kr.logger))
+		err := kr.rawRepo.Close(kopia.SetupKopiaLog(ctx, kr.logger))
 		if err != nil {
 			return errors.Wrap(err, "error to close repo")
 		}
@@ -311,7 +311,7 @@ func (kr *kopiaRepository) NewObjectWriter(ctx context.Context, opt udmrepo.Obje
 		return nil
 	}
 
-	writer := kr.rawWriter.NewObjectWriter(logging.SetupKopiaLog(ctx, kr.logger), object.WriterOptions{
+	writer := kr.rawWriter.NewObjectWriter(kopia.SetupKopiaLog(ctx, kr.logger), object.WriterOptions{
 		Description: opt.Description,
 		Prefix:      index.IDPrefix(opt.Prefix),
 		AsyncWrites: opt.AsyncWrites,
@@ -332,7 +332,7 @@ func (kr *kopiaRepository) PutManifest(ctx context.Context, manifest udmrepo.Rep
 		return "", errors.New("repo writer is closed or not open")
 	}
 
-	id, err := kr.rawWriter.PutManifest(logging.SetupKopiaLog(ctx, kr.logger), manifest.Metadata.Labels, manifest.Payload)
+	id, err := kr.rawWriter.PutManifest(kopia.SetupKopiaLog(ctx, kr.logger), manifest.Metadata.Labels, manifest.Payload)
 	if err != nil {
 		return "", errors.Wrap(err, "error to put manifest")
 	}
@@ -345,7 +345,7 @@ func (kr *kopiaRepository) DeleteManifest(ctx context.Context, id udmrepo.ID) er
 		return errors.New("repo writer is closed or not open")
 	}
 
-	err := kr.rawWriter.DeleteManifest(logging.SetupKopiaLog(ctx, kr.logger), manifest.ID(id))
+	err := kr.rawWriter.DeleteManifest(kopia.SetupKopiaLog(ctx, kr.logger), manifest.ID(id))
 	if err != nil {
 		return errors.Wrap(err, "error to delete manifest")
 	}
@@ -358,7 +358,7 @@ func (kr *kopiaRepository) Flush(ctx context.Context) error {
 		return errors.New("repo writer is closed or not open")
 	}
 
-	err := kr.rawWriter.Flush(logging.SetupKopiaLog(ctx, kr.logger))
+	err := kr.rawWriter.Flush(kopia.SetupKopiaLog(ctx, kr.logger))
 	if err != nil {
 		return errors.Wrap(err, "error to flush repo")
 	}

--- a/pkg/uploader/kopia/snapshot.go
+++ b/pkg/uploader/kopia/snapshot.go
@@ -28,9 +28,9 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/vmware-tanzu/velero/pkg/kopia"
 	"github.com/vmware-tanzu/velero/pkg/repository/udmrepo"
 	"github.com/vmware-tanzu/velero/pkg/uploader"
-	"github.com/vmware-tanzu/velero/pkg/util/logging"
 
 	"github.com/kopia/kopia/fs"
 	"github.com/kopia/kopia/fs/localfs"
@@ -121,7 +121,7 @@ func Backup(ctx context.Context, fsUploader SnapshotUploader, repoWriter repo.Re
 		return nil, false, errors.Wrap(err, "Unable to get local filesystem entry")
 	}
 
-	kopiaCtx := logging.SetupKopiaLog(ctx, log)
+	kopiaCtx := kopia.SetupKopiaLog(ctx, log)
 	snapID, snapshotSize, err := SnapshotSource(kopiaCtx, repoWriter, fsUploader, sourceInfo, rootDir, forceFull, parentSnapshot, tags, log, "Kopia Uploader")
 	if err != nil {
 		return nil, false, err
@@ -306,7 +306,7 @@ func findPreviousSnapshotManifest(ctx context.Context, rep repo.Repository, sour
 func Restore(ctx context.Context, rep repo.RepositoryWriter, progress *Progress, snapshotID, dest string, log logrus.FieldLogger, cancleCh chan struct{}) (int64, int32, error) {
 	log.Info("Start to restore...")
 
-	kopiaCtx := logging.SetupKopiaLog(ctx, log)
+	kopiaCtx := kopia.SetupKopiaLog(ctx, log)
 
 	snapshot, err := snapshot.LoadSnapshot(kopiaCtx, rep, manifest.ID(snapshotID))
 	if err != nil {


### PR DESCRIPTION
when running `go mod why -m github.com/kopia/kopia` in velero-plugins prior to this change you will see following

```
❯ go mod why -m github.com/kopia/kopia
github.com/konveyor/openshift-velero-plugin/velero-plugins
github.com/vmware-tanzu/velero/pkg/plugin/framework
github.com/vmware-tanzu/velero/pkg/util/logging
github.com/kopia/kopia/repo/logging
```

after
```
❯ go mod why -m github.com/kopia/kopia
(main module does not need module github.com/kopia/kopia)
```

Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Velero Plugins no longer need kopia indirect dependency in their go.mod

Motivation for change
- We wanted to depend on https://github.com/openshift/docker-distribution/blob/c7be7b49aed9720742b1c03e694248bd83419348/go.mod#L10 which pulls in `github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.0.0` into our go.mod, this import breaks [velero's import of kopia v0.13.0](https://github.com/vmware-tanzu/velero/blob/49e80580b70e7f8e6706040909e378f23ffa4b60/go.mod#L24) which depends on `azblob v0.3.0`
  - There is an update in kopia/kopia which is yet to be put into a release that velero can pull in
  - It is better that we do not force kopia as an indirect dependency when building.
    - we do that by moving kopia logging dependency away from util/logging which is imported by all plugins via framework package.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
