### PR TITLE
ItemBlock model and phase 1 (single-thread) workflow changes

### DIFF
--- a/changelogs/unreleased/8102-sseago
+++ b/changelogs/unreleased/8102-sseago
@@ -1,0 +1,1 @@
+ItemBlock model and phase 1 (single-thread) workflow changes

--- a/design/backup-performance-improvements.md
+++ b/design/backup-performance-improvements.md
@@ -109,19 +109,27 @@ This mainly applies to plugins that operate on pods which reference resources wh
 
 ### Changes to processing item list from the Item Collector
 
-#### New structs ItemBlock and ItemBlockItem
+#### New structs BackupItemBlock, ItemBlock, and ItemBlockItem
 ```go
-type ItemBlock struct {
-    log           logrus.FieldLogger
+package backup
+
+type BackupItemBlock struct {
+    itemblock.ItemBlock
     // This is a reference to the  shared itemBackupper for the backup
     itemBackupper *itemBackupper
+}
+
+package itemblock
+
+type ItemBlock struct {
+    Log           logrus.FieldLogger
     Items         []ItemBlockItem
 }
 
 type ItemBlockItem struct {
-    gr           schema.GroupResource
-    item         *unstructured.Unstructured
-    preferredGVR schema.GroupVersionResource
+    Gr           schema.GroupResource
+    Item         *unstructured.Unstructured
+    PreferredGVR schema.GroupVersionResource
 }
 ```
 

