### PR TITLE
Delete PartiallyFailed orphaned backups as well as Completed ones

### DIFF
--- a/changelogs/unreleased/6649-sseago
+++ b/changelogs/unreleased/6649-sseago
@@ -1,1 +1,1 @@
-Deal with PartiallyFailed orphaned backups as well as Completed ones
+Delete PartiallyFailed orphaned backups as well as Completed ones

--- a/changelogs/unreleased/6649-sseago
+++ b/changelogs/unreleased/6649-sseago
@@ -1,0 +1,1 @@
+Deal with PartiallyFailed orphaned backups as well as Completed ones

--- a/pkg/controller/backup_sync_controller.go
+++ b/pkg/controller/backup_sync_controller.go
@@ -331,7 +331,7 @@ func (b *backupSyncReconciler) deleteOrphanedBackups(ctx context.Context, locati
 
 	for i, backup := range backupList.Items {
 		log = log.WithField("backup", backup.Name)
-		if backup.Status.Phase != velerov1api.BackupPhaseCompleted || backupStoreBackups.Has(backup.Name) {
+		if !(backup.Status.Phase == velerov1api.BackupPhaseCompleted || backup.Status.Phase == velerov1api.BackupPhasePartiallyFailed) || backupStoreBackups.Has(backup.Name) {
 			continue
 		}
 


### PR DESCRIPTION
Fixes https://github.com/vmware-tanzu/velero/issues/6648

Thank you for contributing to Velero!

When cleaning up orphaned backups, include PartiallyFailed with Completed, since they are treated equivalently by the rest of backup sync.

# Does your change fix a particular issue?

Fixes #6648

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
