### PR TITLE
restore ingresses after services

### DIFF
--- a/changelogs/unreleased/6639-27149chen
+++ b/changelogs/unreleased/6639-27149chen
@@ -1,0 +1,1 @@
+Restore ingresses after services to avoid ingress webhook failure caused by validation that if corresponding service exists

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -531,6 +531,7 @@ High priorities:
   - Endpoints go before Services so no new Endpoints will be created
   - Services go before Clusters so they can be adopted by AKO-operator and no new Services will be created
     for the same clusters
+  - Ingresses go after Services to avoid ingress webhook failure caused by validation that if corresponding service exists
 
 Low priorities:
   - Tanzu ClusterBootstraps go last as it can reference any other kind of resources.
@@ -563,6 +564,8 @@ var defaultRestorePriorities = restore.Priorities{
 		"clusterclasses.cluster.x-k8s.io",
 		"endpoints",
 		"services",
+		"ingresses.extensions",
+		"ingresses.networking.k8s.io",
 	},
 	LowPriorities: []string{
 		"clusterbootstraps.run.tanzu.vmware.com",


### PR DESCRIPTION
# Please add a summary of your change

restore ingresses after services to avoid ingress webhook failure caused by validation that if corresponding service exists

# Does your change fix a particular issue?

N/A

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
