### PR TITLE
Fix nightly issue of missing param WithoutDisableInformerCacheParam during Velero installation

### DIFF
--- a/test/e2e/migration/migration.go
+++ b/test/e2e/migration/migration.go
@@ -168,7 +168,6 @@ func MigrationTest(useVolumeSnapshots bool, veleroCLI2Version VeleroCLI2Version)
 					//TODO: Remove this setting when migration path is from 1.13 to higher version
 					//TODO: or self, because version 1.12 and older versions have no this parameter.
 					OriginVeleroCfg.WithoutDisableInformerCacheParam = true
-					OriginVeleroCfg.DisableInformerCache = false
 				}
 				Expect(VeleroInstall(context.Background(), &OriginVeleroCfg, false)).To(Succeed())
 				if veleroCLI2Version.VeleroVersion != "self" {

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -148,7 +148,6 @@ func BackupUpgradeRestoreTest(useVolumeSnapshots bool, veleroCLI2Version VeleroC
 				//TODO: Remove this setting when upgrade path is from 1.13 to higher
 				//TODO: version, or self version 1.12 and older versions have no this parameter.
 				tmpCfgForOldVeleroInstall.WithoutDisableInformerCacheParam = true
-				tmpCfgForOldVeleroInstall.DisableInformerCache = false
 
 				Expect(VeleroInstall(context.Background(), &tmpCfgForOldVeleroInstall, false)).To(Succeed())
 				Expect(CheckVeleroVersion(context.Background(), tmpCfgForOldVeleroInstall.VeleroCLI,

--- a/test/util/velero/install.go
+++ b/test/util/velero/install.go
@@ -134,10 +134,11 @@ func VeleroInstall(ctx context.Context, veleroCfg *VeleroConfig, isStandbyCluste
 	veleroInstallOptions.DisableInformerCache = veleroCfg.DisableInformerCache
 
 	err = installVeleroServer(ctx, veleroCfg.VeleroCLI, veleroCfg.CloudProvider, &installOptions{
-		Options:                veleroInstallOptions,
-		RegistryCredentialFile: veleroCfg.RegistryCredentialFile,
-		RestoreHelperImage:     veleroCfg.RestoreHelperImage,
-		VeleroServerDebugMode:  veleroCfg.VeleroServerDebugMode,
+		Options:                          veleroInstallOptions,
+		RegistryCredentialFile:           veleroCfg.RegistryCredentialFile,
+		RestoreHelperImage:               veleroCfg.RestoreHelperImage,
+		VeleroServerDebugMode:            veleroCfg.VeleroServerDebugMode,
+		WithoutDisableInformerCacheParam: veleroCfg.WithoutDisableInformerCacheParam,
 	})
 
 	if err != nil {


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
