### PR TITLE
Increase the k8s client QPS/burst

### DIFF
--- a/changelogs/unreleased/7311-ywk253100
+++ b/changelogs/unreleased/7311-ywk253100
@@ -1,0 +1,1 @@
+Increase the k8s client QPS/burst to avoid throttling request errors

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -88,8 +88,8 @@ const (
 	defaultResourceTerminatingTimeout = 10 * time.Minute
 
 	// server's client default qps and burst
-	defaultClientQPS      float32 = 20.0
-	defaultClientBurst    int     = 30
+	defaultClientQPS      float32 = 100.0
+	defaultClientBurst    int     = 100
 	defaultClientPageSize int     = 500
 
 	defaultProfilerAddress = "localhost:6060"


### PR DESCRIPTION
Increase the k8s client QPS/burst to avoid throttling request errors

Fixes #7127
Fixes #3191

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
