### PR TITLE
Fix Backup name duplication

### DIFF
--- a/changelogs/unreleased/6971-learner0810
+++ b/changelogs/unreleased/6971-learner0810
@@ -1,0 +1,1 @@
+Fix Backup name duplication

--- a/pkg/apis/velero/v1/schedule_types.go
+++ b/pkg/apis/velero/v1/schedule_types.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/storage/names"
 )
 
 // ScheduleSpec defines the specification for a Velero schedule
@@ -124,5 +125,5 @@ type ScheduleList struct {
 
 // TimestampedName returns the default backup name format based on the schedule
 func (s *Schedule) TimestampedName(timestamp time.Time) string {
-	return fmt.Sprintf("%s-%s", s.Name, timestamp.Format("20060102150405"))
+	return names.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-%s-", s.Name, timestamp.Format("20060102150405")))
 }


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

We installed velero in multiple clusters with identical configurations, and the backups.velero.io name generated by schedules.velero.io was duplicated, so we added a random number to the backups.velero.io name.

Now backups.velero.io name looks like this  ```schedule-name-20231018165532-6cpgw```

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
