### PR TITLE
Get resource client again after restore actions in case resource's gv is changed

### DIFF
--- a/changelogs/unreleased/6634-27149chen
+++ b/changelogs/unreleased/6634-27149chen
@@ -1,0 +1,1 @@
+Fixes #6498. Get resource client again after restore actions in case resource's gv is changed. This is an improvement of pr #6499, to support group changes. A group change usually happens in a restore plugin which is used for resource conversion: convert a resource from a not supported gv to a supported gv

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1368,7 +1368,8 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 
 	// The object apiVersion might get modified by a RestorePlugin so we need to
 	// get a new client to reflect updated resource path.
-	resourceClient, err = ctx.getResourceClient(groupResource, obj, namespace)
+	newGR := schema.GroupResource{Group: obj.GroupVersionKind().Group, Resource: groupResource.Resource}
+	resourceClient, err = ctx.getResourceClient(newGR, obj, obj.GetNamespace())
 	if err != nil {
 		errs.AddVeleroError(fmt.Errorf("error getting updated resource client for namespace %q, resource %q: %v", namespace, &groupResource, err))
 		return warnings, errs, itemExists


### PR DESCRIPTION
# Please add a summary of your change
Get resource client again after restore actions in case resource's gv is changed.

This is an improvement of pr #6499, to support group changes. A group change usually happens in a restore plugin which is used for resource conversion: convert a resource from a not supported gv to a supported gv

# Does your change fix a particular issue?

Fixes #6498 

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
