### PR TITLE
GetS3Credentials pass profile from config to NewSharedCredentials

### DIFF
--- a/changelogs/unreleased/6565-kaovilai
+++ b/changelogs/unreleased/6565-kaovilai
@@ -1,0 +1,1 @@
+Non default s3 credential profiles work on Unified Repository Provider (kopia)

--- a/pkg/repository/config/aws.go
+++ b/pkg/repository/config/aws.go
@@ -64,7 +64,7 @@ func GetS3Credentials(config map[string]string) (credentials.Value, error) {
 		return credentials.Value{}, errors.New("missing credential file")
 	}
 
-	creds := credentials.NewSharedCredentials(credentialsFile, "")
+	creds := credentials.NewSharedCredentials(credentialsFile, config[awsProfileKey])
 	credValue, err := creds.Get()
 	if err != nil {
 		return credValue, err


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
