### PR TITLE
Update restore controller logic for restore deletion

### DIFF
--- a/changelogs/unreleased/6761-ywk253100
+++ b/changelogs/unreleased/6761-ywk253100
@@ -1,0 +1,1 @@
+Update restore controller logic for restore deletion

--- a/pkg/controller/restore_controller.go
+++ b/pkg/controller/restore_controller.go
@@ -671,12 +671,11 @@ func (r *restoreReconciler) deleteExternalResources(restore *api.Restore) error 
 
 	backupInfo, err := r.fetchBackupInfo(restore.Spec.BackupName)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			r.logger.Errorf("got not found error: %v, skip deleting the restore files in object storage", err)
+			return nil
+		}
 		return errors.Wrap(err, fmt.Sprintf("can't get backup info, backup: %s", restore.Spec.BackupName))
-	}
-
-	// if storage locations is read-only, skip deletion
-	if backupInfo.location.Spec.AccessMode == api.BackupStorageLocationAccessModeReadOnly {
-		return nil
 	}
 
 	// delete restore files in object storage


### PR DESCRIPTION
1. Skip deleting the restore files from storage if the backup/BSL is not found
2. Allow deleting the restore files from storage even though the BSL is readonly

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
