### PR TITLE
Feature/add provider interface for block mode

### DIFF
--- a/changelogs/unreleased/6608-shawn-hurley
+++ b/changelogs/unreleased/6608-shawn-hurley
@@ -1,0 +1,1 @@
+Add API support for volMode block, only error for now.

--- a/pkg/datapath/file_system_test.go
+++ b/pkg/datapath/file_system_test.go
@@ -95,7 +95,7 @@ func TestAsyncBackup(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			fs := newFileSystemBR("job-1", "test", nil, "velero", Callbacks{}, velerotest.NewLogger()).(*fileSystemBR)
 			mockProvider := providerMock.NewProvider(t)
-			mockProvider.On("RunBackup", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(test.result.Backup.SnapshotID, test.result.Backup.EmptySnapshot, test.err)
+			mockProvider.On("RunBackup", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(test.result.Backup.SnapshotID, test.result.Backup.EmptySnapshot, test.err)
 			fs.uploaderProv = mockProvider
 			fs.initialized = true
 			fs.callbacks = test.callbacks
@@ -178,7 +178,7 @@ func TestAsyncRestore(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			fs := newFileSystemBR("job-1", "test", nil, "velero", Callbacks{}, velerotest.NewLogger()).(*fileSystemBR)
 			mockProvider := providerMock.NewProvider(t)
-			mockProvider.On("RunRestore", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(test.err)
+			mockProvider.On("RunRestore", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(test.err)
 			fs.uploaderProv = mockProvider
 			fs.initialized = true
 			fs.callbacks = test.callbacks

--- a/pkg/datapath/types.go
+++ b/pkg/datapath/types.go
@@ -52,7 +52,8 @@ type Callbacks struct {
 
 // AccessPoint represents an access point that has been exposed to a data path instance
 type AccessPoint struct {
-	ByPath string
+	ByPath  string
+	ByBlock string
 }
 
 // AsyncBR is the interface for asynchronous data path methods

--- a/pkg/uploader/kopia/snapshot.go
+++ b/pkg/uploader/kopia/snapshot.go
@@ -88,10 +88,15 @@ func setupDefaultPolicy() *policy.Tree {
 
 // Backup backup specific sourcePath and update progress
 func Backup(ctx context.Context, fsUploader SnapshotUploader, repoWriter repo.RepositoryWriter, sourcePath string, realSource string,
-	forceFull bool, parentSnapshot string, tags map[string]string, log logrus.FieldLogger) (*uploader.SnapshotInfo, bool, error) {
+	forceFull bool, parentSnapshot string, volMode uploader.PersistentVolumeMode, tags map[string]string, log logrus.FieldLogger) (*uploader.SnapshotInfo, bool, error) {
 	if fsUploader == nil {
 		return nil, false, errors.New("get empty kopia uploader")
 	}
+
+	if volMode == uploader.PersistentVolumeBlock {
+		return nil, false, errors.New("unable to handle block storage")
+	}
+
 	dir, err := filepath.Abs(sourcePath)
 	if err != nil {
 		return nil, false, errors.Wrapf(err, "Invalid source path '%s'", sourcePath)

--- a/pkg/uploader/provider/mocks/Provider.go
+++ b/pkg/uploader/provider/mocks/Provider.go
@@ -30,8 +30,8 @@ func (_m *Provider) Close(ctx context.Context) error {
 }
 
 // RunBackup provides a mock function with given fields: ctx, path, realSource, tags, forceFull, parentSnapshot, updater
-func (_m *Provider) RunBackup(ctx context.Context, path string, realSource string, tags map[string]string, forceFull bool, parentSnapshot string, updater uploader.ProgressUpdater) (string, bool, error) {
-	ret := _m.Called(ctx, path, realSource, tags, forceFull, parentSnapshot, updater)
+func (_m *Provider) RunBackup(ctx context.Context, path string, realSource string, tags map[string]string, forceFull bool, parentSnapshot string, volMode uploader.PersistentVolumeMode, updater uploader.ProgressUpdater) (string, bool, error) {
+	ret := _m.Called(ctx, path, realSource, tags, forceFull, parentSnapshot, volMode, updater)
 
 	var r0 string
 	var r1 bool
@@ -61,8 +61,8 @@ func (_m *Provider) RunBackup(ctx context.Context, path string, realSource strin
 }
 
 // RunRestore provides a mock function with given fields: ctx, snapshotID, volumePath, updater
-func (_m *Provider) RunRestore(ctx context.Context, snapshotID string, volumePath string, updater uploader.ProgressUpdater) error {
-	ret := _m.Called(ctx, snapshotID, volumePath, updater)
+func (_m *Provider) RunRestore(ctx context.Context, snapshotID string, volumePath string, volMode uploader.PersistentVolumeMode, updater uploader.ProgressUpdater) error {
+	ret := _m.Called(ctx, snapshotID, volumePath, volMode, updater)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, string, uploader.ProgressUpdater) error); ok {

--- a/pkg/uploader/provider/provider.go
+++ b/pkg/uploader/provider/provider.go
@@ -48,6 +48,7 @@ type Provider interface {
 		tags map[string]string,
 		forceFull bool,
 		parentSnapshot string,
+		volMode uploader.PersistentVolumeMode,
 		updater uploader.ProgressUpdater) (string, bool, error)
 	// RunRestore which will do restore for one specific volume with given snapshot id and return error
 	// updater is used for updating backup progress which implement by third-party
@@ -55,6 +56,7 @@ type Provider interface {
 		ctx context.Context,
 		snapshotID string,
 		volumePath string,
+		volMode uploader.PersistentVolumeMode,
 		updater uploader.ProgressUpdater) error
 	// Close which will close related repository
 	Close(ctx context.Context) error

--- a/pkg/uploader/provider/restic.go
+++ b/pkg/uploader/provider/restic.go
@@ -121,6 +121,7 @@ func (rp *resticProvider) RunBackup(
 	tags map[string]string,
 	forceFull bool,
 	parentSnapshot string,
+	volMode uploader.PersistentVolumeMode,
 	updater uploader.ProgressUpdater) (string, bool, error) {
 	if updater == nil {
 		return "", false, errors.New("Need to initial backup progress updater first")
@@ -132,6 +133,10 @@ func (rp *resticProvider) RunBackup(
 
 	if realSource != "" {
 		return "", false, errors.New("real source is not empty, this is not supported by restic uploader")
+	}
+
+	if volMode == uploader.PersistentVolumeBlock {
+		return "", false, errors.New("unable to support block mode")
 	}
 
 	log := rp.log.WithFields(logrus.Fields{
@@ -179,6 +184,7 @@ func (rp *resticProvider) RunRestore(
 	ctx context.Context,
 	snapshotID string,
 	volumePath string,
+	volMode uploader.PersistentVolumeMode,
 	updater uploader.ProgressUpdater) error {
 	if updater == nil {
 		return errors.New("Need to initial backup progress updater first")
@@ -187,6 +193,10 @@ func (rp *resticProvider) RunRestore(
 		"snapshotID": snapshotID,
 		"volumePath": volumePath,
 	})
+
+	if volMode == uploader.PersistentVolumeBlock {
+		return errors.New("unable to support block mode")
+	}
 
 	restoreCmd := resticRestoreCMDFunc(rp.repoIdentifier, rp.credentialsFile, snapshotID, volumePath)
 	restoreCmd.Env = rp.cmdEnv

--- a/pkg/uploader/types.go
+++ b/pkg/uploader/types.go
@@ -28,6 +28,15 @@ const (
 	SnapshotUploaderTag  = "snapshot-uploader"
 )
 
+type PersistentVolumeMode string
+
+const (
+	// PersistentVolumeBlock means the volume will not be formatted with a filesystem and will remain a raw block device.
+	PersistentVolumeBlock PersistentVolumeMode = "Block"
+	// PersistentVolumeFilesystem means the volume will be or is formatted with a filesystem.
+	PersistentVolumeFilesystem PersistentVolumeMode = "Filesystem"
+)
+
 // ValidateUploaderType validates if the input param is a valid uploader type.
 // It will return an error if it's invalid.
 func ValidateUploaderType(t string) error {


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Adding the block mode to the interfaces, to be included in 1.12.

This will allow us to solve the issue of block support in a Z-stream without breaking the API's in a Z-stream. 

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
