### PR TITLE
Add new-changelog to Makefile

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,5 +9,5 @@ Fixes #(issue)
 # Please indicate you've done the following:
 
 - [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
-- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
+- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
 - [ ] Updated the corresponding documentation in `site/content/docs/main`.

--- a/site/content/docs/main/code-standards.md
+++ b/site/content/docs/main/code-standards.md
@@ -38,6 +38,8 @@ changelog.
 
 Add that to the PR.
 
+A command to do this is `make new-changelog CHANGELOG_BODY="Changes you have made"`
+
 If a PR does not warrant a changelog, the CI check for a changelog can be skipped by applying a `changelog-not-required` label on the PR. If you are making a PR on a release branch, you should still make a new file in the `changelogs/unreleased` folder on the release branch for your change. 
 
 ## Copyright header


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Make it easier to create new changelog file correctly.

Example usage:

```
~/git/velero makefile-changelog*
❯ make new-changelog 
"Add new-changelog to Makefile" added to ./changelogs/unreleased/8104-kaovilai

~/git/velero makefile-changelog*
❯ make new-changelog CHANGELOG_BODY="Changes you have made" 
"Changes you have made" added to ./changelogs/unreleased/8104-kaovilai
```

# Does your change fix a particular issue?

Fixes #7865

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
