### PR TITLE
pkg/podvolume/backupper_test.go:597:14: the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak

### DIFF
--- a/pkg/podvolume/backupper_test.go
+++ b/pkg/podvolume/backupper_test.go
@@ -594,7 +594,10 @@ func (l *logHook) Fire(entry *logrus.Entry) error {
 }
 
 func TestWaitAllPodVolumesProcessed(t *testing.T) {
-	timeoutCtx, _ := context.WithTimeout(context.Background(), 1*time.Second)
+	timeoutCtx, cancelFunc := context.WithTimeout(context.Background(), 1*time.Second)
+	defer func() {
+		cancelFunc()
+	}()
 	cases := []struct {
 		name              string
 		ctx               context.Context


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
