### PR TITLE
Allow `make local` to work without `docker` in path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,17 +74,17 @@ else
 	GCR_IMAGE_TAGS ?= $(GCR_IMAGE):$(VERSION)
 endif
 
-# check buildx is enabled
+# check buildx is enabled only if docker is in path
 # macOS/Windows docker cli without Docker Desktop license: https://github.com/abiosoft/colima
 # To add buildx to docker cli: https://github.com/abiosoft/colima/discussions/273#discussioncomment-2684502
-ifeq ($(shell docker buildx inspect 2>/dev/null | awk '/Status/ { print $$2 }'), running)
+ifeq ($(shell which docker 2>/dev/null 1>&2 && docker buildx inspect 2>/dev/null | awk '/Status/ { print $$2 }'), running)
 	BUILDX_ENABLED ?= true
 # if emulated docker cli from podman, assume enabled
 # emulated docker cli from podman: https://podman-desktop.io/docs/migrating-from-docker/emulating-docker-cli-with-podman
 # podman known issues:
 # - on remote podman, such as on macOS,
 #   --output issue: https://github.com/containers/podman/issues/15922
-else ifeq ($(shell cat $(shell which docker) | grep -c "exec podman"), 1)
+else ifeq ($(shell which docker 2>/dev/null 1>&2 && cat $(shell which docker) | grep -c "exec podman"), 1)
 	BUILDX_ENABLED ?= true
 else
 	BUILDX_ENABLED ?= false


### PR DESCRIPTION
No longer hangs without docker in path 

```
❯ which docker; time make local
docker not found
GOOS=darwin \
        GOARCH=arm64 \
        GOBIN=$(pwd)/.go/bin \
        VERSION=main \
        REGISTRY=velero \
        PKG=github.com/vmware-tanzu/velero \
        BIN=velero \
        GIT_SHA=9172ba88c8aaebfdd56751818ceabfaad48752b2 \
        GIT_TREE_STATE=clean \
        OUTPUT_DIR=$(pwd)/_output/bin/darwin/arm64 \
        ./hack/build.sh
make local  0.78s user 1.27s system 241% cpu 0.847 total
```

Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #8055 (issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
