### PR TITLE
Change the default value of the velero_backup_last_status metrics.

### DIFF
--- a/changelogs/unreleased/6838-yanggangtony
+++ b/changelogs/unreleased/6838-yanggangtony
@@ -1,0 +1,1 @@
+change the metrics backup_attempt_total default value to 1.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -468,7 +468,7 @@ func (m *ServerMetrics) InitSchedule(scheduleName string) {
 		c.WithLabelValues(scheduleName).Add(0)
 	}
 	if c, ok := m.metrics[backupLastStatus].(*prometheus.GaugeVec); ok {
-		c.WithLabelValues(scheduleName).Add(0)
+		c.WithLabelValues(scheduleName).Add(1)
 	}
 	if c, ok := m.metrics[restoreAttemptTotal].(*prometheus.CounterVec); ok {
 		c.WithLabelValues(scheduleName).Add(0)


### PR DESCRIPTION

Thank you for contributing to Velero!

# Please add a summary of your change

As issue describe.
Fix the metrics backup_last_status not report right value when the schedule down unexpectation

# Does your change fix a particular issue?

Fixes #6809 

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
