### PR TITLE
Fix code-standards url rendering for `https://developercertificate.org/)`

### DIFF
--- a/site/content/docs/main/code-standards.md
+++ b/site/content/docs/main/code-standards.md
@@ -108,7 +108,7 @@ Signed-off-by: Joe Beda <joe@heptio.com>
 
 This can easily be done with the `--signoff` option to `git commit`.
 
-By doing this you state that you can certify the following (from https://developercertificate.org/):
+By doing this you state that you can certify the following (from [https://developercertificate.org/](https://developercertificate.org/)):
 
 ```
 Developer Certificate of Origin

--- a/site/content/docs/v1.10/code-standards.md
+++ b/site/content/docs/v1.10/code-standards.md
@@ -108,7 +108,7 @@ Signed-off-by: Joe Beda <joe@heptio.com>
 
 This can easily be done with the `--signoff` option to `git commit`.
 
-By doing this you state that you can certify the following (from https://developercertificate.org/):
+By doing this you state that you can certify the following (from [https://developercertificate.org/](https://developercertificate.org/)):
 
 ```
 Developer Certificate of Origin

--- a/site/content/docs/v1.11/code-standards.md
+++ b/site/content/docs/v1.11/code-standards.md
@@ -108,7 +108,7 @@ Signed-off-by: Joe Beda <joe@heptio.com>
 
 This can easily be done with the `--signoff` option to `git commit`.
 
-By doing this you state that you can certify the following (from https://developercertificate.org/):
+By doing this you state that you can certify the following (from [https://developercertificate.org/](https://developercertificate.org/)):
 
 ```
 Developer Certificate of Origin

--- a/site/content/docs/v1.12/code-standards.md
+++ b/site/content/docs/v1.12/code-standards.md
@@ -108,7 +108,7 @@ Signed-off-by: Joe Beda <joe@heptio.com>
 
 This can easily be done with the `--signoff` option to `git commit`.
 
-By doing this you state that you can certify the following (from https://developercertificate.org/):
+By doing this you state that you can certify the following (from [https://developercertificate.org/](https://developercertificate.org/)):
 
 ```
 Developer Certificate of Origin

--- a/site/content/docs/v1.2.0/code-standards.md
+++ b/site/content/docs/v1.2.0/code-standards.md
@@ -83,7 +83,7 @@ Signed-off-by: Joe Beda <joe@heptio.com>
 
 This can easily be done with the `--signoff` option to `git commit`.
 
-By doing this you state that you can certify the following (from https://developercertificate.org/):
+By doing this you state that you can certify the following (from [https://developercertificate.org/](https://developercertificate.org/)):
 
 ```
 Developer Certificate of Origin

--- a/site/content/docs/v1.3.0/code-standards.md
+++ b/site/content/docs/v1.3.0/code-standards.md
@@ -83,7 +83,7 @@ Signed-off-by: Joe Beda <joe@heptio.com>
 
 This can easily be done with the `--signoff` option to `git commit`.
 
-By doing this you state that you can certify the following (from https://developercertificate.org/):
+By doing this you state that you can certify the following (from [https://developercertificate.org/](https://developercertificate.org/)):
 
 ```
 Developer Certificate of Origin

--- a/site/content/docs/v1.3.1/code-standards.md
+++ b/site/content/docs/v1.3.1/code-standards.md
@@ -82,7 +82,7 @@ Signed-off-by: Joe Beda <joe@heptio.com>
 
 This can easily be done with the `--signoff` option to `git commit`.
 
-By doing this you state that you can certify the following (from https://developercertificate.org/):
+By doing this you state that you can certify the following (from [https://developercertificate.org/](https://developercertificate.org/)):
 
 ```
 Developer Certificate of Origin

--- a/site/content/docs/v1.3.2/code-standards.md
+++ b/site/content/docs/v1.3.2/code-standards.md
@@ -83,7 +83,7 @@ Signed-off-by: Joe Beda <joe@heptio.com>
 
 This can easily be done with the `--signoff` option to `git commit`.
 
-By doing this you state that you can certify the following (from https://developercertificate.org/):
+By doing this you state that you can certify the following (from [https://developercertificate.org/](https://developercertificate.org/)):
 
 ```
 Developer Certificate of Origin

--- a/site/content/docs/v1.4/code-standards.md
+++ b/site/content/docs/v1.4/code-standards.md
@@ -101,7 +101,7 @@ Signed-off-by: Joe Beda <joe@heptio.com>
 
 This can easily be done with the `--signoff` option to `git commit`.
 
-By doing this you state that you can certify the following (from https://developercertificate.org/):
+By doing this you state that you can certify the following (from [https://developercertificate.org/](https://developercertificate.org/)):
 
 ```
 Developer Certificate of Origin

--- a/site/content/docs/v1.7/code-standards.md
+++ b/site/content/docs/v1.7/code-standards.md
@@ -108,7 +108,7 @@ Signed-off-by: Joe Beda <joe@heptio.com>
 
 This can easily be done with the `--signoff` option to `git commit`.
 
-By doing this you state that you can certify the following (from https://developercertificate.org/):
+By doing this you state that you can certify the following (from [https://developercertificate.org/](https://developercertificate.org/)):
 
 ```
 Developer Certificate of Origin

--- a/site/content/docs/v1.9/code-standards.md
+++ b/site/content/docs/v1.9/code-standards.md
@@ -108,7 +108,7 @@ Signed-off-by: Joe Beda <joe@heptio.com>
 
 This can easily be done with the `--signoff` option to `git commit`.
 
-By doing this you state that you can certify the following (from https://developercertificate.org/):
+By doing this you state that you can certify the following (from [https://developercertificate.org/](https://developercertificate.org/)):
 
 ```
 Developer Certificate of Origin


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?
[Before](https://velero.io/docs/v1.12/code-standards/#copyright-header:~:text=By%20doing%20this%20you%20state%20that%20you%20can%20certify%20the%20following%20(from%20https%3A//developercertificate.org/)%3A)
<img width="357" alt="image" src="https://github.com/vmware-tanzu/velero/assets/11228024/24761430-0fca-493f-9239-2bfd31fc7792">

[After](https://velero-k35apjda9-kaovilai.vercel.app/docs/v1.12/code-standards#:~:text=By%20doing%20this%20you%20state%20that%20you%20can%20certify%20the%20following%20(from%20https%3A//developercertificate.org/)%3A)
<img width="343" alt="image" src="https://github.com/vmware-tanzu/velero/assets/11228024/d097ccab-cf60-4ec9-8675-f749d77a30a4">


# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
