### PR TITLE
Returns directly when backup status is BackupPhaseFailedValidation No need for DeepCopy

### DIFF
--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -252,8 +252,6 @@ func (b *backupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err := kubeutil.PatchResource(original, request.Backup, b.kbClient); err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "error updating Backup status to %s", request.Status.Phase)
 	}
-	// store ref to just-updated item for creating patch
-	original = request.Backup.DeepCopy()
 
 	backupScheduleName := request.GetLabels()[velerov1api.ScheduleNameLabel]
 
@@ -264,6 +262,9 @@ func (b *backupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 		return ctrl.Result{}, nil
 	}
+
+	// store ref to just-updated item for creating patch
+	original = request.Backup.DeepCopy()
 
 	b.backupTracker.Add(request.Namespace, request.Name)
 	defer func() {


### PR DESCRIPTION
Thank you for contributing to Velero!

/kind changelog-not-required

# Please add a summary of your change

Returns directly when backup status is BackupPhaseFailedValidation No need for DeepCopy

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
