### PR TITLE
Fix node-agent missing metrics-addr parms to define the server start. #6784

### DIFF
--- a/changelogs/unreleased/6784-yanggangtony
+++ b/changelogs/unreleased/6784-yanggangtony
@@ -1,0 +1,1 @@
+Fix the node-agent missing metrics-address defines.

--- a/pkg/cmd/cli/nodeagent/server.go
+++ b/pkg/cmd/cli/nodeagent/server.go
@@ -114,6 +114,7 @@ func NewServerCommand(f client.Factory) *cobra.Command {
 	command.Flags().Var(formatFlag, "log-format", fmt.Sprintf("The format for log output. Valid values are %s.", strings.Join(formatFlag.AllowedValues(), ", ")))
 	command.Flags().DurationVar(&config.resourceTimeout, "resource-timeout", config.resourceTimeout, "How long to wait for resource processes which are not covered by other specific timeout parameters. Default is 10 minutes.")
 	command.Flags().DurationVar(&config.dataMoverPrepareTimeout, "data-mover-prepare-timeout", config.dataMoverPrepareTimeout, "How long to wait for preparing a DataUpload/DataDownload. Default is 30 minutes.")
+	command.Flags().StringVar(&config.metricsAddress, "metrics-address", config.metricsAddress, "The address to expose prometheus metrics")
 
 	return command
 }
@@ -193,14 +194,15 @@ func newNodeAgentServer(logger logrus.FieldLogger, factory client.Factory, confi
 	}
 
 	s := &nodeAgentServer{
-		logger:     logger,
-		ctx:        ctx,
-		cancelFunc: cancelFunc,
-		fileSystem: filesystem.NewFileSystem(),
-		mgr:        mgr,
-		config:     config,
-		namespace:  factory.Namespace(),
-		nodeName:   nodeName,
+		logger:         logger,
+		ctx:            ctx,
+		cancelFunc:     cancelFunc,
+		fileSystem:     filesystem.NewFileSystem(),
+		mgr:            mgr,
+		config:         config,
+		namespace:      factory.Namespace(),
+		nodeName:       nodeName,
+		metricsAddress: config.metricsAddress,
 	}
 
 	// the cache isn't initialized yet when "validatePodVolumesHostPath" is called, the client returned by the manager cannot

--- a/pkg/install/daemonset.go
+++ b/pkg/install/daemonset.go
@@ -105,6 +105,7 @@ func DaemonSet(namespace string, opts ...podTemplateOption) *appsv1.DaemonSet {
 						{
 							Name:            "node-agent",
 							Image:           c.image,
+							Ports:           containerPorts(),
 							ImagePullPolicy: pullPolicy,
 							Command: []string{
 								"/velero",


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Fix node-agent missing metrics-addr parms to define the server start.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
