### PR TITLE
Use a new variable for resource path

### DIFF
--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -2277,6 +2277,7 @@ func (ctx *restoreContext) getSelectedRestoreableItems(resource string, namespac
 		ctx.log.Infof("Resource '%s' will be restored at cluster scope", resource)
 	}
 
+	resourceForPath := resource
 	// If the APIGroupVersionsFeatureFlag is enabled, the item path will be
 	// updated to include the API group version that was chosen for restore. For
 	// example, for "horizontalpodautoscalers.autoscaling", if v2beta1 is chosen
@@ -2288,11 +2289,11 @@ func (ctx *restoreContext) getSelectedRestoreableItems(resource string, namespac
 	// required backup format version has been met.
 	cgv, ok := ctx.chosenGrpVersToRestore[resource]
 	if ok {
-		resource = filepath.Join(resource, cgv.Dir)
+		resourceForPath = filepath.Join(resource, cgv.Dir)
 	}
 
 	for _, item := range items {
-		itemPath := archive.GetItemFilePath(ctx.restoreDir, resource, originalNamespace, item)
+		itemPath := archive.GetItemFilePath(ctx.restoreDir, resourceForPath, originalNamespace, item)
 
 		obj, err := archive.Unmarshal(ctx.fileSystem, itemPath)
 		if err != nil {


### PR DESCRIPTION
This commit avoids mistakes when checking the type of the resource Fixes #7190

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #7190

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
