### PR TITLE
Fix velero uninstall bug

### DIFF
--- a/pkg/cmd/cli/uninstall/uninstall.go
+++ b/pkg/cmd/cli/uninstall/uninstall.go
@@ -280,7 +280,7 @@ func deleteResources(ctx context.Context, kbClient kbclient.Client, namespace st
 	if err == wait.ErrWaitTimeout {
 		err = forcedlyDeleteResources(ctx, kbClient, namespace)
 		if err != nil {
-			return errors.Wrap(err, "Error deleting restores")
+			return errors.Wrap(err, "Error deleting resources forcedly")
 		}
 	}
 
@@ -315,9 +315,7 @@ func gracefullyDeleteResources(ctx context.Context, kbClient kbclient.Client, na
 }
 
 func gracefullyDeleteResource(ctx context.Context, kbClient kbclient.Client, namespace string, list kbclient.ObjectList) error {
-	var err error
-
-	if err = kbClient.List(ctx, list, &kbclient.ListOptions{Namespace: namespace}); err != nil {
+	if err := kbClient.List(ctx, list, &kbclient.ListOptions{Namespace: namespace}); err != nil {
 		return errors.Wrap(err, "Error getting resources during graceful deletion")
 	}
 
@@ -341,14 +339,14 @@ func gracefullyDeleteResource(ctx context.Context, kbClient kbclient.Client, nam
 
 	// Delete collected resources in a batch
 	for _, resource := range objectsToDelete {
-		if err = kbClient.Delete(ctx, resource); err != nil {
+		if err := kbClient.Delete(ctx, resource); err != nil {
 			if apierrors.IsNotFound(err) {
 				continue
 			}
 			return errors.Wrap(err, "Error deleting resources during graceful deletion")
 		}
 	}
-	return err
+	return nil
 }
 
 func waitDeletingResources(ctx context.Context, kbClient kbclient.Client, namespace string) error {


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)
If one `restore` CR is deleting, and we executing Velero uninstall command at same time,
it may be possible that `kbClient.List` could list the deleting CR, but before executing `kbClient.Delete` the  `restore` CR is deleted, then `kbClient.Delete` failed with NotFound error, and **the error is assigned to global error variable**, and the global error will be return which would lead to Velero uninstall failure
# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
