### PR TITLE
Fix the `velero repo get` nil pointer issue.

### DIFF
--- a/pkg/cmd/cli/repo/get.go
+++ b/pkg/cmd/cli/repo/get.go
@@ -43,9 +43,8 @@ func NewGetCommand(f client.Factory, use string) *cobra.Command {
 			crClient, err := f.KubebuilderClient()
 			cmd.CheckError(err)
 
-			var repos *api.BackupRepositoryList
+			repos := new(api.BackupRepositoryList)
 			if len(args) > 0 {
-				repos = new(api.BackupRepositoryList)
 				for _, name := range args {
 					repo := new(api.BackupRepository)
 					err := crClient.Get(context.TODO(), ctrlclient.ObjectKey{Namespace: f.Namespace(), Name: name}, repo)


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
```
$ velero repo get
An error occurred: expected pointer, but got nil
```


# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
