### PR TITLE
Issue 7244: delete incomplete snapshot automatically for kopia uploader

### DIFF
--- a/changelogs/unreleased/7245-Lyndon-Li
+++ b/changelogs/unreleased/7245-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix issue #7244. By the end of the upload, check the outstanding incomplete snapshots and delete them by calling ApplyRetentionPolicy

--- a/pkg/uploader/kopia/snapshot.go
+++ b/pkg/uploader/kopia/snapshot.go
@@ -45,6 +45,7 @@ import (
 )
 
 // All function mainly used to make testing more convenient
+var applyRetentionPolicyFunc = policy.ApplyRetentionPolicy
 var treeForSourceFunc = policy.TreeForSource
 var setPolicyFunc = policy.SetPolicy
 var saveSnapshotFunc = snapshot.SaveSnapshot
@@ -289,6 +290,11 @@ func SnapshotSource(
 
 	if _, err = saveSnapshotFunc(ctx, rep, manifest); err != nil {
 		return "", 0, errors.Wrapf(err, "Failed to save kopia manifest %v", manifest.ID)
+	}
+
+	_, err = applyRetentionPolicyFunc(ctx, rep, sourceInfo, true)
+	if err != nil {
+		return "", 0, errors.Wrapf(err, "Failed to apply kopia retention policy for si %v", sourceInfo)
 	}
 
 	if err = rep.Flush(ctx); err != nil {

--- a/pkg/uploader/kopia/snapshot_test.go
+++ b/pkg/uploader/kopia/snapshot_test.go
@@ -60,6 +60,7 @@ func injectSnapshotFuncs() *snapshotMockes {
 		repoWriterMock: &repomocks.RepositoryWriter{},
 	}
 
+	applyRetentionPolicyFunc = s.policyMock.ApplyRetentionPolicy
 	setPolicyFunc = s.policyMock.SetPolicy
 	treeForSourceFunc = s.policyMock.TreeForSource
 	loadSnapshotFunc = s.snapshotMock.LoadSnapshot

--- a/pkg/uploader/mocks/policy.go
+++ b/pkg/uploader/mocks/policy.go
@@ -19,6 +19,7 @@ package mocks
 import (
 	"context"
 
+	"github.com/kopia/kopia/repo/manifest"
 	"github.com/kopia/kopia/snapshot/policy"
 	"github.com/stretchr/testify/mock"
 
@@ -56,15 +57,15 @@ func (_m *Policy) TreeForSource(ctx context.Context, rep repo.Repository, si sna
 }
 
 // ApplyRetentionPolicy provides a mock function with given fields: ctx, rep, sourceInfo, reallyDelete
-func (_m *Policy) ApplyRetentionPolicy(ctx context.Context, rep repo.RepositoryWriter, sourceInfo snapshot.SourceInfo, reallyDelete bool) ([]*snapshot.Manifest, error) {
+func (_m *Policy) ApplyRetentionPolicy(ctx context.Context, rep repo.RepositoryWriter, sourceInfo snapshot.SourceInfo, reallyDelete bool) ([]manifest.ID, error) {
 	ret := _m.Called(ctx, rep, sourceInfo, reallyDelete)
 
-	var r0 []*snapshot.Manifest
-	if rf, ok := ret.Get(0).(func(context.Context, repo.RepositoryWriter, snapshot.SourceInfo, bool) []*snapshot.Manifest); ok {
+	var r0 []manifest.ID
+	if rf, ok := ret.Get(0).(func(context.Context, repo.RepositoryWriter, snapshot.SourceInfo, bool) []manifest.ID); ok {
 		r0 = rf(ctx, rep, sourceInfo, reallyDelete)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*snapshot.Manifest)
+			r0 = ret.Get(0).([]manifest.ID)
 		}
 	}
 


### PR DESCRIPTION
Fix issue #7244. By the end of the upload, check the outstanding incomplete snapshots and delete them by calling `ApplyRetentionPolicy`