### PR TITLE
Issue 6964: get volume size from source PVC if it is invalid in VS

### DIFF
--- a/changelogs/unreleased/6976-Lyndon-Li
+++ b/changelogs/unreleased/6976-Lyndon-Li
@@ -1,0 +1,1 @@
+It is a valid case that the Status.RestoreSize field in VolumeSnapshot is not set, if so, get the volume size from the source PVC to create the backup PVC

--- a/pkg/controller/data_upload_controller.go
+++ b/pkg/controller/data_upload_controller.go
@@ -762,6 +762,7 @@ func (r *DataUploadReconciler) setupExposeParam(du *velerov2alpha1api.DataUpload
 			HostingPodLabels: map[string]string{velerov1api.DataUploadLabel: du.Name},
 			AccessMode:       accessMode,
 			Timeout:          du.Spec.OperationTimeout.Duration,
+			VolumeSize:       pvc.Spec.Resources.Requests[corev1.ResourceStorage],
 		}, nil
 	}
 	return nil, nil


### PR DESCRIPTION
It is a valid case that the `Status.RestoreSize` field in VolumeSnapshot is not set, if so, get the volume size from the source PVC to create the backup PVC
