### PR TITLE
[1.12] Issue 6647: add default-snapshot-move-data parameter to Velero install

### DIFF
--- a/changelogs/unreleased/6940-Lyndon-Li
+++ b/changelogs/unreleased/6940-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix issue #6647, add the --default-snapshot-move-data parameter to Velero install, so that users don't need to specify --snapshot-move-data per backup when they want to move snapshot data for all backups

--- a/pkg/cmd/cli/install/install.go
+++ b/pkg/cmd/cli/install/install.go
@@ -80,6 +80,7 @@ type Options struct {
 	Features                        string
 	DefaultVolumesToFsBackup        bool
 	UploaderType                    string
+	DefaultSnapshotMoveData         bool
 }
 
 // BindFlags adds command line values to the options struct.
@@ -120,6 +121,7 @@ func (o *Options) BindFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&o.Features, "features", o.Features, "Comma separated list of Velero feature flags to be set on the Velero deployment and the node-agent daemonset, if node-agent is enabled")
 	flags.BoolVar(&o.DefaultVolumesToFsBackup, "default-volumes-to-fs-backup", o.DefaultVolumesToFsBackup, "Bool flag to configure Velero server to use pod volume file system backup by default for all volumes on all backups. Optional.")
 	flags.StringVar(&o.UploaderType, "uploader-type", o.UploaderType, fmt.Sprintf("The type of uploader to transfer the data of pod volumes, the supported values are '%s', '%s'", uploader.ResticType, uploader.KopiaType))
+	flags.BoolVar(&o.DefaultSnapshotMoveData, "default-snapshot-move-data", o.DefaultSnapshotMoveData, "Bool flag to configure Velero server to move data by default for all snapshots supporting data movement. Optional.")
 }
 
 // NewInstallOptions instantiates a new, default InstallOptions struct.
@@ -146,6 +148,7 @@ func NewInstallOptions() *Options {
 		CRDsOnly:                 false,
 		DefaultVolumesToFsBackup: false,
 		UploaderType:             uploader.KopiaType,
+		DefaultSnapshotMoveData:  false,
 	}
 }
 
@@ -209,6 +212,7 @@ func (o *Options) AsVeleroOptions() (*install.VeleroOptions, error) {
 		Features:                        strings.Split(o.Features, ","),
 		DefaultVolumesToFsBackup:        o.DefaultVolumesToFsBackup,
 		UploaderType:                    o.UploaderType,
+		DefaultSnapshotMoveData:         o.DefaultSnapshotMoveData,
 	}, nil
 }
 

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -135,6 +135,7 @@ type serverConfig struct {
 	defaultVolumesToFsBackup                                                bool
 	uploaderType                                                            string
 	maxConcurrentK8SConnections                                             int
+	defaultSnapshotMoveData                                                 bool
 }
 
 func NewCommand(f client.Factory) *cobra.Command {
@@ -163,6 +164,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 			defaultVolumesToFsBackup:       podvolume.DefaultVolumesToFsBackup,
 			uploaderType:                   uploader.ResticType,
 			maxConcurrentK8SConnections:    defaultMaxConcurrentK8SConnections,
+			defaultSnapshotMoveData:        false,
 		}
 	)
 
@@ -233,6 +235,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 	command.Flags().DurationVar(&config.defaultItemOperationTimeout, "default-item-operation-timeout", config.defaultItemOperationTimeout, "How long to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. Default is 4 hours")
 	command.Flags().DurationVar(&config.resourceTimeout, "resource-timeout", config.resourceTimeout, "How long to wait for resource processes which are not covered by other specific timeout parameters. Default is 10 minutes.")
 	command.Flags().IntVar(&config.maxConcurrentK8SConnections, "max-concurrent-k8s-connections", config.maxConcurrentK8SConnections, "Max concurrent connections number that Velero can create with kube-apiserver. Default is 30.")
+	command.Flags().BoolVar(&config.defaultSnapshotMoveData, "default-snapshot-move-data", config.defaultSnapshotMoveData, "Move data by default for all snapshots supporting data movement.")
 
 	return command
 }
@@ -757,6 +760,7 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 			s.csiSnapshotClient,
 			s.credentialFileStore,
 			s.config.maxConcurrentK8SConnections,
