### PR TITLE
Reuse existing plugin manager for get/put volume info

### DIFF
--- a/changelogs/unreleased/8012-sseago
+++ b/changelogs/unreleased/8012-sseago
@@ -1,0 +1,1 @@
+Reuse existing plugin manager for get/put volume info

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -4532,7 +4532,7 @@ func TestGetVolumeInfos(t *testing.T) {
 	bsl := builder.ForBackupStorageLocation("velero", "default").Result()
 	require.NoError(t, h.backupper.kbClient.Create(context.Background(), bsl))
 
-	_, _, err := h.backupper.getVolumeInfos(*backup, h.log)
+	_, err := h.backupper.getVolumeInfos(*backup, backupStore, h.log)
 	require.NoError(t, err)
 }
 

--- a/pkg/controller/backup_controller_test.go
+++ b/pkg/controller/backup_controller_test.go
@@ -85,6 +85,7 @@ func (b *fakeBackupper) FinalizeBackup(
 	outBackupFile io.Writer,
 	backupItemActionResolver framework.BackupItemActionResolverV2,
 	asyncBIAOperations []*itemoperation.BackupOperation,
+	backupStore persistence.BackupStore,
 ) error {
 	args := b.Called(logger, backup, inBackupFile, outBackupFile, backupItemActionResolver, asyncBIAOperations)
 	return args.Error(0)

--- a/pkg/controller/backup_finalizer_controller.go
+++ b/pkg/controller/backup_finalizer_controller.go
@@ -184,6 +184,7 @@ func (r *backupFinalizerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			outBackupFile,
 			backupItemActionsResolver,
 			operations,
+			backupStore,
 		)
 		if err != nil {
 			log.WithError(err).Error("error finalizing Backup")

--- a/pkg/controller/backup_finalizer_controller_test.go
+++ b/pkg/controller/backup_finalizer_controller_test.go
@@ -225,7 +225,7 @@ func TestBackupFinalizerReconcile(t *testing.T) {
 			backupStore.On("GetBackupVolumeInfos", mock.Anything).Return(nil, nil)
 			backupStore.On("PutBackupVolumeInfos", mock.Anything, mock.Anything).Return(nil)
 			pluginManager.On("GetBackupItemActionsV2").Return(nil, nil)
-			backupper.On("FinalizeBackup", mock.Anything, mock.Anything, mock.Anything, mock.Anything, framework.BackupItemActionResolverV2{}, mock.Anything).Return(nil)
+			backupper.On("FinalizeBackup", mock.Anything, mock.Anything, mock.Anything, mock.Anything, framework.BackupItemActionResolverV2{}, mock.Anything, mock.Anything).Return(nil)
 			_, err := reconciler.Reconcile(context.TODO(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: test.backup.Namespace, Name: test.backup.Name}})
 			gotErr := err != nil
 			assert.Equal(t, test.expectError, gotErr)


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Reuse existing plugin manager for get/put volume info. backup.FinalizeBackup was initializing its own plugin manager in getVolumeInfos but cleaning up too early, causing a new plugin process to be initialized in putVolumeInfos which was never getting cleaned up.

This PR changes the workflow to pass in the already-initialized plugin manager from the backup finalizer controller, since there's no need to have a separate one for get/put volume info.

# Does your change fix a particular issue?

Fixes #7925 

# Please indicate you've done the following:

- [x ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x ] Updated the corresponding documentation in `site/content/docs/main`.
