### PR TITLE
add label selector in Resource Modifiers 

### DIFF
--- a/changelogs/unreleased/6704-27149chen
+++ b/changelogs/unreleased/6704-27149chen
@@ -1,0 +1,3 @@
+This pr made some improvements in Resource Modifiers:
+1. add label selector
+2. change the field name from groupKind to groupResource

--- a/design/Implemented/json-substitution-action-design.md
+++ b/design/Implemented/json-substitution-action-design.md
@@ -26,7 +26,7 @@ Currently velero supports substituting certain values in the K8s resources durin
 <!-- ## Background -->
 
 ## Goals
-- Allow the user to specify a GroupKind, Name(optional), JSON patch for modification.
+- Allow the user to specify a GroupResource, Name(optional), JSON patch for modification.
 - Allow the user to specify multiple JSON patch.
 
 ## Non Goals
@@ -74,7 +74,7 @@ velero restore create --from-backup backup-1 --resource-modifier-configmap resou
 
 ### Resource Modifier ConfigMap Structure
 - User first needs to provide details on which resources the JSON Substitutions need to be applied. 
-    - For this the user will provide 4 inputs - Namespaces(for NS Scoped resources), GroupKind (kind.group format similar to includeResources field in velero) and Name Regex(optional).
+    - For this the user will provide 4 inputs - Namespaces(for NS Scoped resources), GroupResource (resource.group format similar to includeResources field in velero) and Name Regex(optional).
     - If the user does not provide the Name, the JSON Substitutions will be applied to all the resources of the given Group and Kind under the given namespaces.
 
 - Further the use will specify the JSON Patch using the structure of kubectl's "JSON Patch" based inputs.
@@ -83,7 +83,7 @@ velero restore create --from-backup backup-1 --resource-modifier-configmap resou
 version: v1
 resourceModifierRules:
 - conditions:
-    groupKind: persistentvolumeclaims
+    groupResource: persistentvolumeclaims
     resourceNameRegex: "mysql.*"
     namespaces:
     - bar
@@ -119,7 +119,7 @@ kubectl create cm <configmap-name> --from-file <yaml-file> -n velero
 version: v1
 resourceModifierRules:
 - conditions:
-    groupKind: persistentvolumeclaims.storage.k8s.io
+    groupResource: persistentvolumeclaims.storage.k8s.io
     resourceNameRegex: ".*"
     namespaces:
     - bar

--- a/internal/resourcemodifiers/resource_modifiers.go
+++ b/internal/resourcemodifiers/resource_modifiers.go
@@ -86,7 +86,7 @@ func (r *ResourceModifierRule) Apply(obj *unstructured.Unstructured, groupResour
 		return nil
 	}
 
-	if !strings.EqualFold(groupResource, r.Conditions.GroupResource) {
+	if r.Conditions.GroupResource != groupResource {
 		return nil
 	}
 

--- a/internal/resourcemodifiers/resource_modifiers_test.go
+++ b/internal/resourcemodifiers/resource_modifiers_test.go
@@ -90,6 +90,32 @@ func TestGetResourceModifiersFromConfig(t *testing.T) {
 		},
 	}
 
+	cm4 := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-configmap",
+			Namespace: "test-namespace",
+		},
+		Data: map[string]string{
+			"sub.yml": "version: v1\nresourceModifierRules:\n- conditions:\n    groupResource: deployments.apps\n    labelSelector:\n      matchLabels:\n        a: b\n",
+		},
+	}
+
+	rules4 := &ResourceModifiers{
+		Version: "v1",
+		ResourceModifierRules: []ResourceModifierRule{
+			{
+				Conditions: Conditions{
+					GroupResource: "deployments.apps",
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"a": "b",
+						},
+					},
+				},
+			},
+		},
+	}
+
 	type args struct {
 		cm *v1.ConfigMap
 	}
@@ -122,6 +148,14 @@ func TestGetResourceModifiersFromConfig(t *testing.T) {
 			},
 			want:    nil,
 			wantErr: true,
