### PR TITLE
Specify the Kind explicitly in the API resource

### DIFF
--- a/pkg/test/discovery_client.go
+++ b/pkg/test/discovery_client.go
@@ -19,9 +19,6 @@ package test
 import (
 	"strings"
 
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 	discoveryfake "k8s.io/client-go/discovery/fake"
@@ -76,7 +73,7 @@ func (c *DiscoveryClient) WithAPIResource(resource *APIResource) *DiscoveryClien
 		Namespaced:   resource.Namespaced,
 		Group:        resource.Group,
 		Version:      resource.Version,
-		Kind:         cases.Title(language.Und).String(strings.TrimSuffix(resource.Name, "s")),
+		Kind:         resource.Kind,
 		Verbs:        metav1.Verbs([]string{"list", "create", "get", "delete"}),
 		ShortNames:   []string{resource.ShortName},
 	})

--- a/pkg/test/resources.go
+++ b/pkg/test/resources.go
@@ -27,6 +27,7 @@ type APIResource struct {
 	Group      string
 	Version    string
 	Name       string
+	Kind       string
 	ShortName  string
 	Namespaced bool
 	Items      []metav1.Object
@@ -59,6 +60,7 @@ func PVCs(items ...metav1.Object) *APIResource {
 		Version:    "v1",
 		Name:       "persistentvolumeclaims",
 		ShortName:  "pvc",
+		Kind:       "PersistentVolumeClaim",
 		Namespaced: true,
 		Items:      items,
 	}
@@ -70,6 +72,7 @@ func PVs(items ...metav1.Object) *APIResource {
 		Version:    "v1",
 		Name:       "persistentvolumes",
 		ShortName:  "pv",
+		Kind:       "PersistentVolume",
 		Namespaced: false,
 		Items:      items,
 	}
@@ -81,6 +84,7 @@ func Secrets(items ...metav1.Object) *APIResource {
 		Version:    "v1",
 		Name:       "secrets",
 		ShortName:  "secrets",
+		Kind:       "Secret",
 		Namespaced: true,
 		Items:      items,
 	}
@@ -92,6 +96,7 @@ func Deployments(items ...metav1.Object) *APIResource {
 		Version:    "v1",
 		Name:       "deployments",
 		ShortName:  "deploy",
+		Kind:       "Deployment",
 		Namespaced: true,
 		Items:      items,
 	}
@@ -103,6 +108,7 @@ func ExtensionsDeployments(items ...metav1.Object) *APIResource {
 		Version:    "v1",
 		Name:       "deployments",
 		ShortName:  "deploy",
+		Kind:       "Deployment",
 		Namespaced: true,
 		Items:      items,
 	}
@@ -115,6 +121,7 @@ func VeleroDeployments(items ...metav1.Object) *APIResource {
 		Version:    "v1",
 		Name:       "deployments",
 		ShortName:  "deploy",
+		Kind:       "Deployment",
 		Namespaced: true,
 		Items:      items,
 	}
@@ -126,6 +133,7 @@ func Namespaces(items ...metav1.Object) *APIResource {
 		Version:    "v1",
 		Name:       "namespaces",
 		ShortName:  "ns",
+		Kind:       "Namespace",
 		Namespaced: false,
 		Items:      items,
 	}
@@ -137,6 +145,7 @@ func ServiceAccounts(items ...metav1.Object) *APIResource {
 		Version:    "v1",
 		Name:       "serviceaccounts",
 		ShortName:  "sa",
+		Kind:       "ServiceAccount",
 		Namespaced: true,
 		Items:      items,
 	}
@@ -148,6 +157,7 @@ func ConfigMaps(items ...metav1.Object) *APIResource {
 		Version:    "v1",
 		Name:       "configmaps",
 		ShortName:  "cm",
+		Kind:       "ConfigMap",
 		Namespaced: true,
 		Items:      items,
 	}
@@ -159,6 +169,7 @@ func CRDs(items ...metav1.Object) *APIResource {
 		Version:    "v1beta1",
 		Name:       "customresourcedefinitions",
 		ShortName:  "crd",
+		Kind:       "CustomResourceDefinition",
 		Namespaced: false,
 		Items:      items,
 	}
@@ -169,6 +180,7 @@ func VSLs(items ...metav1.Object) *APIResource {
 		Group:      "velero.io",
 		Version:    "v1",
 		Name:       "volumesnapshotlocations",
+		Kind:       "VolumeSnapshotLocation",
 		Namespaced: true,
 		Items:      items,
 	}
@@ -179,6 +191,7 @@ func Backups(items ...metav1.Object) *APIResource {
 		Group:      "velero.io",
 		Version:    "v1",
 		Name:       "backups",
+		Kind:       "Backup",
 		Namespaced: true,
 		Items:      items,
 	}
@@ -190,6 +203,7 @@ func Services(items ...metav1.Object) *APIResource {
 		Version:    "v1",
 		Name:       "services",
 		ShortName:  "svc",
+		Kind:       "Service",
 		Namespaced: true,
 		Items:      items,
 	}
@@ -200,6 +214,7 @@ func DataUploads(items ...metav1.Object) *APIResource {
 		Group:      "velero.io",
 		Version:    "v2alpha1",
 		Name:       "datauploads",
+		Kind:       "DataUpload",
 		Namespaced: true,
 		Items:      items,
 	}


### PR DESCRIPTION
Specify the Kind explicitly in the API resource to avoid wrong Kind conversion

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
