### PR TITLE
Allow for using podman or docker based on what is installed

### DIFF
--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -52,7 +52,7 @@ jobs:
         if: steps.image-cache.outputs.cache-hit != 'true'
         run: |
           IMAGE=velero VERSION=pr-test make container
-          docker save velero:pr-test -o ./velero.tar
+          podman save velero:pr-test -o ./velero.tar
   # Run E2E test against all Kubernetes versions on kind
   run-e2e-test:
     needs: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,13 @@ WORKDIR /go/src/github.com/vmware-tanzu/velero
 
 COPY . /go/src/github.com/vmware-tanzu/velero
 
-RUN mkdir -p /output/usr/bin && \
-    export GOARM=$( echo "${GOARM}" | cut -c2-) && \
+# if TARGETVARIANT is v8, set GOARM to empty string
+RUN if [ "${TARGETVARIANT}" = "v8" ]; then \
+        export GOARM=""; \
+else \
+    export GOARM=$( echo "${GOARM}" | cut -c2-); \
+fi && \
+    mkdir -p /output/usr/bin && \
     go build -o /output/${BIN} \
     -ldflags "${LDFLAGS}" ${PKG}/cmd/${BIN}
 
@@ -52,7 +57,7 @@ ARG TARGETARCH
 ARG TARGETVARIANT
 ARG RESTIC_VERSION
 
-env CGO_ENABLED=0 \
+ENV CGO_ENABLED=0 \
     GO111MODULE=on \
     GOPROXY=${GOPROXY} \
     GOOS=${TARGETOS} \
@@ -61,8 +66,13 @@ env CGO_ENABLED=0 \
 
 COPY . /go/src/github.com/vmware-tanzu/velero
 
-RUN mkdir -p /output/usr/bin && \
-    export GOARM=$(echo "${GOARM}" | cut -c2-) && \
+# if TARGETVARIANT is v8, set GOARM to empty string
+RUN if [ "${TARGETVARIANT}" = "v8" ]; then \
+    export GOARM=""; \
+else \
+    export GOARM=$( echo "${GOARM}" | cut -c2-); \
+fi && \
+    mkdir -p /output/usr/bin && \
     /go/src/github.com/vmware-tanzu/velero/hack/build-restic.sh
 
 # Velero image packing section

--- a/changelogs/unreleased/6481-blackpiglet
+++ b/changelogs/unreleased/6481-blackpiglet
@@ -1,0 +1,1 @@
+Remove PVC's selector in backup's PVC action.

--- a/pkg/backup/backup_pv_action.go
+++ b/pkg/backup/backup_pv_action.go
@@ -72,6 +72,14 @@ func (a *PVCAction) Execute(item runtime.Unstructured, backup *v1.Backup) (runti
 		pvc.Spec.DataSourceRef = nil
 	}
 
