### PR TITLE
Resolve netlify site publish issues due to missing directory `site/site/public`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   base = "site/"
   command = "hugo --gc --minify"
-  publish = "site/public"
+  publish = "public"
 
 [context.production.environment]
   HUGO_VERSION = "0.73.0"


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
remove site/ prefix from publish in netlify.toml
# Does your change fix a particular issue?
Resolve site publish issues due to missing directory from [faulty path appending in netlify](https://answers.netlify.com/t/deploy-did-not-succeed-deploy-directory-site-site-public-does-not-exist/103160/2).

[Deploy before that failed](https://app.netlify.com/sites/velero-k/deploys/651b12951b95bf0008483b5b) commit vmain@[13019b9](https://github.com/kaovilai/velero/commit/13019b943a34a32799a6b8fec2f7bedcec46f2be)
[Deploy after that succeeded](https://app.netlify.com/sites/velero-k/deploys/651b150167d70c0008cba6ec) vmain@[09f7744](https://github.com/kaovilai/velero/commit/09f7744e339a40e3b2848170ddf18e02afba4c74)
git commit that resolve the issue vmain@[09f7744](https://github.com/kaovilai/velero/commit/09f7744e339a40e3b2848170ddf18e02afba4c74)

Fixes #(issue)
`2:51:26 PM:   Error message
2:51:26 PM:   Deploy did not succeed: Deploy directory "site/site/public" does not exist`

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.

/kind changelog-not-required