### PR TITLE
Fix gvr `Group` and `Version` field missing in `KindFor` method

### DIFF
--- a/pkg/discovery/helper.go
+++ b/pkg/discovery/helper.go
@@ -194,6 +194,8 @@ func (h *helper) Refresh() error {
 		for _, resource := range resourceGroup.APIResources {
 			gvr := gv.WithResource(resource.Name)
 			gvk := gv.WithKind(resource.Kind)
+			resource.Group = gv.Group
+			resource.Version = gv.Version
 			h.resourcesMap[gvr] = resource
 			h.kindMap[gvk] = resource
 		}


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
 fix gvr `Group` and `Version` field missing in `KindFor` method of package `discovery`

# Does your change fix a particular issue?

Fixes #(issue)
#7529 

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
