### PR TITLE
Issue 7712: don't append nil error for BatchForget of Restic path

### DIFF
--- a/pkg/repository/provider/restic.go
+++ b/pkg/repository/provider/restic.go
@@ -82,7 +82,9 @@ func (r *resticRepositoryProvider) BatchForget(ctx context.Context, snapshotIDs 
 	errs := []error{}
 	for _, snapshot := range snapshotIDs {
 		err := r.Forget(ctx, snapshot, param)
-		errs = append(errs, err)
+		if err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	return errs


### PR DESCRIPTION
Fix issue #7712, don't append nil error for BatchForget of Restic path