### PR TITLE
[CP -1.12] skip subresource in resource discovery

### DIFF
--- a/changelogs/unreleased/6688-27149chen
+++ b/changelogs/unreleased/6688-27149chen
@@ -1,0 +1,1 @@
+Fixes #6636, skip subresource in resource discovery


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
