### PR TITLE
release-1.11: restore: Use warning when Create IsAlreadyExist and Get error (#7004)

### DIFF
--- a/changelogs/unreleased/7055-kaovilai
+++ b/changelogs/unreleased/7055-kaovilai
@@ -1,0 +1,1 @@
+restore: Use warning when Create IsAlreadyExist and Get error

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1357,8 +1357,8 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 		// otherwise, we will return the original creation error.
 		fromCluster, err = resourceClient.Get(name, metav1.GetOptions{})
 		if err != nil && isAlreadyExistsError {
-			ctx.log.Errorf("Error retrieving in-cluster version of %s: %v", kube.NamespaceAndName(obj), err)
-			errs.Add(namespace, err)
+			ctx.log.Warnf("Unable to retrieve in-cluster version of %s: %v, object won't be restored by velero or have restore labels, and existing resource policy is not applied", kube.NamespaceAndName(obj), err)
+			warnings.Add(namespace, err)
 			return warnings, errs, itemExists
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
