### PR TITLE
Add support for OpenStack CSI drivers topology keys 

### DIFF
--- a/changelogs/unreleased/6488-kayrus
+++ b/changelogs/unreleased/6488-kayrus
@@ -1,0 +1,1 @@
+Add support for OpenStack CSI drivers topology keys

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -448,6 +448,10 @@ const (
 	azureCsiZoneKey  = "topology.disk.csi.azure.com/zone"
 	gkeCsiZoneKey    = "topology.gke.io/zone"
 	gkeZoneSeparator = "__"
+
+	// OpenStack CSI drivers topology keys
+	cinderCsiZoneKey = "topology.manila.csi.openstack.org/zone"
+	manilaCsiZoneKey = "topology.cinder.csi.openstack.org/zone"
 )
 
 // takePVSnapshot triggers a snapshot for the volume/disk underlying a PersistentVolume if the provided
@@ -502,7 +506,7 @@ func (ib *itemBackupper) takePVSnapshot(obj runtime.Unstructured, log logrus.Fie
 		if !labelFound {
 			var k string
 			log.Infof("label %q is not present on PersistentVolume", zoneLabelDeprecated)
-			k, pvFailureDomainZone = zoneFromPVNodeAffinity(pv, awsEbsCsiZoneKey, azureCsiZoneKey, gkeCsiZoneKey, zoneLabel, zoneLabelDeprecated)
+			k, pvFailureDomainZone = zoneFromPVNodeAffinity(pv, awsEbsCsiZoneKey, azureCsiZoneKey, gkeCsiZoneKey, cinderCsiZoneKey, manilaCsiZoneKey, zoneLabel, zoneLabelDeprecated)
 			if pvFailureDomainZone != "" {
 				log.Infof("zone info from nodeAffinity requirements: %s, key: %s", pvFailureDomainZone, k)
 			} else {


### PR DESCRIPTION
This is a backport of the #6464

# Please add a summary of your change

The change adds support for the OpenStack CSI drivers topology keys:

* cinder: https://github.com/kubernetes/cloud-provider-openstack/blob/8b6636c5088851bd1b934ae9ca9dc283de247609/pkg/csi/cinder/driver.go#L33-L34
* manila: https://github.com/kubernetes/cloud-provider-openstack/blob/8b6636c5088851bd1b934ae9ca9dc283de247609/pkg/csi/manila/driver.go#L90

# Does your change fix a particular issue?

Fixes #6440 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
