### PR TITLE
Move Dave Smith-Uchida to Emeritus Maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,7 +6,6 @@
 
 | Maintainer          | GitHub ID                                                     | Affiliation                                      |
 |---------------------|---------------------------------------------------------------|--------------------------------------------------|
-| Dave Smith-Uchida   | [dsu-igeek](https://github.com/dsu-igeek)                     | [Kasten](https://github.com/kastenhq/)           |
 | Scott Seago         | [sseago](https://github.com/sseago)                           | [OpenShift](https://github.com/openshift)        |
 | Daniel Jiang        | [reasonerjt](https://github.com/reasonerjt)                   | [VMware](https://www.github.com/vmware/)         |
 | Wenkai Yin          | [ywk253100](https://github.com/ywk253100)                     | [VMware](https://www.github.com/vmware/)         |
@@ -26,12 +25,12 @@
 * Carlisia Thompson ([carlisia](https://github.com/carlisia))
 * Bridget McErlean ([zubron](https://github.com/zubron))
 * JenTing Hsiao ([jenting](https://github.com/jenting))
-
+* Dave Smith-Uchida ([dsu-igeek](https://github.com/dsu-igeek))
+  
 ## Velero Contributors & Stakeholders
 
 | Feature Area           |                                         Lead                                         |
 |------------------------|:------------------------------------------------------------------------------------:|
-| Architect              |             Dave Smith-Uchida [dsu-igeek](https://github.com/dsu-igeek)              |
 | Technical Lead         |               Daniel Jiang [reasonerjt](https://github.com/reasonerjt)               |
 | Kubernetes CSI Liaison |                                                                                      |
 | Deployment             |                                                                                      |


### PR DESCRIPTION
Move Dave Smith-Uchida to Emeritus Maintainer

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
