### PR TITLE
Add both non-Windows version and Windows version code for PVC block mode logic

### DIFF
--- a/changelogs/unreleased/6986-blackpiglet
+++ b/changelogs/unreleased/6986-blackpiglet
@@ -1,0 +1,1 @@
+Add both non-Windows version and Windows version code for PVC block mode logic.

--- a/pkg/uploader/kopia/block_backup.go
+++ b/pkg/uploader/kopia/block_backup.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 /*
 Copyright The Velero Contributors.
 

--- a/pkg/uploader/kopia/block_backup_windows.go
+++ b/pkg/uploader/kopia/block_backup_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+// +build windows
+
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kopia
+
+import (
+	"fmt"
+
+	"github.com/kopia/kopia/fs"
+)
+
+func getLocalBlockEntry(sourcePath string) (fs.Entry, error) {
+	return nil, fmt.Errorf("block mode is not supported for Windows")
+}

--- a/pkg/uploader/kopia/block_restore.go
+++ b/pkg/uploader/kopia/block_restore.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 /*
 Copyright The Velero Contributors.
 

--- a/pkg/uploader/kopia/block_restore_windows.go
+++ b/pkg/uploader/kopia/block_restore_windows.go
@@ -1,0 +1,42 @@
+//go:build windows
+// +build windows
+
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kopia
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kopia/kopia/fs"
+	"github.com/kopia/kopia/snapshot/restore"
+)
+
+type BlockOutput struct {
+	*restore.FilesystemOutput
+
+	targetFileName string
+}
+
+func (o *BlockOutput) WriteFile(ctx context.Context, relativePath string, remoteFile fs.File) error {
+	return fmt.Errorf("block mode is not supported for Windows")
+}
+
+func (o *BlockOutput) BeginDirectory(ctx context.Context, relativePath string, e fs.Directory) error {
+	return fmt.Errorf("block mode is not supported for Windows")
+}


### PR DESCRIPTION
Release v1.12.rc.1 failed with the Windows binary build. The error message is:
```
# github.com/vmware-tanzu/velero/pkg/uploader/kopia
pkg/uploader/kopia/block_backup.go:41:31: undefined: syscall.Stat_t
pkg/uploader/kopia/block_restore.go:94:31: undefined: syscall.Stat_t
```

The reason is that PVC block mode backup and restore introduced some OS-specific system calls. 
Those calls are not available for Windows, so add both non-Windows version and Windows version code and return an error for block mode on the Windows platform.

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
