### PR TITLE
Add sleep to avoid snapshot throttle issue

### DIFF
--- a/test/e2e/backups/deletion.go
+++ b/test/e2e/backups/deletion.go
@@ -178,6 +178,11 @@ func runBackupDeletionTests(client TestClient, veleroCfg VeleroConfig, backupNam
 			return errors.Wrap(err, "exceed waiting for snapshot created in cloud")
 		}
 	}
+
+	// Hit issue: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html#:~:text=SnapshotCreationPerVolumeRateExceeded
+	// Sleep for more than 15 seconds to avoid this issue.
+	time.Sleep(1 * time.Minute)
+
 	backupName = "backup-1-" + UUIDgen.String()
 	BackupCfg.BackupName = backupName
 

--- a/test/util/csi/common.go
+++ b/test/util/csi/common.go
@@ -21,13 +21,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	snapshotterClientSet "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/vmware-tanzu/velero/test/util/k8s"
 )
@@ -124,7 +122,7 @@ func GetCsiSnapshotHandleV1(client TestClient, backupName string) ([]string, err
 	}
 
 	if len(snapshotHandleList) == 0 {
-		fmt.Printf("No VolumeSnapshotContent from backup %s", backupName)
+		fmt.Printf("No VolumeSnapshotContent from backup %s\n", backupName)
 	}
 	return snapshotHandleList, nil
 }
@@ -170,11 +168,11 @@ func CheckVolumeSnapshotCR(client TestClient, backupName string, expectedCount i
 	var snapshotContentNameList []string
 	if apiVersion == "v1beta1" {
 		if snapshotContentNameList, err = GetCsiSnapshotHandle(client, backupName); err != nil {
-			return nil, errors.Wrap(err, "Fail to get Azure CSI snapshot content")
+			return nil, errors.Wrap(err, "Fail to get Azure CSI snapshot content for v1beta1")
 		}
 	} else if apiVersion == "v1" {
 		if snapshotContentNameList, err = GetCsiSnapshotHandleV1(client, backupName); err != nil {
-			return nil, errors.Wrap(err, "Fail to get Azure CSI snapshot content")
+			return nil, errors.Wrap(err, "Fail to get Azure CSI snapshot content for v1")
 		}
 	} else {
 		return nil, errors.New("API version is invalid")

--- a/test/util/k8s/common.go
+++ b/test/util/k8s/common.go
@@ -225,7 +225,7 @@ func GetAPIVersions(client *TestClient, name string) ([]string, error) {
 		fmt.Println(group.Name)
 		if group.Name == name {
 			for _, v := range group.Versions {
-				fmt.Println(v.Version)
+				fmt.Printf("group: %s version:%s", group.Name, v.Version)
 				version = append(version, v.Version)
 			}
 			return version, nil

--- a/test/util/kibishii/kibishii_utils.go
+++ b/test/util/kibishii/kibishii_utils.go
@@ -117,6 +117,7 @@ func RunKibishiiTests(veleroCfg VeleroConfig, backupName, restoreName, backupLoc
 			}
 		}
 		snapshotCheckPoint, err := GetSnapshotCheckPoint(client, veleroCfg, 2, kibishiiNamespace, backupName, KibishiiPVCNameList)
+
 		if err != nil {
 			return errors.Wrap(err, "Fail to get snapshot checkpoint")
 		}

--- a/test/util/velero/velero_utils.go
+++ b/test/util/velero/velero_utils.go
@@ -35,11 +35,9 @@ import (
 
 	"github.com/pkg/errors"
 	"golang.org/x/exp/slices"
-	"k8s.io/apimachinery/pkg/util/wait"
-
-	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
-
 	ver "k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	cliinstall "github.com/vmware-tanzu/velero/pkg/cmd/cli/install"
@@ -1201,7 +1199,8 @@ func GetSnapshotCheckPoint(client TestClient, VeleroCfg VeleroConfig, expectCoun
 	snapshotCheckPoint.ExpectCount = expectCount
 	snapshotCheckPoint.NamespaceBackedUp = namespaceBackedUp
 	snapshotCheckPoint.PodName = KibishiiPVCNameList
-	if VeleroCfg.CloudProvider == "azure" && strings.EqualFold(VeleroCfg.Features, "EnableCSI") {
+
+	if (VeleroCfg.CloudProvider == "azure" || VeleroCfg.CloudProvider == "aws") && strings.EqualFold(VeleroCfg.Features, "EnableCSI") {
 		snapshotCheckPoint.EnableCSI = true
 		resourceName := "snapshot.storage.k8s.io"
 


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

1. Add sleep in backup deletion E2E test to avoid AWS snapshot throttle issue: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html#:~:text=SnapshotCreationPerVolumeRateExceeded;
2. Support CSI snapshot checkpoint for EKS pipeline.
# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
