### PR TITLE
Do not attempt restore resource with no available GVK in cluster

### DIFF
--- a/changelogs/unreleased/7322-kaovilai
+++ b/changelogs/unreleased/7322-kaovilai
@@ -1,0 +1,1 @@
+Check resource Group Version and Kind is available in cluster before attempting restore to prevent being stuck.

--- a/pkg/discovery/helper.go
+++ b/pkg/discovery/helper.go
@@ -78,12 +78,10 @@ type helper struct {
 	logger          logrus.FieldLogger
 
 	// lock guards mapper, resources and resourcesMap
-	lock         sync.RWMutex
-	mapper       meta.RESTMapper
-	resources    []*metav1.APIResourceList
-	resourcesMap map[schema.GroupVersionResource]metav1.APIResource
-	// kindMap stores APIResources keyed by GroupVersionKind used by KindFor()
-	// Group and Kind are case insensitive so we will store as lowercase so hits are consistent
+	lock          sync.RWMutex
+	mapper        meta.RESTMapper
+	resources     []*metav1.APIResourceList
+	resourcesMap  map[schema.GroupVersionResource]metav1.APIResource
 	kindMap       map[schema.GroupVersionKind]metav1.APIResource
 	apiGroups     []metav1.APIGroup
 	serverVersion *version.Info
@@ -119,7 +117,6 @@ func (h *helper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVer
 	return gvr, apiResource, nil
 }
 
-// KindFor expects input where kind is lowercased to hit the map
 func (h *helper) KindFor(input schema.GroupVersionKind) (schema.GroupVersionResource, metav1.APIResource, error) {
 	h.lock.RLock()
 	defer h.lock.RUnlock()
@@ -196,8 +193,7 @@ func (h *helper) Refresh() error {
 
 		for _, resource := range resourceGroup.APIResources {
 			gvr := gv.WithResource(resource.Name)
-			// gvk kind is lowercased for consistency of hits in KindFor()
-			gvk := gv.WithKind(strings.ToLower(resource.Kind))
+			gvk := gv.WithKind(resource.Kind)
 			h.resourcesMap[gvr] = resource
 			h.kindMap[gvk] = resource
 		}

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1059,6 +1059,19 @@ func (ctx *restoreContext) getResourceClient(groupResource schema.GroupResource,
 }
 
 func (ctx *restoreContext) getResourceLister(groupResource schema.GroupResource, obj *unstructured.Unstructured, namespace string) cache.GenericNamespaceLister {
+	_, _, err := ctx.discoveryHelper.KindFor(schema.GroupVersionKind{
+		Group:   obj.GroupVersionKind().Group,
+		Version: obj.GetAPIVersion(),
+		// we want singular name (Serviceaccount), not plural (serviceaccounts)
+		// obj.GetKind() returns ServiceAccount, not Serviceaccount and was causing issues
+		// so we lowercase it here and in the KindMap that is used in discovery
+		Kind: strings.ToLower(obj.GetKind()),
+	})
+	clusterHasKind := err == nil
+	if !clusterHasKind {
+		ctx.log.Errorf("Cannot get resource lister %s because GVK doesn't exist in the cluster", groupResource)
+		return nil
+	}
 	informer := ctx.dynamicInformerFactory.factory.ForResource(groupResource.WithVersion(obj.GroupVersionKind().Version))
 	// if the restore contains CRDs or the RIA returns new resources, need to make sure the corresponding informers are synced
 	if !informer.Informer().HasSynced() {
@@ -1084,6 +1097,10 @@ func getResourceID(groupResource schema.GroupResource, namespace, name string) s
 
 func (ctx *restoreContext) getResource(groupResource schema.GroupResource, obj *unstructured.Unstructured, namespace, name string) (*unstructured.Unstructured, error) {
 	lister := ctx.getResourceLister(groupResource, obj, namespace)
+	if lister == nil {
+		// getResourceLister logs the error, this func returns error to the caller to trigger partiallyFailed.
+		return nil, errors.Errorf("Error getting lister for %s because no informer for GVK found", getResourceID(groupResource, namespace, name))
+	}
 	clusterObj, err := lister.Get(name)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting resource from lister for %s, %s/%s", groupResource, namespace, name)
@@ -1476,22 +1493,6 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 				errs.Add(namespace, err)
 			}
 		}
-	}
-
-	// Check if cluster has GVK required to restore resource, otherwise return err.
-	// Placed here because the object apiVersion might get modified by a RestorePlugin
-	// So we check for the GVK after the RestorePlugin has run.
-	_, _, err = ctx.discoveryHelper.KindFor(schema.GroupVersionKind{
-		Group:   groupResource.Group,
-		Version: obj.GetAPIVersion(),
-		Kind:    groupResource.Resource,
-	})
-	clusterHasKind := err == nil
-	if !clusterHasKind {
-		ctx.log.Errorf("Cannot restore %s because GVK doesn't exist in the cluster", groupResource)
-		// Adding to errs should cause restore to partially fail
-		errs.Add(namespace, fmt.Errorf("cannot restore %s because gvk doesn't exist in the cluster", groupResource))
-		return warnings, errs, itemExists
 	}
 
 	// Necessary because we may have remapped the namespace if the namespace is

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1062,10 +1062,7 @@ func (ctx *restoreContext) getResourceLister(groupResource schema.GroupResource,
 	_, _, err := ctx.discoveryHelper.KindFor(schema.GroupVersionKind{
 		Group:   obj.GroupVersionKind().Group,
 		Version: obj.GetAPIVersion(),
-		// we want singular name (Serviceaccount), not plural (serviceaccounts)
-		// obj.GetKind() returns ServiceAccount, not Serviceaccount and was causing issues
-		// so we lowercase it here and in the KindMap that is used in discovery
-		Kind: strings.ToLower(obj.GetKind()),
+		Kind:    obj.GetKind(),
 	})
 	clusterHasKind := err == nil
 	if !clusterHasKind {

--- a/pkg/test/resources.go
+++ b/pkg/test/resources.go
@@ -51,6 +51,7 @@ func Pods(items ...metav1.Object) *APIResource {
 		ShortName:  "po",
 		Namespaced: true,
 		Items:      items,
+		Kind:       "Pod",
 	}
 }
 


### PR DESCRIPTION
It is possible to end up in a situation where CRD was not restored due to an already existing CRD with a newer GVK without prior GVK. When restoring CR with older GVK, this PR causes item restore to error early and partially fail.

In the future, it might be desirable to merge CRD.spec.versions from backup with in-cluster if it can be done without conflicts but is out of scope of this PR.

Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #7319 

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
