### PR TITLE
Fix wrong description of the release note for "backup_last_status"

### DIFF
--- a/changelogs/unreleased/6838-yanggangtony
+++ b/changelogs/unreleased/6838-yanggangtony
@@ -1,1 +1,1 @@
-change the metrics backup_attempt_total default value to 1.
+change the metrics backup_last_status default value to 1.


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
When i review the issue [https://github.com/vmware-tanzu/velero/issues/7132](https://github.com/vmware-tanzu/velero/issues/7132) . 
I search the metrics and found my mistake of the before commit about 

```
 "backup_last_status" in changelogs/unreleased/6838-yanggangtony
```


# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
