### PR TITLE
fix error log messages if s3 bucket is versioned

### DIFF
--- a/pkg/persistence/object_store.go
+++ b/pkg/persistence/object_store.go
@@ -235,6 +235,16 @@ func (s *objectBackupStore) ListBackups() ([]string, error) {
 		// each of those off to get the backup name.
 		backupName := strings.TrimSuffix(strings.TrimPrefix(prefix, s.layout.subdirs["backups"]), "/")
 
+		// if a bucket is versioned, the s3 folder still exists, even if all s3 objects have been deleted.
+		// We should only take s3 folders having a velero-backup.json object.
+		if ok, errObjectExists := s.objectStore.ObjectExists(s.bucket, s.layout.getBackupMetadataKey(backupName)); !ok || errObjectExists != nil {
+			// velero-backup.json or error do not add to list
+			if errObjectExists != nil {
+				s.logger.WithError(errObjectExists).Debugf("could not check if %s/%s exists", s.bucket, s.layout.getBackupMetadataKey(backupName))
+			}
+			continue
+		}
+
 		output = append(output, backupName)
 	}
 

--- a/pkg/persistence/object_store_test.go
+++ b/pkg/persistence/object_store_test.go
@@ -194,6 +194,16 @@ func TestListBackups(t *testing.T) {
 			},
 			expectedRes: []string{"backup-1", "backup-2"},
 		},
+		{
+			name:   "normal case with backup store prefix ignore folder missing velero-backup.json ",
+			prefix: "velero-backups/",
+			storageData: map[string][]byte{
+				"velero-backups/backups/backup-1/velero-backup.json": encodeToBytes(builder.ForBackup("", "backup-1").Result()),
+				"velero-backups/backups/backup-2/velero-backup.json": encodeToBytes(builder.ForBackup("", "backup-2").Result()),
+				"velero-backups/backups/backup-3/":                   encodeToBytes(builder.ForBackup("", "backup-3").Result()),
+			},
+			expectedRes: []string{"backup-1", "backup-2"},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION

Thank you for contributing to Velero!

# Please add a summary of your change
if s3 bucket is versioned and velero deletes all files from a specific backup folder, s3 keeps the folder (but not the files inside) visible, because of the deleted files are kept in deleted state. A s3 versioned bucket keeps folders visible until s3 retention completely removes all versions and all delete marker from the s3 folder.  

# Does your change fix a particular issue?

Fixes error message like: 
```
velero time="2023-10-01T12:25:20Z" level=error msg="Error getting backup metadata from backup store" backup=k14-prod-digidatei01-0-every-6h-ttl-23-hours-20230929035140 backupLocation=velero/k14-prod-digidatei01-0 controller=backup-sync error="rpc error: code = Unknown desc = error getting object backups/k14-prod-digidatei01-0-every-6h-ttl-23-hours-20230929035140/velero-backup.json: NoSuchKey: The specified key does not exist.\n\tstatus code: 404, request id: 1789FB5F2C42E211, host id: 470a0afc0f6fdbebb6a8e14ece29122784c0656e19563387135a7c8e02feb163" error.file="/go/src/github.com/vmware-tanzu/velero/pkg/persistence/object_store.go:302" error.function="github.com/vmware-tanzu/velero/pkg/persistence.(*objectBackupStore).GetBackupMetadata" logSource="pkg/controller/backup_sync_controller.go:147"
```

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
