### PR TITLE
Issue 7214: data mover backup describe for legacy backups

### DIFF
--- a/pkg/cmd/util/output/backup_describer_test.go
+++ b/pkg/cmd/util/output/backup_describer_test.go
@@ -379,11 +379,25 @@ func TestCSISnapshots(t *testing.T) {
 	}()
 
 	testcases := []struct {
-		name         string
-		volumeInfo   []*volume.VolumeInfo
-		inputDetails bool
-		expect       string
+		name             string
+		volumeInfo       []*volume.VolumeInfo
+		inputDetails     bool
+		expect           string
+		legacyInfoSource bool
 	}{
+		{
+			name:       "empty info, not legacy",
+			volumeInfo: []*volume.VolumeInfo{},
+			expect: `  CSI Snapshots: <none included>
+`,
+		},
+		{
+			name:             "empty info, legacy",
+			volumeInfo:       []*volume.VolumeInfo{},
+			legacyInfoSource: true,
+			expect: `  CSI Snapshots: <none included or not detectable>
+`,
+		},
 		{
 			name: "no details, local snapshot",
 			volumeInfo: []*volume.VolumeInfo{
@@ -509,7 +523,7 @@ func TestCSISnapshots(t *testing.T) {
 				buf:    &bytes.Buffer{},
 			}
 			d.out.Init(d.buf, 0, 8, 2, ' ', 0)
-			describeCSISnapshots(d, tc.inputDetails, tc.volumeInfo)
+			describeCSISnapshots(d, tc.inputDetails, tc.volumeInfo, tc.legacyInfoSource)
 			d.out.Flush()
 			assert.Equal(t, tc.expect, d.buf.String())
 		})

--- a/pkg/cmd/util/output/backup_structured_describer_test.go
+++ b/pkg/cmd/util/output/backup_structured_describer_test.go
@@ -337,11 +337,27 @@ func TestDescribeCSISnapshotsInSF(t *testing.T) {
 	}()
 
 	testcases := []struct {
-		name         string
-		volumeInfo   []*volume.VolumeInfo
-		inputDetails bool
-		expect       map[string]interface{}
+		name             string
+		volumeInfo       []*volume.VolumeInfo
+		inputDetails     bool
+		expect           map[string]interface{}
+		legacyInfoSource bool
 	}{
+		{
+			name:       "empty info, not legacy",
+			volumeInfo: []*volume.VolumeInfo{},
+			expect: map[string]interface{}{
+				"csiSnapshots": "<none included>",
+			},
+		},
+		{
+			name:             "empty info, legacy",
+			volumeInfo:       []*volume.VolumeInfo{},
+			legacyInfoSource: true,
+			expect: map[string]interface{}{
+				"csiSnapshots": "<none included or not detectable>",
+			},
+		},
 		{
 			name: "no details, local snapshot",
 			volumeInfo: []*volume.VolumeInfo{
@@ -480,7 +496,7 @@ func TestDescribeCSISnapshotsInSF(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(tt *testing.T) {
 			output := make(map[string]interface{})
-			describeCSISnapshotsInSF(tc.inputDetails, tc.volumeInfo, output)
+			describeCSISnapshotsInSF(tc.inputDetails, tc.volumeInfo, output, tc.legacyInfoSource)
 			assert.True(tt, reflect.DeepEqual(output, tc.expect))
 		})
 	}


### PR DESCRIPTION
If backupVolumeInfo is not found and no CSI snapshot info is found either (data movement may have happened), we display the below in the backup describe:
```
Backup Volumes:
  CSI Snapshots: <none included or not detectable>
```

Instead of:
```
Backup Volumes:
  CSI Snapshots: <none included>
```