### PR TITLE
[WIP] Fix logrus-entry-contents when it is in hooks.

### DIFF
--- a/pkg/util/logging/dual_mode_logger_test.go
+++ b/pkg/util/logging/dual_mode_logger_test.go
@@ -18,6 +18,8 @@ package logging
 
 import (
 	"compress/gzip"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -56,6 +58,73 @@ func TestDualModeLogger(t *testing.T) {
 
 	_, err = os.Stat(logFile.Name())
 
+	assert.Equal(t, true, os.IsNotExist(err))
+}
+
+func TestDualModeLoggerEntryHook(t *testing.T) {
+	logCounter := NewLogHook()
+	logger, err := NewTempFileLogger(
+		logrus.WarnLevel,
+		FormatText,
+		logCounter,
+		//logrus.Fields{"namespace": "ns1", "resource": "pod", "name": "podxxx"})
+		logrus.Fields{"namespace": "ns1", "resource": "podxxxx"})
+	require.NoError(t, err)
+
+	logger.Warnln("test 1")
+	logger.Warnln("test 2")
+	logger.Warnln("test 3")
+
+	logger.WithFields(logrus.Fields{"namespace": "ns2", "resource": "pod", "name": "pod1"})
+	logger.Warnln("test 1 with field ns2")
+	logger.WithFields(logrus.Fields{"namespace": "ns2", "resource": "pod", "name": "pod2"})
+	logger.Warnln("test 2 with field ns2")
+	logger.WithFields(logrus.Fields{"namespace": "ns2", "resource": "pod", "name": "pod3"})
+	logger.Warnln("test 3 with field ns2")
+
+	logger.WithFields(logrus.Fields{"namespace": "ns3", "resource": "pod", "name": "pod4"})
+	logger.Warnln("test 4 with field ns3")
+	logger.WithFields(logrus.Fields{"namespace": "ns3", "resource": "pod", "name": "pod5"})
+	logger.Warnln("test 5 with field ns3")
+	logger.WithFields(logrus.Fields{"namespace": "ns3", "resource": "pod", "name": "pod6"})
+	logger.Warnln("test 6 with field ns3")
+
+	logger.WithError(errors.New("found err 1")).WithFields(
+		logrus.Fields{"namespace": "ns4", "resource": "pod", "name": "pod7"})
+	logger.Warnln("test 7 with field ns4 and WithError")
+	logger.WithError(errors.New("found err 2")).WithFields(
+		logrus.Fields{"namespace": "ns4", "resource": "pod", "name": "pod8"})
+	logger.Warnln("test 8 with field ns4 and WithError")
+
+	logger.Errorln("test error 1 in pod 1")
+	logger.Errorln("test error 2 in pod 2")
+	logger.Errorln("test error 3 in pod 3")
+	logger.Errorln("test error 4 in pod 4")
+
+	logger.DoneForPersist(velerotest.NewLogger())
+
+	logCntForWarn := logCounter.GetCount(logrus.WarnLevel)
+	fmt.Printf("logCntForWarn=%v\n", logCntForWarn)
+
+	logCntForError := logCounter.GetCount(logrus.ErrorLevel)
+	fmt.Printf("logCntForError=%v\n", logCntForError)
+
+	logResultForWarn := logCounter.GetEntries(logrus.WarnLevel)
+	for key, value := range logResultForWarn.Namespaces {
+		fmt.Printf("logResultForWarn namespace key=%+v , value=%+v\n", key, value)
+	}
+
+	logResultForError := logCounter.GetEntries(logrus.WarnLevel)
+	for key, value := range logResultForError.Namespaces {
+		fmt.Printf("logResultForError namespace key=%+v , value=%+v\n", key, value)
+	}
+
+	logFile, err := logger.GetPersistFile()
+	require.NoError(t, err)
+
+	logger.Dispose(velerotest.NewLogger())
+
+	_, err = os.Stat(logFile.Name())
 	assert.Equal(t, true, os.IsNotExist(err))
 }
 


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
In the issue [#6187](https://github.com/vmware-tanzu/velero/issues/6187) , we found some strange behaviour of the logs output.
I add some test code for the logrus entry hook.
I found that when the first new the ```NewTempFileLogger``` and init the ```logrus.Fields``` , it works as expect.

But when i override the value of ```logrus.Fields``` , it can not be works. 
Like the pics i test it.


![image](https://github.com/vmware-tanzu/velero/assets/12080746/ab4d7f39-bd80-46fb-87a4-f88f6dd33e28)


# Does your change fix a particular issue?

Fixes [#6187](https://github.com/vmware-tanzu/velero/issues/6187)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
