### PR TITLE
Fix snapshot leak for backup

### DIFF
--- a/changelogs/unreleased/7558-qiuming-best
+++ b/changelogs/unreleased/7558-qiuming-best
@@ -1,0 +1,1 @@
+Fix snapshot leak for backup

--- a/pkg/cmd/cli/nodeagent/server.go
+++ b/pkg/cmd/cli/nodeagent/server.go
@@ -412,8 +412,8 @@ func (s *nodeAgentServer) markInProgressPVBsFailed(client ctrlclient.Client) {
 		}
 
 		if err := controller.UpdatePVBStatusToFailed(s.ctx, client, &pvbs.Items[i],
-			fmt.Sprintf("get a podvolumebackup with status %q during the server starting, mark it as %q", velerov1api.PodVolumeBackupPhaseInProgress, velerov1api.PodVolumeBackupPhaseFailed),
-			time.Now(), s.logger); err != nil {
+			fmt.Errorf("get a podvolumebackup with status %q during the server starting, mark it as %q", velerov1api.PodVolumeBackupPhaseInProgress, velerov1api.PodVolumeBackupPhaseFailed),
+			"", time.Now(), s.logger); err != nil {
 			s.logger.WithError(errors.WithStack(err)).Errorf("failed to patch podvolumebackup %q", pvb.GetName())
 			continue
 		}

--- a/pkg/datapath/error.go
+++ b/pkg/datapath/error.go
@@ -1,0 +1,33 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datapath
+
+// DataPathError represents an error that occurred during a backup or restore operation
+type DataPathError struct {
+	snapshotID string
+	err        error
+}
+
+// Error implements error.
+func (e DataPathError) Error() string {
+	return e.err.Error()
+}
+
+// GetSnapshotID returns the snapshot ID for the error.
+func (e DataPathError) GetSnapshotID() string {
+	return e.snapshotID
+}

--- a/pkg/datapath/error_test.go
+++ b/pkg/datapath/error_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datapath
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestGetSnapshotID(t *testing.T) {
+	// Create a DataPathError instance for testing
+	err := DataPathError{snapshotID: "123", err: errors.New("example error")}
+	// Call the GetSnapshotID method to retrieve the snapshot ID
+	snapshotID := err.GetSnapshotID()
+	// Check if the retrieved snapshot ID matches the expected value
+	if snapshotID != "123" {
+		t.Errorf("GetSnapshotID() returned unexpected snapshot ID: got %s, want %s", snapshotID, "123")
+	}
+}
+
+func TestError(t *testing.T) {
+	// Create a DataPathError instance for testing
+	err := DataPathError{snapshotID: "123", err: errors.New("example error")}
+	// Call the Error method to retrieve the error message
+	errMsg := err.Error()
+	// Check if the retrieved error message matches the expected value
+	expectedErrMsg := "example error"
+	if errMsg != expectedErrMsg {
+		t.Errorf("Error() returned unexpected error message: got %s, want %s", errMsg, expectedErrMsg)
+	}
+}

