### PR TITLE
[1.12] Issue 6734: spread backup pod evenly

### DIFF
--- a/changelogs/unreleased/6935-Lyndon-Li
+++ b/changelogs/unreleased/6935-Lyndon-Li
@@ -1,0 +1,1 @@
+Partially fix #6734, guide Kubernetes' scheduler to spread backup pods evenly across nodes as much as possible, so that data mover backup could achieve better parallelism

--- a/pkg/exposer/types.go
+++ b/pkg/exposer/types.go
@@ -23,6 +23,8 @@ import (
 const (
 	AccessModeFileSystem = "by-file-system"
 	AccessModeBlock      = "by-block-device"
+	podGroupLabel        = "velero.io/exposer-pod-group"
+	podGroupSnapshot     = "snapshot-exposer"
 )
 
 // ExposeResult defines the result of expose.


### PR DESCRIPTION
Partially fix https://github.com/vmware-tanzu/velero/issues/6734, guide Kubernetes' scheduler to spread backup pods evenly across nodes as much as possible, so that data mover backup could achieve better parallelism