### PR TITLE
Fix DataDownload fails during restore for empty PVC workload

### DIFF
--- a/changelogs/unreleased/7521-qiuming-best
+++ b/changelogs/unreleased/7521-qiuming-best
@@ -1,0 +1,2 @@
+Fix DataDownload fails during restore for empty PVC workload
+

--- a/pkg/uploader/kopia/snapshot.go
+++ b/pkg/uploader/kopia/snapshot.go
@@ -156,16 +156,6 @@ func Backup(ctx context.Context, fsUploader SnapshotUploader, repoWriter repo.Re
 		return nil, false, errors.Wrapf(err, "Invalid source path '%s'", sourcePath)
 	}
 
-	if volMode == uploader.PersistentVolumeFilesystem {
-		// to be consistent with restic when backup empty dir returns one error for upper logic handle
-		dirs, err := os.ReadDir(source)
-		if err != nil {
-			return nil, false, errors.Wrapf(err, "Unable to read dir in path %s", source)
-		} else if len(dirs) == 0 {
-			return nil, true, nil
-		}
-	}
-
 	source = filepath.Clean(source)
 
 	sourceInfo := snapshot.SourceInfo{

--- a/pkg/uploader/kopia/snapshot_test.go
+++ b/pkg/uploader/kopia/snapshot_test.go
@@ -610,7 +610,7 @@ func TestBackup(t *testing.T) {
 			name:          "Unable to read directory",
 			sourcePath:    "/invalid/path",
 			tags:          nil,
-			expectedError: errors.New("Unable to read dir"),
+			expectedError: errors.New("no such file or directory"),
 		},
 		{
 			name:          "Source path is not a block device",


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)
https://github.com/vmware-tanzu/velero/issues/7388
There's no need to check whether the folder is empty or not.

The logic here wants to be consistent with Restic when backing up empty.
but empty does not mean backup empty dir, For our velero scenario, it does not generate one empty snapshot with an empty dir for both using Kopia or Restic. so we need to remove the empty dir checking logic for the problem mentioned in https://github.com/vmware-tanzu/velero/issues/7388

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
