### PR TITLE
Fix linter check error

### DIFF
--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -728,7 +728,7 @@ func (kb *kubernetesBackupper) FinalizeBackup(
 		}).Infof("Updated %d items out of an estimated total of %d (estimate will change throughout the backup finalizer)", len(backupRequest.BackedUpItems), totalItems)
 	}
 
-	volumeInfos, err := kb.getVolumeInfos(*backupRequest.Backup, backupStore, log)
+	volumeInfos, err := backupStore.GetBackupVolumeInfos(backupRequest.Backup.Name)
 	if err != nil {
 		log.WithError(err).Errorf("fail to get the backup VolumeInfos for backup %s", backupRequest.Name)
 		return err
@@ -810,19 +810,6 @@ type tarWriter interface {
 	io.Closer
 	Write([]byte) (int, error)
 	WriteHeader(*tar.Header) error
-}
-
-func (kb *kubernetesBackupper) getVolumeInfos(
-	backup velerov1api.Backup,
-	backupStore persistence.BackupStore,
-	log logrus.FieldLogger,
-) ([]*volume.BackupVolumeInfo, error) {
-	volumeInfos, err := backupStore.GetBackupVolumeInfos(backup.Name)
-	if err != nil {
-		return nil, err
-	}
-
-	return volumeInfos, nil
 }
 
 // updateVolumeInfos update the VolumeInfos according to the AsyncOperations

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -54,8 +54,6 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/kuberesource"
 	"github.com/vmware-tanzu/velero/pkg/persistence"
 	persistencemocks "github.com/vmware-tanzu/velero/pkg/persistence/mocks"
-	"github.com/vmware-tanzu/velero/pkg/plugin/clientmgmt"
-	pluginmocks "github.com/vmware-tanzu/velero/pkg/plugin/mocks"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	biav2 "github.com/vmware-tanzu/velero/pkg/plugin/velero/backupitemaction/v2"
 	vsv1 "github.com/vmware-tanzu/velero/pkg/plugin/velero/volumesnapshotter/v1"
@@ -4517,23 +4515,6 @@ func TestBackupNamespaces(t *testing.T) {
 			assertTarballContents(t, backupFile, append(tc.want, "metadata/version")...)
 		})
 	}
-}
-
-func TestGetVolumeInfos(t *testing.T) {
-	h := newHarness(t)
-	pluginManager := new(pluginmocks.Manager)
-	backupStore := new(persistencemocks.BackupStore)
-	h.backupper.pluginManager = func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager }
-	h.backupper.backupStoreGetter = NewFakeSingleObjectBackupStoreGetter(backupStore)
-	backupStore.On("GetBackupVolumeInfos", "backup-01").Return([]*volume.BackupVolumeInfo{}, nil)
-	pluginManager.On("CleanupClients").Return()
-
-	backup := builder.ForBackup("velero", "backup-01").StorageLocation("default").Result()
-	bsl := builder.ForBackupStorageLocation("velero", "default").Result()
-	require.NoError(t, h.backupper.kbClient.Create(context.Background(), bsl))
-
-	_, err := h.backupper.getVolumeInfos(*backup, backupStore, h.log)
-	require.NoError(t, err)
 }
 
 func TestUpdateVolumeInfos(t *testing.T) {


### PR DESCRIPTION
Fix linter check error:
```
Error: pkg/backup/backup.go:818:2: `(*kubernetesBackupper).getVolumeInfos` - `log` is unused (unparam)
  	log logrus.FieldLogger,
  	^
```