### PR TITLE
Check whether the action is a CSI action and whether CSI feature is

### DIFF
--- a/changelogs/unreleased/6968-blackpiglet
+++ b/changelogs/unreleased/6968-blackpiglet
@@ -1,0 +1,1 @@
+Check whether the action is a CSI action and whether CSI feature is enabled, before executing the action.

--- a/internal/delete/delete_item_action_handler.go
+++ b/internal/delete/delete_item_action_handler.go
@@ -119,6 +119,7 @@ func InvokeDeleteActions(ctx *Context) error {
 					if !action.Selector.Matches(labels.Set(obj.GetLabels())) {
 						continue
 					}
+
 					err = action.DeleteItemAction.Execute(&velero.DeleteItemActionExecuteInput{
 						Item:   obj,
 						Backup: ctx.Backup,

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/builder"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/discovery"
+	"github.com/vmware-tanzu/velero/pkg/features"
 	"github.com/vmware-tanzu/velero/pkg/itemoperation"
 	"github.com/vmware-tanzu/velero/pkg/kuberesource"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
@@ -1379,6 +1380,12 @@ func TestBackupItemActionsForSkippedPV(t *testing.T) {
 			expectNotSkippedPVs: []string{"pv-1"},
 		},
 	}
+	// Enable CSI feature before running the test, because Velero will check whether
+	// CSI feature is enabled before executing CSI plugin actions.
+	features.NewFeatureFlagSet("EnableCSI")
+	defer func() {
+		features.NewFeatureFlagSet("")
+	}()
 	for _, tc := range tests {
 		t.Run(tc.name, func(tt *testing.T) {
 			var (

--- a/pkg/util/csi/util.go
+++ b/pkg/util/csi/util.go
@@ -1,0 +1,32 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csi
+
+import (
+	"strings"
+
+	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/features"
+)
+
+const (
+	csiPluginNamePrefix = "velero.io/csi-"
+)
+
+func ShouldSkipAction(actionName string) bool {
+	return !features.IsEnabled(velerov1api.CSIFeatureFlag) && strings.Contains(actionName, csiPluginNamePrefix)
+}

--- a/pkg/util/csi/util_test.go
+++ b/pkg/util/csi/util_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware-tanzu/velero/pkg/features"
+)
+
+func TestCSIFeatureNotEnabledAndPluginIsFromCSI(t *testing.T) {
+
+	features.NewFeatureFlagSet("EnableCSI")
+	require.False(t, ShouldSkipAction("abc"))
+	require.False(t, ShouldSkipAction("velero.io/csi-pvc-backupper"))
+
+	features.NewFeatureFlagSet("")
+	require.True(t, ShouldSkipAction("velero.io/csi-pvc-backupper"))
+	require.False(t, ShouldSkipAction("abc"))
+}


### PR DESCRIPTION
enabled, before executing the action.

The DeleteItemAction is not checked, because the DIA doesn't have a method to get the action's plugin name.
This should be OK, because the CSI will check whether the VS and VSC have a backup name annotation. If the VS and VSC is not handled by the CSI plugin, then they don't have the annotation.

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #6585 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
