### PR TITLE
Don't return error when no credential file found

### DIFF
--- a/pkg/util/azure/util.go
+++ b/pkg/util/azure/util.go
@@ -62,6 +62,10 @@ func LoadCredentials(config map[string]string) (map[string]string, error) {
 		credFile = config[credentialFile]
 	}
 
+	if len(credFile) == 0 {
+		return map[string]string{}, nil
+	}
+
 	// put the credential file content into a map
 	creds, err := godotenv.Read(credFile)
 	if err != nil {

--- a/pkg/util/azure/util_test.go
+++ b/pkg/util/azure/util_test.go
@@ -28,8 +28,9 @@ import (
 
 func TestLoadCredentials(t *testing.T) {
 	// no credential file
-	_, err := LoadCredentials(nil)
-	require.NotNil(t, err)
+	credentials, err := LoadCredentials(nil)
+	require.Nil(t, err)
+	assert.NotNil(t, credentials)
 
 	// specified credential file in the config
 	name := filepath.Join(os.TempDir(), "credential")
@@ -43,7 +44,7 @@ func TestLoadCredentials(t *testing.T) {
 	config := map[string]string{
 		"credentialsFile": name,
 	}
-	credentials, err := LoadCredentials(config)
+	credentials, err = LoadCredentials(config)
 	require.Nil(t, err)
 	assert.Equal(t, "value", credentials["key"])
 


### PR DESCRIPTION
Don't return error when no credential file found

Fixes #7395

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
