### PR TITLE
Patch dbr's status when error happens

### DIFF
--- a/changelogs/unreleased/8086-reasonerjt
+++ b/changelogs/unreleased/8086-reasonerjt
@@ -1,0 +1,1 @@
+Patch dbr's status when error happens

--- a/pkg/controller/backup_deletion_controller_test.go
+++ b/pkg/controller/backup_deletion_controller_test.go
@@ -122,16 +122,16 @@ func TestBackupDeletionControllerReconcile(t *testing.T) {
 				},
 			},
 		}
-		td := setupBackupDeletionControllerTest(t, defaultTestDbr(), location, backup)
+		dbr := defaultTestDbr()
+		td := setupBackupDeletionControllerTest(t, dbr, location, backup)
 		td.controller.backupStoreGetter = &fakeErrorBackupStoreGetter{}
 		_, err := td.controller.Reconcile(ctx, td.req)
 		require.NoError(t, err)
 		res := &velerov1api.DeleteBackupRequest{}
-		err = td.fakeClient.Get(ctx, td.req.NamespacedName, res)
-		require.NoError(t, err)
+		td.fakeClient.Get(ctx, td.req.NamespacedName, res)
 		assert.Equal(t, "Processed", string(res.Status.Phase))
 		assert.Len(t, res.Status.Errors, 1)
-		assert.True(t, strings.HasPrefix(res.Status.Errors[0], fmt.Sprintf("cannot delete backup because backup storage location %s is currently unavailable", location.Name)))
+		assert.True(t, strings.HasPrefix(res.Status.Errors[0], "error getting the backup store"))
 	})
 
 	t.Run("missing spec.backupName", func(t *testing.T) {


### PR DESCRIPTION
This commit makes sure the dbr's status is "Processed" when an error happens before the actual deletion is started

fixes #7812

 #8029 has partially fixed the problem in #7812 but this PR handles more error conditions.

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
