### PR TITLE
Fix default BSL setting not work

### DIFF
--- a/changelogs/unreleased/6771-qiuming-best
+++ b/changelogs/unreleased/6771-qiuming-best
@@ -1,0 +1,1 @@
+Fix default BSL setting not work

--- a/internal/storage/storagelocation.go
+++ b/internal/storage/storagelocation.go
@@ -18,6 +18,7 @@ package storage
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -91,4 +92,19 @@ func ListBackupStorageLocations(ctx context.Context, kbClient client.Client, nam
 	}
 
 	return locations, nil
+}
+
+func GetDefaultBackupStorageLocations(ctx context.Context, kbClient client.Client, namespace string) (*velerov1api.BackupStorageLocationList, error) {
+	locations := new(velerov1api.BackupStorageLocationList)
+	defaultLocations := new(velerov1api.BackupStorageLocationList)
+	if err := kbClient.List(context.Background(), locations, &client.ListOptions{Namespace: namespace}); err != nil {
+		return defaultLocations, errors.Wrapf(err, fmt.Sprintf("failed to list backup storage locations in namespace %s", namespace))
+	}
+
+	for _, location := range locations.Items {
+		if location.Spec.Default {
+			defaultLocations.Items = append(defaultLocations.Items, location)
+		}
+	}
+	return defaultLocations, nil
 }

--- a/pkg/cmd/cli/backuplocation/set_test.go
+++ b/pkg/cmd/cli/backuplocation/set_test.go
@@ -31,6 +31,7 @@ import (
 	cmdtest "github.com/vmware-tanzu/velero/pkg/cmd/test"
 	veleroflag "github.com/vmware-tanzu/velero/pkg/cmd/util/flag"
 	velerotest "github.com/vmware-tanzu/velero/pkg/test"
+	"github.com/vmware-tanzu/velero/pkg/util/boolptr"
 	veleroexec "github.com/vmware-tanzu/velero/pkg/util/exec"
 )
 
