### PR TITLE
delete io/ioutil package as it is deprecated

### DIFF
--- a/pkg/controller/backup_finalizer_controller_test.go
+++ b/pkg/controller/backup_finalizer_controller_test.go
@@ -19,7 +19,7 @@ package controller
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -163,7 +163,7 @@ func TestBackupFinalizerReconcile(t *testing.T) {
 			reconciler, backupper := mockBackupFinalizerReconciler(fakeClient, fakeClock)
 			pluginManager.On("CleanupClients").Return(nil)
 			backupStore.On("GetBackupItemOperations", test.backup.Name).Return(test.backupOperations, nil)
-			backupStore.On("GetBackupContents", mock.Anything).Return(ioutil.NopCloser(bytes.NewReader([]byte("hello world"))), nil)
+			backupStore.On("GetBackupContents", mock.Anything).Return(io.NopCloser(bytes.NewReader([]byte("hello world"))), nil)
 			backupStore.On("PutBackupContents", mock.Anything, mock.Anything).Return(nil)
 			backupStore.On("PutBackupMetadata", mock.Anything, mock.Anything).Return(nil)
 			pluginManager.On("GetBackupItemActionsV2").Return(nil, nil)

--- a/pkg/uploader/provider/restic_test.go
+++ b/pkg/uploader/provider/restic_test.go
@@ -19,7 +19,6 @@ package provider
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -211,13 +210,13 @@ func TestResticRunRestore(t *testing.T) {
 func TestClose(t *testing.T) {
 	t.Run("Delete existing credentials file", func(t *testing.T) {
 		// Create temporary files for the credentials and caCert
-		credentialsFile, err := ioutil.TempFile("", "credentialsFile")
+		credentialsFile, err := os.CreateTemp("", "credentialsFile")
 		if err != nil {
 			t.Fatalf("failed to create temp file: %v", err)
 		}
 		defer os.Remove(credentialsFile.Name())
 
-		caCertFile, err := ioutil.TempFile("", "caCertFile")
+		caCertFile, err := os.CreateTemp("", "caCertFile")
 		if err != nil {
 			t.Fatalf("failed to create temp file: %v", err)
 		}
@@ -240,7 +239,7 @@ func TestClose(t *testing.T) {
 
 	t.Run("Delete existing caCert file", func(t *testing.T) {
 		// Create temporary files for the credentials and caCert
-		caCertFile, err := ioutil.TempFile("", "caCertFile")
+		caCertFile, err := os.CreateTemp("", "caCertFile")
 		if err != nil {
 			t.Fatalf("failed to create temp file: %v", err)
 		}

--- a/test/e2e/basic/api-group/enable_api_group_versions.go
+++ b/test/e2e/basic/api-group/enable_api_group_versions.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -376,7 +375,7 @@ func installTestCRD(ctx context.Context, index int, group, path string) error {
 }
 
 func rerenderTestYaml(index int, group, path string) (string, error) {
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get %s when install test yaml", path)
 	}
@@ -399,7 +398,7 @@ func rerenderTestYaml(index int, group, path string) (string, error) {
 	newContent = strings.ReplaceAll(newContent, group, fmt.Sprintf("%s.%d", group, index))
 
 	By(fmt.Sprintf("\n%s\n", newContent))
-	tmpFile, err := ioutil.TempFile("", "test-yaml")
+	tmpFile, err := os.CreateTemp("", "test-yaml")
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to create temp file  when install storage class")
 	}

--- a/test/e2e/resourcepolicies/resource_policies.go
+++ b/test/e2e/resourcepolicies/resource_policies.go
@@ -19,7 +19,6 @@ package filtering
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -270,7 +269,7 @@ func (r *ResourcePoliciesCase) installTestStorageClasses(path string) error {
 	if err != nil {
 		return err
 	}
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get %s when install storage class", path)
 	}
@@ -278,7 +277,7 @@ func (r *ResourcePoliciesCase) installTestStorageClasses(path string) error {
 	// replace sc to new value
 	newContent := strings.ReplaceAll(string(content), "name: e2e-storage-class", "name: e2e-storage-class-2")
 
-	tmpFile, err := ioutil.TempFile("", "sc-file")
+	tmpFile, err := os.CreateTemp("", "sc-file")
 	if err != nil {
 		return errors.Wrapf(err, "failed to create temp file  when install storage class")
 	}


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Deprecated: As of Go 1.16, the same functionality is now provided
by package io or package os, and those implementations
should be preferred in new code.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
