### PR TITLE
[release-1.14] Don't consider unschedulable pods unrecoverable

### DIFF
--- a/changelogs/unreleased/7926-sseago
+++ b/changelogs/unreleased/7926-sseago
@@ -1,0 +1,1 @@
+Don't consider unschedulable pods unrecoverable

--- a/pkg/exposer/csi_snapshot_test.go
+++ b/pkg/exposer/csi_snapshot_test.go
@@ -642,14 +642,7 @@ func TestPeekExpose(t *testing.T) {
 			Name:      backup.Name,
 		},
 		Status: corev1.PodStatus{
-			Phase: corev1.PodPending,
-			Conditions: []corev1.PodCondition{
-				{
-					Type:    corev1.PodScheduled,
-					Reason:  "Unschedulable",
-					Message: "unrecoverable",
-				},
-			},
+			Phase: corev1.PodFailed,
 		},
 	}
 
@@ -679,7 +672,7 @@ func TestPeekExpose(t *testing.T) {
 			kubeClientObj: []runtime.Object{
 				backupPodUrecoverable,
 			},
-			err: "Pod is unschedulable: unrecoverable",
+			err: "Pod is in abnormal state Failed",
 		},
 		{
 			name:        "succeed",

--- a/pkg/exposer/generic_restore_test.go
+++ b/pkg/exposer/generic_restore_test.go
@@ -429,14 +429,7 @@ func TestRestorePeekExpose(t *testing.T) {
 			Name:      restore.Name,
 		},
 		Status: corev1api.PodStatus{
-			Phase: corev1api.PodPending,
-			Conditions: []corev1api.PodCondition{
-				{
-					Type:    corev1api.PodScheduled,
-					Reason:  "Unschedulable",
-					Message: "unrecoverable",
-				},
-			},
+			Phase: corev1api.PodFailed,
 		},
 	}
 
@@ -463,7 +456,7 @@ func TestRestorePeekExpose(t *testing.T) {
 			kubeClientObj: []runtime.Object{
 				restorePodUrecoverable,
 			},
-			err: "Pod is unschedulable: unrecoverable",
+			err: "Pod is in abnormal state Failed",
 		},
 		{
 			name:         "succeed",

--- a/pkg/util/kube/pod.go
+++ b/pkg/util/kube/pod.go
@@ -121,14 +121,7 @@ func IsPodUnrecoverable(pod *corev1api.Pod, log logrus.FieldLogger) (bool, strin
 		return true, fmt.Sprintf("Pod is in abnormal state %s", pod.Status.Phase)
 	}
 
-	if pod.Status.Phase == corev1api.PodPending && len(pod.Status.Conditions) > 0 {
-		for _, condition := range pod.Status.Conditions {
-			if condition.Type == corev1api.PodScheduled && condition.Reason == "Unschedulable" {
-				log.Warnf("Pod is unschedulable %s", condition.Message)
-				return true, fmt.Sprintf("Pod is unschedulable: %s", condition.Message)
-			}
-		}
-	}
+	// removed "Unschedulable" check since unschedulable condition isn't always permanent
 
 	// Check the Status field
 	for _, containerStatus := range pod.Status.ContainerStatuses {

--- a/pkg/util/kube/pod_test.go
+++ b/pkg/util/kube/pod_test.go
@@ -402,21 +402,6 @@ func TestIsPodUnrecoverable(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "pod is unschedulable",
-			pod: &corev1api.Pod{
-				Status: corev1api.PodStatus{
-					Phase: corev1api.PodPending,
-					Conditions: []corev1api.PodCondition{
-						{
-							Type:   corev1api.PodScheduled,
-							Reason: "Unschedulable",
-						},
-					},
-				},
-			},
-			want: true,
-		},
-		{
 			name: "pod is normal",
 			pod: &corev1api.Pod{
 				Status: corev1api.PodStatus{


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Don't consider "unschedulable" pods unrecoverable (for fast fail purposes), since pods will be briefly unschedulable while waiting for PV provisioning.

cherry-pick of #7899 

# Does your change fix a particular issue?

Fixes #7898

# Please indicate you've done the following:

- [x ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x ] Updated the corresponding documentation in `site/content/docs/main`.