@@ -73,7 +74,7 @@ func TestNewSetCommand(t *testing.T) {
 	// verify all options are set as expected
 	assert.Equal(t, backupName, o.Name)
 	assert.Equal(t, cacert, o.CACertFile)
-	assert.Equal(t, defaultBackupStorageLocation, o.DefaultBackupStorageLocation)
+	assert.Equal(t, defaultBackupStorageLocation, boolptr.IsSetToTrue(o.DefaultBackupStorageLocation.Value))
 	assert.Equal(t, true, reflect.DeepEqual(credential, o.Credential))
 
 	assert.Contains(t, e.Error(), fmt.Sprintf("%s: no such file or directory", cacert))
@@ -102,7 +103,7 @@ func TestSetCommand_Execute(t *testing.T) {
 	_, stderr, err := veleroexec.RunCommand(cmd)
 
 	if err != nil {
-		assert.Contains(t, stderr, fmt.Sprintf("backupstoragelocations.velero.io \"%s\" not found", bsl))
+		assert.Contains(t, stderr, "backupstoragelocations.velero.io \"bsl-1\" not found")
 		return
 	}
 	t.Fatalf("process ran with err %v, want backup delete successfully", err)

--- a/pkg/controller/backup_storage_location_controller.go
+++ b/pkg/controller/backup_storage_location_controller.go
@@ -96,11 +96,8 @@ func (r *backupStorageLocationReconciler) Reconcile(ctx context.Context, req ctr
 	pluginManager := r.newPluginManager(log)
 	defer pluginManager.CleanupClients()
 
-	var defaultFound bool
+	// find the BSL that matches the request
 	for _, bsl := range locationList.Items {
-		if bsl.Spec.Default {
-			defaultFound = true
-		}
 		if bsl.Name == req.Name && bsl.Namespace == req.Namespace {
 			location = bsl
 		}
@@ -111,15 +108,11 @@ func (r *backupStorageLocationReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, nil
 	}
 
-	isDefault := location.Spec.Default
-
-	// TODO(2.0) remove this check since the server default will be deprecated
-	if !defaultFound && location.Name == r.defaultBackupLocationInfo.StorageLocation {
-		// For backward-compatible, to configure the backup storage location as the default if
-		// none of the BSLs be marked as the default and the BSL name matches against the
-		// "velero server --default-backup-storage-location".
-		isDefault = true
-		defaultFound = true
+	// decide the default BSL
+	defaultFound, err := r.ensureSingleDefaultBSL(locationList)
+	if err != nil {
+		log.WithError(err).Error("failed to ensure single default bsl")
+		return ctrl.Result{}, nil
 	}
 
 	func() {
@@ -155,9 +148,6 @@ func (r *backupStorageLocationReconciler) Reconcile(ctx context.Context, req ctr
 			log.WithError(err).Error("fail to validate backup store")
 			return
 		}
-
-		// updates the default backup location
-		location.Spec.Default = isDefault
 	}()
 
 	r.logReconciledPhase(defaultFound, locationList, unavailableErrors)
@@ -219,4 +209,73 @@ func (r *backupStorageLocationReconciler) SetupWithManager(mgr ctrl.Manager) err
 		For(&velerov1api.BackupStorageLocation{}, builder.WithPredicates(kube.SpecChangePredicate{})).
 		Watches(g, nil, builder.WithPredicates(gp)).
 		Complete(r)
+}
+
+// ensureSingleDefaultBSL ensures that there is only one default BSL in the namespace.
+// the default BSL priority is as follows:
+// 1. follow the user's setting (the most recent validation BSL is the default BSL)
+// 2. follow the server's setting ("velero server --default-backup-storage-location")
+func (r *backupStorageLocationReconciler) ensureSingleDefaultBSL(locationList velerov1api.BackupStorageLocationList) (bool, error) {
+	// get all default BSLs
+	var defaultBSLs []*velerov1api.BackupStorageLocation
+	var defaultFound bool
+	for i, location := range locationList.Items {
+		if location.Spec.Default {
+			defaultBSLs = append(defaultBSLs, &locationList.Items[i])
+		}
+	}
+
+	if len(defaultBSLs) > 1 { // more than 1 default BSL
+		// find the most recent updated default BSL
+		var mostRecentCreatedBSL *velerov1api.BackupStorageLocation
+		defaultFound = true
+		for _, bsl := range defaultBSLs {
+			if mostRecentCreatedBSL == nil {
+				mostRecentCreatedBSL = bsl
+				continue
+			}
+			// For lack of a better way to compare timestamps, we use the CreationTimestamp
+			// it cloud not really find the most recent updated BSL, but it is good enough for now
+			bslTimestamp := bsl.CreationTimestamp
+			mostRecentTimestamp := mostRecentCreatedBSL.CreationTimestamp
+			if mostRecentTimestamp.Before(&bslTimestamp) {
+				mostRecentCreatedBSL = bsl
+			}
+		}
+
+		// unset all other default BSLs
+		for _, bsl := range defaultBSLs {
+			if bsl.Name != mostRecentCreatedBSL.Name {
+				bsl.Spec.Default = false
+				if err := r.client.Update(r.ctx, bsl); err != nil {
+					return defaultFound, errors.Wrapf(err, "failed to unset default backup storage location %q", bsl.Name)
+				}
+				r.log.Debugf("update default backup storage location %q to false", bsl.Name)
+			}
+		}
+	} else if len(defaultBSLs) == 0 { // no default BSL
+		// find the BSL that matches the "velero server --default-backup-storage-location"
+		var defaultBSL *velerov1api.BackupStorageLocation
+		for i, location := range locationList.Items {
+			if location.Name == r.defaultBackupLocationInfo.StorageLocation {
+				defaultBSL = &locationList.Items[i]
+				break
+			}
+		}
+
+		// set the default BSL
+		if defaultBSL != nil {
+			defaultBSL.Spec.Default = true
+			defaultFound = true
+			if err := r.client.Update(r.ctx, defaultBSL); err != nil {
+				return defaultFound, errors.Wrapf(err, "failed to set default backup storage location %q", defaultBSL.Name)
+			}
+			r.log.Debugf("update default backup storage location %q to true", defaultBSL.Name)
+		} else {
+			defaultFound = false
+		}
+	} else { // only 1 default BSL
+		defaultFound = true
+	}
+	return defaultFound, nil
 }

--- a/site/content/docs/main/customize-installation.md
+++ b/site/content/docs/main/customize-installation.md
@@ -173,18 +173,43 @@ To configure additional locations after running `velero install`, use the `veler
 
 ### Set default backup storage location or volume snapshot locations
 
-When performing backups, Velero needs to know where to backup your data. This means that if you configure multiple locations, you must specify the location Velero should use each time you run `velero backup create`, or you can set a default backup storage location or default volume snapshot locations. If you only have one backup storage llocation or volume snapshot location set for a provider, Velero will automatically use that location as the default.
+When performing backups, Velero needs to know where to backup your data. This means that if you configure multiple locations, you must specify the location Velero should use each time you run `velero backup create`, or you can set a default backup storage location or default volume snapshot locations. If you only have one backup storage location or volume snapshot location set for a provider, Velero will automatically use that location as the default.
 
-Set a default backup storage location by passing a `--default` flag with when running `velero backup-location create`.
+#### Set default backup storage location
+currently, Velero could set the default backup storage location as below:
+- First way: Set a default backup storage location by passing a `--default` flag when running `velero backup-location create`.
 
-```
-velero backup-location create backups-primary \
+  ```
+  velero backup-location create backups-primary \
     --provider aws \
     --bucket velero-backups \
     --config region=us-east-1 \
     --default
-```
-
+  ```
+- Second way: Set a default backup storage location by passing a  `--default` flag when running `velero backup-location set`.
+  ```bash
+  velero backup-location set backups-primary --default
+  ```
+  We also could remove the default backup storage location by this command, below is one example
+  ```bash
+  velero backup-location set backups-primary --default=false
+  ```
+- Third way: Set a default backup storage location by passing `--default-backup-storage-location` flag on the `velero server` command.
+   ```bash
+  velero server --default-backup-storage-location backups-primary
+   ```
+Note: Only could have one default backup storage location, which means it's not allowed to set two default backup storage locations at the same time, the priorities among these three are as follows:
+- if velero server side has specified one default backup storage location, suppose it's `A`
+  - if `A` backup storage location exists, it's not allowed to set a new default backup storage location
+  - if `A` does not exist
+    - if using `velero backup-location set` or `velero backup-location create --default` command
+      - it could be successful if no default backup storage location exists.
+      - it would fail if already exist one default backup storage location. (So it need to remove other default backup storage location at first)
+- if velero server side has not specified one default backup storage location
+  - if using `velero backup-location set` or `velero backup-location create --default` command
+    - it could be successful if no default backup storage location exists.
+    - it would fail if already exist one default backup storage location. (So it need to remove other default backup storage location at first)
+#### Set default volume snapshot location
 You can set a default volume snapshot location for each of your volume snapshot providers using the `--default-volume-snapshot-locations` flag on the `velero server` command.
 
 ```


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Velero could set the default backup storage location as below:
- First way: Set a default backup storage location by passing a `--default` flag when running `velero backup-location create`.

  ```
  velero backup-location create backups-primary \
    --provider aws \
    --bucket velero-backups \
    --config region=us-east-1 \
    --default
  ```
- Second way: Set a default backup storage location by passing a  `--default` flag when running `velero backup-location set`.
  ```bash
  velero backup-location set backups-primary --default
  ```
  We also could remove the default backup storage location by this command, below is one example
  ```bash
  velero backup-location set backups-primary --default=false
  ```
- Third way: Set a default backup storage location by passing `--default-backup-storage-location` flag on the `velero server` command.
   ```bash
  velero server --default-backup-storage-location backups-primary
   ```
Note: Only could have one default backup storage location, which means it's not allowed to set two default backup storage locations at the same time, the priorities among these three are as follows:
- if velero server side has specified one default backup storage location, suppose it's `A`
  - if `A` backup storage location exists, it's not allowed to set a new default backup storage location
  - if `A` does not exist
    - if using `velero backup-location set` or `velero backup-location create --default` command
      - it could be successful if no default backup storage location exists.
      - it would fail if already exist one default backup storage location. (So it need to remove other default backup storage location at first)
- if velero server side has not specified one default backup storage location
  - if using `velero backup-location set` or `velero backup-location create --default` command
    - it could be successful if no default backup storage location exists.
    - it would fail if already exist one default backup storage location. (So it need to remove other default backup storage location at first)

# Does your change fix a particular issue?

Fixes #(issue)
https://github.com/vmware-tanzu/velero/issues/6572

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
