### PR TITLE
Surface errors when waiting for backupRepository

### DIFF
--- a/changelogs/unreleased/7762-kaovilai
+++ b/changelogs/unreleased/7762-kaovilai
@@ -1,0 +1,1 @@
+Surface errors when waiting for backupRepository and timeout occurs

--- a/pkg/repository/ensurer_test.go
+++ b/pkg/repository/ensurer_test.go
@@ -102,7 +102,7 @@ func TestEnsureRepo(t *testing.T) {
 				bkRepoObjNotReady,
 			},
 			runtimeScheme: scheme,
-			err:           "failed to wait BackupRepository: context deadline exceeded",
+			err:           "failed to wait BackupRepository, timeout exceeded: backup repository not provisioned",
 		},
 		{
 			name:           "create fail",
@@ -110,7 +110,7 @@ func TestEnsureRepo(t *testing.T) {
 			bsl:            "fake-bsl",
 			repositoryType: "fake-repo-type",
 			runtimeScheme:  scheme,
-			err:            "failed to wait BackupRepository: context deadline exceeded",
+			err:            "failed to wait BackupRepository, timeout exceeded: backup repository not provisioned",
 		},
 	}
 
@@ -175,7 +175,7 @@ func TestCreateBackupRepositoryAndWait(t *testing.T) {
 				bkRepoObj,
 			},
 			runtimeScheme: scheme,
-			err:           "failed to wait BackupRepository: more than one BackupRepository found for workload namespace \"fake-ns\", backup storage location \"fake-bsl\", repository type \"fake-repo-type\"",
+			err:           "failed to wait BackupRepository, errored early: more than one BackupRepository found for workload namespace \"fake-ns\", backup storage location \"fake-bsl\", repository type \"fake-repo-type\"",
 		},
 		{
 			name:           "wait repo fail",
@@ -183,7 +183,7 @@ func TestCreateBackupRepositoryAndWait(t *testing.T) {
 			bsl:            "fake-bsl",
 			repositoryType: "fake-repo-type",
 			runtimeScheme:  scheme,
-			err:            "failed to wait BackupRepository: context deadline exceeded",
+			err:            "failed to wait BackupRepository, timeout exceeded: backup repository not provisioned",
 		},
 	}
 


### PR DESCRIPTION
Make errors such as those found in https://github.com/vmware-tanzu/velero/issues/6928#issuecomment-1759369183

Makes errors easier to understand than "timed out waiting for the condition"

Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
