### PR TITLE
Skip PVB creation when PVC excluded

### DIFF
--- a/changelogs/unreleased/7045-sbahar619
+++ b/changelogs/unreleased/7045-sbahar619
@@ -1,0 +1,2 @@
+FS backup create PodVolumeBackup when the backup excluded PVC, 
+so I added logic to skip PVC volume type when PVC is not included in the backup resources to be backed up.

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -3114,6 +3114,9 @@ func TestBackupWithPodVolume(t *testing.T) {
 						Volumes(builder.ForVolume("bar").PersistentVolumeClaimSource("pvc-1").Result()).
 						Result(),
 				),
+				test.PVCs(
+					builder.ForPersistentVolumeClaim("ns-1", "pvc-1").VolumeName("pv-1").Result(),
+				),
 			},
 			want: []*velerov1.PodVolumeBackup{
 				builder.ForPodVolumeBackup("velero", "pvb-ns-1-pod-1-foo").Volume("foo").Result(),
@@ -3134,6 +3137,9 @@ func TestBackupWithPodVolume(t *testing.T) {
 						ObjectMeta(builder.WithAnnotations("backup.velero.io/backup-volumes", "bar")).
 						Volumes(builder.ForVolume("bar").PersistentVolumeClaimSource("pvc-1").Result()).
 						Result(),
+				),
+				test.PVCs(
+					builder.ForPersistentVolumeClaim("ns-1", "pvc-1").VolumeName("pv-1").Result(),
 				),
 			},
 			want: []*velerov1.PodVolumeBackup{


### PR DESCRIPTION
# Please add a summary of your change
FS backup create PodVolumeBackup when the backup excluded PVC, so I added logic to skip PVC volume type when PVC is not included in the backup resources to be backed up.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
