### PR TITLE
[1.12] Issue 6928: remove snapshot deletion timeout for PVB

### DIFF
--- a/changelogs/unreleased/7283-Lyndon-Li
+++ b/changelogs/unreleased/7283-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix issue #6928, remove snapshot deletion timeout for PVB

--- a/pkg/controller/backup_deletion_controller.go
+++ b/pkg/controller/backup_deletion_controller.go
@@ -59,7 +59,6 @@ import (
 )
 
 const (
-	snapshotDeleteTimeout     = time.Minute
 	deleteBackupRequestMaxAge = 24 * time.Hour
 )
 
@@ -513,12 +512,9 @@ func (r *backupDeletionReconciler) deletePodVolumeSnapshots(ctx context.Context,
 		return []error{err}
 	}
 
-	ctx2, cancelFunc := context.WithTimeout(ctx, snapshotDeleteTimeout)
-	defer cancelFunc()
-
 	var errs []error
 	for _, snapshot := range snapshots {
-		if err := r.repoMgr.Forget(ctx2, snapshot); err != nil {
+		if err := r.repoMgr.Forget(ctx, snapshot); err != nil {
 			errs = append(errs, err)
 		}
 	}


### PR DESCRIPTION
Fix issue #6928, remove snapshot deletion timeout for PVB