### PR TITLE
Continue wait on csi snapshot error

### DIFF
--- a/pkg/exposer/csi_snapshot.go
+++ b/pkg/exposer/csi_snapshot.go
@@ -94,7 +94,7 @@ func (e *csiSnapshotExposer) Expose(ctx context.Context, ownerObject corev1.Obje
 
 	curLog.Info("Exposing CSI snapshot")
 
-	volumeSnapshot, err := csi.WaitVolumeSnapshotReady(ctx, e.csiSnapshotClient, csiExposeParam.SnapshotName, csiExposeParam.SourceNamespace, csiExposeParam.Timeout)
+	volumeSnapshot, err := csi.WaitVolumeSnapshotReady(ctx, e.csiSnapshotClient, csiExposeParam.SnapshotName, csiExposeParam.SourceNamespace, csiExposeParam.Timeout, curLog)
 	if err != nil {
 		return errors.Wrapf(err, "error wait volume snapshot ready")
 	}

--- a/pkg/util/csi/volume_snapshot_test.go
+++ b/pkg/util/csi/volume_snapshot_test.go
@@ -84,7 +84,7 @@ func TestWaitVolumeSnapshotReady(t *testing.T) {
 					},
 				},
 			},
-			err: "timed out waiting for the condition",
+			err: "volume snapshot is not ready until timeout, errors: []",
 		},
 		{
 			name:      "vsc is nil in status",
@@ -99,7 +99,7 @@ func TestWaitVolumeSnapshotReady(t *testing.T) {
 					Status: &snapshotv1api.VolumeSnapshotStatus{},
 				},
 			},
-			err: "timed out waiting for the condition",
+			err: "volume snapshot is not ready until timeout, errors: []",
 		},
 		{
 			name:      "ready to use is nil in status",
@@ -116,7 +116,7 @@ func TestWaitVolumeSnapshotReady(t *testing.T) {
 					},
 				},
 			},
-			err: "timed out waiting for the condition",
+			err: "volume snapshot is not ready until timeout, errors: []",
 		},
 		{
 			name:      "ready to use is false",
@@ -134,7 +134,7 @@ func TestWaitVolumeSnapshotReady(t *testing.T) {
 					},
 				},
 			},
-			err: "timed out waiting for the condition",
+			err: "volume snapshot is not ready until timeout, errors: []",
 		},
 		{
 			name:      "snapshot creation error with message",
@@ -153,7 +153,7 @@ func TestWaitVolumeSnapshotReady(t *testing.T) {
 					},
 				},
 			},
-			err: "volume snapshot creation error fake-snapshot-creation-error",
+			err: "volume snapshot is not ready until timeout, errors: [fake-snapshot-creation-error]",
 		},
 		{
 			name:      "snapshot creation error without message",
@@ -170,7 +170,7 @@ func TestWaitVolumeSnapshotReady(t *testing.T) {
 					},
 				},
 			},
-			err: "volume snapshot creation error " + stringptr.NilString,
+			err: "volume snapshot is not ready until timeout, errors: [" + stringptr.NilString + "]",
 		},
 		{
 			name:      "success",
@@ -187,7 +187,7 @@ func TestWaitVolumeSnapshotReady(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			fakeSnapshotClient := snapshotFake.NewSimpleClientset(test.clientObj...)
 
-			vs, err := WaitVolumeSnapshotReady(context.Background(), fakeSnapshotClient.SnapshotV1(), test.vsName, test.namespace, time.Millisecond)
+			vs, err := WaitVolumeSnapshotReady(context.Background(), fakeSnapshotClient.SnapshotV1(), test.vsName, test.namespace, time.Millisecond, velerotest.NewLogger())
 			if err != nil {
 				assert.EqualError(t, err, test.err)
 			} else {


### PR DESCRIPTION
The errors filled into `VolumeSnapshot.VolumeSnapshotStatus.VolumeSnapshotError` may be interim and retry-able, we cannot fail immediately when seeing these errors. So need to change to code to monitor the errors only and then report them when the VS/VSC doesn't reach `readyToUse` finally