### PR TITLE
Add checkpoint in fs backup deletion

### DIFF
--- a/test/e2e/privilegesmgmt/ssr.go
+++ b/test/e2e/privilegesmgmt/ssr.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
 	waitutil "k8s.io/apimachinery/pkg/util/wait"
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -66,8 +67,8 @@ func SSRTest() {
 		})
 		ssrListResp := new(v1.ServerStatusRequestList)
 		By(fmt.Sprintf("Check ssr object in %s namespace", veleroCfg.VeleroNamespace))
-		err = waitutil.PollImmediate(5*time.Second, time.Minute,
-			func() (bool, error) {
+		err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, time.Minute, true,
+			func(context.Context) (bool, error) {
 				if err = veleroCfg.ClientToInstallVelero.Kubebuilder.List(ctx, ssrListResp, &kbclient.ListOptions{Namespace: veleroCfg.VeleroNamespace}); err != nil {
 					return false, fmt.Errorf("failed to list ssr object in %s namespace with err %v", veleroCfg.VeleroNamespace, err)
 				}
@@ -85,9 +86,8 @@ func SSRTest() {
 				}
 				return true, nil
 			})
-		if err == waitutil.ErrWaitTimeout {
-			fmt.Printf("exceed test case deadline and failed to check ssr object in %s namespace", veleroCfg.VeleroNamespace)
-		}
+		fmt.Printf("exceed test case deadline and failed to check ssr object in %s namespace", veleroCfg.VeleroNamespace)
+
 		Expect(err).To(Succeed(), fmt.Sprintf("Failed to check ssr object in %s namespace", veleroCfg.VeleroNamespace))
 
 		By(fmt.Sprintf("Check ssr object in %s namespace", testNS))

--- a/test/util/common/common.go
+++ b/test/util/common/common.go
@@ -20,11 +20,12 @@ func GetListByCmdPipes(ctx context.Context, cmdlines []*OsCommandLine) ([]string
 	var buf bytes.Buffer
 	var err error
 	var cmds []*exec.Cmd
+
 	for _, cmdline := range cmdlines {
 		cmd := exec.Command(cmdline.Cmd, cmdline.Args...)
 		cmds = append(cmds, cmd)
-		fmt.Println(cmd)
 	}
+	fmt.Println(cmds)
 	for i := 0; i < len(cmds); i++ {
 		if i == len(cmds)-1 {
 			break
@@ -55,7 +56,6 @@ func GetListByCmdPipes(ctx context.Context, cmdlines []*OsCommandLine) ([]string
 	if err := scanner.Err(); err != nil {
 		return nil, err
 	}
-
 	return ret, nil
 }
 


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

As per PR https://github.com/vmware-tanzu/velero/issues/7281, if repository count is more than 1, then snapshots deletion is achieved with a fast way, then we should have more than 1 FS backup repository per backup.

# Does your change fix a particular issue?

Fixes #7545

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
