### PR TITLE
[1.10] Flush repo after policy is set

### DIFF
--- a/changelogs/unreleased/6890-Lyndon-Li
+++ b/changelogs/unreleased/6890-Lyndon-Li
@@ -1,0 +1,1 @@
+Flush repo after policy is set so that policy is retrieved correctly by TreeForSource

--- a/pkg/uploader/kopia/snapshot.go
+++ b/pkg/uploader/kopia/snapshot.go
@@ -199,6 +199,10 @@ func SnapshotSource(
 		return "", 0, errors.Wrapf(err, "unable to set policy for si %v", sourceInfo)
 	}
 
+	if err := rep.Flush(ctx); err != nil {
+		return "", 0, errors.Wrap(err, "error to flush policy repo")
+	}
+
 	policyTree, err := treeForSourceFunc(ctx, rep, sourceInfo)
 	if err != nil {
 		return "", 0, errors.Wrapf(err, "unable to create policy getter for si %v", sourceInfo)
@@ -232,7 +236,7 @@ func reportSnapshotStatus(manifest *snapshot.Manifest, policyTree *policy.Tree) 
 	var errs []string
 	if ds := manifest.RootEntry.DirSummary; ds != nil {
 		for _, ent := range ds.FailedEntries {
-			policy := policyTree.DefinedPolicy()
+			policy := policyTree.EffectivePolicy()
 			if !(policy != nil && *policy.ErrorHandlingPolicy.IgnoreUnknownTypes == true && strings.Contains(ent.Error, fs.ErrUnknown.Error())) {
 				errs = append(errs, fmt.Sprintf("Error when processing %v: %v", ent.EntryPath, ent.Error))
 			}


### PR DESCRIPTION
Flush repo after policy is set so that policy is retrieved correctly by TreeForSource