### PR TITLE
Delete ns using kubectl

### DIFF
--- a/test/e2e/basic/nodeport.go
+++ b/test/e2e/basic/nodeport.go
@@ -46,7 +46,7 @@ func (n *NodePort) Init() error {
 	n.NSIncluded = &[]string{}
 	for nsNum := 0; nsNum < n.NamespacesTotal; nsNum++ {
 		createNSName := fmt.Sprintf("%s-%00000d", n.CaseBaseName, nsNum)
-		n.namespaceToCollision = append(n.namespaceToCollision, createNSName+"tmp")
+		n.namespaceToCollision = append(n.namespaceToCollision, createNSName+"-tmp")
 		*n.NSIncluded = append(*n.NSIncluded, createNSName)
 	}
 

--- a/test/util/k8s/common.go
+++ b/test/util/k8s/common.go
@@ -190,6 +190,12 @@ func KubectlGetNS(ctx context.Context, name string) ([]string, error) {
 	}
 	cmds = append(cmds, cmd)
 
+	cmd = &common.OsCommandLine{
+		Cmd:  "awk",
+		Args: []string{"{print $1}"},
+	}
+	cmds = append(cmds, cmd)
+
 	return common.GetListByCmdPipes(ctx, cmds)
 }
 

--- a/test/util/k8s/namespace.go
+++ b/test/util/k8s/namespace.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"slices"
 	"strings"
 	"time"
 
@@ -31,6 +32,7 @@ import (
 	waitutil "k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/vmware-tanzu/velero/pkg/builder"
+	veleroexec "github.com/vmware-tanzu/velero/pkg/util/exec"
 )
 
 func CreateNamespace(ctx context.Context, client TestClient, namespace string) error {
@@ -79,37 +81,44 @@ func GetNamespace(ctx context.Context, client TestClient, namespace string) (*co
 	return client.ClientGo.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 }
 
+func KubectlDeleteNamespace(ctx context.Context, namespace string) error {
+	args := []string{"delete", "namespace", namespace}
+	fmt.Println(args)
+
+	cmd := exec.CommandContext(ctx, "kubectl", args...)
+	fmt.Println(cmd)
+	stdout, stderr, err := veleroexec.RunCommand(cmd)
+	fmt.Printf("Output: %v\n", stdout)
+	if strings.Contains(stderr, "NotFound") {
+		err = nil
+	}
+	return err
+}
+
 func DeleteNamespace(ctx context.Context, client TestClient, namespace string, wait bool) error {
 	tenMinuteTimeout, ctxCancel := context.WithTimeout(context.Background(), time.Minute*10)
 	defer ctxCancel()
 
-	var zero int64 = 0
-	policy := metav1.DeletePropagationForeground
-
 	return waitutil.PollImmediateInfinite(5*time.Second,
 		func() (bool, error) {
 			// Retry namespace deletion, see issue: https://github.com/kubernetes/kubernetes/issues/60807
-			if err := client.ClientGo.CoreV1().Namespaces().Delete(context.TODO(), namespace, metav1.DeleteOptions{
-				GracePeriodSeconds: &zero,
-				PropagationPolicy:  &policy,
-			}); err != nil {
-				if apierrors.IsNotFound(err) {
-					return true, nil
-				} else {
-					fmt.Printf("Delete namespace %s err: %v", namespace, err)
-					return false, errors.Wrap(err, fmt.Sprintf("failed to delete the namespace %q", namespace))
-				}
+			if err := KubectlDeleteNamespace(tenMinuteTimeout, namespace); err != nil {
+				fmt.Printf("Delete namespace %s err: %v", namespace, err)
+				return false, errors.Wrap(err, fmt.Sprintf("failed to delete the namespace %q", namespace))
 			}
 			if !wait {
 				return true, nil
 			}
-			ns, err := KubectlGetNS(tenMinuteTimeout, namespace)
+			nsList, err := KubectlGetNS(tenMinuteTimeout, namespace)
+			fmt.Println("kubectl get ns output:")
+			fmt.Println(nsList)
 			if err != nil {
-				if len(ns) == 0 {
-					return true, nil
-				}
 				fmt.Printf("Get namespace %s err: %v", namespace, err)
 				return false, err
+			} else {
+				if !slices.Contains(nsList, namespace) {
+					return true, nil
+				}
 			}
 			fmt.Printf("namespace %q is still being deleted...\n", namespace)
 			logrus.Debugf("namespace %q is still being deleted...", namespace)


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

After PR #7442 merged, in kubeadm v1.29 pipeline, namespace clean step hit a hung issue by client-go deletion that namespace keep in terminating status although no any namespace related resources left, but kubectl is able to delete that namespace, so modify current deletion function by using kubectl.

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