+			s.config.defaultSnapshotMoveData,
 		).SetupWithManager(s.mgr); err != nil {
 			s.logger.Fatal(err, "unable to create controller", "controller", controller.Backup)
 		}

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -88,6 +88,7 @@ type backupReconciler struct {
 	volumeSnapshotClient        snapshotterClientSet.Interface
 	credentialFileStore         credentials.FileStore
 	maxConcurrentK8SConnections int
+	defaultSnapshotMoveData     bool
 }
 
 func NewBackupReconciler(
@@ -113,6 +114,7 @@ func NewBackupReconciler(
 	volumeSnapshotClient snapshotterClientSet.Interface,
 	credentialStore credentials.FileStore,
 	maxConcurrentK8SConnections int,
+	defaultSnapshotMoveData bool,
 ) *backupReconciler {
 	b := &backupReconciler{
 		ctx:                         ctx,
@@ -138,6 +140,7 @@ func NewBackupReconciler(
 		volumeSnapshotClient:        volumeSnapshotClient,
 		credentialFileStore:         credentialStore,
 		maxConcurrentK8SConnections: maxConcurrentK8SConnections,
+		defaultSnapshotMoveData:     defaultSnapshotMoveData,
 	}
 	b.updateTotalBackupMetric()
 	return b
@@ -351,6 +354,10 @@ func (b *backupReconciler) prepareBackupRequest(backup *velerov1api.Backup, logg
 
 	if request.Spec.DefaultVolumesToFsBackup == nil {
 		request.Spec.DefaultVolumesToFsBackup = &b.defaultVolumesToFsBackup
+	}
+
+	if request.Spec.SnapshotMoveData == nil {
+		request.Spec.SnapshotMoveData = &b.defaultSnapshotMoveData
 	}
 
 	// find which storage location to use

--- a/pkg/install/deployment.go
+++ b/pkg/install/deployment.go
@@ -47,6 +47,7 @@ type podTemplateConfig struct {
 	serviceAccountName              string
 	uploaderType                    string
 	privilegedNodeAgent             bool
+	defaultSnapshotMoveData         bool
 }
 
 func WithImage(image string) podTemplateOption {
@@ -137,6 +138,12 @@ func WithDefaultVolumesToFsBackup() podTemplateOption {
 	}
 }
 
+func WithDefaultSnapshotMoveData() podTemplateOption {
+	return func(c *podTemplateConfig) {
+		c.defaultSnapshotMoveData = true
+	}
+}
+
 func WithServiceAccountName(sa string) podTemplateOption {
 	return func(c *podTemplateConfig) {
 		c.serviceAccountName = sa
@@ -172,6 +179,10 @@ func Deployment(namespace string, opts ...podTemplateOption) *appsv1.Deployment 
 
 	if c.defaultVolumesToFsBackup {
 		args = append(args, "--default-volumes-to-fs-backup=true")
+	}
+
+	if c.defaultSnapshotMoveData {
+		args = append(args, "--default-snapshot-move-data=true")
 	}
 
 	if len(c.uploaderType) > 0 {

--- a/pkg/install/resources.go
+++ b/pkg/install/resources.go
@@ -252,6 +252,7 @@ type VeleroOptions struct {
 	Features                        []string
 	DefaultVolumesToFsBackup        bool
 	UploaderType                    string
+	DefaultSnapshotMoveData         bool
 }
 
 func AllCRDs() *unstructured.UnstructuredList {
@@ -350,6 +351,10 @@ func AllResources(o *VeleroOptions) *unstructured.UnstructuredList {
 
 	if o.DefaultVolumesToFsBackup {
 		deployOpts = append(deployOpts, WithDefaultVolumesToFsBackup())
+	}
+
+	if o.DefaultSnapshotMoveData {
+		deployOpts = append(deployOpts, WithDefaultSnapshotMoveData())
 	}
 
 	deploy := Deployment(o.Namespace, deployOpts...)


### PR DESCRIPTION
Fix issue https://github.com/vmware-tanzu/velero/issues/6647, add the --default-snapshot-move-data parameter to Velero install, so that users don't need to specify --snapshot-move-data per backup when they want to move snapshot data for all backups