--- a/pkg/datapath/file_system.go
+++ b/pkg/datapath/file_system.go
@@ -141,7 +141,11 @@ func (fs *fileSystemBR) StartBackup(source AccessPoint, realSource string, paren
 		if err == provider.ErrorCanceled {
 			fs.callbacks.OnCancelled(context.Background(), fs.namespace, fs.jobName)
 		} else if err != nil {
-			fs.callbacks.OnFailed(context.Background(), fs.namespace, fs.jobName, err)
+			dataPathErr := DataPathError{
+				snapshotID: snapshotID,
+				err:        err,
+			}
+			fs.callbacks.OnFailed(context.Background(), fs.namespace, fs.jobName, dataPathErr)
 		} else {
 			fs.callbacks.OnCompleted(context.Background(), fs.namespace, fs.jobName, Result{Backup: BackupResult{snapshotID, emptySnapshot, source}})
 		}
@@ -161,7 +165,11 @@ func (fs *fileSystemBR) StartRestore(snapshotID string, target AccessPoint, uplo
 		if err == provider.ErrorCanceled {
 			fs.callbacks.OnCancelled(context.Background(), fs.namespace, fs.jobName)
 		} else if err != nil {
-			fs.callbacks.OnFailed(context.Background(), fs.namespace, fs.jobName, err)
+			dataPathErr := DataPathError{
+				snapshotID: snapshotID,
+				err:        err,
+			}
+			fs.callbacks.OnFailed(context.Background(), fs.namespace, fs.jobName, dataPathErr)
 		} else {
 			fs.callbacks.OnCompleted(context.Background(), fs.namespace, fs.jobName, Result{Restore: RestoreResult{Target: target}})
 		}

--- a/pkg/datapath/file_system_test.go
+++ b/pkg/datapath/file_system_test.go
@@ -34,7 +34,7 @@ func TestAsyncBackup(t *testing.T) {
 	var asyncErr error
 	var asyncResult Result
 	finish := make(chan struct{})
-
+	var failErr = errors.New("fake-fail-error")
 	tests := []struct {
 		name         string
 		uploaderProv provider.Provider
@@ -49,12 +49,12 @@ func TestAsyncBackup(t *testing.T) {
 				OnCompleted: nil,
 				OnCancelled: nil,
 				OnFailed: func(ctx context.Context, namespace string, job string, err error) {
-					asyncErr = err
+					asyncErr = failErr
 					asyncResult = Result{}
 					finish <- struct{}{}
 				},
 			},
-			err: errors.New("fake-error"),
+			err: failErr,
 		},
 		{
 			name: "async backup cancel",
@@ -117,7 +117,7 @@ func TestAsyncRestore(t *testing.T) {
 	var asyncErr error
 	var asyncResult Result
 	finish := make(chan struct{})
-
+	var failErr = errors.New("fake-fail-error")
 	tests := []struct {
 		name         string
 		uploaderProv provider.Provider
@@ -133,12 +133,12 @@ func TestAsyncRestore(t *testing.T) {
 				OnCompleted: nil,
 				OnCancelled: nil,
 				OnFailed: func(ctx context.Context, namespace string, job string, err error) {
-					asyncErr = err
+					asyncErr = failErr
 					asyncResult = Result{}
 					finish <- struct{}{}
 				},
 			},
-			err: errors.New("fake-error"),
+			err: failErr,
 		},
 		{
 			name: "async restore cancel",

--- a/pkg/uploader/kopia/snapshot_test.go
+++ b/pkg/uploader/kopia/snapshot_test.go
@@ -227,8 +227,8 @@ func TestReportSnapshotStatus(t *testing.T) {
 		},
 		{
 			shouldError:    true,
-			expectedResult: "",
-			expectedSize:   0,
+			expectedResult: "sample-manifest-id",
+			expectedSize:   1024,
 			directorySummary: &fs.DirectorySummary{
 				FailedEntries: []*fs.EntryWithError{
 					{

--- a/pkg/uploader/provider/kopia_test.go
+++ b/pkg/uploader/provider/kopia_test.go
@@ -91,13 +91,6 @@ func TestRunBackup(t *testing.T) {
 			notError: false,
 		},
 		{
-			name: "got empty snapshot",
-			hookBackupFunc: func(ctx context.Context, fsUploader kopia.SnapshotUploader, repoWriter repo.RepositoryWriter, sourcePath string, realSource string, forceFull bool, parentSnapshot string, volMode uploader.PersistentVolumeMode, uploaderCfg map[string]string, tags map[string]string, log logrus.FieldLogger) (*uploader.SnapshotInfo, bool, error) {
-				return nil, true, errors.New("snapshot is empty")
-			},
-			notError: false,
-		},
-		{
 			name: "success to backup block mode volume",
 			hookBackupFunc: func(ctx context.Context, fsUploader kopia.SnapshotUploader, repoWriter repo.RepositoryWriter, sourcePath string, realSource string, forceFull bool, parentSnapshot string, volMode uploader.PersistentVolumeMode, uploaderCfg map[string]string, tags map[string]string, log logrus.FieldLogger) (*uploader.SnapshotInfo, bool, error) {
 				return &uploader.SnapshotInfo{}, false, nil


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
- Enable fail fast for kopia
- Record snapshot id for failed backup

# Does your change fix a particular issue?

Fixes #(issue)
https://github.com/vmware-tanzu/velero/issues/7503
# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
