### PR TITLE
Make sure the PVs skipped by CSI plugin due to settings in backup spec are tracked

### DIFF
--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -384,8 +384,8 @@ func (ib *itemBackupper) executeActions(
 			// snapshot was skipped by CSI plugin
 			ib.trackSkippedPV(obj, groupResource, csiSnapshotApproach, "skipped b/c it's not a CSI volume", log)
 			delete(u.GetAnnotations(), skippedNoCSIPVAnnotation)
-		} else if actionName == csiBIAPluginName || actionName == vsphereBIAPluginName {
-			// the snapshot has been taken
+		} else if (actionName == csiBIAPluginName || actionName == vsphereBIAPluginName) && !boolptr.IsSetToFalse(ib.backupRequest.Backup.Spec.SnapshotVolumes) {
+			// the snapshot has been taken by the BIA plugin
 			ib.unTrackSkippedPV(obj, groupResource, log)
 		}
 		mustInclude := u.GetAnnotations()[mustIncludeAdditionalItemAnnotation] == "true" || finalize


### PR DESCRIPTION

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
