### PR TITLE
Support to build the build-image on multipe platform.

### DIFF
--- a/hack/build-image/Dockerfile
+++ b/hack/build-image/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=linux/amd64 golang:1.21-bookworm
+FROM --platform=$BUILDPLATFORM golang:1.21-bookworm
 
 ARG GOPROXY
 


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
The build-image Dockerfile only accepts the `linux-amd64`.
It makes the Arm platform environment not work.

# Does your change fix a particular issue?
Align the build-image Dockerfile with the Velero Dockerfile to support multiple build platforms.

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
