### PR TITLE
Bump up goreleaser to v1.26.2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,9 +46,6 @@ archives:
     files:
       - LICENSE
       - examples/**/*
-    # Add the setting to resolve the DEPRECATED warning. Actually, Velero's case is not affected by the rlcp behavior change.
-    # https://github.com/orgs/goreleaser/discussions/3659#discussioncomment-4587257
-    rlcp: true 
 checksum:
   name_template: 'CHECKSUM'
 release:

--- a/hack/build-image/Dockerfile
+++ b/hack/build-image/Dockerfile
@@ -87,7 +87,7 @@ RUN ARCH=$(go env GOARCH) && \
     elif [ "$ARCH" = "ppc64le" ] ; then \
         ARCH="ppc64"; \
     fi && \
-    wget --quiet "https://github.com/goreleaser/goreleaser/releases/download/v1.15.2/goreleaser_Linux_$ARCH.tar.gz" && \
+    wget --quiet "https://github.com/goreleaser/goreleaser/releases/download/v1.26.2/goreleaser_Linux_$ARCH.tar.gz" && \
     tar xvf goreleaser_Linux_$ARCH.tar.gz; \
     mv goreleaser /usr/bin/goreleaser && \
     chmod +x /usr/bin/goreleaser


### PR DESCRIPTION
Also make update to the configuration file according to: https://goreleaser.com/deprecations/#archivesrlcp

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
