### PR TITLE
Ignore missing path error in conditional match

### DIFF
--- a/changelogs/unreleased/7410-seanblong
+++ b/changelogs/unreleased/7410-seanblong
@@ -1,0 +1,1 @@
+Ignore missing path error in conditional match

--- a/internal/resourcemodifiers/resource_modifiers.go
+++ b/internal/resourcemodifiers/resource_modifiers.go
@@ -172,7 +172,7 @@ func matchConditions(u *unstructured.Unstructured, rules []MatchRule, _ logrus.F
 	p := &JSONPatcher{patches: fixed}
 	_, err := p.applyPatch(u)
 	if err != nil {
-		if errors.Is(err, jsonpatch.ErrTestFailed) {
+		if errors.Is(err, jsonpatch.ErrTestFailed) || errors.Is(err, jsonpatch.ErrMissing) {
 			return false, nil
 		}
 		return false, err

--- a/internal/resourcemodifiers/resource_modifiers_test.go
+++ b/internal/resourcemodifiers/resource_modifiers_test.go
@@ -1650,6 +1650,35 @@ func TestResourceModifiers_conditional_patches(t *testing.T) {
 			wantErr:       false,
 			wantObj:       cmWithLabelAToB.DeepCopy(),
 		},
+		{
+			name: "missing condition path and skip patches",
+			rm: &ResourceModifiers{
+				Version: "v1",
+				ResourceModifierRules: []ResourceModifierRule{
+					{
+						Conditions: Conditions{
+							GroupResource: "*",
+							Namespaces:    []string{"fake"},
+							Matches: []MatchRule{
+								{
+									Path:  "/metadata/labels/a/b",
+									Value: "c",
+								},
+							},
+						},
+						MergePatches: []JSONMergePatch{
+							{
+								PatchData: `{"metadata":{"labels":{"a":"c"}}}`,
+							},
+						},
+					},
+				},
+			},
+			obj:           cmWithLabelAToB.DeepCopy(),
+			groupResource: "configmaps",
+			wantErr:       false,
+			wantObj:       cmWithLabelAToB.DeepCopy(),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

For Resource Modifiers, don't treat unmatched paths as an error (`ErrMissing`) instead treat them the same way as an `ErrTestFailed` response.

This is particularly useful when we want to match on paths should they exist, such as the following example where I'm looking to remove a particular affinity rule.

```yaml
resourceModifierRules:
- conditions:
    groupResource: statefulsets.apps
    matches:
    - path: "/spec/template/spec/affinity/nodeAffinity/requiredDuringSchedulingIgnoredDuringExecution/nodeSelectorTerms/0/matchExpressions/0/key"
      value: cloud.google.com/gke-preemptible
  patches:
  - operation: remove
    path: "/spec/template/spec/affinity/nodeAffinity/requiredDuringSchedulingIgnoredDuringExecution/nodeSelectorTerms/0/matchExpressions/0"
```

I've tested this locally and with a deployed container image.  All statefulsets containing this particular path have it removed and all statefulset without it are filtered out, without creating an error message and allowing the restore to finish with a `Completed` status.

# Does your change fix a particular issue?

Fixes #(issue) 

N/A

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
