### PR TITLE
fix backup_controller when credentials to volume snapshot location sh…

### DIFF
--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -590,6 +590,10 @@ func (b *backupReconciler) validateAndGetSnapshotLocations(backup *velerov1api.B
 		}
 	}
 
+	if len(errors) > 0 {
+		return nil, errors
+	}
+
 	return providerLocations, nil
 }
 


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

```
for _, location := range providerLocations {
		err = volume.UpdateVolumeSnapshotLocationWithCredentialConfig(location, b.credentialFileStore)
		if err != nil {
			errors = append(errors, fmt.Sprintf("error adding credentials to volume snapshot location named %s: %v", location.Name, err))
			continue
		}
	}
```
when errors is not nil , should return it .


# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