+		},
+		{
+			name: "match labels",
+			args: args{
+				cm: cm4,
+			},
+			want:    rules4,
+			wantErr: false,
 		},
 		{
 			name: "nil configmap",

--- a/internal/resourcemodifiers/resource_modifiers_test.go
+++ b/internal/resourcemodifiers/resource_modifiers_test.go
@@ -18,7 +18,7 @@ func TestGetResourceModifiersFromConfig(t *testing.T) {
 			Namespace: "test-namespace",
 		},
 		Data: map[string]string{
-			"sub.yml": "version: v1\nresourceModifierRules:\n- conditions:\n    groupKind: persistentvolumeclaims\n    resourceNameRegex: \".*\"\n    namespaces:\n    - bar\n    - foo\n  patches:\n  - operation: replace\n    path: \"/spec/storageClassName\"\n    value: \"premium\"\n  - operation: remove\n    path: \"/metadata/labels/test\"\n\n\n",
+			"sub.yml": "version: v1\nresourceModifierRules:\n- conditions:\n    groupResource: persistentvolumeclaims\n    resourceNameRegex: \".*\"\n    namespaces:\n    - bar\n    - foo\n  patches:\n  - operation: replace\n    path: \"/spec/storageClassName\"\n    value: \"premium\"\n  - operation: remove\n    path: \"/metadata/labels/test\"\n\n\n",
 		},
 	}
 
