### PR TITLE
[1.13] Issue 7308: change the data path requeue time to 5 second

### DIFF
--- a/changelogs/unreleased/7459-Lyndon-Li
+++ b/changelogs/unreleased/7459-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix issue #7308, change the data path requeue time to 5 second for data mover backup/restore, PVB and PVR.

--- a/pkg/controller/data_download_controller.go
+++ b/pkg/controller/data_download_controller.go
@@ -261,7 +261,7 @@ func (r *DataDownloadReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if err != nil {
 			if err == datapath.ConcurrentLimitExceed {
 				log.Info("Data path instance is concurrent limited requeue later")
-				return ctrl.Result{Requeue: true, RequeueAfter: time.Minute}, nil
+				return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
 			} else {
 				return r.errorOut(ctx, dd, err, "error to create data path", log)
 			}

--- a/pkg/controller/data_download_controller_test.go
+++ b/pkg/controller/data_download_controller_test.go
@@ -219,7 +219,7 @@ func TestDataDownloadReconcile(t *testing.T) {
 			dataMgr:        datapath.NewManager(0),
 			notNilExpose:   true,
 			notMockCleanUp: true,
-			expectedResult: &ctrl.Result{Requeue: true, RequeueAfter: time.Minute},
+			expectedResult: &ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5},
 		},
 		{
 			name:              "Error getting volume directory name for pvc in pod",
@@ -416,8 +416,8 @@ func TestDataDownloadReconcile(t *testing.T) {
 			require.NotNil(t, actualResult)
 
 			if test.expectedResult != nil {
-				assert.Equal(t, test.expectedResult.Requeue, test.expectedResult.Requeue)
-				assert.Equal(t, test.expectedResult.RequeueAfter, test.expectedResult.RequeueAfter)
+				assert.Equal(t, test.expectedResult.Requeue, actualResult.Requeue)
+				assert.Equal(t, test.expectedResult.RequeueAfter, actualResult.RequeueAfter)
 			}
 
 			dd := velerov2alpha1api.DataDownload{}

--- a/pkg/controller/data_upload_controller.go
+++ b/pkg/controller/data_upload_controller.go
@@ -269,7 +269,7 @@ func (r *DataUploadReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if err != nil {
 			if err == datapath.ConcurrentLimitExceed {
 				log.Info("Data path instance is concurrent limited requeue later")
-				return ctrl.Result{Requeue: true, RequeueAfter: time.Minute}, nil
+				return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
 			} else {
 				return r.errorOut(ctx, du, err, "error to create data path", log)
 			}

--- a/pkg/controller/data_upload_controller_test.go
+++ b/pkg/controller/data_upload_controller_test.go
@@ -413,7 +413,7 @@ func TestReconcile(t *testing.T) {
 			du:                dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).SnapshotType(fakeSnapshotType).Result(),
 			expectedProcessed: false,
 			expected:          dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).Result(),
-			expectedRequeue:   ctrl.Result{Requeue: true, RequeueAfter: time.Minute},
+			expectedRequeue:   ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5},
 		},
 		{
 			name:     "prepare timeout",

--- a/pkg/controller/pod_volume_backup_controller.go
+++ b/pkg/controller/pod_volume_backup_controller.go
@@ -126,7 +126,7 @@ func (r *PodVolumeBackupReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	fsBackup, err := r.dataPathMgr.CreateFileSystemBR(pvb.Name, pVBRRequestor, ctx, r.Client, pvb.Namespace, callbacks, log)
 	if err != nil {
 		if err == datapath.ConcurrentLimitExceed {
-			return ctrl.Result{Requeue: true, RequeueAfter: time.Minute}, nil
+			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
 		} else {
 			return r.errorOut(ctx, &pvb, err, "error to create data path", log)
 		}

--- a/pkg/controller/pod_volume_backup_controller_test.go
+++ b/pkg/controller/pod_volume_backup_controller_test.go
@@ -383,7 +383,7 @@ var _ = Describe("PodVolumeBackup Reconciler", func() {
 			expected: builder.ForPodVolumeBackup(velerov1api.DefaultNamespace, "pvb-1").
 				Phase("").
 				Result(),
-			expectedRequeue: ctrl.Result{Requeue: true, RequeueAfter: time.Minute},
+			expectedRequeue: ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5},
 		}),
 	)
 })

--- a/pkg/controller/pod_volume_restore_controller.go
+++ b/pkg/controller/pod_volume_restore_controller.go
@@ -122,7 +122,7 @@ func (c *PodVolumeRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	fsRestore, err := c.dataPathMgr.CreateFileSystemBR(pvr.Name, pVBRRequestor, ctx, c.Client, pvr.Namespace, callbacks, log)
 	if err != nil {
 		if err == datapath.ConcurrentLimitExceed {
-			return ctrl.Result{Requeue: true, RequeueAfter: time.Minute}, nil
+			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
 		} else {
 			return c.errorOut(ctx, pvr, err, "error to create data path", log)
 		}


### PR DESCRIPTION
Fix issue https://github.com/vmware-tanzu/velero/issues/7308, change the data path requeue time to 5 second for data mover backup/restore, PVB and PVR.