### PR TITLE
[release-1.11] Fix issue 6534

### DIFF
--- a/changelogs/unreleased/6543-Lyndon-Li
+++ b/changelogs/unreleased/6543-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix issue #6534, reset PVB CR's StorageLocation to the latest one during backup sync as same as the backup CR

--- a/pkg/controller/backup_sync_controller.go
+++ b/pkg/controller/backup_sync_controller.go
@@ -209,6 +209,7 @@ func (b *backupSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 			podVolumeBackup.Namespace = backup.Namespace
 			podVolumeBackup.ResourceVersion = ""
+			podVolumeBackup.Spec.BackupStorageLocation = location.Name
 
 			err = b.client.Create(ctx, podVolumeBackup, &client.CreateOptions{})
 			switch {


### PR DESCRIPTION
Fix issue #6534, reset PVB CR's StorageLocation to the latest one during backup sync as same as the backup CR