### PR TITLE
Issue 6786:always delete VSC regardless of the deletion policy

### DIFF
--- a/changelogs/unreleased/6827-Lyndon-Li
+++ b/changelogs/unreleased/6827-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix issue #6786, always delete VSC regardless of the deletion policy

--- a/pkg/exposer/csi_snapshot.go
+++ b/pkg/exposer/csi_snapshot.go
@@ -282,7 +282,7 @@ func (e *csiSnapshotExposer) createBackupVSC(ctx context.Context, ownerObject co
 			Source: snapshotv1api.VolumeSnapshotContentSource{
 				SnapshotHandle: snapshotVSC.Status.SnapshotHandle,
 			},
-			DeletionPolicy:          snapshotVSC.Spec.DeletionPolicy,
+			DeletionPolicy:          snapshotv1api.VolumeSnapshotContentDelete,
 			Driver:                  snapshotVSC.Spec.Driver,
 			VolumeSnapshotClassName: snapshotVSC.Spec.VolumeSnapshotClassName,
 		},

--- a/pkg/util/csi/volume_snapshot.go
+++ b/pkg/util/csi/volume_snapshot.go
@@ -101,7 +101,7 @@ func GetVolumeSnapshotContentForVolumeSnapshot(volSnap *snapshotv1api.VolumeSnap
 func RetainVSC(ctx context.Context, snapshotClient snapshotter.SnapshotV1Interface,
 	vsc *snapshotv1api.VolumeSnapshotContent) (*snapshotv1api.VolumeSnapshotContent, error) {
 	if vsc.Spec.DeletionPolicy == snapshotv1api.VolumeSnapshotContentRetain {
-		return nil, nil
+		return vsc, nil
 	}
 	origBytes, err := json.Marshal(vsc)
 	if err != nil {

--- a/pkg/util/csi/volume_snapshot_test.go
+++ b/pkg/util/csi/volume_snapshot_test.go
@@ -558,6 +558,14 @@ func TestRetainVSC(t *testing.T) {
 					DeletionPolicy: snapshotv1api.VolumeSnapshotContentRetain,
 				},
 			},
+			updated: &snapshotv1api.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fake-vsc",
+				},
+				Spec: snapshotv1api.VolumeSnapshotContentSpec{
+					DeletionPolicy: snapshotv1api.VolumeSnapshotContentRetain,
+				},
+			},
 		},
 		{
 			name: "path vsc fail",


### PR DESCRIPTION
Fix issue #6786, always delete VSC regardless of the deletion policy