### PR TITLE
Remove snapshotVolumes flag necessity for volume policy snapshot action

### DIFF
--- a/changelogs/unreleased/7786-shubham-pampattiwar
+++ b/changelogs/unreleased/7786-shubham-pampattiwar
@@ -1,0 +1,1 @@
+Remove snapshotVolumes flag necessity for volume policy snapshot action

--- a/internal/volumehelper/volume_policy_helper.go
+++ b/internal/volumehelper/volume_policy_helper.go
@@ -8,7 +8,6 @@ import (
 
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/vmware-tanzu/velero/pkg/util/boolptr"
 	kubeutil "github.com/vmware-tanzu/velero/pkg/util/kube"
 
 	"github.com/sirupsen/logrus"
@@ -26,9 +25,8 @@ type VolumeHelper interface {
 }
 
 type VolumeHelperImpl struct {
-	VolumePolicy    *resourcepolicies.Policies
-	SnapshotVolumes *bool
-	Logger          logrus.FieldLogger
+	VolumePolicy *resourcepolicies.Policies
+	Logger       logrus.FieldLogger
 }
 
 func (v *VolumeHelperImpl) ShouldPerformSnapshot(obj runtime.Unstructured, groupResource schema.GroupResource, kbclient kbclient.Client) (bool, error) {
@@ -61,12 +59,11 @@ func (v *VolumeHelperImpl) ShouldPerformSnapshot(obj runtime.Unstructured, group
 			return false, err
 		}
 
-		// Also account for SnapshotVolumes flag on backup CR
-		if action != nil && action.Type == resourcepolicies.Snapshot && boolptr.IsSetToTrue(v.SnapshotVolumes) {
-			v.Logger.Infof(fmt.Sprintf("performing snapshot action for pv %s as it satisfies the volume policy criteria and snapshotVolumes is set to true", pv.Name))
+		if action != nil && action.Type == resourcepolicies.Snapshot {
+			v.Logger.Infof(fmt.Sprintf("performing snapshot action for pv %s as it satisfies the volume policy criteria", pv.Name))
 			return true, nil
 		}
-		v.Logger.Infof(fmt.Sprintf("skipping snapshot action for pv %s possibly due to not satisfying the volume policy criteria or snapshotVolumes is not true", pv.Name))
+		v.Logger.Infof(fmt.Sprintf("skipping snapshot action for pv %s due to not satisfying the volume policy criteria for snapshot action", pv.Name))
 		return false, nil
 	}
 

--- a/pkg/backup/actions/csi/pvc_action.go
+++ b/pkg/backup/actions/csi/pvc_action.go
@@ -64,8 +64,8 @@ func (p *pvcBackupItemAction) AppliesTo() (velero.ResourceSelector, error) {
 }
 
 func (p *pvcBackupItemAction) validateBackup(backup velerov1api.Backup) (valid bool) {
-	// Do nothing if volume snapshots have not been requested in this backup
-	if boolptr.IsSetToFalse(backup.Spec.SnapshotVolumes) {
+	// Do nothing if volume snapshots have not been requested in this backup (check for snapshotVolumes is only applicable for non-volume policy based approach)
+	if boolptr.IsSetToFalse(backup.Spec.SnapshotVolumes) && backup.Spec.ResourcePolicy == nil {
 		p.log.Infof(
 			"Volume snapshotting not requested for backup %s/%s",
 			backup.Namespace, backup.Name)

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -190,8 +190,7 @@ func (ib *itemBackupper) backupItemInternal(logger logrus.FieldLogger, obj runti
 
 	// Instantiate volumepolicyhelper struct here
 	vh := &volumehelper.VolumeHelperImpl{
-		SnapshotVolumes: ib.backupRequest.Spec.SnapshotVolumes,
-		Logger:          logger,
+		Logger: logger,
 	}
 
 	if ib.backupRequest.ResPolicies != nil {
@@ -552,7 +551,7 @@ func (ib *itemBackupper) takePVSnapshot(obj runtime.Unstructured, log logrus.Fie
 		}
 	}
 
-	if boolptr.IsSetToFalse(ib.backupRequest.Spec.SnapshotVolumes) {
+	if boolptr.IsSetToFalse(ib.backupRequest.Spec.SnapshotVolumes) && vh.VolumePolicy == nil {
 		log.Info("Backup has volume snapshots disabled; skipping volume snapshot action.")
 		ib.trackSkippedPV(obj, kuberesource.PersistentVolumes, volumeSnapshotApproach, "backup has volume snapshots disabled", log)
 		return nil


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Remove snapshotVolumes flag necessity for volume policy snapshot action 

# Does your change fix a particular issue?

Fixes https://github.com/vmware-tanzu/velero/issues/7782

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
