### PR TITLE
[1.12] Issue 7189: generic restore - don't assume the first volume as the restore volume

### DIFF
--- a/changelogs/unreleased/7203-Lyndon-Li
+++ b/changelogs/unreleased/7203-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix issue #7189, data mover generic restore - don't assume the first volume as the restore volume

--- a/pkg/exposer/generic_restore.go
+++ b/pkg/exposer/generic_restore.go
@@ -114,6 +114,7 @@ func (e *genericRestoreExposer) Expose(ctx context.Context, ownerObject corev1.O
 func (e *genericRestoreExposer) GetExposed(ctx context.Context, ownerObject corev1.ObjectReference, nodeClient client.Client, nodeName string, timeout time.Duration) (*ExposeResult, error) {
 	restorePodName := ownerObject.Name
 	restorePVCName := ownerObject.Name
+	volumeName := string(ownerObject.UID)
 
 	curLog := e.log.WithFields(logrus.Fields{
 		"owner": ownerObject.Name,
@@ -127,10 +128,10 @@ func (e *genericRestoreExposer) GetExposed(ctx context.Context, ownerObject core
 	}, pod)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			curLog.WithField("backup pod", restorePodName).Debug("Backup pod is not running in the current node")
+			curLog.WithField("restore pod", restorePodName).Debug("Restore pod is not running in the current node")
 			return nil, nil
 		} else {
-			return nil, errors.Wrapf(err, "error to get backup pod %s", restorePodName)
+			return nil, errors.Wrapf(err, "error to get restore pod %s", restorePodName)
 		}
 	}
 
@@ -143,7 +144,20 @@ func (e *genericRestoreExposer) GetExposed(ctx context.Context, ownerObject core
 
 	curLog.WithField("restore pvc", restorePVCName).Info("Restore PVC is bound")
 
-	return &ExposeResult{ByPod: ExposeByPod{HostingPod: pod, VolumeName: pod.Spec.Volumes[0].Name}}, nil
+	i := 0
+	for i = 0; i < len(pod.Spec.Volumes); i++ {
+		if pod.Spec.Volumes[i].Name == volumeName {
+			break
+		}
+	}
+
+	if i == len(pod.Spec.Volumes) {
+		return nil, errors.Errorf("restore pod %s doesn't have the expected restore volume", pod.Name)
+	}
+
+	curLog.WithField("pod", pod.Name).Infof("Restore volume is found in pod at index %v", i)
+
+	return &ExposeResult{ByPod: ExposeByPod{HostingPod: pod, VolumeName: volumeName}}, nil
 }
 
 func (e *genericRestoreExposer) CleanUp(ctx context.Context, ownerObject corev1.ObjectReference) {


### PR DESCRIPTION
Fix issue https://github.com/vmware-tanzu/velero/issues/7189, data mover generic restore - don't assume the first volume as the restore volume