### PR TITLE
GetS3Credentials pass profile from config to NewSharedCredentials

### DIFF
--- a/changelogs/unreleased/6558-kaovilai
+++ b/changelogs/unreleased/6558-kaovilai
@@ -1,0 +1,1 @@
+Non default s3 credential profiles work on Unified Repository Provider (kopia)

--- a/pkg/repository/config/aws.go
+++ b/pkg/repository/config/aws.go
@@ -70,7 +70,7 @@ func GetS3Credentials(config map[string]string) (*credentials.Value, error) {
 		return nil, errors.New("missing credential file")
 	}
 
-	creds := credentials.NewSharedCredentials(credentialsFile, "")
+	creds := credentials.NewSharedCredentials(credentialsFile, config[awsProfileKey])
 	credValue, err := creds.Get()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Non default s3 credential profiles work on Unified Repository Provider (kopia)
[GetS3Credentials pass profile from config to NewSharedCredentials](https://github.com/vmware-tanzu/velero/pull/6558/commits/5fdf334c30403811e5e9a7577cfb04dff8b3e689)

# Does your change fix a particular issue?

Fixes #6557 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
