### PR TITLE
skip subresource in resource discovery

### DIFF
--- a/changelogs/unreleased/6635-27149chen
+++ b/changelogs/unreleased/6635-27149chen
@@ -1,0 +1,1 @@
+Fixes #6636, skip subresource in resource discovery


### PR DESCRIPTION
# Please add a summary of your change

skip subresource in resource discovery

# Does your change fix a particular issue?

Fixes #6636

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
