### PR TITLE
Fix: append all slice data when range for it

### DIFF
--- a/test/util/velero/velero_utils.go
+++ b/test/util/velero/velero_utils.go
@@ -170,7 +170,7 @@ func getPluginsByVersion(version, cloudProvider, objectStoreProvider, feature st
 		}
 		for _, p := range pluginsForDatamover {
 			if !slices.Contains(plugins, p) {
-				plugins = append(plugins, pluginsForDatamover...)
+				plugins = append(plugins, p)
 			}
 		}
 	}


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

TLDR: FIx a bug

I am writing a linter called [sundrylint](https://github.com/alingse/sundrylint) to address some real-world bugs that I discovered during my work.

When we range over a slice and call the append function within the loop body, we are not appending all elements, but only the ones that we specifically iterate over during the range operation.

```
for _, n := range ns {
   rs = append(rs, n)       # this is ok
   rs = append(rs, ns...)   # this is wrong
}
```

I read the code in here https://github.com/vmware-tanzu/velero/blob/main/test/util/velero/velero_utils.go#L171-L174

I think it was just to append the not exists in origin `plugins`


# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
