### PR TITLE
Modify the label used by the restore CLI to filter the PVR.

### DIFF
--- a/pkg/cmd/cli/restore/describe.go
+++ b/pkg/cmd/cli/restore/describe.go
@@ -74,7 +74,7 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 				podVolumeRestoreList := new(velerov1api.PodVolumeRestoreList)
 				err = kbClient.List(context.TODO(), podVolumeRestoreList, &controllerclient.ListOptions{
 					Namespace:     f.Namespace(),
-					LabelSelector: labels.SelectorFromSet(map[string]string{velerov1api.BackupNameLabel: label.GetValidName(restore.Name)}),
+					LabelSelector: labels.SelectorFromSet(map[string]string{velerov1api.RestoreNameLabel: label.GetValidName(restore.Name)}),
 				})
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "error getting PodVolumeRestores for restore %s: %v\n", restore.Name, err)


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #7464 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
