### PR TITLE
dependabot: support github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,14 @@
 version: 2
 updates:
+  # Dependencies listed in .github/workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "Dependencies"
+      - "github_actions"
+      - "kind/changelog-not-required"
   # Dependencies listed in go.mod
   - package-ecosystem: "gomod"
     directory: "/" # Location of package manifests

--- a/changelogs/unreleased/7594-mmorel-35
+++ b/changelogs/unreleased/7594-mmorel-35
@@ -1,0 +1,1 @@
+dependabot: support github-actions updates


### PR DESCRIPTION
# Please add a summary of your change

dependabot: support github-actions updates

# Does your change fix a particular issue?

Fixes #6628

This will also help fix warning from github-actions like : 
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/labeler@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

Or even worse:
```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/labeler@v3. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```


# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
