### PR TITLE
Don't generate empty structure.

### DIFF
--- a/internal/volume/volumes_information_test.go
+++ b/internal/volume/volumes_information_test.go
@@ -103,7 +103,7 @@ func TestGenerateVolumeInfoForSkippedPV(t *testing.T) {
 					PVName:        "testPV",
 					Skipped:       true,
 					SkippedReason: "CSI: skipped for PodVolumeBackup",
-					PVInfo: PVInfo{
+					PVInfo: &PVInfo{
 						ReclaimPolicy: "Delete",
 						Labels: map[string]string{
 							"a": "b",
@@ -229,13 +229,13 @@ func TestGenerateVolumeInfoForVeleroNativeSnapshot(t *testing.T) {
 					PVCNamespace: "velero",
 					PVName:       "testPV",
 					BackupMethod: NativeSnapshot,
-					PVInfo: PVInfo{
+					PVInfo: &PVInfo{
 						ReclaimPolicy: "Delete",
 						Labels: map[string]string{
 							"a": "b",
 						},
 					},
-					NativeSnapshotInfo: NativeSnapshotInfo{
+					NativeSnapshotInfo: &NativeSnapshotInfo{
 						SnapshotHandle: "pvc-b31e3386-4bbb-4937-95d-7934cd62-b0a1-494b-95d7-0687440e8d0c",
 						VolumeType:     "ssd",
 						VolumeAZ:       "us-central1-a",
@@ -411,16 +411,16 @@ func TestGenerateVolumeInfoForCSIVolumeSnapshot(t *testing.T) {
 					PVCNamespace:          "velero",
 					PVName:                "testPV",
 					BackupMethod:          CSISnapshot,
-					OperationID:           "testID",
 					StartTimestamp:        &now,
 					PreserveLocalSnapshot: true,
-					CSISnapshotInfo: CSISnapshotInfo{
+					CSISnapshotInfo: &CSISnapshotInfo{
 						Driver:         "pd.csi.storage.gke.io",
 						SnapshotHandle: "testSnapshotHandle",
 						Size:           107374182400,
 						VSCName:        "testContent",
+						OperationID:    "testID",
 					},
-					PVInfo: PVInfo{
+					PVInfo: &PVInfo{
 						ReclaimPolicy: "Delete",
 						Labels: map[string]string{
 							"a": "b",
@@ -495,7 +495,7 @@ func TestGenerateVolumeInfoFromPVB(t *testing.T) {
 					PVCNamespace: "",
 					PVName:       "",
 					BackupMethod: PodVolumeBackup,
-					PVBInfo: PodVolumeBackupInfo{
+					PVBInfo: &PodVolumeBackupInfo{
 						PodName:      "testPod",
 						PodNamespace: "velero",
 					},
@@ -567,11 +567,11 @@ func TestGenerateVolumeInfoFromPVB(t *testing.T) {
 					PVCNamespace: "velero",
 					PVName:       "testPV",
 					BackupMethod: PodVolumeBackup,
-					PVBInfo: PodVolumeBackupInfo{
+					PVBInfo: &PodVolumeBackupInfo{
 						PodName:      "testPod",
 						PodNamespace: "velero",
 					},
-					PVInfo: PVInfo{
+					PVInfo: &PVInfo{
 						ReclaimPolicy: string(corev1api.PersistentVolumeReclaimDelete),
 						Labels:        map[string]string{"a": "b"},
 					},
@@ -729,12 +729,18 @@ func TestGenerateVolumeInfoFromDataUpload(t *testing.T) {
 					PVName:            "testPV",
 					BackupMethod:      CSISnapshot,
 					SnapshotDataMoved: true,
-					OperationID:       "testOperation",
-					SnapshotDataMovementInfo: SnapshotDataMovementInfo{
+					CSISnapshotInfo: &CSISnapshotInfo{
+						SnapshotHandle: FieldValueIsUnknown,
+						VSCName:        FieldValueIsUnknown,
+						OperationID:    FieldValueIsUnknown,
+						Size:           0,
+					},
+					SnapshotDataMovementInfo: &SnapshotDataMovementInfo{
 						DataMover:    "velero",
 						UploaderType: "kopia",
+						OperationID:  "testOperation",
 					},
-					PVInfo: PVInfo{
+					PVInfo: &PVInfo{
 						ReclaimPolicy: string(corev1api.PersistentVolumeReclaimDelete),
 						Labels:        map[string]string{"a": "b"},
 					},
@@ -796,16 +802,20 @@ func TestGenerateVolumeInfoFromDataUpload(t *testing.T) {
 					PVName:            "testPV",
 					BackupMethod:      CSISnapshot,
 					SnapshotDataMoved: true,
-					OperationID:       "testOperation",
 					StartTimestamp:    &now,
-					CSISnapshotInfo: CSISnapshotInfo{
-						Driver: "pd.csi.storage.gke.io",
+					CSISnapshotInfo: &CSISnapshotInfo{
+						VSCName:        FieldValueIsUnknown,
+						SnapshotHandle: FieldValueIsUnknown,
+						OperationID:    FieldValueIsUnknown,
+						Size:           0,
+						Driver:         "pd.csi.storage.gke.io",
 					},
-					SnapshotDataMovementInfo: SnapshotDataMovementInfo{
+					SnapshotDataMovementInfo: &SnapshotDataMovementInfo{
 						DataMover:    "velero",
 						UploaderType: "kopia",
+						OperationID:  "testOperation",
 					},
-					PVInfo: PVInfo{
+					PVInfo: &PVInfo{
 						ReclaimPolicy: string(corev1api.PersistentVolumeReclaimDelete),
 						Labels:        map[string]string{"a": "b"},
 					},

--- a/pkg/cmd/util/output/backup_describer.go
+++ b/pkg/cmd/util/output/backup_describer.go
@@ -513,7 +513,7 @@ func retrieveNativeSnapshotLegacy(ctx context.Context, kbClient kbclient.Client,
 	for _, snap := range snapshots {
 		volumeInfo := volume.VolumeInfo{
 			PVName: snap.Spec.PersistentVolumeName,
-			NativeSnapshotInfo: volume.NativeSnapshotInfo{
+			NativeSnapshotInfo: &volume.NativeSnapshotInfo{
 				SnapshotHandle: snap.Status.ProviderSnapshotID,
 				VolumeType:     snap.Spec.VolumeType,
 				VolumeAZ:       snap.Spec.VolumeAZ,
@@ -567,7 +567,7 @@ func retrieveCSISnapshotLegacy(ctx context.Context, kbClient kbclient.Client, ba
 	for _, vsc := range vscList {
 		volInfo := volume.VolumeInfo{
 			PreserveLocalSnapshot: true,
-			CSISnapshotInfo: volume.CSISnapshotInfo{
+			CSISnapshotInfo: &volume.CSISnapshotInfo{
 				VSCName: vsc.Name,
 				Driver:  vsc.Spec.Driver,
 			},
@@ -663,8 +663,8 @@ func describeLocalSnapshot(d *Describer, details bool, info *volume.VolumeInfo) 
 
 	if details {
 		d.Printf("\t\t\tSnapshot:\n")
-		if !info.SnapshotDataMoved && info.OperationID != "" {
-			d.Printf("\t\t\t\tOperation ID: %s\n", info.OperationID)
+		if !info.SnapshotDataMoved && info.CSISnapshotInfo.OperationID != "" {
+			d.Printf("\t\t\t\tOperation ID: %s\n", info.CSISnapshotInfo.OperationID)
 		}
 
 		d.Printf("\t\t\t\tSnapshot Content Name: %s\n", info.CSISnapshotInfo.VSCName)
@@ -683,7 +683,7 @@ func describeDataMovement(d *Describer, details bool, info *volume.VolumeInfo) {
 
 	if details {
 		d.Printf("\t\t\tData Movement:\n")
-		d.Printf("\t\t\t\tOperation ID: %s\n", info.OperationID)
+		d.Printf("\t\t\t\tOperation ID: %s\n", info.SnapshotDataMovementInfo.OperationID)
 
 		dataMover := "velero"
 		if info.SnapshotDataMovementInfo.DataMover != "" {

--- a/pkg/cmd/util/output/backup_describer_test.go
+++ b/pkg/cmd/util/output/backup_describer_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package output
 
 import (
@@ -320,7 +336,7 @@ func TestDescribeNativeSnapshots(t *testing.T) {
 				{
 					BackupMethod: volume.NativeSnapshot,
 					PVName:       "pv-1",
-					NativeSnapshotInfo: volume.NativeSnapshotInfo{
+					NativeSnapshotInfo: &volume.NativeSnapshotInfo{
 						SnapshotHandle: "snapshot-1",
 						VolumeType:     "ebs",
 						VolumeAZ:       "us-east-2",
@@ -338,7 +354,7 @@ func TestDescribeNativeSnapshots(t *testing.T) {
 				{
 					BackupMethod: volume.NativeSnapshot,
 					PVName:       "pv-1",
-					NativeSnapshotInfo: volume.NativeSnapshotInfo{
+					NativeSnapshotInfo: &volume.NativeSnapshotInfo{
 						SnapshotHandle: "snapshot-1",
 						VolumeType:     "ebs",
 						VolumeAZ:       "us-east-2",
@@ -405,12 +421,12 @@ func TestCSISnapshots(t *testing.T) {
 					BackupMethod:          volume.CSISnapshot,
 					PVCName:               "pvc-1",
 					PreserveLocalSnapshot: true,
-					OperationID:           "fake-operation-1",
-					CSISnapshotInfo: volume.CSISnapshotInfo{
+					CSISnapshotInfo: &volume.CSISnapshotInfo{
 						SnapshotHandle: "snapshot-1",
 						Size:           1024,
 						Driver:         "fake-driver",
 						VSCName:        "vsc-1",
+						OperationID:    "fake-operation-1",
 					},
 				},
 			},
@@ -426,12 +442,12 @@ func TestCSISnapshots(t *testing.T) {
 					BackupMethod:          volume.CSISnapshot,
 					PVCName:               "pvc-2",
 					PreserveLocalSnapshot: true,
-					OperationID:           "fake-operation-2",
-					CSISnapshotInfo: volume.CSISnapshotInfo{
+					CSISnapshotInfo: &volume.CSISnapshotInfo{
 						SnapshotHandle: "snapshot-2",
 						Size:           1024,
 						Driver:         "fake-driver",
 						VSCName:        "vsc-2",
+						OperationID:    "fake-operation-2",
 					},
 				},
 			},
@@ -453,11 +469,11 @@ func TestCSISnapshots(t *testing.T) {
 					BackupMethod:      volume.CSISnapshot,
 					PVCName:           "pvc-3",
 					SnapshotDataMoved: true,
-					OperationID:       "fake-operation-3",
-					SnapshotDataMovementInfo: volume.SnapshotDataMovementInfo{
+					SnapshotDataMovementInfo: &volume.SnapshotDataMovementInfo{
 						DataMover:      "velero",
 						UploaderType:   "fake-uploader",
 						SnapshotHandle: "fake-repo-id-3",
+						OperationID:    "fake-operation-3",
 					},
 				},
 			},
@@ -473,11 +489,11 @@ func TestCSISnapshots(t *testing.T) {
 					BackupMethod:      volume.CSISnapshot,
 					PVCName:           "pvc-4",
 					SnapshotDataMoved: true,
-					OperationID:       "fake-operation-4",
-					SnapshotDataMovementInfo: volume.SnapshotDataMovementInfo{
+					SnapshotDataMovementInfo: &volume.SnapshotDataMovementInfo{
 						DataMover:      "velero",
 						UploaderType:   "fake-uploader",
 						SnapshotHandle: "fake-repo-id-4",
+						OperationID:    "fake-operation-4",
 					},
 				},
 			},
@@ -497,10 +513,10 @@ func TestCSISnapshots(t *testing.T) {
 					BackupMethod:      volume.CSISnapshot,
 					PVCName:           "pvc-5",
 					SnapshotDataMoved: true,
-					OperationID:       "fake-operation-5",
-					SnapshotDataMovementInfo: volume.SnapshotDataMovementInfo{
+					SnapshotDataMovementInfo: &volume.SnapshotDataMovementInfo{
 						UploaderType:   "fake-uploader",
 						SnapshotHandle: "fake-repo-id-5",
+						OperationID:    "fake-operation-5",
 					},
 				},
 			},

--- a/pkg/cmd/util/output/backup_structured_describer.go
+++ b/pkg/cmd/util/output/backup_structured_describer.go
@@ -425,7 +425,7 @@ func describeLocalSnapshotInSF(details bool, info *volume.VolumeInfo, snapshotDe
 		localSnapshot := make(map[string]interface{})
 
 		if !info.SnapshotDataMoved {
-			localSnapshot["operationID"] = info.OperationID
+			localSnapshot["operationID"] = info.CSISnapshotInfo.OperationID
 		}
 
 		localSnapshot["snapshotContentName"] = info.CSISnapshotInfo.VSCName
@@ -446,7 +446,7 @@ func describeDataMovementInSF(details bool, info *volume.VolumeInfo, snapshotDet
 
 	if details {
 		dataMovement := make(map[string]interface{})
-		dataMovement["operationID"] = info.OperationID
+		dataMovement["operationID"] = info.SnapshotDataMovementInfo.OperationID
 
 		dataMover := "velero"
 		if info.SnapshotDataMovementInfo.DataMover != "" {

--- a/pkg/cmd/util/output/backup_structured_describer_test.go
+++ b/pkg/cmd/util/output/backup_structured_describer_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package output
 
 import (
@@ -279,7 +295,7 @@ func TestDescribeNativeSnapshotsInSF(t *testing.T) {
 				{
 					BackupMethod: volume.NativeSnapshot,
 					PVName:       "pv-1",
-					NativeSnapshotInfo: volume.NativeSnapshotInfo{
+					NativeSnapshotInfo: &volume.NativeSnapshotInfo{
 						SnapshotHandle: "snapshot-1",
 						VolumeType:     "ebs",
 						VolumeAZ:       "us-east-2",
@@ -299,7 +315,7 @@ func TestDescribeNativeSnapshotsInSF(t *testing.T) {
 				{
 					BackupMethod: volume.NativeSnapshot,
 					PVName:       "pv-1",
-					NativeSnapshotInfo: volume.NativeSnapshotInfo{
+					NativeSnapshotInfo: &volume.NativeSnapshotInfo{
 						SnapshotHandle: "snapshot-1",
 						VolumeType:     "ebs",
 						VolumeAZ:       "us-east-2",
@@ -365,12 +381,12 @@ func TestDescribeCSISnapshotsInSF(t *testing.T) {
 					BackupMethod:          volume.CSISnapshot,
 					PVCName:               "pvc-1",
 					PreserveLocalSnapshot: true,
-					OperationID:           "fake-operation-1",
-					CSISnapshotInfo: volume.CSISnapshotInfo{
+					CSISnapshotInfo: &volume.CSISnapshotInfo{
 						SnapshotHandle: "snapshot-1",
 						Size:           1024,
 						Driver:         "fake-driver",
 						VSCName:        "vsc-1",
+						OperationID:    "fake-operation-1",
 					},
 				},
 			},
@@ -389,12 +405,12 @@ func TestDescribeCSISnapshotsInSF(t *testing.T) {
 					BackupMethod:          volume.CSISnapshot,
 					PVCName:               "pvc-2",
 					PreserveLocalSnapshot: true,
-					OperationID:           "fake-operation-2",
-					CSISnapshotInfo: volume.CSISnapshotInfo{
+					CSISnapshotInfo: &volume.CSISnapshotInfo{
 						SnapshotHandle: "snapshot-2",
 						Size:           1024,
 						Driver:         "fake-driver",
 						VSCName:        "vsc-2",
+						OperationID:    "fake-operation-2",
 					},
 				},
 			},
@@ -420,11 +436,11 @@ func TestDescribeCSISnapshotsInSF(t *testing.T) {
 					BackupMethod:      volume.CSISnapshot,
 					PVCName:           "pvc-3",
 					SnapshotDataMoved: true,
-					OperationID:       "fake-operation-3",
-					SnapshotDataMovementInfo: volume.SnapshotDataMovementInfo{
+					SnapshotDataMovementInfo: &volume.SnapshotDataMovementInfo{
 						DataMover:      "velero",
 						UploaderType:   "fake-uploader",
 						SnapshotHandle: "fake-repo-id-3",
+						OperationID:    "fake-operation-3",
 					},
 				},
 			},
@@ -443,11 +459,11 @@ func TestDescribeCSISnapshotsInSF(t *testing.T) {
 					BackupMethod:      volume.CSISnapshot,
 					PVCName:           "pvc-4",
 					SnapshotDataMoved: true,
-					OperationID:       "fake-operation-4",
-					SnapshotDataMovementInfo: volume.SnapshotDataMovementInfo{
+					SnapshotDataMovementInfo: &volume.SnapshotDataMovementInfo{
 						DataMover:      "velero",
 						UploaderType:   "fake-uploader",
 						SnapshotHandle: "fake-repo-id-4",
+						OperationID:    "fake-operation-4",
 					},
 				},
 			},
@@ -471,10 +487,10 @@ func TestDescribeCSISnapshotsInSF(t *testing.T) {
 					BackupMethod:      volume.CSISnapshot,
 					PVCName:           "pvc-4",
 					SnapshotDataMoved: true,
-					OperationID:       "fake-operation-4",
-					SnapshotDataMovementInfo: volume.SnapshotDataMovementInfo{
+					SnapshotDataMovementInfo: &volume.SnapshotDataMovementInfo{
 						UploaderType:   "fake-uploader",
 						SnapshotHandle: "fake-repo-id-4",
+						OperationID:    "fake-operation-4",
 					},
 				},
 			},

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -88,7 +88,7 @@ func TestRestorePVWithVolumeInfo(t *testing.T) {
 				"pv-1": {
 					BackupMethod: internalVolume.NativeSnapshot,
 					PVName:       "pv-1",
-					NativeSnapshotInfo: internalVolume.NativeSnapshotInfo{
+					NativeSnapshotInfo: &internalVolume.NativeSnapshotInfo{
 						SnapshotHandle: "testSnapshotHandle",
 					},
 				},
@@ -112,7 +112,7 @@ func TestRestorePVWithVolumeInfo(t *testing.T) {
 				"pv-1": {
 					BackupMethod: internalVolume.PodVolumeBackup,
 					PVName:       "pv-1",
-					PVBInfo: internalVolume.PodVolumeBackupInfo{
+					PVBInfo: &internalVolume.PodVolumeBackupInfo{
 						SnapshotHandle: "testSnapshotHandle",
 						Size:           100,
 						NodeName:       "testNode",
@@ -139,7 +139,7 @@ func TestRestorePVWithVolumeInfo(t *testing.T) {
 					BackupMethod:      internalVolume.CSISnapshot,
 					SnapshotDataMoved: false,
 					PVName:            "pv-1",
-					CSISnapshotInfo: internalVolume.CSISnapshotInfo{
+					CSISnapshotInfo: &internalVolume.CSISnapshotInfo{
 						Driver: "pd.csi.storage.gke.io",
 					},
 				},
@@ -164,10 +164,10 @@ func TestRestorePVWithVolumeInfo(t *testing.T) {
 					BackupMethod:      internalVolume.CSISnapshot,
 					SnapshotDataMoved: true,
 					PVName:            "pv-1",
-					CSISnapshotInfo: internalVolume.CSISnapshotInfo{
+					CSISnapshotInfo: &internalVolume.CSISnapshotInfo{
 						Driver: "pd.csi.storage.gke.io",
 					},
-					SnapshotDataMovementInfo: internalVolume.SnapshotDataMovementInfo{
+					SnapshotDataMovementInfo: &internalVolume.SnapshotDataMovementInfo{
 						DataMover: "velero",
 					},
 				},


### PR DESCRIPTION
VolumeInfo contains several sub-structures. They are filled for different scenarios. Do not generate empty structure for the not filled sub-structures.

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
