### PR TITLE
Remove code-generator from hack/update-3generated-crd.code.sh

### DIFF
--- a/hack/update-3generated-crd-code.sh
+++ b/hack/update-3generated-crd-code.sh
@@ -30,23 +30,6 @@ if ! command -v controller-gen > /dev/null; then
   exit 1
 fi
 
-# get code-generation tools (for now keep in GOPATH since they're not fully modules-compatible yet)
-mkdir -p ${GOPATH}/src/k8s.io
-pushd ${GOPATH}/src/k8s.io
-git clone -b v0.22.2 https://github.com/kubernetes/code-generator
-popd
-
-${GOPATH}/src/k8s.io/code-generator/generate-groups.sh \
-  all \
-  github.com/vmware-tanzu/velero/pkg/generated \
-  github.com/vmware-tanzu/velero/pkg/apis \
-  "velero:v1,v2alpha1" \
-  --go-header-file ./hack/boilerplate.go.txt \
-  --output-base ../../.. \
-  $@
-
-# Generate apiextensions.k8s.io/v1
-
 # Generate CRD for v1.
 controller-gen \
   crd:crdVersions=v1 \


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
The `pkg/generated` directory was deleted in PR #8114, but when running `make update` command, the `pkg/generated` directory is still created.
The reason is the `hack/update-3generated-crd.sh` runs the `code-generator`.
Remove the code-generator.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
