### PR TITLE
modify the default value to match helm chart

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -88,6 +88,7 @@ const (
 
 	defaultBackupSyncPeriod           = time.Minute
 	defaultStoreValidationFrequency   = time.Minute
+	defaultGarbageCollectionFrequency = time.Hour
 	defaultPodVolumeOperationTimeout  = 240 * time.Minute
 	defaultResourceTerminatingTimeout = 10 * time.Minute
 
@@ -158,6 +159,8 @@ func NewCommand(f client.Factory) *cobra.Command {
 			storeValidationFrequency:       defaultStoreValidationFrequency,
 			podVolumeOperationTimeout:      defaultPodVolumeOperationTimeout,
 			restoreResourcePriorities:      defaultRestorePriorities,
+			restoreOnly:                    false,
+			garbageCollectionFrequency:     defaultGarbageCollectionFrequency,
 			clientQPS:                      defaultClientQPS,
 			clientBurst:                    defaultClientBurst,
 			clientPageSize:                 defaultClientPageSize,


### PR DESCRIPTION
In helm chart, we set some value such as restoreOnlyMode, it doesn't work.

![image](https://github.com/vmware-tanzu/velero/assets/152238328/9d86a4eb-ce05-4a9b-90c5-eddd70b17526)

