### PR TITLE
[1.11] Fix issue 6571

### DIFF
--- a/changelogs/unreleased/6597-Lyndon-Li
+++ b/changelogs/unreleased/6597-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix issue #6571, fix the problem for restore item operation to set the errors correctly so that they can be recorded by Velero restore and then reflect the correct status for Velero restore.

--- a/pkg/controller/restore_controller.go
+++ b/pkg/controller/restore_controller.go
@@ -477,8 +477,8 @@ func (r *restoreReconciler) runValidatedRestore(restore *api.Restore, info backu
 	// Completed yet.
 	inProgressOperations, _, opsCompleted, opsFailed, errs := getRestoreItemOperationProgress(restoreReq.Restore, pluginManager, *restoreReq.GetItemOperationsList())
 	if len(errs) > 0 {
-		for err := range errs {
-			restoreLog.Error(err)
+		for _, err := range errs {
+			restoreErrors.Velero = append(restoreErrors.Velero, fmt.Sprintf("error from restore item operation: %v", err))
 		}
 	}
 


### PR DESCRIPTION
Fix issue #6571, fix the problem for restore item operation to set the errors correctly so that they can be recorded by Velero restore and then reflect the correct status for Velero restore.