### PR TITLE
Skip PV patch step in Restore workflow for WaitForFirstConsumer VolumeBindingMode Pending state PVCs

### DIFF
--- a/changelogs/unreleased/7953-shubham-pampattiwar
+++ b/changelogs/unreleased/7953-shubham-pampattiwar
@@ -1,0 +1,1 @@
+Skip PV patch step in Restoe workflow for WaitForFirstConsumer VolumeBindingMode Pending state PVCs


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes https://github.com/vmware-tanzu/velero/issues/7866

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
