### PR TITLE
restic: do not log exit code when snapshot is empty

### DIFF
--- a/pkg/restic/exec_commands.go
+++ b/pkg/restic/exec_commands.go
@@ -86,7 +86,6 @@ func RunBackup(backupCmd *Command, log logrus.FieldLogger, updater uploader.Prog
 
 	err := cmd.Start()
 	if err != nil {
-		exec.LogErrorAsExitCode(err, log)
 		return stdoutBuf.String(), stderrBuf.String(), err
 	}
 
@@ -120,7 +119,6 @@ func RunBackup(backupCmd *Command, log logrus.FieldLogger, updater uploader.Prog
 
 	err = cmd.Wait()
 	if err != nil {
-		exec.LogErrorAsExitCode(err, log)
 		return stdoutBuf.String(), stderrBuf.String(), err
 	}
 	quit <- struct{}{}

--- a/pkg/uploader/provider/restic.go
+++ b/pkg/uploader/provider/restic.go
@@ -30,6 +30,7 @@ import (
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/restic"
 	"github.com/vmware-tanzu/velero/pkg/uploader"
+	"github.com/vmware-tanzu/velero/pkg/util/exec"
 	"github.com/vmware-tanzu/velero/pkg/util/filesystem"
 )
 
@@ -161,6 +162,7 @@ func (rp *resticProvider) RunBackup(
 			log.Debugf("Restic backup got empty dir with %s path", path)
 			return "", true, nil
 		}
+		exec.LogErrorAsExitCode(err, log)
 		return "", false, errors.WithStack(fmt.Errorf("error running restic backup command %s with error: %v stderr: %v", backupCmd.String(), err, stderrBuf))
 	}
 	// GetSnapshotID


### PR DESCRIPTION
Restic exit's with exit code 1 when the target directory is empty. This is not an error condition and the exit code
should not be logged in this case.

# Please add a summary of your change

It really confused me to see the following error in the output when updating to [v1.12.0-rc.1](https://github.com/vmware-tanzu/velero/releases/tag/v1.12.0-rc.1)

```
time="2023-08-24T17:12:28Z" level=error msg="Restic command fail with ExitCode: 1. Process ID is 26, Exit error is: exit status 1" backup=velero2/gitea-backup-6 controller=podvolumebackup logSource="pkg/util/exec/exec.go:66" parentSnapshot= path="/host_pods/4d7c854f-9d1e-4ff0-a594-26ca68d3d2df/volumes/kubernetes.io~empty-dir/tmp" podvolumebackup=velero2/gitea-backup-6-5wnhb
time="2023-08-24T17:12:28Z" level=debug msg="Restic backup got empty dir with /host_pods/4d7c854f-9d1e-4ff0-a594-26ca68d3d2df/volumes/kubernetes.io~empty-dir/tmp path" backup=velero2/gitea-backup-6 controller=podvolumebackup logSource=
```
Please note that the second log line is only shown when debug logging is enabled.
The change in logging was introduced with https://github.com/vmware-tanzu/velero/pull/6459

# Does your change fix a particular issue?

No because I did not create one.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
