### PR TITLE
use old namespace in resource modifier

### DIFF
--- a/changelogs/unreleased/6724-27149chen
+++ b/changelogs/unreleased/6724-27149chen
@@ -1,0 +1,1 @@
+Use old(origin) namespace in resource modifier conditions in case namespace may change during restore

--- a/design/Implemented/json-substitution-action-design.md
+++ b/design/Implemented/json-substitution-action-design.md
@@ -96,6 +96,7 @@ resourceModifierRules:
     path: "/metadata/labels/test"
 ```
 - The above configmap will apply the JSON Patch to all the PVCs in the namespaces bar and foo with name starting with mysql. The JSON Patch will replace the storageClassName with "premium" and remove the label "test" from the PVCs.
+- Note that the Namespace here is the origin namespace of the resource, not the new namespace where the resource is going to be restored.
 - The user can specify multiple JSON Patches for a particular resource. The patches will be applied in the order specified in the configmap. A subsequent patch is applied in order and if multiple patches are specified for the same path, the last patch will override the previous patches.
 - The user can specify multiple resourceModifierRules in the configmap. The rules will be applied in the order specified in the configmap. 
 

--- a/design/Implemented/json-substitution-action-design.md
+++ b/design/Implemented/json-substitution-action-design.md
@@ -96,7 +96,7 @@ resourceModifierRules:
     path: "/metadata/labels/test"
 ```
 - The above configmap will apply the JSON Patch to all the PVCs in the namespaces bar and foo with name starting with mysql. The JSON Patch will replace the storageClassName with "premium" and remove the label "test" from the PVCs.
-- Note that the Namespace here is the origin namespace of the resource, not the new namespace where the resource is going to be restored.
+- Note that the Namespace here is the original namespace of the backed up resource, not the new namespace where the resource is going to be restored.
 - The user can specify multiple JSON Patches for a particular resource. The patches will be applied in the order specified in the configmap. A subsequent patch is applied in order and if multiple patches are specified for the same path, the last patch will override the previous patches.
 - The user can specify multiple resourceModifierRules in the configmap. The rules will be applied in the order specified in the configmap. 
 

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1352,6 +1352,14 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 		}
 	}
 
+	if ctx.resourceModifiers != nil {
+		if errList := ctx.resourceModifiers.ApplyResourceModifierRules(obj, groupResource.String(), ctx.log); errList != nil {
+			for _, err := range errList {
+				errs.Add(namespace, err)
+			}
+		}
+	}
+
 	// Necessary because we may have remapped the namespace if the namespace is
 	// blank, don't create the key.
 	originalNamespace := obj.GetNamespace()
@@ -1363,14 +1371,6 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 	// for easy identification of all cluster resources created by this restore
 	// and which backup they came from.
 	addRestoreLabels(obj, ctx.restore.Name, ctx.restore.Spec.BackupName)
-
-	if ctx.resourceModifiers != nil {
-		if errList := ctx.resourceModifiers.ApplyResourceModifierRules(obj, groupResource.String(), ctx.log); errList != nil {
-			for _, err := range errList {
-				errs.Add(namespace, err)
-			}
-		}
-	}
 
 	// The object apiVersion might get modified by a RestorePlugin so we need to
 	// get a new client to reflect updated resource path.

--- a/site/content/docs/main/restore-resource-modifiers.md
+++ b/site/content/docs/main/restore-resource-modifiers.md
@@ -46,7 +46,7 @@ resourceModifierRules:
  ```
 
 - The above configmap will apply the JSON Patch to all the PVCs in the namespaces bar and foo with name starting with mysql and match label `foo: bar`. The JSON Patch will replace the storageClassName with "premium" and remove the label "test" from the PVCs.
-- Note that the Namespace here is the origin namespace of the resource, not the new namespace where the resource is going to be restored.
+- Note that the Namespace here is the original namespace of the backed up resource, not the new namespace where the resource is going to be restored.
 - You can specify multiple JSON Patches for a particular resource. The patches will be applied in the order specified in the configmap. A subsequent patch is applied in order and if multiple patches are specified for the same path, the last patch will override the previous patches.
 - You can specify multiple resourceModifierRules in the configmap. The rules will be applied in the order specified in the configmap. 
 

--- a/site/content/docs/main/restore-resource-modifiers.md
+++ b/site/content/docs/main/restore-resource-modifiers.md
@@ -46,6 +46,7 @@ resourceModifierRules:
  ```
 
 - The above configmap will apply the JSON Patch to all the PVCs in the namespaces bar and foo with name starting with mysql and match label `foo: bar`. The JSON Patch will replace the storageClassName with "premium" and remove the label "test" from the PVCs.
+- Note that the Namespace here is the origin namespace of the resource, not the new namespace where the resource is going to be restored.
 - You can specify multiple JSON Patches for a particular resource. The patches will be applied in the order specified in the configmap. A subsequent patch is applied in order and if multiple patches are specified for the same path, the last patch will override the previous patches.
 - You can specify multiple resourceModifierRules in the configmap. The rules will be applied in the order specified in the configmap. 
 

--- a/site/content/docs/v1.12/restore-resource-modifiers.md
+++ b/site/content/docs/v1.12/restore-resource-modifiers.md
@@ -46,7 +46,7 @@ resourceModifierRules:
  ```
 
 - The above configmap will apply the JSON Patch to all the PVCs in the namespaces bar and foo with name starting with mysql and match label `foo: bar`. The JSON Patch will replace the storageClassName with "premium" and remove the label "test" from the PVCs.
-- Note that the Namespace here is the origin namespace of the resource, not the new namespace where the resource is going to be restored.
+- Note that the Namespace here is the original namespace of the backed up resource, not the new namespace where the resource is going to be restored.
 - You can specify multiple JSON Patches for a particular resource. The patches will be applied in the order specified in the configmap. A subsequent patch is applied in order and if multiple patches are specified for the same path, the last patch will override the previous patches.
 - You can specify multiple resourceModifierRules in the configmap. The rules will be applied in the order specified in the configmap. 
 

--- a/site/content/docs/v1.12/restore-resource-modifiers.md
+++ b/site/content/docs/v1.12/restore-resource-modifiers.md
@@ -46,6 +46,7 @@ resourceModifierRules:
  ```
 
 - The above configmap will apply the JSON Patch to all the PVCs in the namespaces bar and foo with name starting with mysql and match label `foo: bar`. The JSON Patch will replace the storageClassName with "premium" and remove the label "test" from the PVCs.
+- Note that the Namespace here is the origin namespace of the resource, not the new namespace where the resource is going to be restored.
 - You can specify multiple JSON Patches for a particular resource. The patches will be applied in the order specified in the configmap. A subsequent patch is applied in order and if multiple patches are specified for the same path, the last patch will override the previous patches.
 - You can specify multiple resourceModifierRules in the configmap. The rules will be applied in the order specified in the configmap. 
 


### PR DESCRIPTION
# Please add a summary of your change

Use old(origin) namespace in resource modifier conditions in case namespace may change during restore

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
