### PR TITLE
Issue 6988: udmrepo use region specified in BSL when s3URL is empty

### DIFF
--- a/changelogs/unreleased/6990-Lyndon-Li
+++ b/changelogs/unreleased/6990-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix #6988, always get region from BSL if it is not empty

--- a/pkg/repository/provider/unified_repo.go
+++ b/pkg/repository/provider/unified_repo.go
@@ -477,9 +477,11 @@ func getStorageVariables(backupLocation *velerov1api.BackupStorageLocation, repo
 
 		var err error
 		if s3URL == "" {
-			region, err = getS3BucketRegion(bucket)
-			if err != nil {
-				return map[string]string{}, errors.Wrap(err, "error get s3 bucket region")
+			if region == "" {
+				region, err = getS3BucketRegion(bucket)
+				if err != nil {
+					return map[string]string{}, errors.Wrap(err, "error get s3 bucket region")
+				}
 			}
 
 			s3URL = fmt.Sprintf("s3-%s.amazonaws.com", region)


### PR DESCRIPTION
Fix #6988, always get region from BSL if it is not empty