### PR TITLE
Check whether the VolumeSnapshot's source PVC is nil before using it

### DIFF
--- a/changelogs/unreleased/7515-blackpiglet
+++ b/changelogs/unreleased/7515-blackpiglet
@@ -1,0 +1,2 @@
+Check whether the VolumeSnapshot's source PVC is nil before using it.
+Skip populate VolumeInfo for data-moved PV when CSI is not enabled.

--- a/internal/volume/volumes_information.go
+++ b/internal/volume/volumes_information.go
@@ -28,6 +28,7 @@ import (
 
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	velerov2alpha1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v2alpha1"
+	"github.com/vmware-tanzu/velero/pkg/features"
 	"github.com/vmware-tanzu/velero/pkg/itemoperation"
 	"github.com/vmware-tanzu/velero/pkg/kuberesource"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
@@ -462,6 +463,11 @@ func (v *VolumesInformation) generateVolumeInfoFromPVB() {
 
 // generateVolumeInfoFromDataUpload generate VolumeInfo for DataUpload.
 func (v *VolumesInformation) generateVolumeInfoFromDataUpload() {
+	if !features.IsEnabled(velerov1api.CSIFeatureFlag) {
+		v.logger.Debug("Skip generating VolumeInfo when the CSI feature is disabled.")
+		return
+	}
+
 	tmpVolumeInfos := make([]*VolumeInfo, 0)
 	vsClassList := new(snapshotv1api.VolumeSnapshotClassList)
 	if err := v.crClient.List(context.TODO(), vsClassList); err != nil {

--- a/internal/volume/volumes_information_test.go
+++ b/internal/volume/volumes_information_test.go
@@ -31,6 +31,7 @@ import (
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	velerov2alpha1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v2alpha1"
 	"github.com/vmware-tanzu/velero/pkg/builder"
+	"github.com/vmware-tanzu/velero/pkg/features"
 	"github.com/vmware-tanzu/velero/pkg/itemoperation"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	velerotest "github.com/vmware-tanzu/velero/pkg/test"
@@ -605,6 +606,8 @@ func TestGenerateVolumeInfoFromPVB(t *testing.T) {
 }
 
 func TestGenerateVolumeInfoFromDataUpload(t *testing.T) {
+	features.Enable(velerov1api.CSIFeatureFlag)
+	defer features.Disable(velerov1api.CSIFeatureFlag)
 	now := metav1.Now()
 	tests := []struct {
 		name                string

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1955,6 +1955,11 @@ func hasCSIVolumeSnapshot(ctx *restoreContext, unstructuredPV *unstructured.Unst
 	}
 
 	for _, vs := range ctx.csiVolumeSnapshots {
+		// In some error cases, the VSs' source PVC could be nil. Skip them.
+		if vs.Spec.Source.PersistentVolumeClaimName == nil {
+			continue
+		}
+
 		if pv.Spec.ClaimRef.Name == *vs.Spec.Source.PersistentVolumeClaimName &&
 			pv.Spec.ClaimRef.Namespace == vs.Namespace {
 			return true

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -4045,6 +4045,21 @@ func TestHasCSIVolumeSnapshot(t *testing.T) {
 			expectedResult: false,
 		},
 		{
+			name: "VS's source PVC is nil, expect false",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "PersistentVolume",
+					"apiVersion": "v1",
+					"metadata": map[string]interface{}{
+						"namespace": "default",
+						"name":      "test",
+					},
+				},
+			},
+			vs:             builder.ForVolumeSnapshot("velero", "test").Result(),
+			expectedResult: false,
+		},
+		{
 			name: "Find VS, expect true.",
 			obj: &unstructured.Unstructured{
 				Object: map[string]interface{}{


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Two changes are involved in this PR:
* [Check whether the VolumeSnapshot's source PVC is nil before using it.](https://github.com/vmware-tanzu/velero/pull/7515/commits/4d01c7ffa3b1309e0a1d6dd09c8fabccee4f0ef0)
* [Skip populate VolumeInfo for data-moved PV when CSI is not enabled.](https://github.com/vmware-tanzu/velero/pull/7515/commits/f8deea16179e9b83bc9181443e0e1398d3a88761)

# Does your change fix a particular issue?

Fixes #7494 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
