### PR TITLE
Support update the backup VolumeInfos by the Async ops result.

### DIFF
--- a/changelogs/unreleased/7554-blackpiglet
+++ b/changelogs/unreleased/7554-blackpiglet
@@ -1,0 +1,1 @@
+Support update the backup VolumeInfos by the Async ops result.

--- a/pkg/builder/data_upload_builder.go
+++ b/pkg/builder/data_upload_builder.go
@@ -19,6 +19,7 @@ package builder
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/vmware-tanzu/velero/pkg/apis/velero/shared"
 	velerov2alpha1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v2alpha1"
 )
 
@@ -129,5 +130,10 @@ func (d *DataUploadBuilder) CompletionTimestamp(completionTimestamp *metav1.Time
 // Labels sets the DataUpload's Labels.
 func (d *DataUploadBuilder) Labels(labels map[string]string) *DataUploadBuilder {
 	d.object.Labels = labels
+	return d
+}
+
+func (d *DataUploadBuilder) Progress(progress shared.DataMoveOperationProgress) *DataUploadBuilder {
+	d.object.Status.Progress = progress
 	return d
 }

--- a/pkg/builder/data_upload_builder.go
+++ b/pkg/builder/data_upload_builder.go
@@ -115,8 +115,14 @@ func (d *DataUploadBuilder) CSISnapshot(cSISnapshot *velerov2alpha1api.CSISnapsh
 }
 
 // StartTimestamp sets the DataUpload's StartTimestamp.
-func (d *DataUploadBuilder) StartTimestamp(startTime *metav1.Time) *DataUploadBuilder {
-	d.object.Status.StartTimestamp = startTime
+func (d *DataUploadBuilder) StartTimestamp(startTimestamp *metav1.Time) *DataUploadBuilder {
+	d.object.Status.StartTimestamp = startTimestamp
+	return d
+}
+
+// CompletionTimestamp sets the DataUpload's StartTimestamp.
+func (d *DataUploadBuilder) CompletionTimestamp(completionTimestamp *metav1.Time) *DataUploadBuilder {
+	d.object.Status.CompletionTimestamp = completionTimestamp
 	return d
 }
 

--- a/pkg/builder/pod_volume_backup_builder.go
+++ b/pkg/builder/pod_volume_backup_builder.go
@@ -80,6 +80,16 @@ func (b *PodVolumeBackupBuilder) SnapshotID(snapshotID string) *PodVolumeBackupB
 	return b
 }
 
+func (b *PodVolumeBackupBuilder) StartTimestamp(startTimestamp *metav1.Time) *PodVolumeBackupBuilder {
+	b.object.Status.StartTimestamp = startTimestamp
+	return b
+}
+
+func (b *PodVolumeBackupBuilder) CompletionTimestamp(completionTimestamp *metav1.Time) *PodVolumeBackupBuilder {
+	b.object.Status.CompletionTimestamp = completionTimestamp
+	return b
+}
+
 // PodName sets the name of the pod associated with this PodVolumeBackup.
 func (b *PodVolumeBackupBuilder) PodName(name string) *PodVolumeBackupBuilder {
 	b.object.Spec.Pod.Name = name

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -780,6 +780,8 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 			s.config.defaultVolumesToFsBackup,
 			s.config.clientPageSize,
 			s.config.uploaderType,
+			newPluginManager,
+			backupStoreGetter,
 		)
 		cmd.CheckError(err)
 		if err := controller.NewBackupReconciler(
@@ -860,6 +862,8 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 			s.config.defaultVolumesToFsBackup,
 			s.config.clientPageSize,
 			s.config.uploaderType,
+			newPluginManager,
+			backupStoreGetter,
 		)
 		cmd.CheckError(err)
 		r := controller.NewBackupFinalizerReconciler(

--- a/pkg/controller/backup_controller_test.go
+++ b/pkg/controller/backup_controller_test.go
@@ -44,6 +44,7 @@ import (
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakeClient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/vmware-tanzu/velero/internal/volume"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	pkgbackup "github.com/vmware-tanzu/velero/pkg/backup"
 	"github.com/vmware-tanzu/velero/pkg/builder"
@@ -78,9 +79,15 @@ func (b *fakeBackupper) BackupWithResolvers(logger logrus.FieldLogger, backup *p
 	return args.Error(0)
 }
 
-func (b *fakeBackupper) FinalizeBackup(logger logrus.FieldLogger, backup *pkgbackup.Request, inBackupFile io.Reader, outBackupFile io.Writer,
+func (b *fakeBackupper) FinalizeBackup(
+	logger logrus.FieldLogger,
+	backup *pkgbackup.Request,
+	inBackupFile io.Reader,
+	outBackupFile io.Writer,
 	backupItemActionResolver framework.BackupItemActionResolverV2,
-	asyncBIAOperations []*itemoperation.BackupOperation) error {
+	asyncBIAOperations []*itemoperation.BackupOperation,
+	volumeInfos []*volume.VolumeInfo,
+) error {
 	args := b.Called(logger, backup, inBackupFile, outBackupFile, backupItemActionResolver, asyncBIAOperations)
 	return args.Error(0)
 }

--- a/pkg/controller/backup_controller_test.go
+++ b/pkg/controller/backup_controller_test.go
@@ -44,7 +44,6 @@ import (
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakeClient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/vmware-tanzu/velero/internal/volume"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	pkgbackup "github.com/vmware-tanzu/velero/pkg/backup"
 	"github.com/vmware-tanzu/velero/pkg/builder"
@@ -86,7 +85,6 @@ func (b *fakeBackupper) FinalizeBackup(
 	outBackupFile io.Writer,
 	backupItemActionResolver framework.BackupItemActionResolverV2,
 	asyncBIAOperations []*itemoperation.BackupOperation,
-	volumeInfos []*volume.VolumeInfo,
 ) error {
 	args := b.Called(logger, backup, inBackupFile, outBackupFile, backupItemActionResolver, asyncBIAOperations)
 	return args.Error(0)

--- a/pkg/controller/backup_finalizer_controller.go
+++ b/pkg/controller/backup_finalizer_controller.go
@@ -18,9 +18,7 @@ package controller
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
-	"encoding/json"
 	"os"
 
 	"github.com/pkg/errors"
@@ -31,7 +29,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/vmware-tanzu/velero/internal/volume"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	pkgbackup "github.com/vmware-tanzu/velero/pkg/backup"
 	"github.com/vmware-tanzu/velero/pkg/itemoperation"
@@ -157,14 +154,7 @@ func (r *backupFinalizerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		SkippedPVTracker: pkgbackup.NewSkipPVTracker(),
 	}
 	var outBackupFile *os.File
-	var volumeInfos []*volume.VolumeInfo
 	if len(operations) > 0 {
-		volumeInfos, err = backupStore.GetBackupVolumeInfos(backup.Name)
-		if err != nil {
-			log.WithError(err).Error("error getting backup VolumeInfos")
-			return ctrl.Result{}, errors.WithStack(err)
-		}
-
 		log.Info("Setting up finalized backup temp file")
 		inBackupFile, err := downloadToTempFile(backup.Name, backupStore, log)
 		if err != nil {
@@ -194,7 +184,6 @@ func (r *backupFinalizerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			outBackupFile,
 			backupItemActionsResolver,
 			operations,
-			volumeInfos,
 		)
 		if err != nil {
 			log.WithError(err).Error("error finalizing Backup")
@@ -231,24 +220,6 @@ func (r *backupFinalizerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		err = backupStore.PutBackupContents(backup.Name, outBackupFile)
 		if err != nil {
 			return ctrl.Result{}, errors.Wrap(err, "error uploading backup final contents")
-		}
-
-		// Update the backup's VolumeInfos
-		backupVolumeInfoBuf := new(bytes.Buffer)
-		gzw := gzip.NewWriter(backupVolumeInfoBuf)
-		defer gzw.Close()
-
-		if err := json.NewEncoder(gzw).Encode(volumeInfos); err != nil {
-			return ctrl.Result{}, errors.Wrap(err, "error encoding restore results to JSON")
-		}
-
-		if err := gzw.Close(); err != nil {
-			return ctrl.Result{}, errors.Wrap(err, "error closing gzip writer")
-		}
-
-		err = backupStore.PutBackupVolumeInfos(backup.Name, backupVolumeInfoBuf)
-		if err != nil {
-			return ctrl.Result{}, errors.Wrap(err, "fail to upload backup VolumeInfos")
 		}
 	}
 	return ctrl.Result{}, nil

--- a/pkg/controller/backup_finalizer_controller_test.go
+++ b/pkg/controller/backup_finalizer_controller_test.go
@@ -222,6 +222,8 @@ func TestBackupFinalizerReconcile(t *testing.T) {
 			backupStore.On("GetBackupContents", mock.Anything).Return(io.NopCloser(bytes.NewReader([]byte("hello world"))), nil)
 			backupStore.On("PutBackupContents", mock.Anything, mock.Anything).Return(nil)
 			backupStore.On("PutBackupMetadata", mock.Anything, mock.Anything).Return(nil)
+			backupStore.On("GetBackupVolumeInfos", mock.Anything).Return(nil, nil)
+			backupStore.On("PutBackupVolumeInfos", mock.Anything, mock.Anything).Return(nil)
 			pluginManager.On("GetBackupItemActionsV2").Return(nil, nil)
 			backupper.On("FinalizeBackup", mock.Anything, mock.Anything, mock.Anything, mock.Anything, framework.BackupItemActionResolverV2{}, mock.Anything).Return(nil)
 			_, err := reconciler.Reconcile(context.TODO(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: test.backup.Namespace, Name: test.backup.Name}})

--- a/pkg/kuberesource/kuberesource.go
+++ b/pkg/kuberesource/kuberesource.go
@@ -35,4 +35,5 @@ var (
 	VolumeSnapshots           = schema.GroupResource{Group: "snapshot.storage.k8s.io", Resource: "volumesnapshots"}
 	VolumeSnapshotContents    = schema.GroupResource{Group: "snapshot.storage.k8s.io", Resource: "volumesnapshotcontents"}
 	PriorityClasses           = schema.GroupResource{Group: "scheduling.k8s.io", Resource: "priorityclasses"}
+	DataUploads               = schema.GroupResource{Group: "velero.io", Resource: "datauploads"}
 )

--- a/pkg/persistence/mocks/backup_store.go
+++ b/pkg/persistence/mocks/backup_store.go
@@ -314,7 +314,7 @@ func (_m *BackupStore) GetRestoreItemOperations(name string) ([]*itemoperation.R
 	return r0, r1
 }
 
-// GetRestoreItemOperations provides a mock function with given fields: name
+// GetBackupVolumeInfos provides a mock function with given fields: name
 func (_m *BackupStore) GetBackupVolumeInfos(name string) ([]*volume.VolumeInfo, error) {
 	ret := _m.Called(name)
 
@@ -335,6 +335,20 @@ func (_m *BackupStore) GetBackupVolumeInfos(name string) ([]*volume.VolumeInfo, 
 	}
 
 	return r0, r1
+}
+
+// PutBackupVolumeInfos provides a mock function with given fields: name, volumeInfo
+func (_m *BackupStore) PutBackupVolumeInfos(name string, volumeInfo io.Reader) error {
+	ret := _m.Called(name, volumeInfo)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, io.Reader) error); ok {
+		r0 = rf(name, volumeInfo)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // GetRestoreResults provides a mock function with given fields: name

--- a/pkg/persistence/object_store.go
+++ b/pkg/persistence/object_store.go
@@ -75,6 +75,7 @@ type BackupStore interface {
 	GetCSIVolumeSnapshotContents(name string) ([]*snapshotv1api.VolumeSnapshotContent, error)
 	GetCSIVolumeSnapshotClasses(name string) ([]*snapshotv1api.VolumeSnapshotClass, error)
 	GetBackupVolumeInfos(name string) ([]*volume.VolumeInfo, error)
+	PutBackupVolumeInfos(name string, volumeInfo io.Reader) error
 	GetRestoreResults(name string) (map[string]results.Result, error)
 
 	// BackupExists checks if the backup metadata file exists in object storage.
@@ -514,6 +515,10 @@ func (s *objectBackupStore) GetBackupVolumeInfos(name string) ([]*volume.VolumeI
 	}
 
 	return volumeInfos, nil
+}
+
+func (s *objectBackupStore) PutBackupVolumeInfos(name string, volumeInfo io.Reader) error {
+	return s.objectStore.PutObject(s.bucket, s.layout.getBackupVolumeInfoKey(name), volumeInfo)
 }
 
 func (s *objectBackupStore) GetRestoreResults(name string) (map[string]results.Result, error) {

--- a/pkg/repository/maintenance_test.go
+++ b/pkg/repository/maintenance_test.go
@@ -118,7 +118,7 @@ func TestDeleteOldMaintenanceJobs(t *testing.T) {
 	assert.NoError(t, err)
 
 	// We expect the number of jobs to be equal to 'keep'
-	assert.Equal(t, keep, len(jobList.Items))
+	assert.Len(t, jobList.Items, keep)
 
 	// We expect that the oldest jobs were deleted
 	// Job3 should not be present in the remaining list

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1268,7 +1268,7 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 					// want to dynamically re-provision it.
 					return warnings, errs, itemExists
 				} else {
-					obj, err = ctx.handleSkippedPVHasRetainPolicy(obj, resourceID, restoreLogger)
+					obj, err = ctx.handleSkippedPVHasRetainPolicy(obj, restoreLogger)
 					if err != nil {
 						errs.Add(namespace, err)
 						return warnings, errs, itemExists
@@ -1322,7 +1322,7 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 				return warnings, errs, itemExists
 
 			default:
-				obj, err = ctx.handleSkippedPVHasRetainPolicy(obj, resourceID, restoreLogger)
+				obj, err = ctx.handleSkippedPVHasRetainPolicy(obj, restoreLogger)
 				if err != nil {
 					errs.Add(namespace, err)
 					return warnings, errs, itemExists
@@ -2497,7 +2497,6 @@ func (ctx *restoreContext) handlePVHasNativeSnapshot(obj *unstructured.Unstructu
 
 func (ctx *restoreContext) handleSkippedPVHasRetainPolicy(
 	obj *unstructured.Unstructured,
-	resourceID string,
 	logger logrus.FieldLogger,
 ) (*unstructured.Unstructured, error) {
 	logger.Infof("Restoring persistent volume as-is because it doesn't have a snapshot and its reclaim policy is not Delete.")
@@ -2508,13 +2507,5 @@ func (ctx *restoreContext) handleSkippedPVHasRetainPolicy(
 	}
 
 	obj = resetVolumeBindingInfo(obj)
-
-	// We call the pvRestorer here to clear out the PV's claimRef.UID,
-	// so it can be re-claimed when its PVC is restored and gets a new UID.
-	updatedObj, err := ctx.pvRestorer.executePVAction(obj)
-	if err != nil {
-		return nil, fmt.Errorf("error executing PVAction for %s: %v", resourceID, err)
-	}
-
-	return updatedObj, nil
+	return obj, nil
 }


### PR DESCRIPTION
1. Add PutBackupVolumeInfos method.
2. Add CompletionTimestamp in VolumeInfo.
3. Add Size in SnapshotDataMovementInfo.
4. Update CompletionTimpstmap, SnapshotHandle, RetainedSnapshot, and Size in VolumeInfo on DataUpload Operation completes.

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #7357 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
