### PR TITLE
Add check for owner references in backup sync, removing if missing

### DIFF
--- a/changelogs/unreleased/7031-deefdragon
+++ b/changelogs/unreleased/7031-deefdragon
@@ -1,1 +1,0 @@
-Fix #7031. Added check for Owner References when synchronizing backups, removing references that are not found.

--- a/changelogs/unreleased/7031-deefdragon
+++ b/changelogs/unreleased/7031-deefdragon
@@ -1,0 +1,1 @@
+Fix #7031. Added check for Owner References when synchronizing backups, removing references that are not found.

--- a/changelogs/unreleased/7032-deefdragon
+++ b/changelogs/unreleased/7032-deefdragon
@@ -1,0 +1,1 @@
+Fix #6857. Added check for matching Owner References when synchronizing backups, removing references that are not found/have mismatched uid.

--- a/pkg/controller/backup_sync_controller.go
+++ b/pkg/controller/backup_sync_controller.go
@@ -172,24 +172,33 @@ func (b *backupSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 		backup.Labels[velerov1api.StorageLocationLabel] = label.GetValidName(backup.Spec.StorageLocation)
 
-		//check for the backup schedule. If it does not exist, remove it.
+		//check for the ownership references. If they do not exist, remove them.
 		listedReferences := backup.ObjectMeta.OwnerReferences
 		foundReferences := make([]metav1.OwnerReference, 0)
 		for _, v := range listedReferences {
-			schedule := new(velerov1api.Schedule)
-			err := b.client.Get(ctx, types.NamespacedName{
-				Name:      v.Name,
-				Namespace: backup.Namespace,
-			}, schedule)
-			switch {
-			case err != nil && apierrors.IsNotFound(err):
-				log.Debug("Removing missing schedule ownership reference from backup")
-			case err != nil && !apierrors.IsNotFound(err):
-				log.WithError(errors.WithStack(err)).Error("Error finding ownership reference schedule")
-				fallthrough
+			switch v.Kind {
+			case "Schedule":
+
+				schedule := new(velerov1api.Schedule)
+				err := b.client.Get(ctx, types.NamespacedName{
+					Name:      v.Name,
+					Namespace: backup.Namespace,
+				}, schedule)
+				switch {
+				case err != nil && apierrors.IsNotFound(err):
+					log.Warn("Removing missing schedule ownership reference from backup")
+					continue
+				case schedule.UID != v.UID:
+					log.Warnf("Removing schedule ownership reference with mismatched UIDs. Expected %s, got %s", v.UID, schedule.UID)
+					continue
+				case err != nil && !apierrors.IsNotFound(err):
+					log.WithError(errors.WithStack(err)).Error("Error finding schedule ownership reference, keeping schedule on backup")
+				}
 			default:
-				foundReferences = append(foundReferences, v)
+				log.Warnf("Unable to check ownership reference for unknown kind, %s", v.Kind)
 			}
+
+			foundReferences = append(foundReferences, v)
 		}
 		backup.ObjectMeta.OwnerReferences = foundReferences
 

--- a/pkg/controller/backup_sync_controller_test.go
+++ b/pkg/controller/backup_sync_controller_test.go
@@ -724,4 +724,174 @@ var _ = Describe("Backup Sync Reconciler", func() {
 		Expect(testObjList).To(BeEquivalentTo(locationList))
 
 	})
+
+	When("testing validateOwnerReferences", func() {
+
+		testCases := []struct {
+			name               string
+			backup             *velerov1api.Backup
+			toCreate           []ctrlClient.Object
+			expectedReferences []metav1.OwnerReference
+		}{
+			{
+				name: "handles empty owner references",
+				backup: &velerov1api.Backup{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{},
+					},
+				},
+				expectedReferences: []metav1.OwnerReference{},
+			},
+			{
+				name: "handles missing schedule",
+				backup: &velerov1api.Backup{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Kind: "Schedule",
+								Name: "some name",
+							},
+						},
+					},
+				},
+				expectedReferences: []metav1.OwnerReference{},
+			},
+			{
+				name: "handles existing reference",
+				backup: &velerov1api.Backup{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Kind: "Schedule",
+								Name: "existing-schedule",
+							},
+						},
+						Namespace: "test-namespace",
+					},
+				},
+				toCreate: []ctrlClient.Object{
+					&velerov1api.Schedule{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "existing-schedule",
+							Namespace: "test-namespace",
+						},
+					},
+				},
+				expectedReferences: []metav1.OwnerReference{
+					{
+						Kind: "Schedule",
+						Name: "existing-schedule",
+					},
+				},
+			},
+			{
+				name: "handles existing mismatched UID",
+				backup: &velerov1api.Backup{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Kind: "Schedule",
+								Name: "existing-schedule",
+								UID:  "backup-UID",
+							},
+						},
+						Namespace: "test-namespace",
+					},
+				},
+				toCreate: []ctrlClient.Object{
+					&velerov1api.Schedule{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "existing-schedule",
+							Namespace: "test-namespace",
+							UID:       "schedule-UID",
+						},
+					},
+				},
+				expectedReferences: []metav1.OwnerReference{},
+			},
+			{
+				name: "handles multiple references",
+				backup: &velerov1api.Backup{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Kind: "Schedule",
+								Name: "existing-schedule",
+								UID:  "1",
+							},
+							{
+								Kind: "Schedule",
+								Name: "missing-schedule",
+								UID:  "2",
+							},
+							{
+								Kind: "Schedule",
+								Name: "mismatched-uid-schedule",
+								UID:  "3",
+							},
+							{
+								Kind: "Schedule",
+								Name: "another-existing-schedule",
+								UID:  "4",
+							},
+						},
+						Namespace: "test-namespace",
+					},
+				},
+				toCreate: []ctrlClient.Object{
+					&velerov1api.Schedule{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "existing-schedule",
+							Namespace: "test-namespace",
+							UID:       "1",
+						},
+					},
+					&velerov1api.Schedule{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "mismatched-uid-schedule",
+							Namespace: "test-namespace",
+							UID:       "not-3",
+						},
+					},
+					&velerov1api.Schedule{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "another-existing-schedule",
+							Namespace: "test-namespace",
+							UID:       "4",
+						},
+					},
+				},
+				expectedReferences: []metav1.OwnerReference{
+					{
+						Kind: "Schedule",
+						Name: "existing-schedule",
+						UID:  "1",
+					},
+					{
+						Kind: "Schedule",
+						Name: "another-existing-schedule",
+						UID:  "4",
+					},
+				},
+			},
+		}
+		for _, test := range testCases {
+			test := test
+			It(test.name, func() {
+				logger := velerotest.NewLogger()
+				b := backupSyncReconciler{
+					client: ctrlfake.NewClientBuilder().Build(),
+				}
+
+				//create all required schedules as needed.
+				for _, creatable := range test.toCreate {
+					err := b.client.Create(context.Background(), creatable)
+					Expect(err).ShouldNot(HaveOccurred())
+				}
+
+				references := b.filterBackupOwnerReferences(context.Background(), test.backup, logger)
+				Expect(references).To(BeEquivalentTo(test.expectedReferences))
+			})
+		}
+	})
 })


### PR DESCRIPTION
# Please add a summary of your change
Loops through the list of Ownership References in a backup when synchronizing. For each ownership reference, it checks for the referenced schedule, and if it exists, keeps it, but if it does not exist, removes it, and logs as such.

This is only a draft as I am unsure if this is the best approach/inline with the desired usage of OwnershipReferences in velero. If a seperate approach is desired, I can update as requested.

# Does your change fix a particular issue?

Fixes #7031

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.

Will update docs as requested where relevant, but I don't think they are relevant anywhere in this particular case?
