### PR TITLE
Data mover fail earlier for snapshot creation error

### DIFF
--- a/pkg/util/stringptr/stringptr.go
+++ b/pkg/util/stringptr/stringptr.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2017 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stringptr
+
+const NilString = "<nil>"
+
+func GetString(str *string) string {
+	if str == nil {
+		return NilString
+	} else {
+		return *str
+	}
+}


### PR DESCRIPTION
Fix issue #6620, check the status of VS/VSC so that when errors are filled into VS/VSC, data mover could fail earlier