### PR TITLE
Truncate the credential file to avoid the change of secret content messing it up

### DIFF
--- a/changelogs/unreleased/7058-ywk253100
+++ b/changelogs/unreleased/7058-ywk253100
@@ -1,0 +1,1 @@
+Truncate the credential file to avoid the change of secret content messing it up

--- a/internal/credentials/file_store.go
+++ b/internal/credentials/file_store.go
@@ -71,7 +71,7 @@ func (n *namespacedFileStore) Path(selector *corev1api.SecretKeySelector) (strin
 
 	keyFilePath := filepath.Join(n.fsRoot, fmt.Sprintf("%s-%s", selector.Name, selector.Key))
 
-	file, err := n.fs.OpenFile(keyFilePath, os.O_RDWR|os.O_CREATE, 0644)
+	file, err := n.fs.OpenFile(keyFilePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to open credentials file for writing")
 	}


### PR DESCRIPTION
Truncate the credential file to avoid the change of secret content messing it up

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
