### PR TITLE
Fix shedule get and describe CLI nil pointer issue

### DIFF
--- a/pkg/cmd/cli/schedule/describe.go
+++ b/pkg/cmd/cli/schedule/describe.go
@@ -41,9 +41,8 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 			crClient, err := f.KubebuilderClient()
 			cmd.CheckError(err)
 
-			var schedules *v1.ScheduleList
+			schedules := new(v1.ScheduleList)
 			if len(args) > 0 {
-				schedules = new(v1.ScheduleList)
 				for _, name := range args {
 					schedule := new(v1.Schedule)
 					err := crClient.Get(context.TODO(), ctrlclient.ObjectKey{Namespace: f.Namespace(), Name: name}, schedule)

--- a/pkg/cmd/cli/schedule/get.go
+++ b/pkg/cmd/cli/schedule/get.go
@@ -43,9 +43,8 @@ func NewGetCommand(f client.Factory, use string) *cobra.Command {
 			crClient, err := f.KubebuilderClient()
 			cmd.CheckError(err)
 
-			var schedules *api.ScheduleList
+			schedules := new(api.ScheduleList)
 			if len(args) > 0 {
-				schedules = new(api.ScheduleList)
 				for _, name := range args {
 					schedule := new(api.Schedule)
 					err := crClient.Get(context.TODO(), ctrlclient.ObjectKey{Name: name, Namespace: f.Namespace()}, schedule)


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
The `velero schedule get` and `velero schedule describe` commands fail with `An error occurred: expected pointer, but got nil` without this fix.
The reason is the variable `scheduleList` is not initialized when there are no schedule names passed in. 

# Does your change fix a particular issue?

Fixes #7215 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
