### PR TITLE
Remove the redundant newline in backup describe output

### DIFF
--- a/changelogs/unreleased/7229-allenxu404
+++ b/changelogs/unreleased/7229-allenxu404
@@ -1,0 +1,1 @@
+Remove the redundant newline in backup describe output

--- a/pkg/cmd/util/output/backup_describer.go
+++ b/pkg/cmd/util/output/backup_describer.go
@@ -362,8 +362,6 @@ func DescribeBackupStatus(ctx context.Context, kbClient kbclient.Client, d *Desc
 
 	describeBackupVolumes(ctx, kbClient, d, backup, details, insecureSkipTLSVerify, caCertPath, podVolumeBackups)
 
-	d.Println()
-
 	if status.HookStatus != nil {
 		d.Println()
 		d.Printf("HooksAttempted:\t%d\n", status.HookStatus.HooksAttempted)


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
