### PR TITLE
Fix CI out of disk space problem

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -73,7 +73,7 @@ jobs:
       run: |
         sudo swapoff -a
         sudo rm -f /mnt/swapfile
-        docker image prune -a --force
+        docker system prune -a --force
               
         # Build and push Velero image to docker registry
         docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
Fix CI out of disk space problem by running `docker system prune -a --force` before building the container image