### PR TITLE
A small typo duplicated csi-snapshot-data-movement.md in main and v.1.12

### DIFF
--- a/site/content/docs/main/csi-snapshot-data-movement.md
+++ b/site/content/docs/main/csi-snapshot-data-movement.md
@@ -194,7 +194,7 @@ Or if you want to use a customized data mover:
 velero backup create NAME --snapshot-move-data --data-mover DATA-MOVER-NAME OPTIONS...
 ```
 
-When the backup starts, you will see the `VolumeSnapshot` and `VolumeSnapshotContent` objects created, but after the backup finishes, the objects will disppear.  
+When the backup starts, you will see the `VolumeSnapshot` and `VolumeSnapshotContent` objects created, but after the backup finishes, the objects will disappear.  
 After snapshots are created, you will see one or more `DataUpload` CRs created.  
 You may also see some intermediate objects (i.e., pods, PVCs, PVs) created in Velero namespace or the cluster scope, they are to help data movers to move data. And they will be removed after the backup completes.  
 The phase of a `DataUpload` CR changes several times during the backup process and finally goes to one of the terminal status, `Completed`, `Failed` or `Cancelled`. You can see the phase changes as well as the data upload progress by watching the `DataUpload` CRs:  

--- a/site/content/docs/v1.12/csi-snapshot-data-movement.md
+++ b/site/content/docs/v1.12/csi-snapshot-data-movement.md
@@ -207,7 +207,7 @@ Or if you want to use a customized data mover:
 velero backup create NAME --snapshot-move-data --data-mover DATA-MOVER-NAME OPTIONS...
 ```
 
-When the backup starts, you will see the `VolumeSnapshot` and `VolumeSnapshotContent` objects created, but after the backup finishes, the objects will disppear.  
+When the backup starts, you will see the `VolumeSnapshot` and `VolumeSnapshotContent` objects created, but after the backup finishes, the objects will disappear.  
 After snapshots are created, you will see one or more `DataUpload` CRs created.  
 You may also see some intermediate objects (i.e., pods, PVCs, PVs) created in Velero namespace or the cluster scope, they are to help data movers to move data. And they will be removed after the backup completes.  
 The phase of a `DataUpload` CR changes several times during the backup process and finally goes to one of the terminal status, `Completed`, `Failed` or `Cancelled`. You can see the phase changes as well as the data upload progress by watching the `DataUpload` CRs:  


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
* small typo in `csi-snapshot-data-movement.md` for main and v1.12 docs

# Does your change fix a particular issue?
* No - just noticed a typo
Fixes #(issue)
/NA
# Please indicate you've done the following:

- [X ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ X] Updated the corresponding documentation in `site/content/docs/main`.
