### PR TITLE
Do not set "targetNamespace" to namepsace items

### DIFF
--- a/changelogs/unreleased/7274-reasonerjt
+++ b/changelogs/unreleased/7274-reasonerjt
@@ -1,0 +1,1 @@
+Do not set "targetNamespace" to namespace items


### PR DESCRIPTION
fixes #7263
This commit makes the data structures more consistent, that namespaces, as cluster scoped resource will not have "targetNamespace" in the "restoreableItem" instance.

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
