### PR TITLE
[1.12] Issue 6988: udmrepo use region specified in BSL when s3URL is empty

### DIFF
--- a/changelogs/unreleased/6991-Lyndon-Li
+++ b/changelogs/unreleased/6991-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix #6988, always get region from BSL if it is not empty

--- a/pkg/repository/provider/unified_repo.go
+++ b/pkg/repository/provider/unified_repo.go
@@ -480,9 +480,11 @@ func getStorageVariables(backupLocation *velerov1api.BackupStorageLocation, repo
 
 		var err error
 		if s3URL == "" {
-			region, err = getS3BucketRegion(bucket)
-			if err != nil {
-				return map[string]string{}, errors.Wrap(err, "error get s3 bucket region")
+			if region == "" {
+				region, err = getS3BucketRegion(bucket)
+				if err != nil {
+					return map[string]string{}, errors.Wrap(err, "error get s3 bucket region")
+				}
 			}
 
 			s3URL = fmt.Sprintf("s3-%s.amazonaws.com", region)


### PR DESCRIPTION
Fix https://github.com/vmware-tanzu/velero/issues/6988, always get region from BSL if it is not empty