### PR TITLE
[cherry-pick]Check whether the API resource exists before creating the informer cache

### DIFF
--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -593,6 +593,11 @@ func (ctx *restoreContext) execute() (results.Result, results.Result) {
 				break
 			}
 			gvr := schema.ParseGroupResource(informerResource.resource).WithVersion(version)
+			_, _, err := ctx.discoveryHelper.ResourceFor(gvr)
+			if err != nil {
+				ctx.log.Infof("failed to create informer for %s: %v", gvr, err)
+				continue
+			}
 			ctx.dynamicInformerFactory.factory.ForResource(gvr)
 		}
 		ctx.dynamicInformerFactory.factory.Start(ctx.dynamicInformerFactory.context.Done())
@@ -1059,11 +1064,7 @@ func (ctx *restoreContext) getResourceClient(groupResource schema.GroupResource,
 }
 
 func (ctx *restoreContext) getResourceLister(groupResource schema.GroupResource, obj *unstructured.Unstructured, namespace string) (cache.GenericNamespaceLister, error) {
-	_, _, err := ctx.discoveryHelper.KindFor(schema.GroupVersionKind{
-		Group:   obj.GroupVersionKind().Group,
-		Version: obj.GetAPIVersion(),
-		Kind:    obj.GetKind(),
-	})
+	_, _, err := ctx.discoveryHelper.KindFor(obj.GroupVersionKind())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Check whether the API resource exists before creating the informer cache

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
