### PR TITLE
Add restic resource config for file excludes

### DIFF
--- a/pkg/controller/pod_volume_backup_controller.go
+++ b/pkg/controller/pod_volume_backup_controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/velero/internal/credentials"
+	"github.com/vmware-tanzu/velero/internal/resourcepolicies"
 	veleroapishared "github.com/vmware-tanzu/velero/pkg/apis/velero/shared"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/datapath"
@@ -41,6 +43,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/podvolume"
 	"github.com/vmware-tanzu/velero/pkg/repository"
 	"github.com/vmware-tanzu/velero/pkg/uploader"
+	"github.com/vmware-tanzu/velero/pkg/uploader/provider"
 	"github.com/vmware-tanzu/velero/pkg/util/filesystem"
 )
 
@@ -161,6 +164,41 @@ func (r *PodVolumeBackupReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if err := fsBackup.Init(ctx, pvb.Spec.BackupStorageLocation, pvb.Spec.Pod.Namespace, pvb.Spec.UploaderType,
 		podvolume.GetPvbRepositoryType(&pvb), pvb.Spec.RepoIdentifier, r.repositoryEnsurer, r.credentialGetter); err != nil {
 		return r.errorOut(ctx, &pvb, err, "error to initialize data path", log)
+	}
+
+	if b, yes := fsBackup.(provider.HasUploadProvider); yes {
+		prov := b.GetUploadProvider()
+		if prov != nil {
+			// get resource policy name
+			backup := &velerov1api.Backup{}
+			for _, ref := range pvb.OwnerReferences {
+				if ref.Kind == "Backup" {
+					err = r.Client.Get(context.Background(), client.ObjectKey{Namespace: req.Namespace, Name: ref.Name}, backup)
+					if err != nil {
+						log.Errorf("failed to get backup: %sw", err)
+					}
+					break
+				}
+			}
+			// load resource policy and pass it to the upload provider
+			if backup.Spec.ResourcePolicy != nil {
+				resPolicyName := backup.Spec.ResourcePolicy.Name
+				policiesConfigmap := &v1.ConfigMap{}
+				err = r.Client.Get(context.Background(), client.ObjectKey{Namespace: req.Namespace, Name: resPolicyName}, policiesConfigmap)
+				if err != nil {
+					log.Errorf("failed to get resource policies %s/%s configmap with err %v", req.Namespace, resPolicyName, err)
+				}
+				res, err := resourcepolicies.GetResourcePoliciesFromConfig(policiesConfigmap)
+				if err != nil {
+					log.Errorf("resource policies %s/%s: %s", req.Namespace, resPolicyName, err)
+				} else if err = res.Validate(); err != nil {
+					log.Errorf("resource policies %s/%s: %s", req.Namespace, resPolicyName, err)
+				} else {
+					prov.SetPolicy(res)
+				}
+			}
+
+		}
 	}
 
 	// If this is a PVC, look for the most recent completed pod volume backup for it and get

--- a/pkg/datapath/file_system.go
+++ b/pkg/datapath/file_system.go
@@ -61,6 +61,10 @@ func newFileSystemBR(jobName string, requestorType string, client client.Client,
 	return fs
 }
 
+func (fs *fileSystemBR) GetUploadProvider() provider.Provider {
+	return fs.uploaderProv
+}
+
 func (fs *fileSystemBR) Init(ctx context.Context, bslName string, sourceNamespace string, uploaderType string, repositoryType string,
 	repoIdentifier string, repositoryEnsurer *repository.Ensurer, credentialGetter *credentials.CredentialGetter) error {
 	var err error

--- a/pkg/podvolume/backupper.go
+++ b/pkg/podvolume/backupper.go
@@ -284,6 +284,7 @@ func (b *backupper) BackupPodVolumes(backup *velerov1api.Backup, pod *corev1api.
 		}
 
 		volumeBackup := newPodVolumeBackup(backup, pod, volume, repo.Spec.ResticIdentifier, b.uploaderType, pvc)
+
 		if _, err = b.veleroClient.VeleroV1().PodVolumeBackups(volumeBackup.Namespace).Create(context.TODO(), volumeBackup, metav1.CreateOptions{}); err != nil {
 			errs = append(errs, err)
 			continue

--- a/pkg/uploader/provider/kopia.go
+++ b/pkg/uploader/provider/kopia.go
@@ -30,6 +30,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/uploader/kopia"
 
 	"github.com/vmware-tanzu/velero/internal/credentials"
+	"github.com/vmware-tanzu/velero/internal/resourcepolicies"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	repokeys "github.com/vmware-tanzu/velero/pkg/repository/keys"
 	"github.com/vmware-tanzu/velero/pkg/repository/udmrepo"
@@ -82,6 +83,11 @@ func NewKopiaUploaderProvider(
 		return nil, errors.Wrapf(err, "Failed to find kopia repository")
 	}
 	return kp, nil
+}
+
+func (kp *kopiaProvider) SetPolicy(*resourcepolicies.Policies) error {
+	// TODO implement
+	return nil
 }
 
 // CheckContext check context status check if context is timeout or cancel and backup restore once finished it will quit and return

--- a/pkg/uploader/provider/provider.go
+++ b/pkg/uploader/provider/provider.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/velero/internal/credentials"
+	"github.com/vmware-tanzu/velero/internal/resourcepolicies"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/uploader"
 )
@@ -36,6 +37,10 @@ const restoreProgressCheckInterval = 10 * time.Second
 const backupProgressCheckInterval = 10 * time.Second
 
 var ErrorCanceled error = errors.New("uploader is canceled")
+
+type HasUploadProvider interface {
+	GetUploadProvider() Provider
+}
 
 // Provider which is designed for one pod volume to do the backup or restore
 type Provider interface {
@@ -60,6 +65,8 @@ type Provider interface {
 		updater uploader.ProgressUpdater) error
 	// Close which will close related repository
 	Close(ctx context.Context) error
+	// SetPolicy applies additional provider specific configuration from a resource policy (confimap)
+	SetPolicy(*resourcepolicies.Policies) error
 }
 
 // NewUploaderProvider initialize provider with specific uploaderType

--- a/site/content/docs/main/file-system-backup.md
+++ b/site/content/docs/main/file-system-backup.md
@@ -489,6 +489,8 @@ Velero integrate Restic binary directly, so the operations are done by calling R
 - Run `restic backup` commands to backup pod volume data
 - Run `restic restore` commands to restore pod volume data
 
+For restic customization see [resource filtering - restic configuration](resource-filtering.md#restic-configuration)
+
 ### How Velero integrates with Kopia
 Velero integrate Kopia modules into Velero's code, primarily two modules:
 - Kopia Uploader: Velero makes some wrap and isolation around it to create a generic file system uploader, 

--- a/site/content/docs/main/resource-filtering.md
+++ b/site/content/docs/main/resource-filtering.md
@@ -138,6 +138,8 @@ Exclude specific resources from the backup.
 
 Wildcard excludes are ignored.
 
+For restic file excludes see [restic file excludes](#restic-file-excludes)
+
 ### --exclude-namespaces
 
 Namespaces to exclude.
@@ -321,3 +323,20 @@ Velero supported conditions and format listed below:
 **Resource policies rules**
 - Velero already has lots of include or exclude filters. the resource policies are the final filters after others include or exclude filters in one backup processing workflow. So if use a defined similar filter like the opt-in approach to backup one pod volume but skip backup of the same pod volume in resource policies, as resource policies are the final filters that are applied, the volume will not be backed up.
 - If volume resource policies conflict with themselves the first matched policy will be respected when many policies are defined.
+
+### Restic configuration
+
+#### Restic file excludes
+
+See also https://restic.readthedocs.io/en/latest/040_backup.html#excluding-files
+
+```yaml
+version: v1
+resticPolicies:
+  - resticConfig:
+      excludes:
+        - /git/gitea-repositories/mirrors/**
+        - /indexers/**
+```
+
+NOTE: Currently only the first resticConfig is used and the excludes will apply to all persistent volumes.


### PR DESCRIPTION
Add a ResticConfig object that can be used to define restic specific options (e.g excludes) within a resource policy configmap.

The implementation is a bit limited because it only allows the definition of single ResticConfig within  a resource policy configmap
which is used for all volumes that are backed up by the `restic`.

Please see the updated documentation for a simple example.

# Does your change fix a particular issue?

Fixes #4129

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
