### PR TITLE
feat: add ingressclass from ingress

### DIFF
--- a/changelogs/unreleased/7813-AlbeeSo
+++ b/changelogs/unreleased/7813-AlbeeSo
@@ -1,0 +1,1 @@
+Add ingressClass resource to backup or restore if ingress is backuped and its spec.ingressClass is not nil.

--- a/pkg/backup/actions/ingress_action.go
+++ b/pkg/backup/actions/ingress_action.go
@@ -58,7 +58,7 @@ func (a *IngressAction) Execute(item runtime.Unstructured, backup *v1.Backup) (r
 
 	var additionalItems []velero.ResourceIdentifier
 	if ing.Spec.IngressClassName != nil && *ing.Spec.IngressClassName != "" {
-		a.log.Infof("Adding IngressClass %s to additionalItems", ing.Spec.IngressClassName)
+		a.log.Infof("Adding IngressClass %s to additionalItems", *ing.Spec.IngressClassName)
 		additionalItems = append(additionalItems, velero.ResourceIdentifier{
 			GroupResource: kuberesource.IngressClasses,
 			Name:          *ing.Spec.IngressClassName,

--- a/pkg/backup/actions/ingress_action.go
+++ b/pkg/backup/actions/ingress_action.go
@@ -1,0 +1,69 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actions
+
+import (
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	networkapi "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/kuberesource"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+)
+
+// IngressAction implements ItemAction.
+type IngressAction struct {
+	log logrus.FieldLogger
+}
+
+// NewIngressAction creates a new ItemAction for pods.
+func NewIngressAction(logger logrus.FieldLogger) *IngressAction {
+	return &IngressAction{log: logger}
+}
+
+// AppliesTo returns a ResourceSelector that applies only to pods.
+func (a *IngressAction) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+		IncludedResources: []string{"ingresses"},
+	}, nil
+}
+
+// Execute scans the ingress's spec.ingressClassName for ingressClass and returns a
+// ResourceIdentifier list containing references to the ingressClass used by
+// the ingress. This ensures that when a ingress is backed up, related ingressClass is backed up too.
+func (a *IngressAction) Execute(item runtime.Unstructured, backup *v1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, error) {
+	a.log.Info("Executing ingressAction")
+	defer a.log.Info("Done executing ingressAction")
+
+	ing := new(networkapi.Ingress)
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(item.UnstructuredContent(), ing); err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+
+	var additionalItems []velero.ResourceIdentifier
+	if ing.Spec.IngressClassName != nil && *ing.Spec.IngressClassName != "" {
+		a.log.Infof("Adding IngressClass %s to additionalItems", ing.Spec.IngressClassName)
+		additionalItems = append(additionalItems, velero.ResourceIdentifier{
+			GroupResource: kuberesource.IngressClasses,
+			Name:          *ing.Spec.IngressClassName,
+		})
+	}
+
+	return item, additionalItems, nil
+}

--- a/pkg/backup/actions/ingress_action_test.go
+++ b/pkg/backup/actions/ingress_action_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/vmware-tanzu/velero/pkg/kuberesource"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	velerotest "github.com/vmware-tanzu/velero/pkg/test"
+)
+
+func TestIngressActionAppliesTo(t *testing.T) {
+	a := NewIngressAction(velerotest.NewLogger())
+
+	actual, err := a.AppliesTo()
+	require.NoError(t, err)
+
+	expected := velero.ResourceSelector{
+		IncludedResources: []string{"ingresses"},
+	}
+	assert.Equal(t, expected, actual)
+}
+
+func TestIngressActionExecute(t *testing.T) {
+	tests := []struct {
+		name     string
+		ing      runtime.Unstructured
+		expected []velero.ResourceIdentifier
+	}{
+		{
+			name: "no spec.ingressClass",
+			ing: velerotest.UnstructuredOrDie(`
+			{
+				"apiVersion": "networking.k8s.io/v1",
+				"kind": "Ingress",
+				"metadata": {
+					"namespace": "ns",
+					"name": "ing-1"
+				}
+			}
+			`),
+		},
+		{
+			name: "spec.ingressClass equals to nil string",
+			ing: velerotest.UnstructuredOrDie(`
+			{
+				"apiVersion": "networking.k8s.io/v1",
+				"kind": "Ingress",
+				"metadata": {
+					"namespace": "ns",
+					"name": "ing-2"
+				},
+				"spec": {
+					"ingressClassName": ""
+				}
+			}
+			`),
+		},
+		{
+			name: "spec.ingressClass exists",
+			ing: velerotest.UnstructuredOrDie(`
+			{
+				"apiVersion": "networking.k8s.io/v1",
+				"kind": "Ingress",
+				"metadata": {
+					"namespace": "ns",
+					"name": "ing-3"
+				},
+				"spec": {
+					"ingressClassName": "ingressclass"
+				}
+			}
+			`),
+			expected: []velero.ResourceIdentifier{
+				{GroupResource: kuberesource.IngressClasses, Name: "ingressclass"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			a := NewIngressAction(velerotest.NewLogger())
+
+			updated, additionalItems, err := a.Execute(test.ing, nil)
+			require.NoError(t, err)
+			assert.Equal(t, test.ing, updated)
+			assert.Equal(t, test.expected, additionalItems)
+		})
+	}
+}

--- a/pkg/cmd/server/plugin/plugin.go
+++ b/pkg/cmd/server/plugin/plugin.go
@@ -196,6 +196,10 @@ func newPodBackupItemAction(logger logrus.FieldLogger) (interface{}, error) {
 	return bia.NewPodAction(logger), nil
 }
 
+func newIngressBackupItemAction(logger logrus.FieldLogger) (interface{}, error) {
+	return bia.NewIngressAction(logger), nil
+}
+
 func newServiceAccountBackupItemAction(f client.Factory) plugincommon.HandlerInitializer {
 	return func(logger logrus.FieldLogger) (interface{}, error) {
 		// TODO(ncdc): consider a k8s style WantsKubernetesClientSet initialization approach
@@ -288,6 +292,10 @@ func newAddPVCFromPodRestoreItemAction(logger logrus.FieldLogger) (interface{}, 
 
 func newAddPVFromPVCRestoreItemAction(logger logrus.FieldLogger) (interface{}, error) {
 	return ria.NewAddPVFromPVCAction(logger), nil
+}
+
+func newAddIngressClassFromIngAction(logger logrus.FieldLogger) (interface{}, error) {
+	return ria.NewAddIngressClassFromIngAction(logger), nil
 }
 
 func newCRDV1PreserveUnknownFieldsItemAction(logger logrus.FieldLogger) (interface{}, error) {

--- a/pkg/cmd/server/plugin/plugin.go
+++ b/pkg/cmd/server/plugin/plugin.go
@@ -53,6 +53,10 @@ func NewCommand(f client.Factory) *cobra.Command {
 					newPodBackupItemAction,
 				).
 				RegisterBackupItemAction(
+					"velero.io/ingress",
+					newIngressBackupItemAction,
+				).
+				RegisterBackupItemAction(
 					"velero.io/service-account",
 					newServiceAccountBackupItemAction(f),
 				).
@@ -87,6 +91,10 @@ func NewCommand(f client.Factory) *cobra.Command {
 				RegisterRestoreItemAction(
 					"velero.io/add-pv-from-pvc",
 					newAddPVFromPVCRestoreItemAction,
+				).
+				RegisterRestoreItemAction(
+					"velero.io/add-ingressclass-from-ing",
+					newAddIngressClassFromIngAction,
 				).
 				RegisterRestoreItemAction(
 					"velero.io/change-storage-class",

--- a/pkg/kuberesource/kuberesource.go
+++ b/pkg/kuberesource/kuberesource.go
@@ -35,5 +35,6 @@ var (
 	VolumeSnapshots           = schema.GroupResource{Group: "snapshot.storage.k8s.io", Resource: "volumesnapshots"}
 	VolumeSnapshotContents    = schema.GroupResource{Group: "snapshot.storage.k8s.io", Resource: "volumesnapshotcontents"}
 	PriorityClasses           = schema.GroupResource{Group: "scheduling.k8s.io", Resource: "priorityclasses"}
+	IngressClasses            = schema.GroupResource{Group: "networking.k8s.io", Resource: "ingressclasses"}
 	DataUploads               = schema.GroupResource{Group: "velero.io", Resource: "datauploads"}
 )

--- a/pkg/restore/actions/add_ingressclass_from_ing_action.go
+++ b/pkg/restore/actions/add_ingressclass_from_ing_action.go
@@ -51,7 +51,7 @@ func (a *AddIngressClassFromIngAction) Execute(input *velero.RestoreItemActionEx
 	var additionalItems []velero.ResourceIdentifier
 
 	if ing.Spec.IngressClassName != nil && *ing.Spec.IngressClassName != "" {
-		a.logger.Infof("Adding IngressClass %s as an additional item to restore", ing.Namespace, *ing.Spec.IngressClassName)
+		a.logger.Infof("Adding IngressClass %s as an additional item to restore", *ing.Spec.IngressClassName)
 		additionalItems = append(additionalItems, velero.ResourceIdentifier{
 			GroupResource: kuberesource.IngressClasses,
 			Name:          *ing.Spec.IngressClassName,

--- a/pkg/restore/actions/add_ingressclass_from_ing_action.go
+++ b/pkg/restore/actions/add_ingressclass_from_ing_action.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2019 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actions
+
+import (
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	networkapi "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/vmware-tanzu/velero/pkg/kuberesource"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+)
+
+type AddIngressClassFromIngAction struct {
+	logger logrus.FieldLogger
+}
+
+func NewAddIngressClassFromIngAction(logger logrus.FieldLogger) *AddIngressClassFromIngAction {
+	return &AddIngressClassFromIngAction{logger: logger}
+}
+
+func (a *AddIngressClassFromIngAction) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+		IncludedResources: []string{"ingresses"},
+	}, nil
+}
+
+func (a *AddIngressClassFromIngAction) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
+	a.logger.Info("Executing AddIngressClassFromIngAction")
+
+	var ing networkapi.Ingress
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(input.Item.UnstructuredContent(), &ing); err != nil {
+		return nil, errors.Wrap(err, "unable to convert unstructured item to ingress")
+	}
+
+	var additionalItems []velero.ResourceIdentifier
+
+	if ing.Spec.IngressClassName != nil && *ing.Spec.IngressClassName != "" {
+		a.logger.Infof("Adding IngressClass %s as an additional item to restore", ing.Namespace, *ing.Spec.IngressClassName)
+		additionalItems = append(additionalItems, velero.ResourceIdentifier{
+			GroupResource: kuberesource.IngressClasses,
+			Name:          *ing.Spec.IngressClassName,
+		})
+	}
+	return &velero.RestoreItemActionExecuteOutput{
+		UpdatedItem:     input.Item,
+		AdditionalItems: additionalItems,
+	}, nil
+}

--- a/pkg/restore/actions/add_ingressclass_from_ing_action_test.go
+++ b/pkg/restore/actions/add_ingressclass_from_ing_action_test.go
@@ -55,7 +55,7 @@ func TestAddIngressClassFromIngActionExecute(t *testing.T) {
 				},
 			},
 			want: []velero.ResourceIdentifier{
-				{GroupResource: kuberesource.PersistentVolumeClaims, Name: "ingressclass"},
+				{GroupResource: kuberesource.IngressClasses, Name: "ingressclass"},
 			},
 		},
 	}

--- a/pkg/restore/actions/add_ingressclass_from_ing_action_test.go
+++ b/pkg/restore/actions/add_ingressclass_from_ing_action_test.go
@@ -32,6 +32,18 @@ import (
 	velerotest "github.com/vmware-tanzu/velero/pkg/test"
 )
 
+func TestAddIngressClassFromIngAppliesTo(t *testing.T) {
+	a := NewAddIngressClassFromIngAction(velerotest.NewLogger())
+
+	actual, err := a.AppliesTo()
+	require.NoError(t, err)
+
+	expected := velero.ResourceSelector{
+		IncludedResources: []string{"ingresses"},
+	}
+	assert.Equal(t, expected, actual)
+}
+
 func TestAddIngressClassFromIngActionExecute(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/restore/actions/add_ingressclass_from_ing_action_test.go
+++ b/pkg/restore/actions/add_ingressclass_from_ing_action_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2019 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	networkapi "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+
+	"github.com/vmware-tanzu/velero/pkg/kuberesource"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	velerotest "github.com/vmware-tanzu/velero/pkg/test"
+)
+
+func TestAddIngressClassFromIngActionExecute(t *testing.T) {
+	tests := []struct {
+		name string
+		item *networkapi.Ingress
+		want []velero.ResourceIdentifier
+	}{
+		{
+			name: "ingress with no related ingressClass",
+			item: &networkapi.Ingress{},
+			want: nil,
+		},
+		{
+			name: "ingress with related ingressClass returns ingressClass as additional item",
+			item: &networkapi.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing",
+				},
+				Spec: networkapi.IngressSpec{
+					IngressClassName: pointer.StringPtr("ingressclass"),
+				},
+			},
+			want: []velero.ResourceIdentifier{
+				{GroupResource: kuberesource.PersistentVolumeClaims, Name: "ingressclass"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			itemData, err := runtime.DefaultUnstructuredConverter.ToUnstructured(test.item)
+			require.NoError(t, err)
+
+			action := &AddIngressClassFromIngAction{logger: velerotest.NewLogger()}
+
+			input := &velero.RestoreItemActionExecuteInput{
+				Item: &unstructured.Unstructured{Object: itemData},
+			}
+
+			res, err := action.Execute(input)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.want, res.AdditionalItems)
+		})
+	}
+}


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
To backup / restore ingressclass if ingress is backuped and spec.ingressClass is not nil.

After PR, ingressclass will be backuped with logs like
```
time="2024-05-22T17:48:36+08:00" level=info msg="Executing custom action" backup=velero/test-velero-ing logSource="pkg/backup/item_backupper.go:371" name=test-ing namespace=default resource=ingresses.networking.k8s.io
time="2024-05-22T17:48:36+08:00" level=info msg="Executing ingressAction" backup=velero/test-velero-ing cmd=/velero logSource="pkg/backup/actions/ingress_action.go:51" pluginName=velero
time="2024-05-22T17:48:36+08:00" level=info msg="Adding IngressClass nginx to additionalItems" backup=velero/test-velero-ing cmd=/velero logSource="pkg/backup/actions/ingress_action.go:61" pluginName=velero
time="2024-05-22T17:48:36+08:00" level=info msg="Done executing ingressAction" backup=velero/test-velero-ing cmd=/velero logSource="pkg/backup/actions/ingress_action.go:68" pluginName=velero
```
And will be restored with logs like
```
time="2024-05-22T17:59:30+08:00" level=info msg="Executing item action for ingresses.networking.k8s.io" logSource="pkg/restore/restore.go:1319" restore=velero/restore-ing
time="2024-05-22T17:59:30+08:00" level=info msg="Executing AddIngressClassFromIngAction" cmd=/velero logSource="pkg/restore/actions/add_ingressclass_from_ing_action.go:44" pluginName=velero restore=velero/restore-ing
time="2024-05-22T17:59:30+08:00" level=info msg="Adding IngressClass nginx as an additional item to restore" cmd=/velero logSource="pkg/restore/actions/add_ingressclass_from_ing_action.go:54" pluginName=velero restore=velero/restore-ing
```
# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
