### PR TITLE
Use native cache from actions/setup-go

### DIFF
--- a/.github/workflows/crds-verify-kind.yaml
+++ b/.github/workflows/crds-verify-kind.yaml
@@ -11,11 +11,12 @@ jobs:
   build-cli:
     runs-on: ubuntu-latest
     steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
-        id: go
+          go-version-file: 'go.mod'
       # Look for a CLI that's made for this PR
       - name: Fetch built CLI
         id: cache
@@ -29,26 +30,11 @@ jobs:
           # This key controls the prefixes that we'll look at in the cache to restore from
           restore-keys: |
             velero-${{ github.event.pull_request.number }}-
-
-      - name: Fetch cached go modules
-        uses: actions/cache@v4
-        if: steps.cache.outputs.cache-hit != 'true'
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: Check out the code
-        uses: actions/checkout@v4
-        if: steps.cache.outputs.cache-hit != 'true'
-
       # If no binaries were built for this PR, build it now.
       - name: Build Velero CLI
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           make local
-
   # Check the common CLI against all Kubernetes versions
   crd-check:
     needs: build-cli

--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -11,11 +11,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
-        id: go
+          go-version-file: 'go.mod'
       # Look for a CLI that's made for this PR
       - name: Fetch built CLI
         id: cli-cache
@@ -31,17 +32,6 @@ jobs:
           path: ./velero.tar
           # The cache key a combination of the current PR number and the commit SHA
           key: velero-image-${{ github.event.pull_request.number }}-${{ github.sha }}
-      - name: Fetch cached go modules
-        uses: actions/cache@v4
-        if: steps.cli-cache.outputs.cache-hit != 'true'
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Check out the code
-        uses: actions/checkout@v4
-        if: steps.cli-cache.outputs.cache-hit != 'true' || steps.image-cache.outputs.cache-hit != 'true'
       # If no binaries were built for this PR, build it now.
       - name: Build Velero CLI
         if: steps.cli-cache.outputs.cache-hit != 'true'
@@ -75,13 +65,12 @@ jobs:
           - (NamespaceMapping && Single && Restic) || (NamespaceMapping && Multiple && Restic)
       fail-fast: false
     steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
-        id: go
-      - name: Check out the code
-        uses: actions/checkout@v4
+          go-version-file: 'go.mod'
       - name: Install MinIO
         run:
           docker run -d --rm -p 9000:9000 -e "MINIO_ACCESS_KEY=minio" -e "MINIO_SECRET_KEY=minio123" -e "MINIO_DEFAULT_BUCKETS=bucket,additional-bucket" bitnami/minio:2021.6.17-debian-10-r7
@@ -104,14 +93,6 @@ jobs:
       - name: Load Velero Image
         run:
           kind load image-archive velero.tar
-      # always try to fetch the cached go modules as the e2e test needs it either
-      - name: Fetch cached go modules
-        uses: actions/cache@v4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - name: Run E2E test
         run: |
           cat << EOF > /tmp/credential

--- a/.github/workflows/pr-ci-check.yml
+++ b/.github/workflows/pr-ci-check.yml
@@ -7,20 +7,12 @@ jobs:
     strategy:
       fail-fast: false
     steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
-        id: go
-      - name: Check out the code
-        uses: actions/checkout@v4
-      - name: Fetch cached go modules
-        uses: actions/cache@v4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version-file: 'go.mod'
       - name: Make ci
         run: make ci
       - name: Upload test coverage

--- a/.github/workflows/pr-linter-check.yml
+++ b/.github/workflows/pr-linter-check.yml
@@ -12,7 +12,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-        id: go
       - name: Linter check
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,95 +14,82 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.22'
-      id: go
-
-    - uses: actions/checkout@v4
-
-    # Fix issue of setup-gcloud
-    - run: |
-        sudo apt-get install python2.7
-        export CLOUDSDK_PYTHON="/usr/bin/python2"
-
-    - id: 'auth'
-      uses: google-github-actions/auth@v2
-      with:
-        credentials_json: '${{ secrets.GCS_SA_KEY }}'
-
-    - name: 'set up GCloud SDK'
-      uses: google-github-actions/setup-gcloud@v2
-
-    - name: 'use gcloud CLI'
-      run: |
-        gcloud info
-
-    - name: Set up QEMU
-      id: qemu
-      uses: docker/setup-qemu-action@v3
-      with:
-        platforms: all
-
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v3
-      with:
-        version: latest
-
-    - name: Build
-      run: |
-        make local
-        # Clean go cache to ease the build environment storage pressure.
-        go clean -modcache -cache
-
-    - name: Test
-      run: make test
-
-    - name: Upload test coverage
-      uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: coverage.out
-        verbose: true
-
-    # Use the JSON key in secret to login gcr.io
-    - uses: 'docker/login-action@v3'
-      with:
-        registry: 'gcr.io' # or REGION.docker.pkg.dev
-        username: '_json_key'
-        password: '${{ secrets.GCR_SA_KEY }}'
-
-    # Only try to publish the container image from the root repo; forks don't have permission to do so and will always get failures.
-    - name: Publish container image
-      if: github.repository == 'vmware-tanzu/velero'
-      run: |
-        sudo swapoff -a
-        sudo rm -f /mnt/swapfile
-        docker system prune -a --force
+      - name: Check out the code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      # Fix issue of setup-gcloud
+      - run: |
+          sudo apt-get install python2.7
+          export CLOUDSDK_PYTHON="/usr/bin/python2"
+      - id: 'auth'
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: '${{ secrets.GCS_SA_KEY }}'
+      - name: 'set up GCloud SDK'
+        uses: google-github-actions/setup-gcloud@v2
+      - name: 'use gcloud CLI'
+        run: |
+          gcloud info
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
+      - name: Build
+        run: |
+          make local
+          # Clean go cache to ease the build environment storage pressure.
+          go clean -modcache -cache
+      - name: Test
+        run: make test
+      - name: Upload test coverage
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.out
+          verbose: true
+      # Use the JSON key in secret to login gcr.io
+      - uses: 'docker/login-action@v3'
+        with:
+          registry: 'gcr.io' # or REGION.docker.pkg.dev
+          username: '_json_key'
+          password: '${{ secrets.GCR_SA_KEY }}'
+      # Only try to publish the container image from the root repo; forks don't have permission to do so and will always get failures.
+      - name: Publish container image
+        if: github.repository == 'vmware-tanzu/velero'
+        run: |
+          sudo swapoff -a
+          sudo rm -f /mnt/swapfile
+          docker system prune -a --force
               
