### PR TITLE
In backup sync flow put snapshotHandle as source in CSI VSContent

### DIFF
--- a/pkg/controller/backup_sync_controller.go
+++ b/pkg/controller/backup_sync_controller.go
@@ -272,6 +272,10 @@ func (b *backupSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			for _, snapCont := range snapConts {
 				// TODO: Reset ResourceVersion prior to persisting VolumeSnapshotContents
 				snapCont.ResourceVersion = ""
+				// For creating static VSContent, we should put snapshothandle in source rather than volume handle.
+				// Because if VSContent syncs to a different cluster, having volumeHandle will force rePUTs on the snapshot
+				snapCont.Spec.Source.SnapshotHandle = snapCont.Status.SnapshotHandle
+				snapCont.Spec.Source.VolumeHandle = nil
 				err := b.client.Create(ctx, snapCont, &client.CreateOptions{})
 				switch {
 				case err != nil && apierrors.IsAlreadyExists(err):


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)
https://kubernetes.io/docs/concepts/storage/volume-snapshots/
![image](https://github.com/vmware-tanzu/velero/assets/36476228/93b99986-b2df-489c-a689-921d2af7d61f)

Context:
We have few customers which have used same storage bucket across clusters, as a result of that their VSContents are syncing across clusters, After the sync the other cluster does not have permission on the snapshot of original cluster, it starts to rePUT the snapshot.
This leads to significant load on the CSI driver.
# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
