### PR TITLE
Add confirm flag to velero plugin add

### DIFF
--- a/changelogs/unreleased/7566-kaovilai
+++ b/changelogs/unreleased/7566-kaovilai
@@ -1,0 +1,1 @@
+Add confirm flag to velero plugin add

--- a/pkg/cmd/cli/backup/delete.go
+++ b/pkg/cmd/cli/backup/delete.go
@@ -32,6 +32,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
 	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
+	"github.com/vmware-tanzu/velero/pkg/cmd/util/confirm"
 	"github.com/vmware-tanzu/velero/pkg/label"
 )
 
@@ -70,7 +71,7 @@ func NewDeleteCommand(f client.Factory, use string) *cobra.Command {
 
 // Run performs the delete backup operation.
 func Run(o *cli.DeleteOptions) error {
-	if !o.Confirm && !cli.GetConfirmation() {
+	if !o.Confirm && !confirm.GetConfirmation() {
 		// Don't do anything unless we get confirmation
 		return nil
 	}

--- a/pkg/cmd/cli/backuplocation/delete.go
+++ b/pkg/cmd/cli/backuplocation/delete.go
@@ -31,6 +31,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
 	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
+	"github.com/vmware-tanzu/velero/pkg/cmd/util/confirm"
 )
 
 // NewDeleteCommand creates and returns a new cobra command for deleting backup-locations.
@@ -67,7 +68,7 @@ func NewDeleteCommand(f client.Factory, use string) *cobra.Command {
 
 // Run performs the delete backup-location operation.
 func Run(f client.Factory, o *cli.DeleteOptions) error {
-	if !o.Confirm && !cli.GetConfirmation() {
+	if !o.Confirm && !confirm.GetConfirmation() {
 		// Don't do anything unless we get confirmation
 		return nil
 	}

--- a/pkg/cmd/cli/plugin/add.go
+++ b/pkg/cmd/cli/plugin/add.go
@@ -32,6 +32,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/builder"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
+	"github.com/vmware-tanzu/velero/pkg/cmd/util/confirm"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/flag"
 )
 
@@ -45,12 +46,17 @@ func NewAddCommand(f client.Factory) *cobra.Command {
 		imagePullPolicies   = []string{string(corev1api.PullAlways), string(corev1api.PullIfNotPresent), string(corev1api.PullNever)}
 		imagePullPolicyFlag = flag.NewEnum(string(corev1api.PullIfNotPresent), imagePullPolicies...)
 	)
-
+	o := confirm.NewConfirmOptionsWithDescription("Confirm add?, may cause the Velero server pod restart which will fail all ongoing jobs")
 	c := &cobra.Command{
 		Use:   "add IMAGE",
 		Short: "Add a plugin",
 		Args:  cobra.ExactArgs(1),
 		Run: func(c *cobra.Command, args []string) {
+			if !o.Confirm && !confirm.GetConfirmation("velero plugin add may cause the Velero server pod restart, so it is a dangerous operation",
+				"once Velero server restarts, all the ongoing jobs will fail.") {
+				// Don't do anything unless we get confirmation
+				return
+			}
 			kubeClient, err := f.KubeClient()
 			if err != nil {
 				cmd.CheckError(err)
@@ -122,6 +128,7 @@ func NewAddCommand(f client.Factory) *cobra.Command {
 	}
 
 	c.Flags().Var(imagePullPolicyFlag, "image-pull-policy", fmt.Sprintf("The imagePullPolicy for the plugin container. Valid values are %s.", strings.Join(imagePullPolicies, ", ")))
+	o.BindFlags(c.Flags())
 
 	return c
 }

--- a/pkg/cmd/cli/restore/delete.go
+++ b/pkg/cmd/cli/restore/delete.go
@@ -31,6 +31,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
 	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
+	"github.com/vmware-tanzu/velero/pkg/cmd/util/confirm"
 )
 
 // NewDeleteCommand creates and returns a new cobra command for deleting restores.
@@ -66,7 +67,7 @@ func NewDeleteCommand(f client.Factory, use string) *cobra.Command {
 
 // Run performs the deletion of restore(s).
 func Run(o *cli.DeleteOptions) error {
-	if !o.Confirm && !cli.GetConfirmation() {
+	if !o.Confirm && !confirm.GetConfirmation() {
 		return nil
 	}
 	var (

--- a/pkg/cmd/cli/schedule/delete.go
+++ b/pkg/cmd/cli/schedule/delete.go
@@ -31,6 +31,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
 	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
+	"github.com/vmware-tanzu/velero/pkg/cmd/util/confirm"
 )
 
 // NewDeleteCommand creates and returns a new cobra command for deleting schedules.
@@ -67,7 +68,7 @@ func NewDeleteCommand(f client.Factory, use string) *cobra.Command {
 
 // Run performs the deletion of schedules.
 func Run(o *cli.DeleteOptions) error {
-	if !o.Confirm && !cli.GetConfirmation() {
+	if !o.Confirm && !confirm.GetConfirmation() {
 		return nil
 	}
 	var (

--- a/pkg/cmd/cli/uninstall/uninstall.go
+++ b/pkg/cmd/cli/uninstall/uninstall.go
@@ -45,7 +45,7 @@ import (
 	velerov2alpha1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v2alpha1"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
-	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
+	"github.com/vmware-tanzu/velero/pkg/cmd/util/confirm"
 	"github.com/vmware-tanzu/velero/pkg/controller"
 	"github.com/vmware-tanzu/velero/pkg/install"
 	kubeutil "github.com/vmware-tanzu/velero/pkg/util/kube"
@@ -88,7 +88,7 @@ Use '--force' to skip the prompt confirming if you want to uninstall Velero.
 			// Confirm if not asked to force-skip confirmation
 			if !o.force {
 				fmt.Println("You are about to uninstall Velero.")
-				if !cli.GetConfirmation() {
+				if !confirm.GetConfirmation() {
 					// Don't do anything unless we get confirmation
 					return
 				}

--- a/pkg/cmd/util/confirm/confirm.go
+++ b/pkg/cmd/util/confirm/confirm.go
@@ -1,0 +1,57 @@
+package confirm
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+type ConfirmOptions struct {
+	Confirm         bool
+	flagDescription string
+}
+
+func NewConfirmOptions() *ConfirmOptions {
+	return &ConfirmOptions{flagDescription: "Confirm action"}
+}
+
+func NewConfirmOptionsWithDescription(desc string) *ConfirmOptions {
+	return &ConfirmOptions{flagDescription: desc}
+}
+
+// Bind confirm flags.
+func (o *ConfirmOptions) BindFlags(flags *pflag.FlagSet) {
+	flags.BoolVar(&o.Confirm, "confirm", o.Confirm, o.flagDescription)
+}
+
+// GetConfirmation ensures that the user confirms the action before proceeding.
+func GetConfirmation(prompts ...string) bool {
+	reader := bufio.NewReader(os.Stdin)
+
+	for {
+		for i := range prompts {
+			fmt.Println(prompts[i])
+		}
+		fmt.Printf("Are you sure you want to continue (Y/N)? ")
+
+		confirmation, err := reader.ReadString('\n')
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error reading user input: %v\n", err)
+			return false
+		}
+		confirmation = strings.TrimSpace(confirmation)
+		if len(confirmation) != 1 {
+			continue
+		}
+
+		switch strings.ToLower(confirmation) {
+		case "y":
+			return true
+		case "n":
+			return false
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Add confirm flag to velero plugin add
```
~/git/velero biaOperationErrorsPluginName* 15s
❯ go run ./cmd/velero plugin add testImage --confirm
An error occurred: Unauthorized
exit status 1

~/git/velero biaOperationErrorsPluginName* 7s
❯ go run ./cmd/velero plugin add testImage          
velero plugin add may cause the Velero server pod restart, so it is a dangerous operation
once Velero server restarts, all the ongoing jobs will fail.
Are you sure you want to continue (Y/N)? y
An error occurred: Unauthorized
exit status 1

~/git/velero biaOperationErrorsPluginName*
❯ go run ./cmd/velero plugin add testImage 
velero plugin add may cause the Velero server pod restart, so it is a dangerous operation
once Velero server restarts, all the ongoing jobs will fail.
Are you sure you want to continue (Y/N)? n

~/git/velero biaOperationErrorsPluginName*
❯ go run ./cmd/velero backup delete --all
Are you sure you want to continue (Y/N)? y
An error occurred: failed to get API group resources: unable to retrieve the complete list of server APIs: velero.io/v1: Unauthorized
exit status 1

~/git/velero biaOperationErrorsPluginName* 6s
❯ 
```
# Does your change fix a particular issue?

Fixes #6542

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
