### PR TITLE
Add additional keys from BSL secret to credentials file store

### DIFF
--- a/changelogs/unreleased/7943-kaovilai
+++ b/changelogs/unreleased/7943-kaovilai
@@ -1,0 +1,1 @@
+Write all keys from BSL credentials secret to velero pod


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Add additional files from secret to velero pod without restart to assists with some BSL encryption file requirements without restarting pod. It may require readding BSL to trigger write.
# Does your change fix a particular issue?

Fixes #7767 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
