### PR TITLE
doc: Alert that plugins run as binaries when turning on debug logs

### DIFF
--- a/site/content/docs/main/troubleshooting.md
+++ b/site/content/docs/main/troubleshooting.md
@@ -46,6 +46,8 @@ kubectl edit deployment/velero -n velero
 ...
 ```
 
+**Note:** Velero plugins run as binaries, i.e. after they are executed, either successful or not, they exit. So, if you see **received EOF, stopping recv loop** messages in debug logs, that does not mean an error occurred.
+
 ## Known issue with restoring LoadBalancer Service
 
 Because of how Kubernetes handles Service objects of `type=LoadBalancer`, when you restore these objects you might encounter an issue with changed values for Service UIDs. Kubernetes automatically generates the name of the cloud resource based on the Service UID, which is different when restored, resulting in a different name for the cloud load balancer. If the DNS CNAME for your application points to the DNS name of your cloud load balancer, you'll need to update the CNAME pointer when you perform a Velero restore.


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

Add alert in docs about plugins behaviors. This already has come up mistakenly in an issue https://github.com/vmware-tanzu/velero/issues/5115 

Also, this has been already explained in some issues: 
- https://github.com/vmware-tanzu/velero/issues/5641#issuecomment-1342283436 
- https://github.com/vmware-tanzu/velero/issues/5205#issuecomment-1370792133

# Does your change fix a particular issue?

No

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
