### PR TITLE
Updating IBM COS documentation for current version

### DIFF
--- a/changelogs/unreleased/8081-gjanders
+++ b/changelogs/unreleased/8081-gjanders
@@ -1,0 +1,1 @@
+Updates to IBM COS documentation to match current version

--- a/site/content/docs/main/contributions/ibm-config.md
+++ b/site/content/docs/main/contributions/ibm-config.md
@@ -65,8 +65,9 @@ velero install \
     --provider aws \
     --bucket <YOUR_BUCKET> \
     --secret-file ./credentials-velero \
+    --plugins velero/velero-plugin-for-aws:v1.10.0\
     --use-volume-snapshots=false \
-    --backup-location-config region=<YOUR_REGION>,s3ForcePathStyle="true",s3Url=<YOUR_URL_ACCESS_POINT>
+    --backup-location-config region=<YOUR_REGION>,s3ForcePathStyle="true",s3Url=<YOUR_URL_ACCESS_POINT>,checksumAlgorithm=""
 ```
 
 Velero does not have a volume snapshot plugin for IBM Cloud, so creating volume snapshots is disabled.
@@ -74,12 +75,6 @@ Velero does not have a volume snapshot plugin for IBM Cloud, so creating volume 
 Additionally, you can specify `--use-node-agent` to enable [File System Backup][16], and `--wait` to wait for the deployment to be ready.
 
 (Optional) Specify [CPU and memory resource requests and limits][15] for the Velero/node-agent pods.
-
-Once the installation is complete, remove the default `VolumeSnapshotLocation` that was created by `velero install`, since it's specific to AWS and won't work for IBM Cloud:
-
-```bash
-kubectl -n velero delete volumesnapshotlocation.velero.io default
-```
 
 For more complex installation needs, use either the Helm chart, or add `--dry-run -o yaml` options for generating the YAML representation for the installation.
 


### PR DESCRIPTION
# Please add a summary of your change

Updated cksumAlgorithm to avoid 403 errors as per  https://github.com/vmware-tanzu/velero/issues/7543
Added plugins line as velero install failed without this option in version 1.14.0

Removed the volumesnapshotlocation as it does not exist in 1.14.0

# Does your change fix a particular issue?

Documentation updates only

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [X] Updated the corresponding documentation in `site/content/docs/main`.