-        # Build and push Velero image to docker registry
-        docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
-        VERSION=$(./hack/docker-push.sh | grep 'VERSION:' | awk -F: '{print $2}' | xargs)
+          # Build and push Velero image to docker registry
+          docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
+          VERSION=$(./hack/docker-push.sh | grep 'VERSION:' | awk -F: '{print $2}' | xargs)
 
-        # Upload Velero image package to GCS
-        source hack/ci/build_util.sh
-        BIN=velero
-        RESTORE_HELPER_BIN=velero-restore-helper
-        GCS_BUCKET=velero-builds
-        VELERO_IMAGE=${BIN}-${VERSION}
-        VELERO_RESTORE_HELPER_IMAGE=${RESTORE_HELPER_BIN}-${VERSION}
-        VELERO_IMAGE_FILE=${VELERO_IMAGE}.tar.gz
-        VELERO_RESTORE_HELPER_IMAGE_FILE=${VELERO_RESTORE_HELPER_IMAGE}.tar.gz
-        VELERO_IMAGE_BACKUP_FILE=${VELERO_IMAGE}-'build.'${GITHUB_RUN_NUMBER}.tar.gz
-        VELERO_RESTORE_HELPER_IMAGE_BACKUP_FILE=${VELERO_RESTORE_HELPER_IMAGE}-'build.'${GITHUB_RUN_NUMBER}.tar.gz
+          # Upload Velero image package to GCS
+          source hack/ci/build_util.sh
+          BIN=velero
+          RESTORE_HELPER_BIN=velero-restore-helper
+          GCS_BUCKET=velero-builds
+          VELERO_IMAGE=${BIN}-${VERSION}
+          VELERO_RESTORE_HELPER_IMAGE=${RESTORE_HELPER_BIN}-${VERSION}
+          VELERO_IMAGE_FILE=${VELERO_IMAGE}.tar.gz
+          VELERO_RESTORE_HELPER_IMAGE_FILE=${VELERO_RESTORE_HELPER_IMAGE}.tar.gz
+          VELERO_IMAGE_BACKUP_FILE=${VELERO_IMAGE}-'build.'${GITHUB_RUN_NUMBER}.tar.gz
+          VELERO_RESTORE_HELPER_IMAGE_BACKUP_FILE=${VELERO_RESTORE_HELPER_IMAGE}-'build.'${GITHUB_RUN_NUMBER}.tar.gz
 
-        cp ${VELERO_IMAGE_FILE} ${VELERO_IMAGE_BACKUP_FILE}
-        cp ${VELERO_RESTORE_HELPER_IMAGE_FILE} ${VELERO_RESTORE_HELPER_IMAGE_BACKUP_FILE}
+          cp ${VELERO_IMAGE_FILE} ${VELERO_IMAGE_BACKUP_FILE}
+          cp ${VELERO_RESTORE_HELPER_IMAGE_FILE} ${VELERO_RESTORE_HELPER_IMAGE_BACKUP_FILE}
 
-        uploader ${VELERO_IMAGE_FILE} ${GCS_BUCKET}
-        uploader ${VELERO_RESTORE_HELPER_IMAGE_FILE} ${GCS_BUCKET}
-        uploader ${VELERO_IMAGE_BACKUP_FILE} ${GCS_BUCKET}
-        uploader ${VELERO_RESTORE_HELPER_IMAGE_BACKUP_FILE} ${GCS_BUCKET}
+          uploader ${VELERO_IMAGE_FILE} ${GCS_BUCKET}
+          uploader ${VELERO_RESTORE_HELPER_IMAGE_FILE} ${GCS_BUCKET}
+          uploader ${VELERO_IMAGE_BACKUP_FILE} ${GCS_BUCKET}
+          uploader ${VELERO_RESTORE_HELPER_IMAGE_BACKUP_FILE} ${GCS_BUCKET}


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

Use native cache from actions/setup-go instead of defining actions/cache for `~/go/pkg/mod` path

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