--- a/internal/hook/hook_tracker.go
+++ b/internal/hook/hook_tracker.go
@@ -37,7 +37,7 @@ type hookKey struct {
 	// For hooks specified in pod annotation, this field is the pod where hooks are annotated.
 	podName string
 	// HookPhase is only for backup hooks, for restore hooks, this field is empty.
-	hookPhase hookPhase
+	hookPhase HookPhase
 	// HookName is only for hooks specified in the backup/restore spec.
 	// For hooks specified in pod annotation, this field is empty or "<from-annotation>".
 	hookName string
@@ -83,7 +83,7 @@ func NewHookTracker() *HookTracker {
 // Add adds a hook to the hook tracker
 // Add must precede the Record for each individual hook.
 // In other words, a hook must be added to the tracker before its execution result is recorded.
-func (ht *HookTracker) Add(podNamespace, podName, container, source, hookName string, hookPhase hookPhase) {
+func (ht *HookTracker) Add(podNamespace, podName, container, source, hookName string, hookPhase HookPhase) {
 	ht.lock.Lock()
 	defer ht.lock.Unlock()
 
@@ -108,7 +108,7 @@ func (ht *HookTracker) Add(podNamespace, podName, container, source, hookName st
 // Record records the hook's execution status
 // Add must precede the Record for each individual hook.
 // In other words, a hook must be added to the tracker before its execution result is recorded.
-func (ht *HookTracker) Record(podNamespace, podName, container, source, hookName string, hookPhase hookPhase, hookFailed bool, hookErr error) error {
+func (ht *HookTracker) Record(podNamespace, podName, container, source, hookName string, hookPhase HookPhase, hookFailed bool, hookErr error) error {
 	ht.lock.Lock()
 	defer ht.lock.Unlock()
 
@@ -179,7 +179,7 @@ func NewMultiHookTracker() *MultiHookTracker {
 }
 
 // Add adds a backup/restore hook to the tracker
-func (mht *MultiHookTracker) Add(name, podNamespace, podName, container, source, hookName string, hookPhase hookPhase) {
+func (mht *MultiHookTracker) Add(name, podNamespace, podName, container, source, hookName string, hookPhase HookPhase) {
 	mht.lock.Lock()
 	defer mht.lock.Unlock()
 
@@ -190,7 +190,7 @@ func (mht *MultiHookTracker) Add(name, podNamespace, podName, container, source,
 }
 
 // Record records a backup/restore hook execution status
-func (mht *MultiHookTracker) Record(name, podNamespace, podName, container, source, hookName string, hookPhase hookPhase, hookFailed bool, hookErr error) error {
+func (mht *MultiHookTracker) Record(name, podNamespace, podName, container, source, hookName string, hookPhase HookPhase, hookFailed bool, hookErr error) error {
 	mht.lock.RLock()
 	defer mht.lock.RUnlock()
 

--- a/internal/hook/item_hook_handler.go
+++ b/internal/hook/item_hook_handler.go
@@ -43,11 +43,11 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/util/kube"
 )
 
-type hookPhase string
+type HookPhase string
 
 const (
-	PhasePre  hookPhase = "pre"
-	PhasePost hookPhase = "post"
+	PhasePre  HookPhase = "pre"
+	PhasePost HookPhase = "post"
 )
 
 const (
@@ -81,7 +81,7 @@ type ItemHookHandler interface {
 		groupResource schema.GroupResource,
 		obj runtime.Unstructured,
 		resourceHooks []ResourceHook,
-		phase hookPhase,
+		phase HookPhase,
 		hookTracker *HookTracker,
 	) error
 }
@@ -200,7 +200,7 @@ func (h *DefaultItemHookHandler) HandleHooks(
 	groupResource schema.GroupResource,
 	obj runtime.Unstructured,
 	resourceHooks []ResourceHook,
-	phase hookPhase,
+	phase HookPhase,
 	hookTracker *HookTracker,
 ) error {
 	// We only support hooks on pods right now
@@ -312,27 +312,27 @@ func (h *NoOpItemHookHandler) HandleHooks(
 	groupResource schema.GroupResource,
 	obj runtime.Unstructured,
 	resourceHooks []ResourceHook,
-	phase hookPhase,
+	phase HookPhase,
 	hookTracker *HookTracker,
 ) error {
 	return nil
 }
 
-func phasedKey(phase hookPhase, key string) string {
+func phasedKey(phase HookPhase, key string) string {
 	if phase != "" {
 		return fmt.Sprintf("%v.%v", phase, key)
 	}
 	return key
 }
 
-func getHookAnnotation(annotations map[string]string, key string, phase hookPhase) string {
+func getHookAnnotation(annotations map[string]string, key string, phase HookPhase) string {
 	return annotations[phasedKey(phase, key)]
 }
 
 // getPodExecHookFromAnnotations returns an ExecHook based on the annotations, as long as the
 // 'command' annotation is present. If it is absent, this returns nil.
 // If there is an error in parsing a supplied timeout, it is logged.
-func getPodExecHookFromAnnotations(annotations map[string]string, phase hookPhase, log logrus.FieldLogger) *velerov1api.ExecHook {
+func getPodExecHookFromAnnotations(annotations map[string]string, phase HookPhase, log logrus.FieldLogger) *velerov1api.ExecHook {
 	commandValue := getHookAnnotation(annotations, podBackupHookCommandAnnotationKey, phase)
 	if commandValue == "" {
 		return nil
@@ -561,7 +561,7 @@ func GroupRestoreExecHooks(
 		if hookFromAnnotation.Container == "" {
 			hookFromAnnotation.Container = pod.Spec.Containers[0].Name
 		}
-		hookTrack.Add(restoreName, metadata.GetNamespace(), metadata.GetName(), hookFromAnnotation.Container, HookSourceAnnotation, "<from-annotation>", hookPhase(""))
+		hookTrack.Add(restoreName, metadata.GetNamespace(), metadata.GetName(), hookFromAnnotation.Container, HookSourceAnnotation, "<from-annotation>", HookPhase(""))
 		byContainer[hookFromAnnotation.Container] = []PodExecRestoreHook{
 			{
 				HookName:   "<from-annotation>",
@@ -596,7 +596,7 @@ func GroupRestoreExecHooks(
 			if named.Hook.Container == "" {
 				named.Hook.Container = pod.Spec.Containers[0].Name
 			}
-			hookTrack.Add(restoreName, metadata.GetNamespace(), metadata.GetName(), named.Hook.Container, HookSourceSpec, rrh.Name, hookPhase(""))
+			hookTrack.Add(restoreName, metadata.GetNamespace(), metadata.GetName(), named.Hook.Container, HookSourceSpec, rrh.Name, HookPhase(""))
 			byContainer[named.Hook.Container] = append(byContainer[named.Hook.Container], named)
 		}
 	}

--- a/internal/hook/item_hook_handler_test.go
+++ b/internal/hook/item_hook_handler_test.go
@@ -128,7 +128,7 @@ func TestHandleHooksSkips(t *testing.T) {
 func TestHandleHooks(t *testing.T) {
 	tests := []struct {
 		name                  string
-		phase                 hookPhase
+		phase                 HookPhase
 		groupResource         string
 		item                  runtime.Unstructured
 		hooks                 []ResourceHook
@@ -500,7 +500,7 @@ func TestHandleHooks(t *testing.T) {
 }
 
 func TestGetPodExecHookFromAnnotations(t *testing.T) {
-	phases := []hookPhase{"", PhasePre, PhasePost}
+	phases := []HookPhase{"", PhasePre, PhasePost}
 	for _, phase := range phases {
 		tests := []struct {
 			name         string
@@ -1999,7 +1999,7 @@ func TestBackupHookTracker(t *testing.T) {
 	}
 	test1 := []struct {
 		name                  string
-		phase                 hookPhase
+		phase                 HookPhase
 		groupResource         string
 		pods                  []podWithHook
 		hookTracker           *HookTracker

--- a/internal/hook/wait_exec_hook_handler.go
+++ b/internal/hook/wait_exec_hook_handler.go
@@ -169,7 +169,7 @@ func (e *DefaultWaitExecHookHandler) HandleHooks(
 					hookLog.Error(err)
 					errors = append(errors, err)
 
-					errTracker := multiHookTracker.Record(restoreName, newPod.Namespace, newPod.Name, hook.Hook.Container, hook.HookSource, hook.HookName, hookPhase(""), true, err)
+					errTracker := multiHookTracker.Record(restoreName, newPod.Namespace, newPod.Name, hook.Hook.Container, hook.HookSource, hook.HookName, HookPhase(""), true, err)
 					if errTracker != nil {
 						hookLog.WithError(errTracker).Warn("Error recording the hook in hook tracker")
 					}
@@ -195,7 +195,7 @@ func (e *DefaultWaitExecHookHandler) HandleHooks(
 					hookFailed = true
 				}
 
-				errTracker := multiHookTracker.Record(restoreName, newPod.Namespace, newPod.Name, hook.Hook.Container, hook.HookSource, hook.HookName, hookPhase(""), hookFailed, hookErr)
+				errTracker := multiHookTracker.Record(restoreName, newPod.Namespace, newPod.Name, hook.Hook.Container, hook.HookSource, hook.HookName, HookPhase(""), hookFailed, hookErr)
 				if errTracker != nil {
 					hookLog.WithError(errTracker).Warn("Error recording the hook in hook tracker")
 				}
@@ -247,7 +247,7 @@ func (e *DefaultWaitExecHookHandler) HandleHooks(
 				},
 			)
 
-			errTracker := multiHookTracker.Record(restoreName, pod.Namespace, pod.Name, hook.Hook.Container, hook.HookSource, hook.HookName, hookPhase(""), true, err)
+			errTracker := multiHookTracker.Record(restoreName, pod.Namespace, pod.Name, hook.Hook.Container, hook.HookSource, hook.HookName, HookPhase(""), true, err)
 			if errTracker != nil {
 				hookLog.WithError(errTracker).Warn("Error recording the hook in hook tracker")
 			}

--- a/internal/hook/wait_exec_hook_handler_test.go
+++ b/internal/hook/wait_exec_hook_handler_test.go
@@ -1012,17 +1012,17 @@ func TestRestoreHookTrackerUpdate(t *testing.T) {
 	}
 
 	hookTracker1 := NewMultiHookTracker()
-	hookTracker1.Add("restore1", "default", "my-pod", "container1", HookSourceAnnotation, "<from-annotation>", hookPhase(""))
+	hookTracker1.Add("restore1", "default", "my-pod", "container1", HookSourceAnnotation, "<from-annotation>", HookPhase(""))
 
 	hookTracker2 := NewMultiHookTracker()
-	hookTracker2.Add("restore1", "default", "my-pod", "container1", HookSourceSpec, "my-hook-1", hookPhase(""))
+	hookTracker2.Add("restore1", "default", "my-pod", "container1", HookSourceSpec, "my-hook-1", HookPhase(""))
 
 	hookTracker3 := NewMultiHookTracker()
-	hookTracker3.Add("restore1", "default", "my-pod", "container1", HookSourceSpec, "my-hook-1", hookPhase(""))
-	hookTracker3.Add("restore1", "default", "my-pod", "container2", HookSourceSpec, "my-hook-2", hookPhase(""))
+	hookTracker3.Add("restore1", "default", "my-pod", "container1", HookSourceSpec, "my-hook-1", HookPhase(""))
+	hookTracker3.Add("restore1", "default", "my-pod", "container2", HookSourceSpec, "my-hook-2", HookPhase(""))
 
 	hookTracker4 := NewMultiHookTracker()
-	hookTracker4.Add("restore1", "default", "my-pod", "container1", HookSourceSpec, "my-hook-1", hookPhase(""))
+	hookTracker4.Add("restore1", "default", "my-pod", "container1", HookSourceSpec, "my-hook-1", HookPhase(""))
 
 	tests1 := []struct {
 		name               string

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -56,6 +56,7 @@ import (
 	persistencemocks "github.com/vmware-tanzu/velero/pkg/persistence/mocks"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	biav2 "github.com/vmware-tanzu/velero/pkg/plugin/velero/backupitemaction/v2"
+	ibav1 "github.com/vmware-tanzu/velero/pkg/plugin/velero/itemblockaction/v1"
 	vsv1 "github.com/vmware-tanzu/velero/pkg/plugin/velero/volumesnapshotter/v1"
 	"github.com/vmware-tanzu/velero/pkg/podvolume"
 	"github.com/vmware-tanzu/velero/pkg/test"
@@ -97,7 +98,7 @@ func TestBackedUpItemsMatchesTarballContents(t *testing.T) {
 		h.addItems(t, resource)
 	}
 
-	h.backupper.Backup(h.log, req, backupFile, nil, nil)
+	h.backupper.Backup(h.log, req, backupFile, nil, nil, nil)
 
 	// go through BackedUpItems after the backup to assemble the list of files we
 	// expect to see in the tarball and compare to see if they match
@@ -155,7 +156,7 @@ func TestBackupProgressIsUpdated(t *testing.T) {
 		h.addItems(t, resource)
 	}
 
-	h.backupper.Backup(h.log, req, backupFile, nil, nil)
+	h.backupper.Backup(h.log, req, backupFile, nil, nil, nil)
 
 	require.NotNil(t, req.Status.Progress)
 	assert.Len(t, req.BackedUpItems, req.Status.Progress.TotalItems)
@@ -878,7 +879,7 @@ func TestBackupOldResourceFiltering(t *testing.T) {
 				h.addItems(t, resource)
 			}
 
-			h.backupper.Backup(h.log, req, backupFile, tc.actions, nil)
+			h.backupper.Backup(h.log, req, backupFile, tc.actions, nil, nil)
 
 			assertTarballContents(t, backupFile, append(tc.want, "metadata/version")...)
 		})
@@ -1055,7 +1056,7 @@ func TestCRDInclusion(t *testing.T) {
 				h.addItems(t, resource)
 			}
 
-			h.backupper.Backup(h.log, req, backupFile, nil, nil)
+			h.backupper.Backup(h.log, req, backupFile, nil, nil, nil)
 
 			assertTarballContents(t, backupFile, append(tc.want, "metadata/version")...)
 		})
@@ -1150,7 +1151,7 @@ func TestBackupResourceCohabitation(t *testing.T) {
 				h.addItems(t, resource)
 			}
 
-			h.backupper.Backup(h.log, req, backupFile, nil, nil)
+			h.backupper.Backup(h.log, req, backupFile, nil, nil, nil)
 
 			assertTarballContents(t, backupFile, append(tc.want, "metadata/version")...)
 		})
@@ -1174,7 +1175,7 @@ func TestBackupUsesNewCohabitatingResourcesForEachBackup(t *testing.T) {
 	h.addItems(t, test.Deployments(builder.ForDeployment("ns-1", "deploy-1").Result()))
 	h.addItems(t, test.ExtensionsDeployments(builder.ForDeployment("ns-1", "deploy-1").Result()))
 
-	h.backupper.Backup(h.log, backup1, backup1File, nil, nil)
+	h.backupper.Backup(h.log, backup1, backup1File, nil, nil, nil)
 
 	assertTarballContents(t, backup1File, "metadata/version", "resources/deployments.apps/namespaces/ns-1/deploy-1.json", "resources/deployments.apps/v1-preferredversion/namespaces/ns-1/deploy-1.json")
 
@@ -1185,7 +1186,7 @@ func TestBackupUsesNewCohabitatingResourcesForEachBackup(t *testing.T) {
 	}
 	backup2File := bytes.NewBuffer([]byte{})
 
-	h.backupper.Backup(h.log, backup2, backup2File, nil, nil)
+	h.backupper.Backup(h.log, backup2, backup2File, nil, nil, nil)
 
 	assertTarballContents(t, backup2File, "metadata/version", "resources/deployments.apps/namespaces/ns-1/deploy-1.json", "resources/deployments.apps/v1-preferredversion/namespaces/ns-1/deploy-1.json")
 }
@@ -1240,7 +1241,7 @@ func TestBackupResourceOrdering(t *testing.T) {
 				h.addItems(t, resource)
 			}
 
-			h.backupper.Backup(h.log, req, backupFile, nil, nil)
+			h.backupper.Backup(h.log, req, backupFile, nil, nil, nil)
 
 			assertTarballOrdering(t, backupFile, "pods", "persistentvolumeclaims", "persistentvolumes")
 		})
@@ -1439,7 +1440,7 @@ func TestBackupItemActionsForSkippedPV(t *testing.T) {
 				require.NoError(t, tc.backupReq.ResPolicies.BuildPolicy(tc.resPolicies))
 			}
 
-			err := h.backupper.Backup(h.log, tc.backupReq, backupFile, actions, nil)
+			err := h.backupper.Backup(h.log, tc.backupReq, backupFile, actions, nil, nil)
 			assert.NoError(t, err)
 
 			if tc.expectSkippedPVs != nil {
@@ -1653,7 +1654,7 @@ func TestBackupActionsRunForCorrectItems(t *testing.T) {
 				actions = append(actions, action)
 			}
 
-			err := h.backupper.Backup(h.log, req, backupFile, actions, nil)
+			err := h.backupper.Backup(h.log, req, backupFile, actions, nil, nil)
 			assert.NoError(t, err)
 
 			for action, want := range tc.actions {
@@ -1729,7 +1730,7 @@ func TestBackupWithInvalidActions(t *testing.T) {
 				h.addItems(t, resource)
 			}
 
-			assert.Error(t, h.backupper.Backup(h.log, req, backupFile, tc.actions, nil))
+			assert.Error(t, h.backupper.Backup(h.log, req, backupFile, tc.actions, nil, nil))
 		})
 	}
 }
@@ -1743,6 +1744,10 @@ func (a *appliesToErrorAction) AppliesTo() (velero.ResourceSelector, error) {
 }
 
 func (a *appliesToErrorAction) Execute(item runtime.Unstructured, backup *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
+	panic("not implemented")
+}
+
+func (a *appliesToErrorAction) GetRelatedItems(item runtime.Unstructured, backup *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
 	panic("not implemented")
 }
 
@@ -1875,7 +1880,7 @@ func TestBackupActionModifications(t *testing.T) {
 				h.addItems(t, resource)
 			}
 
-			err := h.backupper.Backup(h.log, req, backupFile, tc.actions, nil)
+			err := h.backupper.Backup(h.log, req, backupFile, tc.actions, nil, nil)
 			assert.NoError(t, err)
 
 			assertTarballFileContents(t, backupFile, tc.want)
@@ -1893,6 +1898,7 @@ func TestBackupActionAdditionalItems(t *testing.T) {
 		backup       *velerov1.Backup
 		apiResources []*test.APIResource
 		actions      []biav2.BackupItemAction
+		ibActions    []ibav1.ItemBlockAction
 		want         []string
 	}{
 		{
@@ -2130,7 +2136,597 @@ func TestBackupActionAdditionalItems(t *testing.T) {
 				h.addItems(t, resource)
 			}
 
-			err := h.backupper.Backup(h.log, req, backupFile, tc.actions, nil)
+			err := h.backupper.Backup(h.log, req, backupFile, tc.actions, nil, nil)
+			assert.NoError(t, err)
+
+			assertTarballContents(t, backupFile, append(tc.want, "metadata/version")...)
+		})
+	}
+}
+
+// recordResourcesIBA is an ItemBlock item action that can be configured
+// to run for specific resources/namespaces and simply records the items
+// that it is executed for.
+type recordResourcesIBA struct {
+	name         string
+	selector     velero.ResourceSelector
+	ids          []string
+	backups      []velerov1.Backup
+	executionErr error
+	relatedItems []velero.ResourceIdentifier
+}
+
+func (a *recordResourcesIBA) GetRelatedItems(item runtime.Unstructured, backup *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
+	metadata, err := meta.Accessor(item)
+	if err != nil {
+		return a.relatedItems, err
+	}
+	a.ids = append(a.ids, kubeutil.NamespaceAndName(metadata))
+	a.backups = append(a.backups, *backup)
+	return a.relatedItems, a.executionErr
+}
+
+func (a *recordResourcesIBA) AppliesTo() (velero.ResourceSelector, error) {
+	return a.selector, nil
+}
+
+func (a *recordResourcesIBA) Name() string {
+	return a.name
+}
+
+func (a *recordResourcesIBA) ForResource(resource string) *recordResourcesIBA {
+	a.selector.IncludedResources = append(a.selector.IncludedResources, resource)
+	return a
+}
+
+func (a *recordResourcesIBA) ForNamespace(namespace string) *recordResourcesIBA {
+	a.selector.IncludedNamespaces = append(a.selector.IncludedNamespaces, namespace)
+	return a
+}
+
+func (a *recordResourcesIBA) ForLabelSelector(selector string) *recordResourcesIBA {
+	a.selector.LabelSelector = selector
+	return a
+}
+
+func (a *recordResourcesIBA) WithRelatedItems(items []velero.ResourceIdentifier) *recordResourcesIBA {
+	a.relatedItems = items
+	return a
+}
+
+func (a *recordResourcesIBA) WithName(name string) *recordResourcesIBA {
+	a.name = name
+	return a
+}
+
+func (a *recordResourcesIBA) WithExecutionErr(executionErr error) *recordResourcesIBA {
+	a.executionErr = executionErr
+	return a
+}
+
+// TestItemBlockActionsRunForCorrectItems runs backups with ItemBlock actions, and
+// verifies that each action is run for the correct set of resources based on its
+// AppliesTo() resource selector. Verification is done by using the recordResourcesIBA struct,
+// which records which resources it's executed for.
+func TestItemBlockActionsRunForCorrectItems(t *testing.T) {
+	tests := []struct {
+		name         string
+		backup       *velerov1.Backup
+		apiResources []*test.APIResource
+
+		// actions is a map from a recordResourcesIBA (which will record the items it was called for)
+		// to a slice of expected items, formatted as {namespace}/{name}.
+		actions map[*recordResourcesIBA][]string
+	}{
+		{
+			name: "single action with no selector runs for all items",
+			backup: defaultBackup().
+				Result(),
+			apiResources: []*test.APIResource{
+				test.Pods(
+					builder.ForPod("ns-1", "pod-1").Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+				),
+				test.PVs(
+					builder.ForPersistentVolume("pv-1").Result(),
+					builder.ForPersistentVolume("pv-2").Result(),
+				),
+			},
+			actions: map[*recordResourcesIBA][]string{
+				new(recordResourcesIBA): {"ns-1/pod-1", "ns-2/pod-2", "pv-1", "pv-2"},
+			},
+		},
+		{
+			name: "single action with a resource selector for namespaced resources runs only for matching resources",
+			backup: defaultBackup().
+				Result(),
+			apiResources: []*test.APIResource{
+				test.Pods(
+					builder.ForPod("ns-1", "pod-1").Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+				),
+				test.PVs(
+					builder.ForPersistentVolume("pv-1").Result(),
+					builder.ForPersistentVolume("pv-2").Result(),
+				),
+			},
+			actions: map[*recordResourcesIBA][]string{
+				new(recordResourcesIBA).ForResource("pods"): {"ns-1/pod-1", "ns-2/pod-2"},
+			},
+		},
+		{
+			name: "single action with a resource selector for cluster-scoped resources runs only for matching resources",
+			backup: defaultBackup().
+				Result(),
+			apiResources: []*test.APIResource{
+				test.Pods(
+					builder.ForPod("ns-1", "pod-1").Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+				),
+				test.PVs(
+					builder.ForPersistentVolume("pv-1").Result(),
+					builder.ForPersistentVolume("pv-2").Result(),
+				),
+			},
+			actions: map[*recordResourcesIBA][]string{
+				new(recordResourcesIBA).ForResource("persistentvolumes"): {"pv-1", "pv-2"},
+			},
+		},
+		{
+			name: "single action with a namespace selector runs only for resources in that namespace",
+			backup: defaultBackup().
+				Result(),
+			apiResources: []*test.APIResource{
+				test.Pods(
+					builder.ForPod("ns-1", "pod-1").Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+				),
+				test.PVCs(
+					builder.ForPersistentVolumeClaim("ns-1", "pvc-1").Result(),
+					builder.ForPersistentVolumeClaim("ns-2", "pvc-2").Result(),
+				),
+				test.PVs(
+					builder.ForPersistentVolume("pv-1").Result(),
+					builder.ForPersistentVolume("pv-2").Result(),
+				),
+				test.Namespaces(
+					builder.ForNamespace("ns-1").Result(),
+					builder.ForNamespace("ns-2").Result(),
+				),
+			},
+			actions: map[*recordResourcesIBA][]string{
+				new(recordResourcesIBA).ForNamespace("ns-1"): {"ns-1/pod-1", "ns-1/pvc-1"},
+			},
+		},
+		{
+			name: "single action with a resource and namespace selector runs only for matching resources",
+			backup: defaultBackup().
+				Result(),
+			apiResources: []*test.APIResource{
+				test.Pods(
+					builder.ForPod("ns-1", "pod-1").Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+				),
+				test.PVs(
+					builder.ForPersistentVolume("pv-1").Result(),
+					builder.ForPersistentVolume("pv-2").Result(),
+				),
+			},
+			actions: map[*recordResourcesIBA][]string{
+				new(recordResourcesIBA).ForResource("pods").ForNamespace("ns-1"): {"ns-1/pod-1"},
+			},
+		},
+		{
+			name: "multiple actions, each with a different resource selector using short name, run for matching resources",
+			backup: defaultBackup().
+				Result(),
+			apiResources: []*test.APIResource{
+				test.Pods(
+					builder.ForPod("ns-1", "pod-1").Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+				),
+				test.PVs(
+					builder.ForPersistentVolume("pv-1").Result(),
+					builder.ForPersistentVolume("pv-2").Result(),
+				),
+			},
+			actions: map[*recordResourcesIBA][]string{
+				new(recordResourcesIBA).ForResource("po"): {"ns-1/pod-1", "ns-2/pod-2"},
+				new(recordResourcesIBA).ForResource("pv"): {"pv-1", "pv-2"},
+			},
+		},
+		{
+			name: "actions with selectors that don't match anything don't run for any resources",
+			backup: defaultBackup().
+				Result(),
+			apiResources: []*test.APIResource{
+				test.Pods(
+					builder.ForPod("ns-1", "pod-1").Result(),
+				),
+				test.PVCs(
+					builder.ForPersistentVolumeClaim("ns-2", "pvc-2").Result(),
+				),
+				test.PVs(
+					builder.ForPersistentVolume("pv-1").Result(),
+					builder.ForPersistentVolume("pv-2").Result(),
+				),
+			},
+			actions: map[*recordResourcesIBA][]string{
+				new(recordResourcesIBA).ForNamespace("ns-1").ForResource("persistentvolumeclaims"): nil,
+				new(recordResourcesIBA).ForNamespace("ns-2").ForResource("pods"):                   nil,
+			},
+		},
+		{
+			name: "action with a selector that has unresolvable resources doesn't run for any resources",
+			backup: defaultBackup().
+				Result(),
+			apiResources: []*test.APIResource{
+				test.Pods(
+					builder.ForPod("ns-1", "pod-1").Result(),
+				),
+				test.PVCs(
+					builder.ForPersistentVolumeClaim("ns-2", "pvc-2").Result(),
+				),
+				test.PVs(
+					builder.ForPersistentVolume("pv-1").Result(),
+					builder.ForPersistentVolume("pv-2").Result(),
+				),
+			},
+			actions: map[*recordResourcesIBA][]string{
+				new(recordResourcesIBA).ForResource("unresolvable"): nil,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				h   = newHarness(t)
+				req = &Request{
+					Backup:           tc.backup,
+					SkippedPVTracker: NewSkipPVTracker(),
+				}
+				backupFile = bytes.NewBuffer([]byte{})
+			)
+
+			for _, resource := range tc.apiResources {
+				h.addItems(t, resource)
+			}
+
+			actions := []ibav1.ItemBlockAction{}
+			for action := range tc.actions {
+				actions = append(actions, action)
+			}
+
+			err := h.backupper.Backup(h.log, req, backupFile, nil, actions, nil)
+			assert.NoError(t, err)
+
+			for action, want := range tc.actions {
+				assert.Equal(t, want, action.ids)
+			}
+		})
+	}
+}
+
+// TestBackupWithInvalidItemBlockActions runs backups with ItemBlock actions that are invalid
+// in some way (e.g. an invalid label selector returned from AppliesTo(), an error returned
+// from AppliesTo()) and verifies that this causes the backupper.Backup(...) method to
+// return an error.
+func TestBackupWithInvalidItemBlockActions(t *testing.T) {
+	// all test cases in this function are expected to cause the method under test
+	// to return an error, so no expected results need to be set up.
+	tests := []struct {
+		name         string
+		backup       *velerov1.Backup
+		apiResources []*test.APIResource
+		actions      []ibav1.ItemBlockAction
+	}{
+		{
+			name: "action with invalid label selector results in an error",
+			backup: defaultBackup().
+				Result(),
+			apiResources: []*test.APIResource{
+				test.Pods(
+					builder.ForPod("foo", "bar").Result(),
+					builder.ForPod("zoo", "raz").Result(),
+				),
+				test.PVs(
+					builder.ForPersistentVolume("bar").Result(),
+					builder.ForPersistentVolume("baz").Result(),
+				),
+			},
+			actions: []ibav1.ItemBlockAction{
+				new(recordResourcesIBA).ForLabelSelector("=invalid-selector"),
+			},
+		},
+		{
+			name: "action returning an error from AppliesTo results in an error",
+			backup: defaultBackup().
+				Result(),
+			apiResources: []*test.APIResource{
+				test.Pods(
+					builder.ForPod("foo", "bar").Result(),
+					builder.ForPod("zoo", "raz").Result(),
+				),
+				test.PVs(
+					builder.ForPersistentVolume("bar").Result(),
+					builder.ForPersistentVolume("baz").Result(),
+				),
+			},
+			actions: []ibav1.ItemBlockAction{
+				&appliesToErrorAction{},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				h   = newHarness(t)
+				req = &Request{
+					Backup:           tc.backup,
+					SkippedPVTracker: NewSkipPVTracker(),
+				}
+				backupFile = bytes.NewBuffer([]byte{})
+			)
+
+			for _, resource := range tc.apiResources {
+				h.addItems(t, resource)
+			}
+
+			assert.Error(t, h.backupper.Backup(h.log, req, backupFile, nil, tc.actions, nil))
+		})
+	}
+}
+
+// TestItemBlockActionRelatedItems runs backups with ItemBlock actions that return
+// related items, and verifies that those items are included in the
+// backup tarball as appropriate. Verification is done by looking at the files that exist
+// in the backup tarball.
+func TestItemBlockActionRelatedItems(t *testing.T) {
+	tests := []struct {
+		name         string
+		backup       *velerov1.Backup
+		apiResources []*test.APIResource
+		actions      []ibav1.ItemBlockAction
+		want         []string
+	}{
+		{
+			name:   "related items that are already being backed up are not backed up twice",
+			backup: defaultBackup().Result(),
+			apiResources: []*test.APIResource{
+				test.Pods(
+					builder.ForPod("ns-1", "pod-1").Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+					builder.ForPod("ns-3", "pod-3").Result(),
+				),
+			},
+			actions: []ibav1.ItemBlockAction{
+				&pluggableIBA{
+					selector: velero.ResourceSelector{IncludedNamespaces: []string{"ns-1"}},
+					getRelatedItemsFunc: func(item runtime.Unstructured, backup *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
+						relatedItems := []velero.ResourceIdentifier{
+							{GroupResource: kuberesource.Pods, Namespace: "ns-2", Name: "pod-2"},
+							{GroupResource: kuberesource.Pods, Namespace: "ns-3", Name: "pod-3"},
+						}
+
+						return relatedItems, nil
+					},
+				},
+			},
+			want: []string{
+				"resources/pods/namespaces/ns-1/pod-1.json",
+				"resources/pods/namespaces/ns-2/pod-2.json",
+				"resources/pods/namespaces/ns-3/pod-3.json",
+				"resources/pods/v1-preferredversion/namespaces/ns-1/pod-1.json",
+				"resources/pods/v1-preferredversion/namespaces/ns-2/pod-2.json",
+				"resources/pods/v1-preferredversion/namespaces/ns-3/pod-3.json",
+			},
+		},
+		{
+			name:   "when using a backup namespace filter, related items that are in a non-included namespace are not backed up",
+			backup: defaultBackup().IncludedNamespaces("ns-1").Result(),
+			apiResources: []*test.APIResource{
+				test.Pods(
+					builder.ForPod("ns-1", "pod-1").Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+					builder.ForPod("ns-3", "pod-3").Result(),
+				),
+			},
+			actions: []ibav1.ItemBlockAction{
+				&pluggableIBA{
+					getRelatedItemsFunc: func(item runtime.Unstructured, backup *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
+						relatedItems := []velero.ResourceIdentifier{
+							{GroupResource: kuberesource.Pods, Namespace: "ns-2", Name: "pod-2"},
+							{GroupResource: kuberesource.Pods, Namespace: "ns-3", Name: "pod-3"},
+						}
+
+						return relatedItems, nil
+					},
+				},
+			},
+			want: []string{
+				"resources/pods/namespaces/ns-1/pod-1.json",
+				"resources/pods/v1-preferredversion/namespaces/ns-1/pod-1.json",
+			},
+		},
+		{
+			name:   "when using a backup namespace filter, related items that are cluster-scoped are backed up",
+			backup: defaultBackup().IncludedNamespaces("ns-1").Result(),
+			apiResources: []*test.APIResource{
+				test.Pods(
+					builder.ForPod("ns-1", "pod-1").Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+				),
+				test.PVs(
+					builder.ForPersistentVolume("pv-1").Result(),
+					builder.ForPersistentVolume("pv-2").Result(),
+				),
+			},
+			actions: []ibav1.ItemBlockAction{
+				&pluggableIBA{
+					getRelatedItemsFunc: func(item runtime.Unstructured, backup *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
+						relatedItems := []velero.ResourceIdentifier{
+							{GroupResource: kuberesource.PersistentVolumes, Name: "pv-1"},
+							{GroupResource: kuberesource.PersistentVolumes, Name: "pv-2"},
+						}
+
+						return relatedItems, nil
+					},
+				},
+			},
+			want: []string{
+				"resources/pods/namespaces/ns-1/pod-1.json",
+				"resources/persistentvolumes/cluster/pv-1.json",
+				"resources/persistentvolumes/cluster/pv-2.json",
+				"resources/pods/v1-preferredversion/namespaces/ns-1/pod-1.json",
+				"resources/persistentvolumes/v1-preferredversion/cluster/pv-1.json",
+				"resources/persistentvolumes/v1-preferredversion/cluster/pv-2.json",
+			},
+		},
+		{
+			name:   "when using a backup resource filter, related items that are non-included resources are not backed up",
+			backup: defaultBackup().IncludedResources("pods").Result(),
+			apiResources: []*test.APIResource{
+				test.Pods(
+					builder.ForPod("ns-1", "pod-1").Result(),
+				),
+				test.PVs(
+					builder.ForPersistentVolume("pv-1").Result(),
+					builder.ForPersistentVolume("pv-2").Result(),
+				),
+			},
+			actions: []ibav1.ItemBlockAction{
+				&pluggableIBA{
+					getRelatedItemsFunc: func(item runtime.Unstructured, backup *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
+						relatedItems := []velero.ResourceIdentifier{
+							{GroupResource: kuberesource.PersistentVolumes, Name: "pv-1"},
+							{GroupResource: kuberesource.PersistentVolumes, Name: "pv-2"},
+						}
+
+						return relatedItems, nil
+					},
+				},
+			},
+			want: []string{
+				"resources/pods/namespaces/ns-1/pod-1.json",
+				"resources/pods/v1-preferredversion/namespaces/ns-1/pod-1.json",
+			},
+		},
+		{
+			name:   "when IncludeClusterResources=false, related items that are cluster-scoped are not backed up",
+			backup: defaultBackup().IncludeClusterResources(false).Result(),
+			apiResources: []*test.APIResource{
+				test.Pods(
+					builder.ForPod("ns-1", "pod-1").Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+				),
+				test.PVs(
+					builder.ForPersistentVolume("pv-1").Result(),
+					builder.ForPersistentVolume("pv-2").Result(),
+				),
+			},
+			actions: []ibav1.ItemBlockAction{
+				&pluggableIBA{
+					getRelatedItemsFunc: func(item runtime.Unstructured, backup *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
+						relatedItems := []velero.ResourceIdentifier{
+							{GroupResource: kuberesource.PersistentVolumes, Name: "pv-1"},
+							{GroupResource: kuberesource.PersistentVolumes, Name: "pv-2"},
+						}
+
+						return relatedItems, nil
+					},
+				},
+			},
+			want: []string{
+				"resources/pods/namespaces/ns-1/pod-1.json",
+				"resources/pods/namespaces/ns-2/pod-2.json",
+				"resources/pods/v1-preferredversion/namespaces/ns-1/pod-1.json",
+				"resources/pods/v1-preferredversion/namespaces/ns-2/pod-2.json",
+			},
+		},
+		{
+			name:   "related items with the velero.io/exclude-from-backup label are not backed up",
+			backup: defaultBackup().IncludedNamespaces("ns-1").Result(),
+			apiResources: []*test.APIResource{
+				test.Pods(
+					builder.ForPod("ns-1", "pod-1").Result(),
+				),
+				test.PVs(
+					builder.ForPersistentVolume("pv-1").ObjectMeta(builder.WithLabels(velerov1.ExcludeFromBackupLabel, "true")).Result(),
+					builder.ForPersistentVolume("pv-2").Result(),
+				),
+			},
+			actions: []ibav1.ItemBlockAction{
+				&pluggableIBA{
+					getRelatedItemsFunc: func(item runtime.Unstructured, backup *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
+						relatedItems := []velero.ResourceIdentifier{
+							{GroupResource: kuberesource.PersistentVolumes, Name: "pv-1"},
+							{GroupResource: kuberesource.PersistentVolumes, Name: "pv-2"},
+						}
+
+						return relatedItems, nil
+					},
+				},
+			},
+			want: []string{
+				"resources/pods/namespaces/ns-1/pod-1.json",
+				"resources/persistentvolumes/cluster/pv-2.json",
+				"resources/pods/v1-preferredversion/namespaces/ns-1/pod-1.json",
+				"resources/persistentvolumes/v1-preferredversion/cluster/pv-2.json",
+			},
+		},
+
+		{
+			name:   "if related items aren't found in the API, they're skipped and the original item is still backed up",
+			backup: defaultBackup().Result(),
+			apiResources: []*test.APIResource{
+				test.Pods(
+					builder.ForPod("ns-1", "pod-1").Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+					builder.ForPod("ns-3", "pod-3").Result(),
+				),
+			},
+			actions: []ibav1.ItemBlockAction{
+				&pluggableIBA{
+					selector: velero.ResourceSelector{IncludedNamespaces: []string{"ns-1"}},
+					getRelatedItemsFunc: func(item runtime.Unstructured, backup *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
+						relatedItems := []velero.ResourceIdentifier{
+							{GroupResource: kuberesource.Pods, Namespace: "ns-4", Name: "pod-4"},
+							{GroupResource: kuberesource.Pods, Namespace: "ns-5", Name: "pod-5"},
+						}
+
+						return relatedItems, nil
+					},
+				},
+			},
+			want: []string{
+				"resources/pods/namespaces/ns-1/pod-1.json",
+				"resources/pods/namespaces/ns-2/pod-2.json",
+				"resources/pods/namespaces/ns-3/pod-3.json",
+				"resources/pods/v1-preferredversion/namespaces/ns-1/pod-1.json",
+				"resources/pods/v1-preferredversion/namespaces/ns-2/pod-2.json",
+				"resources/pods/v1-preferredversion/namespaces/ns-3/pod-3.json",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				h   = newHarness(t)
+				req = &Request{
+					Backup:           tc.backup,
+					SkippedPVTracker: NewSkipPVTracker(),
+				}
+				backupFile = bytes.NewBuffer([]byte{})
+			)
+
+			for _, resource := range tc.apiResources {
+				h.addItems(t, resource)
+			}
+
+			err := h.backupper.Backup(h.log, req, backupFile, nil, tc.actions, nil)
 			assert.NoError(t, err)
 
 			assertTarballContents(t, backupFile, append(tc.want, "metadata/version")...)
@@ -2585,7 +3181,7 @@ func TestBackupWithSnapshots(t *testing.T) {
 				h.addItems(t, resource)
 			}
 
-			err := h.backupper.Backup(h.log, tc.req, backupFile, nil, tc.snapshotterGetter)
+			err := h.backupper.Backup(h.log, tc.req, backupFile, nil, nil, tc.snapshotterGetter)
 			assert.NoError(t, err)
 
 			assert.Equal(t, tc.want, tc.req.VolumeSnapshots)
@@ -2744,7 +3340,7 @@ func TestBackupWithAsyncOperations(t *testing.T) {
 				h.addItems(t, resource)
 			}
 
-			err := h.backupper.Backup(h.log, tc.req, backupFile, tc.actions, nil)
+			err := h.backupper.Backup(h.log, tc.req, backupFile, tc.actions, nil, nil)
 			assert.NoError(t, err)
 
 			resultOper := *tc.req.GetItemOperationsList()
@@ -2810,7 +3406,7 @@ func TestBackupWithInvalidHooks(t *testing.T) {
 				h.addItems(t, resource)
 			}
 
-			assert.EqualError(t, h.backupper.Backup(h.log, req, backupFile, nil, nil), tc.want.Error())
+			assert.EqualError(t, h.backupper.Backup(h.log, req, backupFile, nil, nil, nil), tc.want.Error())
 		})
 	}
 }
@@ -2832,8 +3428,10 @@ func TestBackupWithHooks(t *testing.T) {
 		name                       string
 		backup                     *velerov1.Backup
 		apiResources               []*test.APIResource
+		actions                    []ibav1.ItemBlockAction
 		wantExecutePodCommandCalls []*expectedCall
 		wantBackedUp               []string
+		wantHookExecutionLog       []test.HookExecutionEntry
 	}{
 		{
 			name: "pre hook with no resource filters runs for all pods",
@@ -2993,6 +3591,223 @@ func TestBackupWithHooks(t *testing.T) {
 			},
 		},
 		{
+			name: "pre and post hooks run for two pods sequentially by pods in different ItemBlocks",
+			backup: defaultBackup().
+				Hooks(velerov1.BackupHooks{
+					Resources: []velerov1.BackupResourceHookSpec{
+						{
+							Name: "hook-1",
+							PreHooks: []velerov1.BackupResourceHook{
+								{
+									Exec: &velerov1.ExecHook{
+										Command: []string{"pre"},
+									},
+								},
+							},
+							PostHooks: []velerov1.BackupResourceHook{
+								{
+									Exec: &velerov1.ExecHook{
+										Command: []string{"post"},
+									},
+								},
+							},
+						},
+					},
+				}).
+				Result(),
+			apiResources: []*test.APIResource{
+				test.Pods(
+					builder.ForPod("ns-1", "pod-1").Result(),
+					builder.ForPod("ns-1", "pod-2").Result(),
+				),
+			},
+			wantExecutePodCommandCalls: []*expectedCall{
+				{
+					podNamespace: "ns-1",
+					podName:      "pod-1",
+					hookName:     "hook-1",
+					hook: &velerov1.ExecHook{
+						Command: []string{"pre"},
+					},
+					err: nil,
+				},
+				{
+					podNamespace: "ns-1",
+					podName:      "pod-1",
+					hookName:     "hook-1",
+					hook: &velerov1.ExecHook{
+						Command: []string{"post"},
+					},
+					err: nil,
+				},
+				{
+					podNamespace: "ns-1",
+					podName:      "pod-2",
+					hookName:     "hook-1",
+					hook: &velerov1.ExecHook{
+						Command: []string{"pre"},
+					},
+					err: nil,
+				},
+				{
+					podNamespace: "ns-1",
+					podName:      "pod-2",
+					hookName:     "hook-1",
+					hook: &velerov1.ExecHook{
+						Command: []string{"post"},
+					},
+					err: nil,
+				},
+			},
+			wantHookExecutionLog: []test.HookExecutionEntry{
+				{
+					Namespace:   "ns-1",
+					Name:        "pod-1",
+					HookName:    "hook-1",
+					HookCommand: []string{"pre"},
+				},
+				{
+					Namespace:   "ns-1",
+					Name:        "pod-1",
+					HookName:    "hook-1",
+					HookCommand: []string{"post"},
+				},
+				{
+					Namespace:   "ns-1",
+					Name:        "pod-2",
+					HookName:    "hook-1",
+					HookCommand: []string{"pre"},
+				},
+				{
+					Namespace:   "ns-1",
+					Name:        "pod-2",
+					HookName:    "hook-1",
+					HookCommand: []string{"post"},
+				},
+			},
+			wantBackedUp: []string{
+				"resources/pods/namespaces/ns-1/pod-1.json",
+				"resources/pods/namespaces/ns-1/pod-2.json",
+				"resources/pods/v1-preferredversion/namespaces/ns-1/pod-1.json",
+				"resources/pods/v1-preferredversion/namespaces/ns-1/pod-2.json",
+			},
+		},
+		{
+			name: "both pre hooks run before both post hooks for pods in the same ItemBlock",
+			backup: defaultBackup().
+				Hooks(velerov1.BackupHooks{
+					Resources: []velerov1.BackupResourceHookSpec{
+						{
+							Name: "hook-1",
+							PreHooks: []velerov1.BackupResourceHook{
+								{
+									Exec: &velerov1.ExecHook{
+										Command: []string{"pre"},
+									},
+								},
+							},
+							PostHooks: []velerov1.BackupResourceHook{
+								{
+									Exec: &velerov1.ExecHook{
+										Command: []string{"post"},
+									},
+								},
+							},
+						},
+					},
+				}).
+				Result(),
+			apiResources: []*test.APIResource{
+				test.Pods(
+					builder.ForPod("ns-1", "pod-1").Result(),
+					builder.ForPod("ns-1", "pod-2").Result(),
+				),
+			},
+			actions: []ibav1.ItemBlockAction{
+				&pluggableIBA{
+					selector: velero.ResourceSelector{IncludedNamespaces: []string{"ns-1"}},
+					getRelatedItemsFunc: func(item runtime.Unstructured, backup *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
+						relatedItems := []velero.ResourceIdentifier{
+							{GroupResource: kuberesource.Pods, Namespace: "ns-1", Name: "pod-1"},
+							{GroupResource: kuberesource.Pods, Namespace: "ns-1", Name: "pod-2"},
+						}
+
+						return relatedItems, nil
+					},
+				},
+			},
+			wantExecutePodCommandCalls: []*expectedCall{
+				{
+					podNamespace: "ns-1",
+					podName:      "pod-1",
+					hookName:     "hook-1",
+					hook: &velerov1.ExecHook{
+						Command: []string{"pre"},
+					},
+					err: nil,
+				},
+				{
+					podNamespace: "ns-1",
+					podName:      "pod-1",
+					hookName:     "hook-1",
+					hook: &velerov1.ExecHook{
+						Command: []string{"post"},
+					},
+					err: nil,
+				},
+				{
+					podNamespace: "ns-1",
+					podName:      "pod-2",
+					hookName:     "hook-1",
+					hook: &velerov1.ExecHook{
+						Command: []string{"pre"},
+					},
+					err: nil,
+				},
+				{
+					podNamespace: "ns-1",
+					podName:      "pod-2",
+					hookName:     "hook-1",
+					hook: &velerov1.ExecHook{
+						Command: []string{"post"},
+					},
+					err: nil,
+				},
+			},
+			wantHookExecutionLog: []test.HookExecutionEntry{
+				{
+					Namespace:   "ns-1",
+					Name:        "pod-1",
+					HookName:    "hook-1",
+					HookCommand: []string{"pre"},
+				},
+				{
+					Namespace:   "ns-1",
+					Name:        "pod-2",
+					HookName:    "hook-1",
+					HookCommand: []string{"pre"},
+				},
+				{
+					Namespace:   "ns-1",
+					Name:        "pod-1",
+					HookName:    "hook-1",
+					HookCommand: []string{"post"},
+				},
+				{
+					Namespace:   "ns-1",
+					Name:        "pod-2",
+					HookName:    "hook-1",
+					HookCommand: []string{"post"},
+				},
+			},
+			wantBackedUp: []string{
+				"resources/pods/namespaces/ns-1/pod-1.json",
+				"resources/pods/namespaces/ns-1/pod-2.json",
+				"resources/pods/v1-preferredversion/namespaces/ns-1/pod-1.json",
+				"resources/pods/v1-preferredversion/namespaces/ns-1/pod-2.json",
+			},
+		},
+		{
 			name: "item is not backed up if hook returns an error when OnError=Fail",
 			backup: defaultBackup().
 				Hooks(velerov1.BackupHooks{
@@ -3076,8 +3891,11 @@ func TestBackupWithHooks(t *testing.T) {
 				h.addItems(t, resource)
 			}
 
-			require.NoError(t, h.backupper.Backup(h.log, req, backupFile, nil, nil))
+			require.NoError(t, h.backupper.Backup(h.log, req, backupFile, nil, tc.actions, nil))
 
+			if tc.wantHookExecutionLog != nil {
+				assert.Equal(t, tc.wantHookExecutionLog, podCommandExecutor.HookExecutionLog)
+			}
 			assertTarballContents(t, backupFile, append(tc.wantBackedUp, "metadata/version")...)
 		})
 	}
@@ -3267,7 +4085,7 @@ func TestBackupWithPodVolume(t *testing.T) {
 				h.addItems(t, resource)
 			}
 
-			require.NoError(t, h.backupper.Backup(h.log, req, backupFile, nil, tc.snapshotterGetter))
+			require.NoError(t, h.backupper.Backup(h.log, req, backupFile, nil, nil, tc.snapshotterGetter))
 
 			assert.Equal(t, tc.want, req.PodVolumeBackups)
 
@@ -3310,6 +4128,28 @@ func (a *pluggableAction) Cancel(operationID string, backup *velerov1.Backup) er
 }
 
 func (a *pluggableAction) Name() string {
+	return ""
+}
+
+// pluggableIBA is an ItemBlock action that can be plugged with GetRelatedItems function bodies at runtime.
+type pluggableIBA struct {
+	selector            velero.ResourceSelector
+	getRelatedItemsFunc func(runtime.Unstructured, *velerov1.Backup) ([]velero.ResourceIdentifier, error)
+}
+
+func (a *pluggableIBA) GetRelatedItems(item runtime.Unstructured, backup *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
+	if a.getRelatedItemsFunc == nil {
+		return nil, nil
+	}
+
+	return a.getRelatedItemsFunc(item, backup)
+}
+
+func (a *pluggableIBA) AppliesTo() (velero.ResourceSelector, error) {
+	return a.selector, nil
+}
+
+func (a *pluggableIBA) Name() string {
 	return ""
 }
 
@@ -4349,7 +5189,7 @@ func TestBackupNewResourceFiltering(t *testing.T) {
 				h.addItems(t, resource)
 			}
 
-			h.backupper.Backup(h.log, req, backupFile, tc.actions, nil)
+			h.backupper.Backup(h.log, req, backupFile, tc.actions, nil, nil)
 
 			assertTarballContents(t, backupFile, append(tc.want, "metadata/version")...)
 		})
@@ -4510,7 +5350,7 @@ func TestBackupNamespaces(t *testing.T) {
 				h.addItems(t, resource)
 			}
 
-			h.backupper.Backup(h.log, req, backupFile, nil, nil)
+			h.backupper.Backup(h.log, req, backupFile, nil, nil, nil)
 
 			assertTarballContents(t, backupFile, append(tc.want, "metadata/version")...)
 		})

--- a/pkg/backup/item_collector.go
+++ b/pkg/backup/item_collector.go
@@ -178,6 +178,8 @@ type kubernetesResource struct {
 	groupResource         schema.GroupResource
 	preferredGVR          schema.GroupVersionResource
 	namespace, name, path string
+	orderedResource       bool
+	inItemBlock           bool // set to true during backup processing when added to an ItemBlock
 }
 
 // getItemsFromResourceIdentifiers get the kubernetesResources
@@ -294,6 +296,7 @@ func sortResourcesByOrder(
 	// First select items from the order
 	for _, name := range order {
 		if item, ok := itemMap[name]; ok {
+			item.orderedResource = true
 			sortedItems = append(sortedItems, item)
 			log.Debugf("%s added to sorted resource list.", item.name)
 			delete(itemMap, name)

--- a/pkg/backup/item_collector_test.go
+++ b/pkg/backup/item_collector_test.go
@@ -65,13 +65,15 @@ func TestSortCoreGroup(t *testing.T) {
 func TestSortOrderedResource(t *testing.T) {
 	log := logrus.StandardLogger()
 	podResources := []*kubernetesResource{
+		{namespace: "ns1", name: "pod3"},
 		{namespace: "ns1", name: "pod1"},
 		{namespace: "ns1", name: "pod2"},
 	}
 	order := []string{"ns1/pod2", "ns1/pod1"}
 	expectedResources := []*kubernetesResource{
-		{namespace: "ns1", name: "pod2"},
-		{namespace: "ns1", name: "pod1"},
+		{namespace: "ns1", name: "pod2", orderedResource: true},
+		{namespace: "ns1", name: "pod1", orderedResource: true},
+		{namespace: "ns1", name: "pod3"},
 	}
 	sortedResources := sortResourcesByOrder(log, podResources, order)
 	assert.Equal(t, expectedResources, sortedResources)
@@ -80,11 +82,13 @@ func TestSortOrderedResource(t *testing.T) {
 	pvResources := []*kubernetesResource{
 		{name: "pv1"},
 		{name: "pv2"},
+		{name: "pv3"},
 	}
 	pvOrder := []string{"pv5", "pv2", "pv1"}
 	expectedPvResources := []*kubernetesResource{
-		{name: "pv2"},
-		{name: "pv1"},
+		{name: "pv2", orderedResource: true},
+		{name: "pv1", orderedResource: true},
+		{name: "pv3"},
 	}
 	sortedPvResources := sortResourcesByOrder(log, pvResources, pvOrder)
 	assert.Equal(t, expectedPvResources, sortedPvResources)

--- a/pkg/backup/itemblock.go
+++ b/pkg/backup/itemblock.go
@@ -1,0 +1,66 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backup
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/vmware-tanzu/velero/pkg/itemblock"
+)
+
+type BackupItemBlock struct {
+	itemblock.ItemBlock
+	// This is a reference to the  shared itemBackupper for the backup
+	itemBackupper *itemBackupper
+}
+
+func NewBackupItemBlock(log logrus.FieldLogger, itemBackupper *itemBackupper) *BackupItemBlock {
+	return &BackupItemBlock{
+		ItemBlock:     itemblock.ItemBlock{Log: log},
+		itemBackupper: itemBackupper,
+	}
+}
+
+func (b *BackupItemBlock) addKubernetesResource(item *kubernetesResource, log logrus.FieldLogger) *unstructured.Unstructured {
+	// no-op if item is already in a block
+	if item.inItemBlock {
+		return nil
+	}
+	var unstructured unstructured.Unstructured
+	item.inItemBlock = true
+
+	f, err := os.Open(item.path)
+	if err != nil {
+		log.WithError(errors.WithStack(err)).Error("Error opening file containing item")
+		return nil
+	}
+	defer f.Close()
+	defer os.Remove(f.Name())
+
+	if err := json.NewDecoder(f).Decode(&unstructured); err != nil {
+		log.WithError(errors.WithStack(err)).Error("Error decoding JSON from file")
+		return nil
+	}
+	log.Infof("adding %s %s/%s to ItemBlock", item.groupResource, item.namespace, item.name)
+	b.AddUnstructured(item.groupResource, &unstructured, item.preferredGVR)
+	return &unstructured
+}

--- a/pkg/backup/request.go
+++ b/pkg/backup/request.go
@@ -46,6 +46,7 @@ type Request struct {
 	ResourceIncludesExcludes  collections.IncludesExcludesInterface
 	ResourceHooks             []hook.ResourceHook
 	ResolvedActions           []framework.BackupItemResolvedActionV2
+	ResolvedItemBlockActions  []framework.ItemBlockResolvedAction
 	VolumeSnapshots           []*volume.Snapshot
 	PodVolumeBackups          []*velerov1api.PodVolumeBackup
 	BackedUpItems             map[itemKey]struct{}

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -618,6 +618,11 @@ func (b *backupReconciler) runBackup(backup *pkgbackup.Request) error {
 	if err != nil {
 		return err
 	}
+	backupLog.Info("Getting ItemBlock actions")
+	ibActions, err := pluginManager.GetItemBlockActions()
+	if err != nil {
+		return err
+	}
 	backupLog.Info("Setting up backup store to check for backup existence")
 	backupStore, err := b.backupStoreGetter.Get(backup.StorageLocation, pluginManager, backupLog)
 	if err != nil {
@@ -635,9 +640,10 @@ func (b *backupReconciler) runBackup(backup *pkgbackup.Request) error {
 	}
 
 	backupItemActionsResolver := framework.NewBackupItemActionResolverV2(actions)
+	itemBlockActionResolver := framework.NewItemBlockActionResolver(ibActions)
 
 	var fatalErrs []error
-	if err := b.backupper.BackupWithResolvers(backupLog, backup, backupFile, backupItemActionsResolver, pluginManager); err != nil {
+	if err := b.backupper.BackupWithResolvers(backupLog, backup, backupFile, backupItemActionsResolver, itemBlockActionResolver, pluginManager); err != nil {
 		fatalErrs = append(fatalErrs, err)
 	}
 

--- a/pkg/itemblock/itemblock.go
+++ b/pkg/itemblock/itemblock.go
@@ -1,0 +1,60 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package itemblock
+
+import (
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type ItemBlock struct {
+	Log   logrus.FieldLogger
+	Items []ItemBlockItem
+}
+
+type ItemBlockItem struct {
+	Gr           schema.GroupResource
+	Item         *unstructured.Unstructured
+	PreferredGVR schema.GroupVersionResource
+}
+
+func (ib *ItemBlock) AddUnstructured(gr schema.GroupResource, item *unstructured.Unstructured, preferredGVR schema.GroupVersionResource) {
+	ib.Items = append(ib.Items, ItemBlockItem{
+		Gr:           gr,
+		Item:         item,
+		PreferredGVR: preferredGVR,
+	})
+}
+
+// Could return multiple items if EnableAPIGroupVersions is set. The item matching the preferredGVR is returned first
+func (ib *ItemBlock) FindItem(gr schema.GroupResource, namespace, name string) []ItemBlockItem {
+	var itemList []ItemBlockItem
+	var returnList []ItemBlockItem
+
+	for _, item := range ib.Items {
+		if item.Gr == gr && item.Item != nil && item.Item.GetName() == name && item.Item.GetNamespace() == namespace {
+			itemGV, err := schema.ParseGroupVersion(item.Item.GetAPIVersion())
+			if err == nil && item.PreferredGVR.GroupVersion() == itemGV {
+				returnList = append(returnList, item)
+			} else {
+				itemList = append(itemList, item)
+			}
+		}
+	}
+	return append(returnList, itemList...)
+}

--- a/pkg/test/mock_pod_command_executor.go
+++ b/pkg/test/mock_pod_command_executor.go
@@ -24,9 +24,22 @@ import (
 
 type MockPodCommandExecutor struct {
 	mock.Mock
+	// hook execution order
+	HookExecutionLog []HookExecutionEntry
+}
+
+type HookExecutionEntry struct {
+	Namespace, Name, HookName string
+	HookCommand               []string
 }
 
 func (e *MockPodCommandExecutor) ExecutePodCommand(log logrus.FieldLogger, item map[string]interface{}, namespace, name, hookName string, hook *v1.ExecHook) error {
+	e.HookExecutionLog = append(e.HookExecutionLog, HookExecutionEntry{
+		Namespace:   namespace,
+		Name:        name,
+		HookName:    hookName,
+		HookCommand: hook.Command,
+	})
 	args := e.Called(log, item, namespace, name, hookName, hook)
 	return args.Error(0)
 }


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

This PR adds the ItemBlock model and introduces the workflow changes for (single-threaded) ItemBlock functionality. ItemBlocks are created based on:
1) ItemBlockAction plugins for an item which return other related items are placed in the same ItemBlock
2) OrderedResources in the backup spec (ordered resources for a particular GroupResource are placed in the same ItemBlock to guarantee their relative backup order)
3) Items of the same GroupResource+Namespace+Name but different APIVersions (only happens if EnableAPIGroupVersions feature flag is set) are placed in the same ItemBlock

ItemBlocks are then backed up together using the new kubernetesBackupper.backupItemBlock func which
1) runs pre hooks for any pods in the ItemBlock
2) calls BackupItem on each item in the ItemBlock
3) runs post hooks for any pods in the ItemBlock

This change does not yet introduce worker threads to back up ItemBlocks in parallel -- that is out of scope for Velero 1.15
# Does your change fix a particular issue?

Third PR for #7900

# Please indicate you've done the following:

- [ x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ x] Updated the corresponding documentation in `site/content/docs/main`.
