### PR TITLE
[Cherry-Pick] Fix server start failure when no default BSL

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	corev1api "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -467,7 +468,12 @@ func setDefaultBackupLocation(ctx context.Context, client ctrlclient.Client, nam
 
 	backupLocation := &velerov1api.BackupStorageLocation{}
 	if err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: defaultBackupLocation}, backupLocation); err != nil {
-		return errors.WithStack(err)
+		if apierrors.IsNotFound(err) {
+			logger.WithField("backupStorageLocation", defaultBackupLocation).WithError(err).Warn("Failed to set default backup storage location at server start")
+			return nil
+		} else {
+			return errors.WithStack(err)
+		}
 	}
 
 	if !backupLocation.Spec.Default {

--- a/pkg/cmd/server/server_test.go
+++ b/pkg/cmd/server/server_test.go
@@ -409,4 +409,13 @@ func Test_setDefaultBackupLocation(t *testing.T) {
 	nonDefaultLocation := &velerov1api.BackupStorageLocation{}
 	require.Nil(t, c.Get(context.Background(), client.ObjectKey{Namespace: "velero", Name: "non-default"}, nonDefaultLocation))
 	assert.False(t, nonDefaultLocation.Spec.Default)
+
+	// no default location specified
+	c = fake.NewClientBuilder().WithScheme(scheme).Build()
+	err := setDefaultBackupLocation(context.Background(), c, "velero", "", logrus.New())
+	assert.NoError(t, err)
+
+	// no default location created
+	err = setDefaultBackupLocation(context.Background(), c, "velero", "default", logrus.New())
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)
https://github.com/vmware-tanzu/velero/issues/7359
# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
