### PR TITLE
[cherry-pick]Make "disable-informer-cache" option false(enabled) by default to keep it consistent with the help message

### DIFF
--- a/changelogs/unreleased/7298-ywk253100
+++ b/changelogs/unreleased/7298-ywk253100
@@ -1,0 +1,1 @@
+Make "disable-informer-cache" option false(enabled) by default to keep it consistent with the help message

--- a/pkg/cmd/cli/install/install.go
+++ b/pkg/cmd/cli/install/install.go
@@ -151,7 +151,7 @@ func NewInstallOptions() *Options {
 		DefaultVolumesToFsBackup: false,
 		UploaderType:             uploader.KopiaType,
 		DefaultSnapshotMoveData:  false,
-		DisableInformerCache:     true,
+		DisableInformerCache:     false,
 	}
 }
 


### PR DESCRIPTION
Make "disable-informer-cache" option false(enabled) by default to keep it consi stent with the help message

Fixes #7264

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