@@ -27,7 +27,7 @@ func TestGetResourceModifiersFromConfig(t *testing.T) {
 		ResourceModifierRules: []ResourceModifierRule{
 			{
 				Conditions: Conditions{
-					GroupKind:         "persistentvolumeclaims",
+					GroupResource:     "persistentvolumeclaims",
 					ResourceNameRegex: ".*",
 					Namespaces:        []string{"bar", "foo"},
 				},
@@ -51,7 +51,7 @@ func TestGetResourceModifiersFromConfig(t *testing.T) {
 			Namespace: "test-namespace",
 		},
 		Data: map[string]string{
-			"sub.yml": "version: v1\nresourceModifierRules:\n- conditions:\n    groupKind: deployments.apps\n    resourceNameRegex: \"^test-.*$\"\n    namespaces:\n    - bar\n    - foo\n  patches:\n  - operation: add\n    path: \"/spec/template/spec/containers/0\"\n    value: \"{\\\"name\\\": \\\"nginx\\\", \\\"image\\\": \\\"nginx:1.14.2\\\", \\\"ports\\\": [{\\\"containerPort\\\": 80}]}\"\n  - operation: copy\n    from: \"/spec/template/spec/containers/0\"\n    path: \"/spec/template/spec/containers/1\"\n\n\n",
+			"sub.yml": "version: v1\nresourceModifierRules:\n- conditions:\n    groupResource: deployments.apps\n    resourceNameRegex: \"^test-.*$\"\n    namespaces:\n    - bar\n    - foo\n  patches:\n  - operation: add\n    path: \"/spec/template/spec/containers/0\"\n    value: \"{\\\"name\\\": \\\"nginx\\\", \\\"image\\\": \\\"nginx:1.14.2\\\", \\\"ports\\\": [{\\\"containerPort\\\": 80}]}\"\n  - operation: copy\n    from: \"/spec/template/spec/containers/0\"\n    path: \"/spec/template/spec/containers/1\"\n\n\n",
 		},
 	}
 
@@ -60,7 +60,7 @@ func TestGetResourceModifiersFromConfig(t *testing.T) {
 		ResourceModifierRules: []ResourceModifierRule{
 			{
 				Conditions: Conditions{
-					GroupKind:         "deployments.apps",
+					GroupResource:     "deployments.apps",
 					ResourceNameRegex: "^test-.*$",
 					Namespaces:        []string{"bar", "foo"},
 				},
@@ -86,7 +86,7 @@ func TestGetResourceModifiersFromConfig(t *testing.T) {
 			Namespace: "test-namespace",
 		},
 		Data: map[string]string{
-			"sub.yml": "version1: v1\nresourceModifierRules:\n- conditions:\n    groupKind: deployments.apps\n    resourceNameRegex: \"^test-.*$\"\n    namespaces:\n    - bar\n    - foo\n  patches:\n  - operation: add\n    path: \"/spec/template/spec/containers/0\"\n    value: \"{\\\"name\\\": \\\"nginx\\\", \\\"image\\\": \\\"nginx:1.14.2\\\", \\\"ports\\\": [{\\\"containerPort\\\": 80}]}\"\n  - operation: copy\n    from: \"/spec/template/spec/containers/0\"\n    path: \"/spec/template/spec/containers/1\"\n\n\n",
+			"sub.yml": "version1: v1\nresourceModifierRules:\n- conditions:\n    groupResource: deployments.apps\n    resourceNameRegex: \"^test-.*$\"\n    namespaces:\n    - bar\n    - foo\n  patches:\n  - operation: add\n    path: \"/spec/template/spec/containers/0\"\n    value: \"{\\\"name\\\": \\\"nginx\\\", \\\"image\\\": \\\"nginx:1.14.2\\\", \\\"ports\\\": [{\\\"containerPort\\\": 80}]}\"\n  - operation: copy\n    from: \"/spec/template/spec/containers/0\"\n    path: \"/spec/template/spec/containers/1\"\n\n\n",
 		},
 	}
 
@@ -287,7 +287,7 @@ func TestResourceModifiers_ApplyResourceModifierRules(t *testing.T) {
 				ResourceModifierRules: []ResourceModifierRule{
 					{
 						Conditions: Conditions{
-							GroupKind:         "persistentvolumeclaims",
+							GroupResource:     "persistentvolumeclaims",
 							ResourceNameRegex: "[a-z",
 							Namespaces:        []string{"foo"},
 						},
@@ -320,7 +320,7 @@ func TestResourceModifiers_ApplyResourceModifierRules(t *testing.T) {
 				ResourceModifierRules: []ResourceModifierRule{
 					{
 						Conditions: Conditions{
-							GroupKind:         "persistentvolumeclaims",
+							GroupResource:     "persistentvolumeclaims",
 							ResourceNameRegex: ".*",
 							Namespaces:        []string{"foo"},
 						},
@@ -353,7 +353,7 @@ func TestResourceModifiers_ApplyResourceModifierRules(t *testing.T) {
 				ResourceModifierRules: []ResourceModifierRule{
 					{
 						Conditions: Conditions{
-							GroupKind:         "deployments.apps",
+							GroupResource:     "deployments.apps",
 							ResourceNameRegex: "^test-.*$",
 							Namespaces:        []string{"foo"},
 						},
@@ -386,7 +386,7 @@ func TestResourceModifiers_ApplyResourceModifierRules(t *testing.T) {
 				ResourceModifierRules: []ResourceModifierRule{
 					{
 						Conditions: Conditions{
-							GroupKind:         "deployments.apps",
+							GroupResource:     "deployments.apps",
 							ResourceNameRegex: "^test-.*$",
 							Namespaces:        []string{"foo"},
 						},
@@ -419,8 +419,8 @@ func TestResourceModifiers_ApplyResourceModifierRules(t *testing.T) {
 				ResourceModifierRules: []ResourceModifierRule{
 					{
 						Conditions: Conditions{
-							GroupKind:  "deployments.apps",
-							Namespaces: []string{"foo"},
+							GroupResource: "deployments.apps",
+							Namespaces:    []string{"foo"},
 						},
 						Patches: []JSONPatch{
 							{
@@ -451,7 +451,7 @@ func TestResourceModifiers_ApplyResourceModifierRules(t *testing.T) {
 				ResourceModifierRules: []ResourceModifierRule{
 					{
 						Conditions: Conditions{
-							GroupKind: "deployments.apps",
+							GroupResource: "deployments.apps",
 						},
 						Patches: []JSONPatch{
 							{
@@ -482,7 +482,7 @@ func TestResourceModifiers_ApplyResourceModifierRules(t *testing.T) {
 				ResourceModifierRules: []ResourceModifierRule{
 					{
 						Conditions: Conditions{
-							GroupKind:         "deployments.apps",
+							GroupResource:     "deployments.apps",
 							ResourceNameRegex: ".*",
 							Namespaces:        []string{"bar"},
 						},
@@ -515,7 +515,7 @@ func TestResourceModifiers_ApplyResourceModifierRules(t *testing.T) {
 				ResourceModifierRules: []ResourceModifierRule{
 					{
 						Conditions: Conditions{
-							GroupKind:         "deployments.apps",
+							GroupResource:     "deployments.apps",
 							ResourceNameRegex: "^test-.*$",
 							Namespaces:        []string{"foo"},
 						},
@@ -543,7 +543,7 @@ func TestResourceModifiers_ApplyResourceModifierRules(t *testing.T) {
 				ResourceModifierRules: []ResourceModifierRule{
 					{
 						Conditions: Conditions{
-							GroupKind:         "deployments.apps",
+							GroupResource:     "deployments.apps",
 							ResourceNameRegex: "^test-.*$",
 							Namespaces:        []string{"foo"},
 						},

--- a/internal/resourcemodifiers/resource_modifiers_test.go
+++ b/internal/resourcemodifiers/resource_modifiers_test.go
@@ -183,6 +183,9 @@ func TestResourceModifiers_ApplyResourceModifierRules(t *testing.T) {
 			"metadata": map[string]interface{}{
 				"name":      "test-deployment",
 				"namespace": "foo",
+				"labels": map[string]interface{}{
+					"app": "nginx",
+				},
 			},
 			"spec": map[string]interface{}{
 				"replicas": int64(1),
@@ -211,6 +214,9 @@ func TestResourceModifiers_ApplyResourceModifierRules(t *testing.T) {
 			"metadata": map[string]interface{}{
 				"name":      "test-deployment",
 				"namespace": "foo",
+				"labels": map[string]interface{}{
+					"app": "nginx",
+				},
 			},
 			"spec": map[string]interface{}{
 				"replicas": int64(2),
@@ -239,6 +245,9 @@ func TestResourceModifiers_ApplyResourceModifierRules(t *testing.T) {
 			"metadata": map[string]interface{}{
 				"name":      "test-deployment",
 				"namespace": "foo",
+				"labels": map[string]interface{}{
+					"app": "nginx",
+				},
 			},
 			"spec": map[string]interface{}{
 				"replicas": int64(1),
@@ -578,6 +587,80 @@ func TestResourceModifiers_ApplyResourceModifierRules(t *testing.T) {
 			},
 			wantErr: false,
 			wantObj: deployNginxMysql.DeepCopy(),
+		},
+		{
+			name: "nginx deployment: match label selector",
+			fields: fields{
+				Version: "v1",
+				ResourceModifierRules: []ResourceModifierRule{
+					{
+						Conditions: Conditions{
+							GroupResource: "deployments.apps",
+							Namespaces:    []string{"foo"},
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app": "nginx",
+								},
+							},
+						},
+						Patches: []JSONPatch{
+							{
+								Operation: "test",
+								Path:      "/spec/replicas",
+								Value:     "1",
+							},
+							{
+								Operation: "replace",
+								Path:      "/spec/replicas",
+								Value:     "2",
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				obj:           deployNginxOneReplica.DeepCopy(),
+				groupResource: "deployments.apps",
+			},
+			wantErr: false,
+			wantObj: deployNginxTwoReplica.DeepCopy(),
+		},
+		{
+			name: "nginx deployment: mismatch label selector",
+			fields: fields{
+				Version: "v1",
+				ResourceModifierRules: []ResourceModifierRule{
+					{
+						Conditions: Conditions{
+							GroupResource: "deployments.apps",
+							Namespaces:    []string{"foo"},
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app": "nginx-mismatch",
+								},
+							},
+						},
+						Patches: []JSONPatch{
+							{
+								Operation: "test",
+								Path:      "/spec/replicas",
+								Value:     "1",
+							},
+							{
+								Operation: "replace",
+								Path:      "/spec/replicas",
+								Value:     "2",
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				obj:           deployNginxOneReplica.DeepCopy(),
+				groupResource: "deployments.apps",
+			},
+			wantErr: false,
+			wantObj: deployNginxOneReplica.DeepCopy(),
 		},
 	}
 

--- a/internal/resourcemodifiers/resource_modifiers_validator.go
+++ b/internal/resourcemodifiers/resource_modifiers_validator.go
@@ -1,9 +1,8 @@
 package resourcemodifiers
 
 import (
-	"strings"
-
 	"fmt"
+	"strings"
 )
 
 func (r *ResourceModifierRule) Validate() error {
@@ -48,8 +47,8 @@ func (p *JSONPatch) Validate() error {
 }
 
 func (c *Conditions) Validate() error {
-	if c.GroupKind == "" {
-		return fmt.Errorf("groupkind cannot be empty")
+	if c.GroupResource == "" {
+		return fmt.Errorf("groupkResource cannot be empty")
 	}
 	return nil
 }

--- a/internal/resourcemodifiers/resource_modifiers_validator_test.go
+++ b/internal/resourcemodifiers/resource_modifiers_validator_test.go
@@ -21,7 +21,7 @@ func TestResourceModifiers_Validate(t *testing.T) {
 				ResourceModifierRules: []ResourceModifierRule{
 					{
 						Conditions: Conditions{
-							GroupKind:         "persistentvolumeclaims",
+							GroupResource:     "persistentvolumeclaims",
 							ResourceNameRegex: ".*",
 							Namespaces:        []string{"bar", "foo"},
 						},
@@ -44,7 +44,7 @@ func TestResourceModifiers_Validate(t *testing.T) {
 				ResourceModifierRules: []ResourceModifierRule{
 					{
 						Conditions: Conditions{
-							GroupKind:         "persistentvolumeclaims",
+							GroupResource:     "persistentvolumeclaims",
 							ResourceNameRegex: ".*",
 							Namespaces:        []string{"bar", "foo"},
 						},
@@ -75,7 +75,7 @@ func TestResourceModifiers_Validate(t *testing.T) {
 				ResourceModifierRules: []ResourceModifierRule{
 					{
 						Conditions: Conditions{
-							GroupKind:         "persistentvolumeclaims",
+							GroupResource:     "persistentvolumeclaims",
 							ResourceNameRegex: ".*",
 							Namespaces:        []string{"bar", "foo"},
 						},
@@ -92,13 +92,13 @@ func TestResourceModifiers_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Condition has empty GroupKind",
+			name: "Condition has empty GroupResource",
 			fields: fields{
 				Version: "v1",
 				ResourceModifierRules: []ResourceModifierRule{
 					{
 						Conditions: Conditions{
-							GroupKind:         "",
+							GroupResource:     "",
 							ResourceNameRegex: ".*",
 							Namespaces:        []string{"bar", "foo"},
 						},

--- a/pkg/controller/restore_controller_test.go
+++ b/pkg/controller/restore_controller_test.go
@@ -760,7 +760,7 @@ func TestValidateAndCompleteWithResourceModifierSpecified(t *testing.T) {
 			Namespace: velerov1api.DefaultNamespace,
 		},
 		Data: map[string]string{
-			"sub.yml": "version: v1\nresourceModifierRules:\n- conditions:\n    groupKind: persistentvolumeclaims\n    resourceNameRegex: \".*\"\n    namespaces:\n    - bar\n    - foo\n  patches:\n  - operation: replace\n    path: \"/spec/storageClassName\"\n    value: \"premium\"\n  - operation: remove\n    path: \"/metadata/labels/test\"\n\n\n",
+			"sub.yml": "version: v1\nresourceModifierRules:\n- conditions:\n    groupResource: persistentvolumeclaims\n    resourceNameRegex: \".*\"\n    namespaces:\n    - bar\n    - foo\n  patches:\n  - operation: replace\n    path: \"/spec/storageClassName\"\n    value: \"premium\"\n  - operation: remove\n    path: \"/metadata/labels/test\"\n\n\n",
 		},
 	}
 	require.NoError(t, r.kbClient.Create(context.Background(), cm1))
@@ -788,7 +788,7 @@ func TestValidateAndCompleteWithResourceModifierSpecified(t *testing.T) {
 			Namespace: velerov1api.DefaultNamespace,
 		},
 		Data: map[string]string{
-			"sub.yml": "version1: v1\nresourceModifierRules:\n- conditions:\n    groupKind: persistentvolumeclaims\n    resourceNameRegex: \".*\"\n    namespaces:\n    - bar\n    - foo\n  patches:\n  - operation: replace\n    path: \"/spec/storageClassName\"\n    value: \"premium\"\n  - operation: remove\n    path: \"/metadata/labels/test\"\n\n\n",
+			"sub.yml": "version1: v1\nresourceModifierRules:\n- conditions:\n    groupResource: persistentvolumeclaims\n    resourceNameRegex: \".*\"\n    namespaces:\n    - bar\n    - foo\n  patches:\n  - operation: replace\n    path: \"/spec/storageClassName\"\n    value: \"premium\"\n  - operation: remove\n    path: \"/metadata/labels/test\"\n\n\n",
 		},
 	}
 	require.NoError(t, r.kbClient.Create(context.Background(), invalidVersionCm))
@@ -816,7 +816,7 @@ func TestValidateAndCompleteWithResourceModifierSpecified(t *testing.T) {
 			Namespace: velerov1api.DefaultNamespace,
 		},
 		Data: map[string]string{
-			"sub.yml": "version: v1\nresourceModifierRules:\n- conditions:\n    groupKind: persistentvolumeclaims\n    resourceNameRegex: \".*\"\n    namespaces:\n    - bar\n    - foo\n  patches:\n  - operation: invalid\n    path: \"/spec/storageClassName\"\n    value: \"premium\"\n  - operation: remove\n    path: \"/metadata/labels/test\"\n\n\n",
+			"sub.yml": "version: v1\nresourceModifierRules:\n- conditions:\n    groupResource: persistentvolumeclaims\n    resourceNameRegex: \".*\"\n    namespaces:\n    - bar\n    - foo\n  patches:\n  - operation: invalid\n    path: \"/spec/storageClassName\"\n    value: \"premium\"\n  - operation: remove\n    path: \"/metadata/labels/test\"\n\n\n",
 		},
 	}
 	require.NoError(t, r.kbClient.Create(context.Background(), invalidOperatorCm))

--- a/site/content/docs/main/restore-resource-modifiers.md
+++ b/site/content/docs/main/restore-resource-modifiers.md
@@ -34,6 +34,9 @@ resourceModifierRules:
      namespaces:
      - bar
      - foo
+     labelSelector:
+        matchLabels:
+           foo: bar
   patches:
   - operation: replace
     path: "/spec/storageClassName"
@@ -42,9 +45,9 @@ resourceModifierRules:
     path: "/metadata/labels/test"
  ```
 
-- The above configmap will apply the JSON Patch to all the PVCs in the namespaces bar and foo with name starting with mysql. The JSON Patch will replace the storageClassName with "premium" and remove the label "test" from the PVCs.
+- The above configmap will apply the JSON Patch to all the PVCs in the namespaces bar and foo with name starting with mysql and match label `foo: bar`. The JSON Patch will replace the storageClassName with "premium" and remove the label "test" from the PVCs.
 - You can specify multiple JSON Patches for a particular resource. The patches will be applied in the order specified in the configmap. A subsequent patch is applied in order and if multiple patches are specified for the same path, the last patch will override the previous patches.
-- You can can specify multiple resourceModifierRules in the configmap. The rules will be applied in the order specified in the configmap. 
+- You can specify multiple resourceModifierRules in the configmap. The rules will be applied in the order specified in the configmap. 
 
 ### Operations supported by the JSON Patch RFC: 
 - add

--- a/site/content/docs/main/restore-resource-modifiers.md
+++ b/site/content/docs/main/restore-resource-modifiers.md
@@ -29,7 +29,7 @@ Below is the two-step of using resource modifiers to modify the resources during
 version: v1
 resourceModifierRules:
 - conditions:
-     groupKind: persistentvolumeclaims
+     groupResource: persistentvolumeclaims
      resourceNameRegex: "^mysql.*$"
      namespaces:
      - bar
@@ -61,7 +61,7 @@ resourceModifierRules:
 version: v1
 resourceModifierRules:
 - conditions:
-    groupKind: persistentvolumeclaims
+    groupResource: persistentvolumeclaims
     resourceNameRegex: ".*"
     namespaces:
     - bar
@@ -80,7 +80,7 @@ resourceModifierRules:
 version: v1
 resourceModifierRules:
 - conditions:
-    groupKind: deployments.apps
+    groupResource: deployments.apps
     resourceNameRegex: "^test-.*$"
     namespaces:
     - bar

--- a/site/content/docs/v1.12/restore-resource-modifiers.md
+++ b/site/content/docs/v1.12/restore-resource-modifiers.md
@@ -29,14 +29,14 @@ Below is the two-step of using resource modifiers to modify the resources during
 version: v1
 resourceModifierRules:
 - conditions:
-     groupResource: persistentvolumeclaims
-     resourceNameRegex: "^mysql.*$"
-     namespaces:
-     - bar
-     - foo
-     labelSelector:
-       matchLabels:
-          foo: bar
+    groupResource: persistentvolumeclaims
+    resourceNameRegex: "^mysql.*$"
+    namespaces:
+    - bar
+    - foo
+    labelSelector:
+      matchLabels:
+        foo: bar
   patches:
   - operation: replace
     path: "/spec/storageClassName"

--- a/site/content/docs/v1.12/restore-resource-modifiers.md
+++ b/site/content/docs/v1.12/restore-resource-modifiers.md
@@ -34,6 +34,9 @@ resourceModifierRules:
      namespaces:
      - bar
      - foo
+     labelSelector:
+       matchLabels:
+          foo: bar
   patches:
   - operation: replace
     path: "/spec/storageClassName"
@@ -42,9 +45,9 @@ resourceModifierRules:
     path: "/metadata/labels/test"
  ```
 
-- The above configmap will apply the JSON Patch to all the PVCs in the namespaces bar and foo with name starting with mysql. The JSON Patch will replace the storageClassName with "premium" and remove the label "test" from the PVCs.
+- The above configmap will apply the JSON Patch to all the PVCs in the namespaces bar and foo with name starting with mysql and match label `foo: bar`. The JSON Patch will replace the storageClassName with "premium" and remove the label "test" from the PVCs.
 - You can specify multiple JSON Patches for a particular resource. The patches will be applied in the order specified in the configmap. A subsequent patch is applied in order and if multiple patches are specified for the same path, the last patch will override the previous patches.
-- You can can specify multiple resourceModifierRules in the configmap. The rules will be applied in the order specified in the configmap. 
+- You can specify multiple resourceModifierRules in the configmap. The rules will be applied in the order specified in the configmap. 
 
 ### Operations supported by the JSON Patch RFC: 
 - add

--- a/site/content/docs/v1.12/restore-resource-modifiers.md
+++ b/site/content/docs/v1.12/restore-resource-modifiers.md
@@ -29,7 +29,7 @@ Below is the two-step of using resource modifiers to modify the resources during
 version: v1
 resourceModifierRules:
 - conditions:
-     groupKind: persistentvolumeclaims
+     groupResource: persistentvolumeclaims
      resourceNameRegex: "^mysql.*$"
      namespaces:
      - bar
@@ -61,7 +61,7 @@ resourceModifierRules:
 version: v1
 resourceModifierRules:
 - conditions:
-    groupKind: persistentvolumeclaims
+    groupResource: persistentvolumeclaims
     resourceNameRegex: ".*"
     namespaces:
     - bar
@@ -80,7 +80,7 @@ resourceModifierRules:
 version: v1
 resourceModifierRules:
 - conditions:
-    groupKind: deployments.apps
+    groupResource: deployments.apps
     resourceNameRegex: "^test-.*$"
     namespaces:
     - bar

--- a/test/e2e/resourcemodifiers/resource_modifiers.go
+++ b/test/e2e/resourcemodifiers/resource_modifiers.go
@@ -36,7 +36,7 @@ var yamlData = `
 version: v1
 resourceModifierRules:
 - conditions:
-    groupKind: deployments.apps
+    groupResource: deployments.apps
     resourceNameRegex: "resource-modifiers-.*"
   patches:
   - operation: add


### PR DESCRIPTION
# Please add a summary of your change

This pr made some improvements in Resource Modifiers:
1. add label selector
2. change the field name from groupKind to groupResource

# Does your change fix a particular issue?

N/A

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
