### PR TITLE
Fix backup log to show error string, not index

### DIFF
--- a/changelogs/unreleased/7805-piny940
+++ b/changelogs/unreleased/7805-piny940
@@ -1,0 +1,1 @@
+Fix backup log to show error string, not index

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -692,7 +692,7 @@ func (b *backupReconciler) runBackup(backup *pkgbackup.Request) error {
 	// Completed yet.
 	inProgressOperations, _, opsCompleted, opsFailed, errs := getBackupItemOperationProgress(backup.Backup, pluginManager, *backup.GetItemOperationsList())
 	if len(errs) > 0 {
-		for err := range errs {
+		for _, err := range errs {
 			backupLog.Error(err)
 		}
 	}


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
There was a mistake in golang `range`.
Since `errs`'s type is `[]string` in this case, the code should be:

```
for _, err := range errs {
...
}
```

# Does your change fix a particular issue?

No issue, but this is related to discussion #7800 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
