### PR TITLE
Add CRD name to error message when it is not ready to use

### DIFF
--- a/changelogs/unreleased/7295-josemarevalo
+++ b/changelogs/unreleased/7295-josemarevalo
@@ -1,0 +1,1 @@
+Add CRD name to error message when it is not ready to use

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1757,7 +1757,7 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 	if groupResource == kuberesource.CustomResourceDefinitions {
 		available, err := ctx.crdAvailable(name, resourceClient)
 		if err != nil {
-			errs.Add(namespace, errors.Wrapf(err, "error verifying custom resource definition is ready to use"))
+			errs.Add(namespace, errors.Wrapf(err, "error verifying the CRD %s is ready to use", name))
 		} else if !available {
 			errs.Add(namespace, fmt.Errorf("the CRD %s is not available to use for custom resources", name))
 		}


### PR DESCRIPTION
# Please add a summary of your change

When debugging this error it is currently hard to identify what CRD is causing the issue. This is particularly difficult when dealing with over a hundred CRDs.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
