### PR TITLE
docs: fix link to kubectl port forwarding docs

### DIFF
--- a/site/content/docs/main/troubleshooting.md
+++ b/site/content/docs/main/troubleshooting.md
@@ -231,7 +231,7 @@ Follow the below troubleshooting steps to confirm that Velero is using the corre
 [6]: https://github.com/vmware-tanzu/helm-charts/blob/main/charts/velero
 [7]: https://github.com/vmware-tanzu/helm-charts/blob/main/charts/velero/values.yaml#L44
 [8]: https://github.com/vmware-tanzu/helm-charts/blob/main/charts/velero/values.yaml#L49-L52
-[9]: https://kubectl.docs.kubernetes.io/pages/container_debugging/port_forward_to_pods.html
+[9]: https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#port-forward
 [10]: locations.md
 [11]: /plugins
 [12]: https://kubernetes.io/docs/concepts/configuration/secret/#editing-a-secret


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Simple change of a link in the troubleshooting.md velero docs from a broken (404) link on kubernetes.io to a working link on kubernetes.io

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
