### PR TITLE
[1.12] Fix issue 6748 [2]

### DIFF
--- a/pkg/uploader/kopia/snapshot.go
+++ b/pkg/uploader/kopia/snapshot.go
@@ -255,6 +255,7 @@ func SnapshotSource(
 	manifest.Tags = snapshotTags
 
 	manifest.Description = description
+	manifest.Pins = []string{"velero-pin"}
 
 	if _, err = saveSnapshotFunc(ctx, rep, manifest); err != nil {
 		return "", 0, errors.Wrapf(err, "Failed to save kopia manifest %v", manifest.ID)

--- a/pkg/uploader/provider/kopia.go
+++ b/pkg/uploader/provider/kopia.go
@@ -159,6 +159,10 @@ func (kp *kopiaProvider) RunBackup(
 	tags[uploader.SnapshotRequesterTag] = kp.requestorType
 	tags[uploader.SnapshotUploaderTag] = uploader.KopiaType
 
+	if realSource != "" {
+		realSource = fmt.Sprintf("%s/%s/%s", kp.requestorType, uploader.KopiaType, realSource)
+	}
+
 	snapshotInfo, isSnapshotEmpty, err := BackupFunc(ctx, kpUploader, repoWriter, path, realSource, forceFull, parentSnapshot, volMode, tags, log)
 	if err != nil {
 		if kpUploader.IsCanceled() {


### PR DESCRIPTION
Further enhance the code for https://github.com/vmware-tanzu/velero/issues/6748 -- isolate Velero snapshots by requestors, uploaders and sources so that they are not mixed from Kopia snapshot perspective. And pin Velero snapshots so that they are never deleted by Kopia retention policy