### PR TITLE
Modify E2E and perf test report generated directory

### DIFF
--- a/changelogs/unreleased/8129-blackpiglet
+++ b/changelogs/unreleased/8129-blackpiglet
@@ -1,0 +1,1 @@
+Modify E2E and perf test report generated directory

--- a/test/Makefile
+++ b/test/Makefile
@@ -167,7 +167,7 @@ run-e2e: ginkgo
 			(echo "Cloud provider for target cloud/plugin provider is required, please rerun with CLOUD_PROVIDER=<aws,azure,kind,vsphere>"; exit 1)
 	@$(GINKGO) run \
 		-v \
-		--junit-report report.xml \
+		--junit-report e2e/report.xml \
 		--label-filter="$(GINKGO_LABELS)" \
 		--timeout=5h \
 		./e2e \
@@ -207,7 +207,7 @@ run-perf: ginkgo
 			(echo "Cloud provider for target cloud/plugin provider is required, please rerun with CLOUD_PROVIDER=<aws,azure,kind,vsphere>"; exit 1)
 	@$(GINKGO) run \
 		-v \
-		--junit-report report.xml \
+		--junit-report perf/report.xml \
 		--label-filter="$(GINKGO_LABELS)" \
 		--timeout=5h \
 		./perf \

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -113,7 +113,7 @@ func init() {
 //   cases can be executed as expected successful result.
 
 var _ = Describe("Velero tests with various CRD API group versions",
-	Label("APIGroup", "APIVersion", "SKIP_KIND"), APIGroupVersionsTest)
+	Label("APIGroup", "APIVersion", "SKIP_KIND", "LongTime"), APIGroupVersionsTest)
 var _ = Describe("CRD of apiextentions v1beta1 should be B/R successfully from cluster(k8s version < 1.22) to cluster(k8s version >= 1.22)",
 	Label("APIGroup", "APIExtensions", "SKIP_KIND"), APIExtensionsVersionsTest)
 
@@ -197,9 +197,9 @@ var _ = Describe("Backups in object storage are synced to a new Velero and delet
 var _ = Describe("Backup will be created periodically by schedule defined by a Cron expression",
 	Label("Schedule", "BR", "Pause", "LongTime"), ScheduleBackupTest)
 var _ = Describe("Backup resources should follow the specific order in schedule",
-	Label("Schedule", "OrderedResources"), ScheduleOrderedResources)
+	Label("Schedule", "OrderedResources", "LongTime"), ScheduleOrderedResources)
 var _ = Describe("Schedule controller wouldn't create a new backup when it still has pending or InProgress backup",
-	Label("Schedule", "BackupCreation", "SKIP_KIND"), ScheduleBackupCreationTest)
+	Label("Schedule", "BackupCreation", "SKIP_KIND", "LongTime"), ScheduleBackupCreationTest)
 
 var _ = Describe("Velero test on ssr object when controller namespace mix-ups",
 	Label("PrivilegesMgmt", "SSR"), SSRTest)


### PR DESCRIPTION
Add LongTime label to more E2E cases.

Signed-off-by: Xun Jiang <xun.jiang@broadcom.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
