### PR TITLE
Avoid wrapping failed PVB status with empty message.

### DIFF
--- a/changelogs/unreleased/8028-mrnold
+++ b/changelogs/unreleased/8028-mrnold
@@ -1,0 +1,1 @@
+Avoid wrapping failed PVB status with empty message.

--- a/pkg/cmd/cli/nodeagent/server.go
+++ b/pkg/cmd/cli/nodeagent/server.go
@@ -412,7 +412,7 @@ func (s *nodeAgentServer) markInProgressPVBsFailed(client ctrlclient.Client) {
 		}
 
 		if err := controller.UpdatePVBStatusToFailed(s.ctx, client, &pvbs.Items[i],
-			fmt.Errorf("get a podvolumebackup with status %q during the server starting, mark it as %q", velerov1api.PodVolumeBackupPhaseInProgress, velerov1api.PodVolumeBackupPhaseFailed),
+			fmt.Errorf("found a podvolumebackup with status %q during the server starting, mark it as %q", velerov1api.PodVolumeBackupPhaseInProgress, velerov1api.PodVolumeBackupPhaseFailed),
 			"", time.Now(), s.logger); err != nil {
 			s.logger.WithError(errors.WithStack(err)).Errorf("failed to patch podvolumebackup %q", pvb.GetName())
 			continue

--- a/pkg/controller/pod_volume_backup_controller.go
+++ b/pkg/controller/pod_volume_backup_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -373,7 +374,11 @@ func UpdatePVBStatusToFailed(ctx context.Context, c client.Client, pvb *velerov1
 	if dataPathError, ok := errOut.(datapath.DataPathError); ok {
 		pvb.Status.SnapshotID = dataPathError.GetSnapshotID()
 	}
-	pvb.Status.Message = errors.WithMessage(errOut, msg).Error()
+	if len(strings.TrimSpace(msg)) == 0 {
+		pvb.Status.Message = errOut.Error()
+	} else {
+		pvb.Status.Message = errors.WithMessage(errOut, msg).Error()
+	}
 	err := c.Patch(ctx, pvb, client.MergeFrom(original))
 	if err != nil {
 		log.WithError(err).Error("error updating PodVolumeBackup status")


### PR DESCRIPTION
# Please add a summary of your change
This change removes a leading ':' character in the status message of a failed PVB, and changes "get" to "found". For example, from:
`: get a podvolumebackup with status "InProgress" during the server starting, mark it as "Failed"`
to:
`found a podvolumebackup with status "InProgress" during the server starting, mark it as "Failed"`

# Does your change fix a particular issue?

Fixes #7857

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
