### PR TITLE
Enable --fail-fast by default for E2E and performance tests.

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -50,6 +50,10 @@ OUTPUT_DIR := _output/$(GOOS)/$(GOARCH)/bin
 # Please reference to this document for Ginkgo label spec format.
 # https://onsi.github.io/ginkgo/#spec-labels
 GINKGO_LABELS ?=
+# When --fail-fast is set, the entire suite will stop when the first failure occurs.
+# Enable --fail-fast by default.
+# https://onsi.github.io/ginkgo/#mental-model-how-ginkgo-handles-failure
+FAIL_FAST ?= true
 VELERO_CLI ?=$$(pwd)/../_output/bin/$(GOOS)/$(GOARCH)/velero
 VELERO_IMAGE ?= velero/velero:main
 PLUGINS ?=
@@ -170,6 +174,7 @@ run-e2e: ginkgo
 		--junit-report e2e/report.xml \
 		--label-filter="$(GINKGO_LABELS)" \
 		--timeout=5h \
+		--fail-fast=$(FAIL_FAST) \
 		./e2e \
 		-- $(COMMON_ARGS) \
 		--upgrade-from-velero-cli=$(UPGRADE_FROM_VELERO_CLI) \
@@ -210,6 +215,7 @@ run-perf: ginkgo
 		--junit-report perf/report.xml \
 		--label-filter="$(GINKGO_LABELS)" \
 		--timeout=5h \
+		--fail-fast=$(FAIL_FAST) \
 		./perf \
 		-- $(COMMON_ARGS) \
 		--nfs-server-path=$(NFS_SERVER_PATH) \


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #7883 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