+	// When StorageClassName is set to "", it means no StorageClass is specified,
+	// even the default StorageClass is not used. Only keep the Selector for this case.
+	// https://kubernetes.io/docs/concepts/storage/persistent-volumes/#reserving-a-persistentvolume
+	if pvc.Spec.StorageClassName == nil || *pvc.Spec.StorageClassName != "" {
+		// Clean the selector to make the PVC to dynamically allocate PV.
+		pvc.Spec.Selector = nil
+	}
+
 	// remove label selectors with "velero.io/" prefixing in the key which is left by Velero restore
 	if pvc.Spec.Selector != nil && pvc.Spec.Selector.MatchLabels != nil {
 		for k := range pvc.Spec.Selector.MatchLabels {

--- a/pkg/backup/backup_pv_action_test.go
+++ b/pkg/backup/backup_pv_action_test.go
@@ -21,10 +21,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	corev1api "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/builder"
 	"github.com/vmware-tanzu/velero/pkg/kuberesource"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	velerotest "github.com/vmware-tanzu/velero/pkg/test"
@@ -54,6 +58,61 @@ func TestBackupPVAction(t *testing.T) {
 	_, additional, err = a.Execute(pvc, backup)
 	assert.NoError(t, err)
 	assert.Len(t, additional, 0)
+
+	// Action should clean the spec.Selector when the StorageClassName is not set.
+	input := builder.ForPersistentVolumeClaim("abc", "abc").VolumeName("pv").Selector(&metav1.LabelSelector{MatchLabels: map[string]string{"abc": "abc"}}).Phase(corev1.ClaimBound).Result()
+	inputUnstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(input)
+	require.NoError(t, err)
+	item, additional, err := a.Execute(&unstructured.Unstructured{Object: inputUnstructured}, backup)
+	require.NoError(t, err)
+	require.Len(t, additional, 1)
+	modifiedPVC := new(corev1.PersistentVolumeClaim)
+	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(item.UnstructuredContent(), modifiedPVC))
+	require.Nil(t, modifiedPVC.Spec.Selector)
+
+	// Action should clean the spec.Selector when the StorageClassName is set to specific StorageClass
+	input2 := builder.ForPersistentVolumeClaim("abc", "abc").VolumeName("pv").StorageClass("sc1").Selector(&metav1.LabelSelector{MatchLabels: map[string]string{"abc": "abc"}}).Phase(corev1.ClaimBound).Result()
+	inputUnstructured2, err2 := runtime.DefaultUnstructuredConverter.ToUnstructured(input2)
+	require.NoError(t, err2)
+	item2, additional2, err2 := a.Execute(&unstructured.Unstructured{Object: inputUnstructured2}, backup)
+	require.NoError(t, err2)
+	require.Len(t, additional2, 1)
+	modifiedPVC2 := new(corev1.PersistentVolumeClaim)
+	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(item2.UnstructuredContent(), modifiedPVC2))
+	require.Nil(t, modifiedPVC2.Spec.Selector)
+
+	// Action should keep the spec.Selector when the StorageClassName is set to ""
+	input3 := builder.ForPersistentVolumeClaim("abc", "abc").StorageClass("").Selector(&metav1.LabelSelector{MatchLabels: map[string]string{"abc": "abc"}}).VolumeName("pv").Phase(corev1.ClaimBound).Result()
+	inputUnstructured3, err3 := runtime.DefaultUnstructuredConverter.ToUnstructured(input3)
+	require.NoError(t, err3)
+	item3, additional3, err3 := a.Execute(&unstructured.Unstructured{Object: inputUnstructured3}, backup)
+	require.NoError(t, err3)
+	require.Len(t, additional3, 1)
+	modifiedPVC3 := new(corev1.PersistentVolumeClaim)
+	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(item3.UnstructuredContent(), modifiedPVC3))
+	require.Equal(t, input3.Spec.Selector, modifiedPVC3.Spec.Selector)
+
+	// Action should delete label started with"velero.io/" from the spec.Selector when the StorageClassName is set to ""
+	input4 := builder.ForPersistentVolumeClaim("abc", "abc").StorageClass("").Selector(&metav1.LabelSelector{MatchLabels: map[string]string{"velero.io/abc": "abc", "abc": "abc"}}).VolumeName("pv").Phase(corev1.ClaimBound).Result()
+	inputUnstructured4, err4 := runtime.DefaultUnstructuredConverter.ToUnstructured(input4)
+	require.NoError(t, err4)
+	item4, additional4, err4 := a.Execute(&unstructured.Unstructured{Object: inputUnstructured4}, backup)
+	require.NoError(t, err4)
+	require.Len(t, additional4, 1)
+	modifiedPVC4 := new(corev1.PersistentVolumeClaim)
+	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(item4.UnstructuredContent(), modifiedPVC4))
+	require.Equal(t, &metav1.LabelSelector{MatchLabels: map[string]string{"abc": "abc"}}, modifiedPVC4.Spec.Selector)
+
+	// Action should clean the spec.Selector when the StorageClassName has value
+	input5 := builder.ForPersistentVolumeClaim("abc", "abc").StorageClass("sc1").Selector(&metav1.LabelSelector{MatchLabels: map[string]string{"velero.io/abc": "abc", "abc": "abc"}}).VolumeName("pv").Phase(corev1.ClaimBound).Result()
+	inputUnstructured5, err5 := runtime.DefaultUnstructuredConverter.ToUnstructured(input5)
+	require.NoError(t, err5)
+	item5, additional5, err5 := a.Execute(&unstructured.Unstructured{Object: inputUnstructured5}, backup)
+	require.NoError(t, err5)
+	require.Len(t, additional5, 1)
+	modifiedPVC5 := new(corev1.PersistentVolumeClaim)
+	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(item5.UnstructuredContent(), modifiedPVC5))
+	require.Nil(t, modifiedPVC5.Spec.Selector)
 
 	// non-empty spec.volumeName when status.phase is empty
 	// should result in no error and no additional items


### PR DESCRIPTION
* Adds ability for mac os builds. The GOARM is not used on linux and was not set, Adding 7 as that is what is required by Darwin.

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

/kind changelog-not-required

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
