### PR TITLE
More prow actions

### DIFF
--- a/.github/workflows/prow-action.yml
+++ b/.github/workflows/prow-action.yml
@@ -13,8 +13,17 @@ jobs:
         with:
           # TODO: before allowing the /lgtm command, see if we can block merging if changelog labels are missing.
           prow-commands: |
+            /approve
             /area
+            /assign
             /cc
+            /close
+            /hold
             /kind
+            /milestone
+            /retitle
+            /remove
+            /reopen
             /uncc
+            /unassign
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,24 @@
+# This file is used by the [PROW action](https://github.com/jpmcb/prow-github-actions) to approve and merge PRs.
+# The file's format follows the [OWNERS SPEC](https://www.kubernetes.dev/docs/guide/owners/#owners-spec).
+
+# List of usernames who may use /lgtm
+reviewers:
+- @Lyndon-Li
+- @anshulahuja98
+- @blackpiglet
+- @qiuming-best
+- @reasonerjt
+- @shubham-pampattiwar
+- @sseago
+- @ywk253100
+
+# List of usernames who may use /approve
+approvers:
+- @Lyndon-Li
+- @anshulahuja98
+- @blackpiglet
+- @qiuming-best
+- @reasonerjt
+- @shubham-pampattiwar
+- @sseago
+- @ywk253100


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
This PR introduces more k8s PROW style commands, including:

* approve: approve PR, e.g. `/approve`.
* assign: assign issue or PR to specified users, e.g. `/assign @blackpiglet @reasonerjt`.
* close: close an issue or PR, e.g. `/close`.
* hold: add a `hold` label to an issue or PR. This label blocks the auto-merging, e.g. `/hold` to hold the PR from auto-merging or `/hold cancel` to cancel the hold.
* milestone: add the issue or PR to a specified milestone, e.g. `/milestone v1.14`.
* retitle: modify the issue's title or PR, e.g. `/retitle Introduce more PROW actions`.
* remove: remove specified labels from issue and PR, e.g. `/remove kind/changelog-not-required`.
* reopen: reopen the issue or PR, e.g. `/reopen`.
* unassign: unassign the specified users from the issue or PR, e.g. `/unassign @blackpiglet @reasonerjt`.

Also, add some introduction to the already supported PROW commands:
* kind: add labels starting with `kind/`, e.g. `/kind changelog-not-required release-note`.
* area: add labels starting with `Area/` or `area/`, e.g. `/area CLI CSI`.
* cc: request review from the specified users, e.g. `/cc @blackpiglet @reasonerjt`.
* uncc: remove the specified users from the reviewers, e.g. `/uncc @blackpiglet @reasonerjt`.

Please put those commands in the issue or the PR's comments to try them out.

# Does your change fix a particular issue?

Fixes #7783 

This PR is based on the ongoing PR #7776. 

# Please indicate you've done the following:


- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
