### PR TITLE
Update .dockerignore so build caches are hit more often.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,9 @@
 .go/
 .go.std/
 site/
+.github/
+_output/
+changelogs/
+*.md
+Dockerfile
+hack/build-image/Dockerfile


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Update .dockerignore so build caches are hit more often.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
