### PR TITLE
Fix makefile param issue

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -132,7 +132,7 @@ POD_VOLUME_OPERATION_TIMEOUT ?= 6h
 COMMON_ARGS := -velerocli=$(VELERO_CLI) \
 	-velero-image=$(VELERO_IMAGE) \
 	-plugins=$(PLUGINS) \
-	-velero-version=$(VELERO_VERSION) \
+	-velero-version=$(VERSION) \
 	-restore-helper-image=$(RESTORE_HELPER_IMAGE) \
 	-velero-namespace=$(VELERO_NAMESPACE) \
 	-credentials-file=$(CREDS_FILE) \


### PR DESCRIPTION
Using VERSION instead of VELERO_VERSION, since VERSION is passed from root Makefile.

Signed-off-by: danfengl <danfengl@vmware.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
