### PR TITLE
[1.12] Fix issue 6733

### DIFF
--- a/pkg/exposer/generic_restore.go
+++ b/pkg/exposer/generic_restore.go
@@ -221,7 +221,7 @@ func (e *genericRestoreExposer) RebindVolume(ctx context.Context, ownerObject co
 	}
 
 	restorePVName := restorePV.Name
-	restorePV, err = kube.ResetPVBinding(ctx, e.kubeClient.CoreV1(), restorePV, matchLabel)
+	restorePV, err = kube.ResetPVBinding(ctx, e.kubeClient.CoreV1(), restorePV, matchLabel, targetPVC)
 	if err != nil {
 		return errors.Wrapf(err, "error to reset binding info for restore PV %s", restorePVName)
 	}


### PR DESCRIPTION
Fix issue https://github.com/vmware-tanzu/velero/issues/6733, constrain the restore PV to bind to the target PVC only