### PR TITLE
Refactor DownloadRequest Stream function

### DIFF
--- a/changelogs/unreleased/7175-blackpiglet
+++ b/changelogs/unreleased/7175-blackpiglet
@@ -1,0 +1,1 @@
+Refactor DownloadRequest Stream function


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

* Fix PR #7151 introduced context bug.
* Refactor the DownloadRequest Stream function. Split it into two parts: GetDownloadURL and Download.
* Refactor the context usage to replace the wait logic.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
