### PR TITLE
Skip PV patch step in Restore workflow for WaitForFirstConsumer VolumeBindingMode Pending state PVCs (#7953)

### DIFF
--- a/changelogs/unreleased/8006-shubham-pampattiwar
+++ b/changelogs/unreleased/8006-shubham-pampattiwar
@@ -1,0 +1,1 @@
+Skip PV patch step in Restoe workflow for WaitForFirstConsumer VolumeBindingMode Pending state PVCs


### PR DESCRIPTION
Signed-off-by: Shubham Pampattiwar <spampatt@redhat.com>
(cherry picked from commit 3bd8a7da7d206b4e0019ac9d51faedc7d16ccd7b)

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes https://github.com/vmware-tanzu/velero/issues/7866

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
