### PR TITLE
[WIP] Do not install kubebuiler in build-image

### DIFF
--- a/changelogs/unreleased/7665-reasonerjt
+++ b/changelogs/unreleased/7665-reasonerjt
@@ -1,0 +1,1 @@
+Do not install kubebuiler in build-image

--- a/hack/build-image/Dockerfile
+++ b/hack/build-image/Dockerfile
@@ -20,15 +20,6 @@ ENV GO111MODULE=on
 # Use a proxy for go modules to reduce the likelihood of various hosts being down and breaking the build
 ENV GOPROXY=${GOPROXY}
 
-# kubebuilder test bundle is separated from kubebuilder. Need to setup it for CI test.
-RUN curl -sSLo envtest-bins.tar.gz https://go.kubebuilder.io/test-tools/1.22.1/linux/$(go env GOARCH) && \
-    mkdir /usr/local/kubebuilder && \
-    tar -C /usr/local/kubebuilder --strip-components=1 -zvxf envtest-bins.tar.gz
-
-RUN wget --quiet https://github.com/kubernetes-sigs/kubebuilder/releases/download/v3.2.0/kubebuilder_linux_$(go env GOARCH) && \
-    mv kubebuilder_linux_$(go env GOARCH) /usr/local/kubebuilder/bin/kubebuilder && \
-    chmod +x /usr/local/kubebuilder/bin/kubebuilder
-
 # get controller-tools
 RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.12.0
 


### PR DESCRIPTION
It's not needed as we are using controller-gen

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
