### PR TITLE
release-1.13: ignore .git/ when formatting

### DIFF
--- a/hack/update-1fmt.sh
+++ b/hack/update-1fmt.sh
@@ -33,7 +33,7 @@ if ! command -v goimports > /dev/null; then
   exit 1
 fi
 
-files="$(find . -type f -name '*.go' -not -path './.go/*' -not -path './vendor/*' -not -path './site/*' -not -path '*/generated/*' -not -name 'zz_generated*' -not -path '*/mocks/*')"
+files="$(find . -type f -name '*.go' -not -path './.go/*' -not -path './vendor/*' -not -path './site/*' -not -path './.git/*' -not -path '*/generated/*' -not -name 'zz_generated*' -not -path '*/mocks/*')"
 echo "${ACTION} gofmt"
 output=$(gofmt "${MODE}" -s ${files})
 if [[ -n "${output}" ]]; then


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Pulled update-1fmt.sh changes to ignore `.git/` from https://github.com/vmware-tanzu/velero/pull/7757

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
