### PR TITLE
Change base image to Debian-based distroless image with fewer vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN mkdir -p /output/usr/bin && \
     go clean -modcache -cache
 
 # Velero image packing section
-FROM paketobuildpacks/run-jammy-tiny:latest
+FROM gcr.io/distroless/base-debian12:latest
 
 LABEL maintainer="Xun Jiang <jxun@vmware.com>"
 


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Change base image to Debian-based distroless image with fewer vulnerabilities

Packages before (output from syft):
```
NAME             VERSION                   TYPE
base-files       12ubuntu4.6               deb
ca-certificates  20230311ubuntu0.22.04.1   deb
libc6            2.35-0ubuntu3.8           deb
libssl3          3.0.2-0ubuntu1.17         deb
netbase          6.3                       deb
openssl          3.0.2                     binary
openssl          3.0.2-0ubuntu1.17         deb
tzdata           2024a-0ubuntu0.22.04.1    deb
zlib1g           1:1.2.11.dfsg-2ubuntu9.2  deb
```

Packages after (output from syft):
```
NAME        VERSION           TYPE
base-files  12.4+deb12u6      deb
libc6       2.36-9+deb12u7    deb
libssl3     3.0.13-1~deb12u1  deb
netbase     6.4               deb
tzdata      2024a-0+deb12u1   deb
```

Closes the following high and critical vulnerabilities (output from grype):
```
openssl  3.0.2                        binary  CVE-2024-5535   Critical
openssl  3.0.2                        binary  CVE-2022-2068   Critical
openssl  3.0.2                        binary  CVE-2022-1292   Critical
openssl  3.0.2                        binary  CVE-2023-5363   High
openssl  3.0.2                        binary  CVE-2023-4807   High
openssl  3.0.2                        binary  CVE-2023-0464   High
openssl  3.0.2                        binary  CVE-2023-0401   High
openssl  3.0.2                        binary  CVE-2023-0286   High
openssl  3.0.2                        binary  CVE-2023-0217   High
openssl  3.0.2                        binary  CVE-2023-0216   High
openssl  3.0.2                        binary  CVE-2023-0215   High
openssl  3.0.2                        binary  CVE-2022-4450   High
openssl  3.0.2                        binary  CVE-2022-3996   High
openssl  3.0.2                        binary  CVE-2022-3786   High
openssl  3.0.2                        binary  CVE-2022-3602   High
openssl  3.0.2                        binary  CVE-2022-3358   High
openssl  3.0.2                        binary  CVE-2022-1473   High
```

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
