### PR TITLE
Documentation Update for OpenShift IBM Cloud for CSI snapshot data movement

### DIFF
--- a/site/content/docs/main/csi-snapshot-data-movement.md
+++ b/site/content/docs/main/csi-snapshot-data-movement.md
@@ -121,6 +121,24 @@ oc annotate namespace <velero namespace> openshift.io/node-selector=""
 oc create -n <velero namespace> -f ds.yaml
 ```
 
+**OpenShift on IBM Cloud**
+
+
+Update the host path for volumes in the node-agent DaemonSet in the Velero namespace from `/var/lib/kubelet/pods` to
+`/var/data/kubelet/pods`.
+
+```yaml
+hostPath:
+  path: /var/lib/kubelet/pods
+```
+
+to
+
+```yaml
+hostPath:
+  path: /var/data/kubet/pods
+```
+
 **VMware Tanzu Kubernetes Grid Integrated Edition (formerly VMware Enterprise PKS)**  
 
 You need to enable the `Allow Privileged` option in your plan configuration so that Velero is able to mount the hostpath.  

--- a/site/content/docs/main/csi-snapshot-data-movement.md
+++ b/site/content/docs/main/csi-snapshot-data-movement.md
@@ -136,7 +136,7 @@ to
 
 ```yaml
 hostPath:
-  path: /var/data/kubet/pods
+  path: /var/data/kubelet/pods
 ```
 
 **VMware Tanzu Kubernetes Grid Integrated Edition (formerly VMware Enterprise PKS)**  

--- a/site/content/docs/main/csi-snapshot-data-movement.md
+++ b/site/content/docs/main/csi-snapshot-data-movement.md
@@ -41,7 +41,7 @@ velero install --use-node-agent
 ### Configure Node Agent DaemonSet spec
 
 After installation, some PaaS/CaaS platforms based on Kubernetes also require modifications the node-agent DaemonSet spec. 
-The steps in this section are only needed if you are installing on RancherOS, Nutanix, OpenShift, VMware Tanzu Kubernetes Grid 
+The steps in this section are only needed if you are installing on RancherOS, Nutanix, OpenShift, OpenShift on IBM Cloud, VMware Tanzu Kubernetes Grid 
 Integrated Edition (formerly VMware Enterprise PKS), or Microsoft Azure.  
 
 

--- a/site/content/docs/v1.13/csi-snapshot-data-movement.md
+++ b/site/content/docs/v1.13/csi-snapshot-data-movement.md
@@ -121,6 +121,24 @@ oc annotate namespace <velero namespace> openshift.io/node-selector=""
 oc create -n <velero namespace> -f ds.yaml
 ```
 
+**OpenShift on IBM Cloud**
+
+
+Update the host path for volumes in the node-agent DaemonSet in the Velero namespace from `/var/lib/kubelet/pods` to
+`/var/data/kubelet/pods`.
+
+```yaml
+hostPath:
+  path: /var/lib/kubelet/pods
+```
+
+to
+
+```yaml
+hostPath:
+  path: /var/data/kubet/pods
+```
+
 **VMware Tanzu Kubernetes Grid Integrated Edition (formerly VMware Enterprise PKS)**  
 
 You need to enable the `Allow Privileged` option in your plan configuration so that Velero is able to mount the hostpath.  

--- a/site/content/docs/v1.13/csi-snapshot-data-movement.md
+++ b/site/content/docs/v1.13/csi-snapshot-data-movement.md
@@ -136,7 +136,7 @@ to
 
 ```yaml
 hostPath:
-  path: /var/data/kubet/pods
+  path: /var/data/kubelet/pods
 ```
 
 **VMware Tanzu Kubernetes Grid Integrated Edition (formerly VMware Enterprise PKS)**  

--- a/site/content/docs/v1.13/csi-snapshot-data-movement.md
+++ b/site/content/docs/v1.13/csi-snapshot-data-movement.md
@@ -41,7 +41,7 @@ velero install --use-node-agent
 ### Configure Node Agent DaemonSet spec
 
 After installation, some PaaS/CaaS platforms based on Kubernetes also require modifications the node-agent DaemonSet spec. 
-The steps in this section are only needed if you are installing on RancherOS, Nutanix, OpenShift, VMware Tanzu Kubernetes Grid 
+The steps in this section are only needed if you are installing on RancherOS, Nutanix, OpenShift, OpenShift on IBM Cloud, VMware Tanzu Kubernetes Grid 
 Integrated Edition (formerly VMware Enterprise PKS), or Microsoft Azure.  
 
 

--- a/site/content/docs/v1.14/csi-snapshot-data-movement.md
+++ b/site/content/docs/v1.14/csi-snapshot-data-movement.md
@@ -121,6 +121,24 @@ oc annotate namespace <velero namespace> openshift.io/node-selector=""
 oc create -n <velero namespace> -f ds.yaml
 ```
 
+**OpenShift on IBM Cloud**
+
+
+Update the host path for volumes in the node-agent DaemonSet in the Velero namespace from `/var/lib/kubelet/pods` to
+`/var/data/kubelet/pods`.
+
+```yaml
+hostPath:
+  path: /var/lib/kubelet/pods
+```
+
+to
+
+```yaml
+hostPath:
+  path: /var/data/kubet/pods
+```
+
 **VMware Tanzu Kubernetes Grid Integrated Edition (formerly VMware Enterprise PKS)**  
 
 You need to enable the `Allow Privileged` option in your plan configuration so that Velero is able to mount the hostpath.  

--- a/site/content/docs/v1.14/csi-snapshot-data-movement.md
+++ b/site/content/docs/v1.14/csi-snapshot-data-movement.md
@@ -136,7 +136,7 @@ to
 
 ```yaml
 hostPath:
-  path: /var/data/kubet/pods
+  path: /var/data/kubelet/pods
 ```
 
 **VMware Tanzu Kubernetes Grid Integrated Edition (formerly VMware Enterprise PKS)**  

--- a/site/content/docs/v1.14/csi-snapshot-data-movement.md
+++ b/site/content/docs/v1.14/csi-snapshot-data-movement.md
@@ -41,7 +41,7 @@ velero install --use-node-agent
 ### Configure Node Agent DaemonSet spec
 
 After installation, some PaaS/CaaS platforms based on Kubernetes also require modifications the node-agent DaemonSet spec. 
-The steps in this section are only needed if you are installing on RancherOS, Nutanix, OpenShift, VMware Tanzu Kubernetes Grid 
+The steps in this section are only needed if you are installing on RancherOS, Nutanix, OpenShift, OpenShift on IBM Cloud, VMware Tanzu Kubernetes Grid 
 Integrated Edition (formerly VMware Enterprise PKS), or Microsoft Azure.  
 
 


### PR DESCRIPTION
# Please add a summary of your change

Updates the documentation for CSI snapshot data movement for OpenShift on IBM Cloud.

The default hostpath /var/lib/kubelet/pods cannot find PersistentVolumeClaims with volumeMode: Block on host.

The correct hostpath for OpenShift on IBM Cloud is /var/data/kubelet/pods

# Does your change fix a particular issue?

Fixes #(issue)
Documentation only. Fixes failed CSI snapshot movement for OpenShift on IBM Cloud

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
