### PR TITLE
release-1.12: On restore, delete Kubernetes 1.27 job controller uid label

### DIFF
--- a/changelogs/unreleased/6713-kaovilai
+++ b/changelogs/unreleased/6713-kaovilai
@@ -1,0 +1,1 @@
+Kubernetes 1.27 new job label batch.kubernetes.io/controller-uid are deleted during restore per https://github.com/kubernetes/kubernetes/pull/114930

--- a/pkg/discovery/helper.go
+++ b/pkg/discovery/helper.go
@@ -312,11 +312,3 @@ func (h *helper) ServerVersion() *version.Info {
 	defer h.lock.RUnlock()
 	return h.serverVersion
 }
-
-func ServerVersion(logger logrus.FieldLogger) (*version.Info, error) {
-	discoveryHelper, err := NewHelper(&discovery.DiscoveryClient{}, logger)
-	if err != nil {
-		return nil, err
-	}
-	return discoveryHelper.ServerVersion(), nil
-}

--- a/pkg/discovery/helper.go
+++ b/pkg/discovery/helper.go
@@ -312,3 +312,11 @@ func (h *helper) ServerVersion() *version.Info {
 	defer h.lock.RUnlock()
 	return h.serverVersion
 }
+
+func ServerVersion(logger logrus.FieldLogger) (*version.Info, error) {
+	discoveryHelper, err := NewHelper(&discovery.DiscoveryClient{}, logger)
+	if err != nil {
+		return nil, err
+	}
+	return discoveryHelper.ServerVersion(), nil
+}


### PR DESCRIPTION
- Handle 1.27 k8s job label changes
- changelog

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #6711 

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
