### PR TITLE
Data mover restore abort for existing PVC

### DIFF
--- a/pkg/exposer/generic_restore.go
+++ b/pkg/exposer/generic_restore.go
@@ -78,6 +78,10 @@ func (e *genericRestoreExposer) Expose(ctx context.Context, ownerObject corev1.O
 
 	curLog.WithField("target PVC", targetPVCName).WithField("selected node", selectedNode).Info("Target PVC is consumed")
 
+	if kube.IsPVCBound(targetPVC) {
+		return errors.Errorf("Target PVC %s/%s has already been bound, abort", sourceNamespace, targetPVCName)
+	}
+
 	restorePod, err := e.createRestorePod(ctx, ownerObject, hostingPodLabels, selectedNode)
 	if err != nil {
 		return errors.Wrapf(err, "error to create restore pod")

--- a/pkg/exposer/generic_restore_test.go
+++ b/pkg/exposer/generic_restore_test.go
@@ -54,6 +54,16 @@ func TestRestoreExpose(t *testing.T) {
 		},
 	}
 
+	targetPVCObjBound := &corev1api.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "fake-ns",
+			Name:      "fake-target-pvc",
+		},
+		Spec: corev1api.PersistentVolumeClaimSpec{
+			VolumeName: "fake-pv",
+		},
+	}
+
 	tests := []struct {
 		name            string
 		kubeClientObj   []runtime.Object
@@ -69,6 +79,16 @@ func TestRestoreExpose(t *testing.T) {
 			sourceNamespace: "fake-ns",
 			ownerRestore:    restore,
 			err:             "error to wait target PVC consumed, fake-ns/fake-target-pvc: error to wait for PVC: error to get pvc fake-ns/fake-target-pvc: persistentvolumeclaims \"fake-target-pvc\" not found",
+		},
+		{
+			name:            "target pvc is already bound",
+			targetPVCName:   "fake-target-pvc",
+			sourceNamespace: "fake-ns",
+			ownerRestore:    restore,
+			kubeClientObj: []runtime.Object{
+				targetPVCObjBound,
+			},
+			err: "Target PVC fake-ns/fake-target-pvc has already been bound, abort",
 		},
 		{
 			name:            "create restore pod fail",

--- a/pkg/util/kube/pvc_pv.go
+++ b/pkg/util/kube/pvc_pv.go
@@ -284,11 +284,11 @@ func WaitPVBound(ctx context.Context, pvGetter corev1client.CoreV1Interface, pvN
 		}
 
 		if tmpPV.Spec.ClaimRef.Name != pvcName {
-			return false, nil
+			return false, errors.Errorf("pv has been bound by unexpected pvc %s/%s", tmpPV.Spec.ClaimRef.Namespace, tmpPV.Spec.ClaimRef.Name)
 		}
 
 		if tmpPV.Spec.ClaimRef.Namespace != pvcNamespace {
-			return false, nil
+			return false, errors.Errorf("pv has been bound by unexpected pvc %s/%s", tmpPV.Spec.ClaimRef.Namespace, tmpPV.Spec.ClaimRef.Name)
 		}
 
 		updated = tmpPV
@@ -301,4 +301,9 @@ func WaitPVBound(ctx context.Context, pvGetter corev1client.CoreV1Interface, pvN
 	} else {
 		return updated, nil
 	}
+}
+
+// IsPVCBound returns true if the specified PVC has been bound
+func IsPVCBound(pvc *corev1api.PersistentVolumeClaim) bool {
+	return pvc.Spec.VolumeName != ""
 }


### PR DESCRIPTION
Fail earlier when the target PVC already exists (e.g., the target namespace already exists at the time of restore), otherwise, the restore won't fail until all the data is downloaded, which may take a long time if the backup size is large