### PR TITLE
Check if restore crd exist before operating restore

### DIFF
--- a/changelogs/unreleased/6544-allenxu404
+++ b/changelogs/unreleased/6544-allenxu404
@@ -1,0 +1,1 @@
+check if restore crd exist before operating restores

--- a/pkg/cmd/cli/uninstall/uninstall.go
+++ b/pkg/cmd/cli/uninstall/uninstall.go
@@ -212,7 +212,18 @@ func deleteNamespace(ctx context.Context, kbClient kbclient.Client, namespace st
 }
 
 func deleteResourcesWithFinalizer(ctx context.Context, kbClient kbclient.Client, namespace string) error {
-	// delete restores
+	//check if restore crd exists
+	v1crd := &apiextv1.CustomResourceDefinition{}
+	key := kbclient.ObjectKey{Name: "restores.velero.io"}
+	if err := kbClient.Get(ctx, key, v1crd); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		} else {
+			return err
+		}
+	}
+
+	// delete all the restores
 	restoreList := &velerov1api.RestoreList{}
 	if err := kbClient.List(ctx, restoreList, &kbclient.ListOptions{Namespace: namespace}); err != nil {
 		return err


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
check the existance of restore crd before operating restores.
# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
