### PR TITLE
Fix issue 6662

### DIFF
--- a/pkg/cmd/util/output/backup_describer.go
+++ b/pkg/cmd/util/output/backup_describer.go
@@ -206,7 +206,7 @@ func DescribeBackupSpec(d *Describer, spec velerov1api.BackupSpec) {
 	d.Printf("Velero-Native Snapshot PVs:\t%s\n", BoolPointerString(spec.SnapshotVolumes, "false", "true", "auto"))
 	d.Printf("Snapshot Move Data:\t%s\n", BoolPointerString(spec.SnapshotMoveData, "false", "true", "auto"))
 	if len(spec.DataMover) == 0 {
-		s = emptyDisplay
+		s = defaultDataMover
 	} else {
 		s = spec.DataMover
 	}

--- a/pkg/cmd/util/output/backup_describer_test.go
+++ b/pkg/cmd/util/output/backup_describer_test.go
@@ -212,7 +212,7 @@ Storage Location:  backup-location
 
 Velero-Native Snapshot PVs:  auto
 Snapshot Move Data:          auto
-Data Mover:                  <none>
+Data Mover:                  velero
 
 TTL:  0s
 

--- a/pkg/cmd/util/output/output.go
+++ b/pkg/cmd/util/output/output.go
@@ -37,6 +37,7 @@ import (
 const (
 	downloadRequestTimeout = 30 * time.Second
 	emptyDisplay           = "<none>"
+	defaultDataMover       = "velero"
 )
 
 // BindFlags defines a set of output-specific flags within the provided

--- a/pkg/cmd/util/output/schedule_describe_test.go
+++ b/pkg/cmd/util/output/schedule_describe_test.go
@@ -42,7 +42,7 @@ Backup Template:
   
   Velero-Native Snapshot PVs:  auto
   Snapshot Move Data:          auto
-  Data Mover:                  <none>
+  Data Mover:                  velero
   
   TTL:  0s
   
@@ -86,7 +86,7 @@ Backup Template:
   
   Velero-Native Snapshot PVs:  auto
   Snapshot Move Data:          auto
-  Data Mover:                  <none>
+  Data Mover:                  velero
   
   TTL:  0s
   


### PR DESCRIPTION
Fix issue #6662, if the `dataMover` filed in `Backup` CR is empty, show it as `velero` for `velero backup describe`. As the design, the empty value equals to `velero` both of which indicate VBDM is used