### PR TITLE
Apply backupPVCConfig to backupPod volume spec

### DIFF
--- a/changelogs/unreleased/8141-shubham-pampattiwar
+++ b/changelogs/unreleased/8141-shubham-pampattiwar
@@ -1,0 +1,1 @@
+Apply backupPVCConfig to backupPod volume spec

--- a/pkg/exposer/csi_snapshot.go
+++ b/pkg/exposer/csi_snapshot.go
@@ -435,7 +435,7 @@ func (e *csiSnapshotExposer) createBackupPod(ctx context.Context, ownerObject co
 	}
 
 	var gracePeriod int64 = 0
-	volumeMounts, volumeDevices, volumePath := kube.MakePodPVCAttachment(volumeName, backupPVC.Spec.VolumeMode)
+	volumeMounts, volumeDevices, volumePath := kube.MakePodPVCAttachment(volumeName, backupPVC.Spec.VolumeMode, true)
 	volumeMounts = append(volumeMounts, podInfo.volumeMounts...)
 
 	volumes := []corev1.Volume{{
@@ -443,6 +443,7 @@ func (e *csiSnapshotExposer) createBackupPod(ctx context.Context, ownerObject co
 		VolumeSource: corev1.VolumeSource{
 			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 				ClaimName: backupPVC.Name,
+				ReadOnly:  true,
 			},
 		},
 	}}

--- a/pkg/exposer/generic_restore.go
+++ b/pkg/exposer/generic_restore.go
@@ -310,7 +310,7 @@ func (e *genericRestoreExposer) createRestorePod(ctx context.Context, ownerObjec
 	}
 
 	var gracePeriod int64 = 0
-	volumeMounts, volumeDevices, volumePath := kube.MakePodPVCAttachment(volumeName, targetPVC.Spec.VolumeMode)
+	volumeMounts, volumeDevices, volumePath := kube.MakePodPVCAttachment(volumeName, targetPVC.Spec.VolumeMode, false)
 	volumeMounts = append(volumeMounts, podInfo.volumeMounts...)
 
 	volumes := []corev1.Volume{{

--- a/pkg/util/kube/pvc_pv.go
+++ b/pkg/util/kube/pvc_pv.go
@@ -346,7 +346,7 @@ func IsPVCBound(pvc *corev1api.PersistentVolumeClaim) bool {
 }
 
 // MakePodPVCAttachment returns the volume mounts and devices for a pod needed to attach a PVC
-func MakePodPVCAttachment(volumeName string, volumeMode *corev1api.PersistentVolumeMode) ([]corev1api.VolumeMount, []corev1api.VolumeDevice, string) {
+func MakePodPVCAttachment(volumeName string, volumeMode *corev1api.PersistentVolumeMode, readOnly bool) ([]corev1api.VolumeMount, []corev1api.VolumeDevice, string) {
 	var volumeMounts []corev1api.VolumeMount = nil
 	var volumeDevices []corev1api.VolumeDevice = nil
 	volumePath := "/" + volumeName
@@ -360,6 +360,7 @@ func MakePodPVCAttachment(volumeName string, volumeMode *corev1api.PersistentVol
 		volumeMounts = []corev1api.VolumeMount{{
 			Name:      volumeName,
 			MountPath: volumePath,
+			ReadOnly:  readOnly,
 		}}
 	}
 

--- a/pkg/util/kube/pvc_pv_test.go
+++ b/pkg/util/kube/pvc_pv_test.go
@@ -1386,6 +1386,7 @@ func TestMakePodPVCAttachment(t *testing.T) {
 		name                 string
 		volumeName           string
 		volumeMode           corev1api.PersistentVolumeMode
+		readOnly             bool
 		expectedVolumeMount  []corev1api.VolumeMount
 		expectedVolumeDevice []corev1api.VolumeDevice
 		expectedVolumePath   string
@@ -1393,10 +1394,12 @@ func TestMakePodPVCAttachment(t *testing.T) {
 		{
 			name:       "no volume mode specified",
 			volumeName: "volume-1",
+			readOnly:   true,
 			expectedVolumeMount: []corev1api.VolumeMount{
 				{
 					Name:      "volume-1",
 					MountPath: "/volume-1",
+					ReadOnly:  true,
 				},
 			},
 			expectedVolumePath: "/volume-1",
@@ -1405,10 +1408,12 @@ func TestMakePodPVCAttachment(t *testing.T) {
 			name:       "fs mode specified",
 			volumeName: "volume-2",
 			volumeMode: corev1api.PersistentVolumeFilesystem,
+			readOnly:   true,
 			expectedVolumeMount: []corev1api.VolumeMount{
 				{
 					Name:      "volume-2",
 					MountPath: "/volume-2",
+					ReadOnly:  true,
 				},
 			},
 			expectedVolumePath: "/volume-2",
@@ -1425,6 +1430,20 @@ func TestMakePodPVCAttachment(t *testing.T) {
 			},
 			expectedVolumePath: "/volume-3",
 		},
+		{
+			name:       "fs mode specified with readOnly as false",
+			volumeName: "volume-4",
+			readOnly:   false,
+			volumeMode: corev1api.PersistentVolumeFilesystem,
+			expectedVolumeMount: []corev1api.VolumeMount{
+				{
+					Name:      "volume-4",
+					MountPath: "/volume-4",
+					ReadOnly:  false,
+				},
+			},
+			expectedVolumePath: "/volume-4",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1434,11 +1453,14 @@ func TestMakePodPVCAttachment(t *testing.T) {
 				volMode = &tc.volumeMode
 			}
 
-			mount, device, path := MakePodPVCAttachment(tc.volumeName, volMode)
+			mount, device, path := MakePodPVCAttachment(tc.volumeName, volMode, tc.readOnly)
 
 			assert.Equal(t, tc.expectedVolumeMount, mount)
 			assert.Equal(t, tc.expectedVolumeDevice, device)
 			assert.Equal(t, tc.expectedVolumePath, path)
+			if tc.expectedVolumeMount != nil {
+				assert.Equal(t, tc.expectedVolumeMount[0].ReadOnly, tc.readOnly)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
- Modified `createBackupPod` function to accept backupPVCConfig and make changes wherever applicable to pod spec
     - Pod VolumeSource PVC
- Modified `MakePodPVCAttachment` to accept readOnly volume boolean and apply the flag to `PersistentVolumeFilesystem` type volumeMounts
- Added more unit tests to the csi exposer module 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
