### PR TITLE
Add explicit enableCSI to TestProcessBackupCompletions

### DIFF
--- a/pkg/controller/backup_controller_test.go
+++ b/pkg/controller/backup_controller_test.go
@@ -595,6 +595,7 @@ func TestProcessBackupCompletions(t *testing.T) {
 		backupLocation           *velerov1api.BackupStorageLocation
 		defaultVolumesToFsBackup bool
 		defaultSnapshotMoveData  bool
+		enableCSI                bool
 		expectedResult           *velerov1api.Backup
 		backupExists             bool
 		existenceCheckError      error
@@ -1034,6 +1035,7 @@ func TestProcessBackupCompletions(t *testing.T) {
 			backup:                   defaultBackup().SnapshotMoveData(true).Result(),
 			backupLocation:           defaultBackupLocation,
 			defaultVolumesToFsBackup: false,
+			enableCSI:                true,
 			expectedResult: &velerov1api.Backup{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Backup",
@@ -1074,6 +1076,7 @@ func TestProcessBackupCompletions(t *testing.T) {
 			backup:                   defaultBackup().SnapshotMoveData(false).Result(),
 			backupLocation:           defaultBackupLocation,
 			defaultVolumesToFsBackup: false,
+			enableCSI:                true,
 			expectedResult: &velerov1api.Backup{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Backup",
@@ -1114,6 +1117,7 @@ func TestProcessBackupCompletions(t *testing.T) {
 			backup:                   defaultBackup().Result(),
 			backupLocation:           defaultBackupLocation,
 			defaultVolumesToFsBackup: false,
+			enableCSI:                true,
 			expectedResult: &velerov1api.Backup{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Backup",
@@ -1196,6 +1200,7 @@ func TestProcessBackupCompletions(t *testing.T) {
 			backupLocation:           defaultBackupLocation,
 			defaultVolumesToFsBackup: false,
 			defaultSnapshotMoveData:  true,
+			enableCSI:                true,
 			expectedResult: &velerov1api.Backup{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Backup",
@@ -1371,7 +1376,7 @@ func TestProcessBackupCompletions(t *testing.T) {
 			require.NoError(t, fakeClient.Create(context.Background(), defaultBackupLocation))
 
 			// Enable CSI feature flag for SnapshotDataMovement test.
-			if strings.Contains(test.name, "backup with snapshot data movement") {
+			if test.enableCSI {
 				features.Enable(velerov1api.CSIFeatureFlag)
 			}
 
@@ -1380,7 +1385,7 @@ func TestProcessBackupCompletions(t *testing.T) {
 			assert.Nil(t, err)
 
 			// Disable CSI feature to not impact other test cases.
-			if strings.Contains(test.name, "backup with snapshot data movement") {
+			if test.enableCSI {
 				features.Disable(velerov1api.CSIFeatureFlag)
 			}
 


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Making it clearer which tests have CSI enabled.

Previously the requirement was that test name contains "backup with snapshot data movement".

Some of the tests have "backup with snapshot data movement <false/disabled>" so it's ambiguous not clear if CSI is enabled there.
# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
