### PR TITLE
Expanded PR section of code standards doc

### DIFF
--- a/site/content/docs/main/code-standards.md
+++ b/site/content/docs/main/code-standards.md
@@ -8,6 +8,24 @@ toc: "true"
 
 When opening a pull request, please fill out the checklist supplied the template. This will help others properly categorize and review your pull request.
 
+### PR title
+
+Make sure that the pull request title summarizes the change made (and not just "fixes issue #xxxx"):
+
+Example PR titles:
+
+ - "Check for nil when validating foo"
+ - "Issue #1234: Check for nil when validating foo"
+
+### Cherry-pick PRs
+
+When a PR to main needs to be cherry-picked to a release branch, please wait until the main PR is merged first before creating the CP PR. If the CP PR is made before the main PR is merged, there is a risk that PR modifications in response to review comments will not make it into the CP PR.
+
+The Cherry-pick PR title should reference the branch it's cherry-picked to and the fact that it's a CP of a commit to main:
+
+ - "[release-1.13 CP] Issue #1234: Check for nil when validating foo"
+
+
 ## Adding a changelog
 
 Authors are expected to include a changelog file with their pull requests. The changelog file


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Updates code standards doc with some additional content around PR best practices, as discussed in a recent community meeting.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
