### PR TITLE
Adjust velero server side default backup location setting logic

### DIFF
--- a/pkg/cmd/cli/backuplocation/set.go
+++ b/pkg/cmd/cli/backuplocation/set.go
@@ -125,7 +125,13 @@ func (o *SetOptions) Run(c *cobra.Command, f client.Factory) error {
 				return errors.WithStack(err)
 			}
 			if len(defalutBSLs.Items) > 0 {
-				return errors.New("there is already a default backup storage location")
+				if len(defalutBSLs.Items) == 1 && defalutBSLs.Items[0].Name == o.Name {
+					// the default backup storage location is the one we want to set
+					// so we do not need to do anything
+					fmt.Printf("Backup storage location %q is already the default backup storage location.\n", o.Name)
+					return nil
+				}
+				return errors.New("there are already exist default backup storage locations, please unset them first")
 			}
 		}
 	} else {

--- a/pkg/cmd/server/server_test.go
+++ b/pkg/cmd/server/server_test.go
@@ -376,3 +376,37 @@ func Test_markInProgressRestoresFailed(t *testing.T) {
 	require.Nil(t, c.Get(context.Background(), client.ObjectKey{Namespace: "velero", Name: "restore02"}, restore02))
 	assert.Equal(t, velerov1api.RestorePhaseCompleted, restore02.Status.Phase)
 }
+
+func Test_setDefaultBackupLocation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	velerov1api.AddToScheme(scheme)
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithLists(&velerov1api.BackupStorageLocationList{
+			Items: []velerov1api.BackupStorageLocation{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "velero",
+						Name:      "default",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "velero",
+						Name:      "non-default",
+					},
+				},
+			},
+		}).
+		Build()
+	setDefaultBackupLocation(context.Background(), c, "velero", "default", logrus.New())
+
+	defaultLocation := &velerov1api.BackupStorageLocation{}
+	require.Nil(t, c.Get(context.Background(), client.ObjectKey{Namespace: "velero", Name: "default"}, defaultLocation))
+	assert.True(t, defaultLocation.Spec.Default)
+
+	nonDefaultLocation := &velerov1api.BackupStorageLocation{}
+	require.Nil(t, c.Get(context.Background(), client.ObjectKey{Namespace: "velero", Name: "non-default"}, nonDefaultLocation))
+	assert.False(t, nonDefaultLocation.Spec.Default)
+}

--- a/pkg/controller/backup_storage_location_controller.go
+++ b/pkg/controller/backup_storage_location_controller.go
@@ -250,26 +250,7 @@ func (r *backupStorageLocationReconciler) ensureSingleDefaultBSL(locationList ve
 			}
 		}
 	} else if len(defaultBSLs) == 0 { // no default BSL
-		// find the BSL that matches the "velero server --default-backup-storage-location"
-		var defaultBSL *velerov1api.BackupStorageLocation
-		for i, location := range locationList.Items {
-			if location.Name == r.defaultBackupLocationInfo.StorageLocation {
-				defaultBSL = &locationList.Items[i]
-				break
-			}
-		}
-
-		// set the default BSL
-		if defaultBSL != nil {
-			defaultBSL.Spec.Default = true
-			defaultFound = true
-			if err := r.client.Update(r.ctx, defaultBSL); err != nil {
-				return defaultFound, errors.Wrapf(err, "failed to set default backup storage location %q", defaultBSL.Name)
-			}
-			r.log.Debugf("update default backup storage location %q to true", defaultBSL.Name)
-		} else {
-			defaultFound = false
-		}
+		defaultFound = false
 	} else { // only 1 default BSL
 		defaultFound = true
 	}

--- a/pkg/controller/backup_storage_location_controller_test.go
+++ b/pkg/controller/backup_storage_location_controller_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Backup Storage Location Reconciler", func() {
 			expectedPhase     velerov1api.BackupStorageLocationPhase
 		}{
 			{
-				backupLocation:    builder.ForBackupStorageLocation("ns-1", "location-1").ValidationFrequency(1 * time.Second).Result(),
+				backupLocation:    builder.ForBackupStorageLocation("ns-1", "location-1").ValidationFrequency(1 * time.Second).Default(true).Result(),
 				isValidError:      nil,
 				expectedIsDefault: true,
 				expectedPhase:     velerov1api.BackupStorageLocationPhaseAvailable,
@@ -206,7 +206,7 @@ func TestEnsureSingleDefaultBSL(t *testing.T) {
 			defaultBackupInfo: storage.DefaultBackupLocationInfo{
 				StorageLocation: "location-2",
 			},
-			expectedDefaultSet: true,
+			expectedDefaultSet: false,
 			expectedError:      nil,
 		},
 		{


### PR DESCRIPTION

Thank you for contributing to Velero!

# Please add a summary of your change
Move the Velero server-side default backup location setting logic into server start

# Does your change fix a particular issue?

Fixes #(issue)
https://github.com/vmware-tanzu/velero/issues/7219

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
