### PR TITLE
Issue 7068: add a finalizer to protect retained VSC

### DIFF
--- a/changelogs/unreleased/7102-Lyndon-Li
+++ b/changelogs/unreleased/7102-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix issue #7068, due to a behavior of CSI external snapshotter, manipulations of VS and VSC may not be handled in the same order inside external snapshotter as the API is called. So add a protection finalizer to ensure the order


### PR DESCRIPTION
Fix issue https://github.com/vmware-tanzu/velero/issues/7068, due to a behavior of CSI external snapshotter, manipulations of VS and VSC may not be handled in the same order inside external snapshotter as the API is called. So add a protection finalizer to ensure the order