### PR TITLE
Data mover wrong bsl after sync

### DIFF
--- a/changelogs/unreleased/6533-Lyndon-Li
+++ b/changelogs/unreleased/6533-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix issue #6534, reset PVB CR's StorageLocation to the latest one during backup sync as same as the backup CR. Also fix similar problem with DataUploadResult for data mover restore.

--- a/pkg/cmd/server/plugin/plugin.go
+++ b/pkg/cmd/server/plugin/plugin.go
@@ -248,10 +248,11 @@ func newSecretRestoreItemAction(f client.Factory) plugincommon.HandlerInitialize
 
 func newDataUploadRetrieveAction(f client.Factory) plugincommon.HandlerInitializer {
 	return func(logger logrus.FieldLogger) (interface{}, error) {
-		client, err := f.KubeClient()
+		client, err := f.KubebuilderClient()
 		if err != nil {
 			return nil, err
 		}
-		return restore.NewDataUploadRetrieveAction(logger, client.CoreV1().ConfigMaps(f.Namespace())), nil
+
+		return restore.NewDataUploadRetrieveAction(logger, client), nil
 	}
 }

--- a/pkg/controller/backup_sync_controller.go
+++ b/pkg/controller/backup_sync_controller.go
@@ -208,6 +208,7 @@ func (b *backupSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 			podVolumeBackup.Namespace = backup.Namespace
 			podVolumeBackup.ResourceVersion = ""
+			podVolumeBackup.Spec.BackupStorageLocation = location.Name
 
 			err = b.client.Create(ctx, podVolumeBackup, &client.CreateOptions{})
 			switch {

--- a/pkg/restore/dataupload_retrieve_action_test.go
+++ b/pkg/restore/dataupload_retrieve_action_test.go
@@ -23,10 +23,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	velerov2alpha1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v2alpha1"
@@ -37,31 +38,58 @@ import (
 )
 
 func TestDataUploadRetrieveActionExectue(t *testing.T) {
+	scheme := runtime.NewScheme()
+	velerov1.AddToScheme(scheme)
+	corev1.AddToScheme(scheme)
+
 	tests := []struct {
 		name                     string
 		dataUpload               *velerov2alpha1.DataUpload
 		restore                  *velerov1.Restore
 		expectedDataUploadResult *corev1.ConfigMap
 		expectedErr              string
+		runtimeScheme            *runtime.Scheme
+		veleroObjs               []runtime.Object
 	}{
 		{
-			name:                     "DataUploadRetrieve Action test",
-			dataUpload:               builder.ForDataUpload("velero", "testDU").SourceNamespace("testNamespace").SourcePVC("testPVC").Result(),
-			restore:                  builder.ForRestore("velero", "testRestore").ObjectMeta(builder.WithUID("testingUID")).Result(),
-			expectedDataUploadResult: builder.ForConfigMap("velero", "").ObjectMeta(builder.WithGenerateName("testDU-"), builder.WithLabels(velerov1.PVCNamespaceNameLabel, "testNamespace.testPVC", velerov1.RestoreUIDLabel, "testingUID", velerov1.ResourceUsageLabel, string(velerov1.VeleroResourceUsageDataUploadResult))).Data("testingUID", `{"backupStorageLocation":"","sourceNamespace":"testNamespace"}`).Result(),
+			name:          "error to find backup",
+			dataUpload:    builder.ForDataUpload("velero", "testDU").SourceNamespace("testNamespace").SourcePVC("testPVC").Result(),
+			restore:       builder.ForRestore("velero", "testRestore").ObjectMeta(builder.WithUID("testingUID")).Backup("testBackup").Result(),
+			runtimeScheme: scheme,
+			expectedErr:   "error to get backup for restore testRestore: backups.velero.io \"testBackup\" not found",
 		},
 		{
-			name:                     "Long source namespace and PVC name should also work",
-			dataUpload:               builder.ForDataUpload("velero", "testDU").SourceNamespace("migre209d0da-49c7-45ba-8d5a-3e59fd591ec1").SourcePVC("kibishii-data-kibishii-deployment-0").Result(),
-			restore:                  builder.ForRestore("velero", "testRestore").ObjectMeta(builder.WithUID("testingUID")).Result(),
-			expectedDataUploadResult: builder.ForConfigMap("velero", "").ObjectMeta(builder.WithGenerateName("testDU-"), builder.WithLabels(velerov1.PVCNamespaceNameLabel, "migre209d0da-49c7-45ba-8d5a-3e59fd591ec1.kibishii-data-ki152333", velerov1.RestoreUIDLabel, "testingUID", velerov1.ResourceUsageLabel, string(velerov1.VeleroResourceUsageDataUploadResult))).Data("testingUID", `{"backupStorageLocation":"","sourceNamespace":"migre209d0da-49c7-45ba-8d5a-3e59fd591ec1"}`).Result(),
+			name:          "DataUploadRetrieve Action test",
+			dataUpload:    builder.ForDataUpload("velero", "testDU").SourceNamespace("testNamespace").SourcePVC("testPVC").Result(),
+			restore:       builder.ForRestore("velero", "testRestore").ObjectMeta(builder.WithUID("testingUID")).Backup("testBackup").Result(),
+			runtimeScheme: scheme,
+			veleroObjs: []runtime.Object{
+				builder.ForBackup("velero", "testBackup").StorageLocation("testLocation").Result(),
+			},
+			expectedDataUploadResult: builder.ForConfigMap("velero", "").ObjectMeta(builder.WithGenerateName("testDU-"), builder.WithLabels(velerov1.PVCNamespaceNameLabel, "testNamespace.testPVC", velerov1.RestoreUIDLabel, "testingUID", velerov1.ResourceUsageLabel, string(velerov1.VeleroResourceUsageDataUploadResult))).Data("testingUID", `{"backupStorageLocation":"testLocation","sourceNamespace":"testNamespace"}`).Result(),
+		},
+		{
+			name:          "Long source namespace and PVC name should also work",
+			dataUpload:    builder.ForDataUpload("velero", "testDU").SourceNamespace("migre209d0da-49c7-45ba-8d5a-3e59fd591ec1").SourcePVC("kibishii-data-kibishii-deployment-0").Result(),
+			restore:       builder.ForRestore("velero", "testRestore").ObjectMeta(builder.WithUID("testingUID")).Backup("testBackup").Result(),
+			runtimeScheme: scheme,
+			veleroObjs: []runtime.Object{
+				builder.ForBackup("velero", "testBackup").StorageLocation("testLocation").Result(),
+			},
+			expectedDataUploadResult: builder.ForConfigMap("velero", "").ObjectMeta(builder.WithGenerateName("testDU-"), builder.WithLabels(velerov1.PVCNamespaceNameLabel, "migre209d0da-49c7-45ba-8d5a-3e59fd591ec1.kibishii-data-ki152333", velerov1.RestoreUIDLabel, "testingUID", velerov1.ResourceUsageLabel, string(velerov1.VeleroResourceUsageDataUploadResult))).Data("testingUID", `{"backupStorageLocation":"testLocation","sourceNamespace":"migre209d0da-49c7-45ba-8d5a-3e59fd591ec1"}`).Result(),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			logger := velerotest.NewLogger()
-			cmClient := fake.NewSimpleClientset()
+
+			fakeClientBuilder := fake.NewClientBuilder()
+			if tc.runtimeScheme != nil {
+				fakeClientBuilder = fakeClientBuilder.WithScheme(tc.runtimeScheme)
+			}
+
+			fakeClient := fakeClientBuilder.WithRuntimeObjects(tc.veleroObjs...).Build()
 
 			var unstructuredDataUpload map[string]interface{}
 			if tc.dataUpload != nil {
@@ -74,21 +102,28 @@ func TestDataUploadRetrieveActionExectue(t *testing.T) {
 				ItemFromBackup: &unstructured.Unstructured{Object: unstructuredDataUpload},
 			}
 
-			action := NewDataUploadRetrieveAction(logger, cmClient.CoreV1().ConfigMaps("velero"))
+			action := NewDataUploadRetrieveAction(logger, fakeClient)
 			_, err := action.Execute(&input)
 			if tc.expectedErr != "" {
 				require.Equal(t, tc.expectedErr, err.Error())
+			} else {
+				require.NoError(t, err)
 			}
-			require.NoError(t, err)
 
 			if tc.expectedDataUploadResult != nil {
-				cmList, err := cmClient.CoreV1().ConfigMaps("velero").List(context.Background(), metav1.ListOptions{
-					LabelSelector: fmt.Sprintf("%s=%s,%s=%s", velerov1.RestoreUIDLabel, "testingUID", velerov1.PVCNamespaceNameLabel, label.GetValidName(tc.dataUpload.Spec.SourceNamespace+"."+tc.dataUpload.Spec.SourcePVC)),
+				var cmList corev1.ConfigMapList
+				err := fakeClient.List(context.Background(), &cmList, &client.ListOptions{
+					LabelSelector: labels.SelectorFromSet(map[string]string{
+						velerov1.RestoreUIDLabel:       "testingUID",
+						velerov1.PVCNamespaceNameLabel: label.GetValidName(tc.dataUpload.Spec.SourceNamespace + "." + tc.dataUpload.Spec.SourcePVC),
+					}),
 				})
+
 				require.NoError(t, err)
 				// debug
 				fmt.Printf("CM: %s\n", &cmList.Items[0])
-				require.Equal(t, *tc.expectedDataUploadResult, cmList.Items[0])
+				require.Equal(t, tc.expectedDataUploadResult.Labels, cmList.Items[0].Labels)
+				require.Equal(t, tc.expectedDataUploadResult.Data, cmList.Items[0].Data)
 			}
 		})
 	}


### PR DESCRIPTION
This PR fixes two issues:
1. The PVB CR's `StorageLocation` is not reset to the latest one after backup sync, as a result, when deleting the PVB, the backup deletion controller cannot delete the repo snapshot from the correct backup storage location, so there will be data leak in the repo
2. During data mover restore, the DataUploadResult's `StorageLocation` is retrieved from the DataUpload CR, while the value in DataUpload CR is not up to date if the BSL's name has changed in the new cluster, as a result, the data mover restore will fail

As the fixes:

- For 1, reset PVB CR's `StorageLocation` to the latest one during backup sync
- For 2, retrieve DataUploadResult's `StorageLocation` from the latest backup CR whose `StorageLocation` has been reset during backup sync

Fix #6534 