### PR TITLE
Reduces ~140 indirect imports for plugin/framework importers

### DIFF
--- a/changelogs/unreleased/8208-kaovilai
+++ b/changelogs/unreleased/8208-kaovilai
@@ -1,0 +1,1 @@
+Reduces indirect imports for plugin/framework importers

--- a/pkg/cmd/server/config/config.go
+++ b/pkg/cmd/server/config/config.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/flag"
 	"github.com/vmware-tanzu/velero/pkg/constant"
-	"github.com/vmware-tanzu/velero/pkg/podvolume"
+	podvolumeconfigs "github.com/vmware-tanzu/velero/pkg/podvolume/configs"
 	"github.com/vmware-tanzu/velero/pkg/types"
 	"github.com/vmware-tanzu/velero/pkg/uploader"
 	"github.com/vmware-tanzu/velero/pkg/util/kube"
@@ -198,7 +198,7 @@ func GetDefaultConfig() *Config {
 		ResourceTerminatingTimeout:     defaultResourceTerminatingTimeout,
 		LogLevel:                       logging.LogLevelFlag(logrus.InfoLevel),
 		LogFormat:                      logging.NewFormatFlag(),
-		DefaultVolumesToFsBackup:       podvolume.DefaultVolumesToFsBackup,
+		DefaultVolumesToFsBackup:       podvolumeconfigs.DefaultVolumesToFsBackup,
 		UploaderType:                   uploader.ResticType,
 		MaxConcurrentK8SConnections:    defaultMaxConcurrentK8SConnections,
 		DefaultSnapshotMoveData:        false,

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -78,6 +78,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/podvolume"
 	"github.com/vmware-tanzu/velero/pkg/repository"
 	repokey "github.com/vmware-tanzu/velero/pkg/repository/keys"
+	repomanager "github.com/vmware-tanzu/velero/pkg/repository/manager"
 	"github.com/vmware-tanzu/velero/pkg/restore"
 	"github.com/vmware-tanzu/velero/pkg/uploader"
 	"github.com/vmware-tanzu/velero/pkg/util/filesystem"
@@ -147,7 +148,7 @@ type server struct {
 	logger                logrus.FieldLogger
 	logLevel              logrus.Level
 	pluginRegistry        process.Registry
-	repoManager           repository.Manager
+	repoManager           repomanager.Manager
 	repoLocker            *repository.RepoLocker
 	repoEnsurer           *repository.Ensurer
 	metrics               *metrics.ServerMetrics
@@ -469,7 +470,7 @@ func (s *server) initRepoManager() error {
 	s.repoLocker = repository.NewRepoLocker()
 	s.repoEnsurer = repository.NewEnsurer(s.mgr.GetClient(), s.logger, s.config.ResourceTimeout)
 
-	s.repoManager = repository.NewManager(
+	s.repoManager = repomanager.NewManager(
 		s.namespace,
 		s.mgr.GetClient(),
 		s.repoLocker,

--- a/pkg/controller/backup_deletion_controller_test.go
+++ b/pkg/controller/backup_deletion_controller_test.go
@@ -55,7 +55,9 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero/mocks"
 	"github.com/vmware-tanzu/velero/pkg/repository"
+	repomanager "github.com/vmware-tanzu/velero/pkg/repository/manager"
 	repomocks "github.com/vmware-tanzu/velero/pkg/repository/mocks"
+	repotypes "github.com/vmware-tanzu/velero/pkg/repository/types"
 	velerotest "github.com/vmware-tanzu/velero/pkg/test"
 )
 
@@ -698,13 +700,13 @@ func TestGetSnapshotsInBackup(t *testing.T) {
 	tests := []struct {
 		name                  string
 		podVolumeBackups      []velerov1api.PodVolumeBackup
-		expected              map[string][]repository.SnapshotIdentifier
+		expected              map[string][]repotypes.SnapshotIdentifier
 		longBackupNameEnabled bool
 	}{
 		{
 			name:             "no pod volume backups",
 			podVolumeBackups: nil,
-			expected:         map[string][]repository.SnapshotIdentifier{},
+			expected:         map[string][]repotypes.SnapshotIdentifier{},
 		},
 		{
 			name: "no pod volume backups with matching label",
@@ -724,7 +726,7 @@ func TestGetSnapshotsInBackup(t *testing.T) {
 					Status: velerov1api.PodVolumeBackupStatus{SnapshotID: "snap-2"},
 				},
 			},
-			expected: map[string][]repository.SnapshotIdentifier{},
+			expected: map[string][]repotypes.SnapshotIdentifier{},
 		},
 		{
 			name: "some pod volume backups with matching label",
@@ -765,7 +767,7 @@ func TestGetSnapshotsInBackup(t *testing.T) {
 					Status: velerov1api.PodVolumeBackupStatus{SnapshotID: ""},
 				},
 			},
-			expected: map[string][]repository.SnapshotIdentifier{
+			expected: map[string][]repotypes.SnapshotIdentifier{
 				"ns-1": {
 					{
 						VolumeNamespace: "ns-1",
@@ -820,7 +822,7 @@ func TestGetSnapshotsInBackup(t *testing.T) {
 					Status: velerov1api.PodVolumeBackupStatus{SnapshotID: ""},
 				},
 			},
-			expected: map[string][]repository.SnapshotIdentifier{
+			expected: map[string][]repotypes.SnapshotIdentifier{
 				"ns-1": {
 					{
 						VolumeNamespace: "ns-1",
@@ -856,18 +858,18 @@ func TestGetSnapshotsInBackup(t *testing.T) {
 	}
 }
 
-func batchDeleteSucceed(ctx context.Context, repoEnsurer *repository.Ensurer, repoMgr repository.Manager, directSnapshots map[string][]repository.SnapshotIdentifier, backup *velerov1api.Backup, logger logrus.FieldLogger) []error {
+func batchDeleteSucceed(ctx context.Context, repoEnsurer *repository.Ensurer, repoMgr repomanager.Manager, directSnapshots map[string][]repotypes.SnapshotIdentifier, backup *velerov1api.Backup, logger logrus.FieldLogger) []error {
 	return nil
 }
 
-func batchDeleteFail(ctx context.Context, repoEnsurer *repository.Ensurer, repoMgr repository.Manager, directSnapshots map[string][]repository.SnapshotIdentifier, backup *velerov1api.Backup, logger logrus.FieldLogger) []error {
+func batchDeleteFail(ctx context.Context, repoEnsurer *repository.Ensurer, repoMgr repomanager.Manager, directSnapshots map[string][]repotypes.SnapshotIdentifier, backup *velerov1api.Backup, logger logrus.FieldLogger) []error {
 	return []error{
 		errors.New("fake-delete-1"),
 		errors.New("fake-delete-2"),
 	}
 }
 
-func generateSnapshotData(snapshot *repository.SnapshotIdentifier) (map[string]string, error) {
+func generateSnapshotData(snapshot *repotypes.SnapshotIdentifier) (map[string]string, error) {
 	if snapshot == nil {
 		return nil, nil
 	}
@@ -888,10 +890,10 @@ func generateSnapshotData(snapshot *repository.SnapshotIdentifier) (map[string]s
 func TestDeleteMovedSnapshots(t *testing.T) {
 	tests := []struct {
 		name               string
-		repoMgr            repository.Manager
+		repoMgr            repomanager.Manager
 		batchDeleteSucceed bool
 		backupName         string
-		snapshots          []*repository.SnapshotIdentifier
+		snapshots          []*repotypes.SnapshotIdentifier
 		expected           []string
 	}{
 		{
@@ -905,14 +907,14 @@ func TestDeleteMovedSnapshots(t *testing.T) {
 			name:       "bad cm info",
 			repoMgr:    repomocks.NewManager(t),
 			backupName: "backup-01",
-			snapshots:  []*repository.SnapshotIdentifier{nil},
+			snapshots:  []*repotypes.SnapshotIdentifier{nil},
 			expected:   []string{"no snapshot info in config"},
 		},
 		{
 			name:       "invalid snapshots",
 			repoMgr:    repomocks.NewManager(t),
 			backupName: "backup-01",
-			snapshots: []*repository.SnapshotIdentifier{
+			snapshots: []*repotypes.SnapshotIdentifier{
 				{
 					RepositoryType:  "repo-1",
 					VolumeNamespace: "ns-1",
@@ -937,7 +939,7 @@ func TestDeleteMovedSnapshots(t *testing.T) {
 			name:       "batch delete succeed",
 			repoMgr:    repomocks.NewManager(t),
 			backupName: "backup-01",
-			snapshots: []*repository.SnapshotIdentifier{
+			snapshots: []*repotypes.SnapshotIdentifier{
 
 				{
 					SnapshotID:      "snapshot-1",
@@ -952,7 +954,7 @@ func TestDeleteMovedSnapshots(t *testing.T) {
 			name:       "batch delete fail",
 			repoMgr:    repomocks.NewManager(t),
 			backupName: "backup-01",
-			snapshots: []*repository.SnapshotIdentifier{
+			snapshots: []*repotypes.SnapshotIdentifier{
 				{
 					RepositoryType:  "repo-1",
 					VolumeNamespace: "ns-1",

--- a/pkg/controller/backup_repository_controller.go
+++ b/pkg/controller/backup_repository_controller.go
@@ -35,14 +35,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	corev1api "k8s.io/api/core/v1"
+
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/constant"
 	"github.com/vmware-tanzu/velero/pkg/label"
-	"github.com/vmware-tanzu/velero/pkg/repository"
 	repoconfig "github.com/vmware-tanzu/velero/pkg/repository/config"
+	repomanager "github.com/vmware-tanzu/velero/pkg/repository/manager"
 	"github.com/vmware-tanzu/velero/pkg/util/kube"
-
-	corev1api "k8s.io/api/core/v1"
 )
 
 const (
@@ -57,11 +57,11 @@ type BackupRepoReconciler struct {
 	clock                clocks.WithTickerAndDelayedExecution
 	maintenanceFrequency time.Duration
 	backupRepoConfig     string
-	repositoryManager    repository.Manager
+	repositoryManager    repomanager.Manager
 }
 
 func NewBackupRepoReconciler(namespace string, logger logrus.FieldLogger, client client.Client,
-	maintenanceFrequency time.Duration, backupRepoConfig string, repositoryManager repository.Manager) *BackupRepoReconciler {
+	maintenanceFrequency time.Duration, backupRepoConfig string, repositoryManager repomanager.Manager) *BackupRepoReconciler {
 	c := &BackupRepoReconciler{
 		client,
 		namespace,
@@ -294,7 +294,7 @@ func (r *BackupRepoReconciler) getRepositoryMaintenanceFrequency(req *velerov1ap
 
 // ensureRepo calls repo manager's PrepareRepo to ensure the repo is ready for use.
 // An error is returned if the repository can't be connected to or initialized.
-func ensureRepo(repo *velerov1api.BackupRepository, repoManager repository.Manager) error {
+func ensureRepo(repo *velerov1api.BackupRepository, repoManager repomanager.Manager) error {
 	return repoManager.PrepareRepo(repo)
 }
 

--- a/pkg/controller/backup_repository_controller_test.go
+++ b/pkg/controller/backup_repository_controller_test.go
@@ -28,8 +28,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
-	"github.com/vmware-tanzu/velero/pkg/repository"
 	repomokes "github.com/vmware-tanzu/velero/pkg/repository/mocks"
+	repotypes "github.com/vmware-tanzu/velero/pkg/repository/types"
 	velerotest "github.com/vmware-tanzu/velero/pkg/test"
 
 	clientFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -210,7 +210,7 @@ func TestBackupRepoReconcile(t *testing.T) {
 func TestGetRepositoryMaintenanceFrequency(t *testing.T) {
 	tests := []struct {
 		name            string
-		mgr             repository.Manager
+		mgr             repotypes.SnapshotIdentifier
 		repo            *velerov1api.BackupRepository
 		freqReturn      time.Duration
 		freqError       error

--- a/pkg/datamover/dataupload_delete_action.go
+++ b/pkg/datamover/dataupload_delete_action.go
@@ -15,7 +15,7 @@ import (
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	velerov2alpha1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v2alpha1"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
-	"github.com/vmware-tanzu/velero/pkg/repository"
+	repotypes "github.com/vmware-tanzu/velero/pkg/repository/types"
 )
 
 type DataUploadDeleteAction struct {
@@ -52,7 +52,7 @@ func genConfigmap(bak *velerov1.Backup, du velerov2alpha1.DataUpload) *corev1api
 	if !IsBuiltInUploader(du.Spec.DataMover) || du.Status.SnapshotID == "" {
 		return nil
 	}
-	snapshot := repository.SnapshotIdentifier{
+	snapshot := repotypes.SnapshotIdentifier{
 		VolumeNamespace:       du.Spec.SourceNamespace,
 		BackupStorageLocation: bak.Spec.StorageLocation,
 		SnapshotID:            du.Status.SnapshotID,

--- a/pkg/install/import_test.go
+++ b/pkg/install/import_test.go
@@ -1,0 +1,55 @@
+package install
+
+import (
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// test that this framework do not import cloud provider
+
+// Prevent https://github.com/vmware-tanzu/velero/issues/8207 and https://github.com/vmware-tanzu/velero/issues/8157
+func TestPkgImportNoCloudProvider(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatalf("No caller information")
+	}
+	t.Logf("Current test file path: %s", filename)
+	t.Logf("Current test directory: %s", filepath.Dir(filename)) // should be "pkg/install"
+	// go list -f {{.Deps}} ./pkg/install/
+	cmd := exec.Command(
+		"go",
+		"list",
+		"-f",
+		"{{.Deps}}",
+		".",
+	)
+	// set cmd.Dir to this package even if executed from different dir
+	cmd.Dir = filepath.Dir(filename)
+	output, err := cmd.Output()
+	require.NoError(t, err)
+	// split dep by line, replace space with newline
+	deps := strings.ReplaceAll(string(output), " ", "\n")
+	require.NotEmpty(t, deps)
+	// ignore k8s.io
+	k8sio, err := regexp.Compile("^k8s.io")
+	require.NoError(t, err)
+	cloudProvider, err := regexp.Compile("aws|gcp|azure")
+	require.NoError(t, err)
+	// depsArr :=[]string{}
+	cloudProviderDeps := []string{}
+	for _, dep := range strings.Split(deps, "\n") {
+		if !k8sio.MatchString(dep) {
+			// depsArr = append(depsArr, dep)
+			if cloudProvider.MatchString(dep) {
+				cloudProviderDeps = append(cloudProviderDeps, dep)
+			}
+		}
+	}
+	require.Empty(t, cloudProviderDeps)
+}

--- a/pkg/install/import_test.go
+++ b/pkg/install/import_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// test that this framework do not import cloud provider
+// test that this package do not import cloud provider
 
 // Prevent https://github.com/vmware-tanzu/velero/issues/8207 and https://github.com/vmware-tanzu/velero/issues/8157
 func TestPkgImportNoCloudProvider(t *testing.T) {
@@ -20,8 +20,8 @@ func TestPkgImportNoCloudProvider(t *testing.T) {
 		t.Fatalf("No caller information")
 	}
 	t.Logf("Current test file path: %s", filename)
-	t.Logf("Current test directory: %s", filepath.Dir(filename)) // should be "pkg/install"
-	// go list -f {{.Deps}} ./pkg/install/
+	t.Logf("Current test directory: %s", filepath.Dir(filename)) // should be this package name
+	// go list -f {{.Deps}} ./<path-to-this-package-dir>
 	cmd := exec.Command(
 		"go",
 		"list",
@@ -39,13 +39,11 @@ func TestPkgImportNoCloudProvider(t *testing.T) {
 	// ignore k8s.io
 	k8sio, err := regexp.Compile("^k8s.io")
 	require.NoError(t, err)
-	cloudProvider, err := regexp.Compile("aws|gcp|azure")
+	cloudProvider, err := regexp.Compile("aws|cloud.google.com|azure")
 	require.NoError(t, err)
-	// depsArr :=[]string{}
 	cloudProviderDeps := []string{}
 	for _, dep := range strings.Split(deps, "\n") {
 		if !k8sio.MatchString(dep) {
-			// depsArr = append(depsArr, dep)
 			if cloudProvider.MatchString(dep) {
 				cloudProviderDeps = append(cloudProviderDeps, dep)
 			}

--- a/pkg/plugin/framework/import_test.go
+++ b/pkg/plugin/framework/import_test.go
@@ -1,0 +1,55 @@
+package framework
+
+import (
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// test that this framework do not import cloud provider
+
+// Prevent https://github.com/vmware-tanzu/velero/issues/8207 and https://github.com/vmware-tanzu/velero/issues/8157
+func TestPkgImportNoCloudProvider(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatalf("No caller information")
+	}
+	t.Logf("Current test file path: %s", filename)
+	t.Logf("Current test directory: %s", filepath.Dir(filename)) // should be "pkg/install"
+	// go list -f {{.Deps}} ./pkg/install/
+	cmd := exec.Command(
+		"go",
+		"list",
+		"-f",
+		"{{.Deps}}",
+		".",
+	)
+	// set cmd.Dir to this package even if executed from different dir
+	cmd.Dir = filepath.Dir(filename)
+	output, err := cmd.Output()
+	require.NoError(t, err)
+	// split dep by line, replace space with newline
+	deps := strings.ReplaceAll(string(output), " ", "\n")
+	require.NotEmpty(t, deps)
+	// ignore k8s.io
+	k8sio, err := regexp.Compile("^k8s.io")
+	require.NoError(t, err)
+	cloudProvider, err := regexp.Compile("aws|gcp|azure")
+	require.NoError(t, err)
+	// depsArr :=[]string{}
+	cloudProviderDeps := []string{}
+	for _, dep := range strings.Split(deps, "\n") {
+		if !k8sio.MatchString(dep) {
+			// depsArr = append(depsArr, dep)
+			if cloudProvider.MatchString(dep) {
+				cloudProviderDeps = append(cloudProviderDeps, dep)
+			}
+		}
+	}
+	require.Empty(t, cloudProviderDeps)
+}

--- a/pkg/plugin/framework/import_test.go
+++ b/pkg/plugin/framework/import_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// test that this framework do not import cloud provider
+// test that this package do not import cloud provider
 
 // Prevent https://github.com/vmware-tanzu/velero/issues/8207 and https://github.com/vmware-tanzu/velero/issues/8157
 func TestPkgImportNoCloudProvider(t *testing.T) {
@@ -20,8 +20,8 @@ func TestPkgImportNoCloudProvider(t *testing.T) {
 		t.Fatalf("No caller information")
 	}
 	t.Logf("Current test file path: %s", filename)
-	t.Logf("Current test directory: %s", filepath.Dir(filename)) // should be "pkg/install"
-	// go list -f {{.Deps}} ./pkg/install/
+	t.Logf("Current test directory: %s", filepath.Dir(filename)) // should be this package name
+	// go list -f {{.Deps}} ./<path-to-this-package-dir>
 	cmd := exec.Command(
 		"go",
 		"list",
@@ -39,13 +39,11 @@ func TestPkgImportNoCloudProvider(t *testing.T) {
 	// ignore k8s.io
 	k8sio, err := regexp.Compile("^k8s.io")
 	require.NoError(t, err)
-	cloudProvider, err := regexp.Compile("aws|gcp|azure")
+	cloudProvider, err := regexp.Compile("aws|cloud.google.com|azure")
 	require.NoError(t, err)
-	// depsArr :=[]string{}
 	cloudProviderDeps := []string{}
 	for _, dep := range strings.Split(deps, "\n") {
 		if !k8sio.MatchString(dep) {
-			// depsArr = append(depsArr, dep)
 			if cloudProvider.MatchString(dep) {
 				cloudProviderDeps = append(cloudProviderDeps, dep)
 			}

--- a/pkg/podvolume/backupper.go
+++ b/pkg/podvolume/backupper.go
@@ -35,6 +35,7 @@ import (
 	veleroclient "github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/label"
 	"github.com/vmware-tanzu/velero/pkg/nodeagent"
+	"github.com/vmware-tanzu/velero/pkg/podvolume/configs"
 	"github.com/vmware-tanzu/velero/pkg/repository"
 	"github.com/vmware-tanzu/velero/pkg/uploader"
 	uploaderutil "github.com/vmware-tanzu/velero/pkg/uploader/util"
@@ -419,7 +420,7 @@ func newPodVolumeBackup(backup *velerov1api.Backup, pod *corev1api.Pod, volume c
 		// this annotation is used in pkg/restore to identify if a PVC
 		// has a pod volume backup.
 		pvb.Annotations = map[string]string{
-			PVCNameAnnotation: pvc.Name,
+			configs.PVCNameAnnotation: pvc.Name,
 		}
 
 		// this label is used by the pod volume backup controller to tell

--- a/pkg/podvolume/configs/configs.go
+++ b/pkg/podvolume/configs/configs.go
@@ -1,0 +1,11 @@
+package configs
+
+const (
+	// PVCNameAnnotation is the key for the annotation added to
+	// pod volume backups when they're for a PVC.
+	PVCNameAnnotation = "velero.io/pvc-name"
+
+	// DefaultVolumesToFsBackup specifies whether pod volume backup should be used, by default, to
+	// take backup of all pod volumes.
+	DefaultVolumesToFsBackup = false
+)

--- a/pkg/podvolume/util.go
+++ b/pkg/podvolume/util.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
-	"github.com/vmware-tanzu/velero/pkg/repository"
+	repotypes "github.com/vmware-tanzu/velero/pkg/repository/types"
 	"github.com/vmware-tanzu/velero/pkg/uploader"
 )
 
@@ -122,20 +122,20 @@ func getVolumeBackupInfoForPod(podVolumeBackups []*velerov1api.PodVolumeBackup, 
 }
 
 // GetSnapshotIdentifier returns the snapshots represented by SnapshotIdentifier for the given PVBs
-func GetSnapshotIdentifier(podVolumeBackups *velerov1api.PodVolumeBackupList) map[string][]repository.SnapshotIdentifier {
-	res := map[string][]repository.SnapshotIdentifier{}
+func GetSnapshotIdentifier(podVolumeBackups *velerov1api.PodVolumeBackupList) map[string][]repotypes.SnapshotIdentifier {
+	res := map[string][]repotypes.SnapshotIdentifier{}
 	for _, item := range podVolumeBackups.Items {
 		if item.Status.SnapshotID == "" {
 			continue
 		}
 
 		if res[item.Spec.Pod.Namespace] == nil {
-			res[item.Spec.Pod.Namespace] = []repository.SnapshotIdentifier{}
+			res[item.Spec.Pod.Namespace] = []repotypes.SnapshotIdentifier{}
 		}
 
 		snapshots := res[item.Spec.Pod.Namespace]
 
-		snapshots = append(snapshots, repository.SnapshotIdentifier{
+		snapshots = append(snapshots, repotypes.SnapshotIdentifier{
 			VolumeNamespace:       item.Spec.Pod.Namespace,
 			BackupStorageLocation: item.Spec.BackupStorageLocation,
 			SnapshotID:            item.Status.SnapshotID,

--- a/pkg/podvolume/util.go
+++ b/pkg/podvolume/util.go
@@ -28,18 +28,10 @@ import (
 )
 
 const (
-	// PVCNameAnnotation is the key for the annotation added to
-	// pod volume backups when they're for a PVC.
-	PVCNameAnnotation = "velero.io/pvc-name"
-
 	// Deprecated.
 	//
 	// TODO(2.0): remove
 	podAnnotationPrefix = "snapshot.velero.io/"
-
-	// DefaultVolumesToFsBackup specifies whether pod volume backup should be used, by default, to
-	// take backup of all pod volumes.
-	DefaultVolumesToFsBackup = false
 )
 
 // volumeBackupInfo describes the backup info of a volume backed up by PodVolumeBackups

--- a/pkg/repository/maintenance.go
+++ b/pkg/repository/maintenance.go
@@ -50,7 +50,7 @@ type JobConfigs struct {
 	PodResources *kube.PodResources `json:"podResources,omitempty"`
 }
 
-func generateJobName(repo string) string {
+func GenerateJobName(repo string) string {
 	millisecond := time.Now().UTC().UnixMilli() // millisecond
 
 	jobName := fmt.Sprintf("%s-maintain-job-%d", repo, millisecond)
@@ -61,8 +61,8 @@ func generateJobName(repo string) string {
 	return jobName
 }
 
-// deleteOldMaintenanceJobs deletes old maintenance jobs and keeps the latest N jobs
-func deleteOldMaintenanceJobs(cli client.Client, repo string, keep int) error {
+// DeleteOldMaintenanceJobs deletes old maintenance jobs and keeps the latest N jobs
+func DeleteOldMaintenanceJobs(cli client.Client, repo string, keep int) error {
 	// Get the maintenance job list by label
 	jobList := &batchv1.JobList{}
 	err := cli.List(context.TODO(), jobList, client.MatchingLabels(map[string]string{RepositoryNameLabel: repo}))
@@ -86,7 +86,7 @@ func deleteOldMaintenanceJobs(cli client.Client, repo string, keep int) error {
 	return nil
 }
 
-func waitForJobComplete(ctx context.Context, client client.Client, job *batchv1.Job) error {
+func WaitForJobComplete(ctx context.Context, client client.Client, job *batchv1.Job) error {
 	return wait.PollUntilContextCancel(ctx, 1, true, func(ctx context.Context) (bool, error) {
 		err := client.Get(ctx, types.NamespacedName{Namespace: job.Namespace, Name: job.Name}, job)
 		if err != nil && !apierrors.IsNotFound(err) {
@@ -104,7 +104,7 @@ func waitForJobComplete(ctx context.Context, client client.Client, job *batchv1.
 	})
 }
 
-func getMaintenanceResultFromJob(cli client.Client, job *batchv1.Job) (string, error) {
+func GetMaintenanceResultFromJob(cli client.Client, job *batchv1.Job) (string, error) {
 	// Get the maintenance job related pod by label selector
 	podList := &v1.PodList{}
 	err := cli.List(context.TODO(), podList, client.InNamespace(job.Namespace), client.MatchingLabels(map[string]string{"job-name": job.Name}))
@@ -120,7 +120,7 @@ func getMaintenanceResultFromJob(cli client.Client, job *batchv1.Job) (string, e
 	return podList.Items[0].Status.ContainerStatuses[0].State.Terminated.Message, nil
 }
 
-func getLatestMaintenanceJob(cli client.Client, ns string) (*batchv1.Job, error) {
+func GetLatestMaintenanceJob(cli client.Client, ns string) (*batchv1.Job, error) {
 	// Get the maintenance job list by label
 	jobList := &batchv1.JobList{}
 	err := cli.List(context.TODO(), jobList, &client.ListOptions{
@@ -145,7 +145,7 @@ func getLatestMaintenanceJob(cli client.Client, ns string) (*batchv1.Job, error)
 	return &jobList.Items[0], nil
 }
 
-// getMaintenanceJobConfig is called to get the Maintenance Job Config for the
+// GetMaintenanceJobConfig is called to get the Maintenance Job Config for the
 // BackupRepository specified by the repo parameter.
 //
 // Params:
@@ -156,7 +156,7 @@ func getLatestMaintenanceJob(cli client.Client, ns string) (*batchv1.Job, error)
 //	veleroNamespace: the Velero-installed namespace. It's used to retrieve the BackupRepository.
 //	repoMaintenanceJobConfig: the repository maintenance job ConfigMap name.
 //	repo: the BackupRepository needs to run the maintenance Job.
-func getMaintenanceJobConfig(
+func GetMaintenanceJobConfig(
 	ctx context.Context,
 	client client.Client,
 	logger logrus.FieldLogger,

--- a/pkg/repository/maintenance_test.go
+++ b/pkg/repository/maintenance_test.go
@@ -56,7 +56,7 @@ func TestGenerateJobName1(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.repo, func(t *testing.T) {
 			// Call the function to test
-			jobName := generateJobName(tc.repo)
+			jobName := GenerateJobName(tc.repo)
 
 			// Check if the generated job name starts with the expected prefix
 			if !strings.HasPrefix(jobName, tc.expectedStart) {
@@ -108,7 +108,7 @@ func TestDeleteOldMaintenanceJobs(t *testing.T) {
 	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
 
 	// Call the function
-	err := deleteOldMaintenanceJobs(cli, repo, keep)
+	err := DeleteOldMaintenanceJobs(cli, repo, keep)
 	assert.NoError(t, err)
 
 	// Get the remaining jobs
@@ -167,7 +167,7 @@ func TestWaitForJobComplete(t *testing.T) {
 			// Create a fake Kubernetes client
 			cli := fake.NewClientBuilder().WithObjects(job).Build()
 			// Call the function
-			err := waitForJobComplete(context.Background(), cli, job)
+			err := WaitForJobComplete(context.Background(), cli, job)
 
 			// Check if the error matches the expectation
 			if tc.expectError {
@@ -212,7 +212,7 @@ func TestGetMaintenanceResultFromJob(t *testing.T) {
 	cli := fake.NewClientBuilder().WithObjects(job, pod).Build()
 
 	// Call the function
-	result, err := getMaintenanceResultFromJob(cli, job)
+	result, err := GetMaintenanceResultFromJob(cli, job)
 
 	// Check if the result and error match the expectation
 	assert.NoError(t, err)
@@ -256,7 +256,7 @@ func TestGetLatestMaintenanceJob(t *testing.T) {
 	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
 
 	// Call the function
-	job, err := getLatestMaintenanceJob(cli, "default")
+	job, err := GetLatestMaintenanceJob(cli, "default")
 	assert.NoError(t, err)
 
 	// We expect the returned job to be the newer job
@@ -419,7 +419,7 @@ func TestGetMaintenanceJobConfig(t *testing.T) {
 				fakeClient = velerotest.NewFakeControllerRuntimeClient(t)
 			}
 
-			jobConfig, err := getMaintenanceJobConfig(
+			jobConfig, err := GetMaintenanceJobConfig(
 				ctx,
 				fakeClient,
 				logger,

--- a/pkg/repository/manager/manager_test.go
+++ b/pkg/repository/manager/manager_test.go
@@ -33,6 +33,7 @@ import (
 
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/repository"
 	"github.com/vmware-tanzu/velero/pkg/repository/provider"
 	"github.com/vmware-tanzu/velero/pkg/util/kube"
 	"github.com/vmware-tanzu/velero/pkg/util/logging"
@@ -63,7 +64,7 @@ func TestGetRepositoryProvider(t *testing.T) {
 func TestBuildMaintenanceJob(t *testing.T) {
 	testCases := []struct {
 		name            string
-		m               *JobConfigs
+		m               *repository.JobConfigs
 		deploy          *appsv1.Deployment
 		logLevel        logrus.Level
 		logFormat       *logging.FormatFlag
@@ -72,7 +73,7 @@ func TestBuildMaintenanceJob(t *testing.T) {
 	}{
 		{
 			name: "Valid maintenance job",
-			m: &JobConfigs{
+			m: &repository.JobConfigs{
 				PodResources: &kube.PodResources{
 					CPURequest:    "100m",
 					MemoryRequest: "128Mi",
@@ -105,7 +106,7 @@ func TestBuildMaintenanceJob(t *testing.T) {
 		},
 		{
 			name: "Error getting Velero server deployment",
-			m: &JobConfigs{
+			m: &repository.JobConfigs{
 				PodResources: &kube.PodResources{
 					CPURequest:    "100m",
 					MemoryRequest: "128Mi",
@@ -179,7 +180,7 @@ func TestBuildMaintenanceJob(t *testing.T) {
 				assert.NotNil(t, job)
 				assert.Contains(t, job.Name, tc.expectedJobName)
 				assert.Equal(t, param.BackupRepo.Namespace, job.Namespace)
-				assert.Equal(t, param.BackupRepo.Name, job.Labels[RepositoryNameLabel])
+				assert.Equal(t, param.BackupRepo.Name, job.Labels[repository.RepositoryNameLabel])
 
 				// Check container
 				assert.Len(t, job.Spec.Template.Spec.Containers, 1)

--- a/pkg/repository/types/snapshotidentifier.go
+++ b/pkg/repository/types/snapshotidentifier.go
@@ -1,0 +1,30 @@
+package types
+
+// SnapshotIdentifier uniquely identifies a snapshot
+// taken by Velero.
+type SnapshotIdentifier struct {
+	// VolumeNamespace is the namespace of the pod/volume that
+	// the snapshot is for.
+	VolumeNamespace string `json:"volumeNamespace"`
+
+	// BackupStorageLocation is the backup's storage location
+	// name.
+	BackupStorageLocation string `json:"backupStorageLocation"`
+
+	// SnapshotID is the short ID of the snapshot.
+	SnapshotID string `json:"snapshotID"`
+
+	// RepositoryType is the type of the repository where the
+	// snapshot is stored
+	RepositoryType string `json:"repositoryType"`
+
+	// Source is the source of the data saved in the repo by the snapshot
+	Source string `json:"source"`
+
+	// UploaderType is the type of uploader which saved the snapshot data
+	UploaderType string `json:"uploaderType"`
+
+	// RepoIdentifier is the identifier of the repository where the
+	// snapshot is stored
+	RepoIdentifier string `json:"repoIdentifier"`
+}

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -67,6 +67,7 @@ import (
 	vsv1 "github.com/vmware-tanzu/velero/pkg/plugin/velero/volumesnapshotter/v1"
 	"github.com/vmware-tanzu/velero/pkg/podexec"
 	"github.com/vmware-tanzu/velero/pkg/podvolume"
+	"github.com/vmware-tanzu/velero/pkg/podvolume/configs"
 	"github.com/vmware-tanzu/velero/pkg/types"
 	"github.com/vmware-tanzu/velero/pkg/util/boolptr"
 	"github.com/vmware-tanzu/velero/pkg/util/collections"
@@ -2020,7 +2021,7 @@ func hasPodVolumeBackup(unstructuredPV *unstructured.Unstructured, ctx *restoreC
 
 	var found bool
 	for _, pvb := range ctx.podVolumeBackups {
-		if pvb.Spec.Pod.Namespace == pv.Spec.ClaimRef.Namespace && pvb.GetAnnotations()[podvolume.PVCNameAnnotation] == pv.Spec.ClaimRef.Name {
+		if pvb.Spec.Pod.Namespace == pv.Spec.ClaimRef.Namespace && pvb.GetAnnotations()[configs.PVCNameAnnotation] == pv.Spec.ClaimRef.Name {
 			found = true
 			break
 		}


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Refactor struct imports to avoid framework importers from needing cloud provider imports.
Moving repository/manager.go to repository/manager/manager.go

This would help a ton with avoiding CVEs false alarms for unrelated plugin.

This change can supplement or replace https://github.com/vmware-tanzu/velero/pull/8180
# Does your change fix a particular issue?

Fixes #8207
Fixes #8157

Problem Demo: https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/pull/252/commits/7e31b61f9c7d009331d16c023887a41be377b4dd
Fix Demo: https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/pull/252/commits/64ea9027b7f2c4bd2ab95096811b0c21a9c25d75
Problem Demo2: https://github.com/kubevirt/kubevirt-velero-plugin/pull/284/commits/faf981584e8532b0ef9d2a73ec7679d7c77ad4fa
Fix Demo2: https://github.com/kubevirt/kubevirt-velero-plugin/pull/284/commits/2c0e171d44b446d9153abe9202caa27ebf0861fc
<details><summary>Before</summary>
<p>

```
❯ git fetch upstream && git checkout upstream/main && go list -f {{.Deps}} ./pkg/install/... | sed 's/ /\n/g' | grep -E 'aws|azure|gcp|s3'  
HEAD is now at 7c9b7c1ba Merge pull request #8144 from Lyndon-Li/data-mover-ms-doc
github.com/Azure/azure-sdk-for-go/sdk/azcore
github.com/Azure/azure-sdk-for-go/sdk/azcore/arm
github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/internal/resource
github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/policy
github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime
github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud
github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported
github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/log
github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/pollers
github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/pollers/async
github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/pollers/body
github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/pollers/fake
github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/pollers/loc
github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/pollers/op
github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared
github.com/Azure/azure-sdk-for-go/sdk/azcore/log
github.com/Azure/azure-sdk-for-go/sdk/azcore/policy
github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime
github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming
github.com/Azure/azure-sdk-for-go/sdk/azcore/to
github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing
github.com/Azure/azure-sdk-for-go/sdk/azidentity
github.com/Azure/azure-sdk-for-go/sdk/azidentity/internal
github.com/Azure/azure-sdk-for-go/sdk/internal/diag
github.com/Azure/azure-sdk-for-go/sdk/internal/errorinfo
github.com/Azure/azure-sdk-for-go/sdk/internal/exported
github.com/Azure/azure-sdk-for-go/sdk/internal/log
github.com/Azure/azure-sdk-for-go/sdk/internal/poller
github.com/Azure/azure-sdk-for-go/sdk/internal/temporal
github.com/Azure/azure-sdk-for-go/sdk/internal/uuid
github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage
github.com/Azure/azure-sdk-for-go/sdk/storage/azblob
github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/appendblob
github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob
github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror
github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob
github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container
github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/base
github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/exported
github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/generated
github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/shared
github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/pageblob
github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas
github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/service
github.com/aws/aws-sdk-go-v2/aws
github.com/aws/aws-sdk-go-v2/aws/arn
github.com/aws/aws-sdk-go-v2/aws/defaults
github.com/aws/aws-sdk-go-v2/aws/middleware
github.com/aws/aws-sdk-go-v2/aws/middleware/private/metrics
github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream
github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream/eventstreamapi
github.com/aws/aws-sdk-go-v2/aws/protocol/query
github.com/aws/aws-sdk-go-v2/aws/protocol/restjson
github.com/aws/aws-sdk-go-v2/aws/protocol/xml
github.com/aws/aws-sdk-go-v2/aws/ratelimit
github.com/aws/aws-sdk-go-v2/aws/retry
github.com/aws/aws-sdk-go-v2/aws/signer/internal/v4
github.com/aws/aws-sdk-go-v2/aws/signer/v4
github.com/aws/aws-sdk-go-v2/aws/transport/http
github.com/aws/aws-sdk-go-v2/config
github.com/aws/aws-sdk-go-v2/credentials
github.com/aws/aws-sdk-go-v2/credentials/ec2rolecreds
github.com/aws/aws-sdk-go-v2/credentials/endpointcreds
github.com/aws/aws-sdk-go-v2/credentials/endpointcreds/internal/client
github.com/aws/aws-sdk-go-v2/credentials/processcreds
github.com/aws/aws-sdk-go-v2/credentials/ssocreds
github.com/aws/aws-sdk-go-v2/credentials/stscreds
github.com/aws/aws-sdk-go-v2/feature/ec2/imds
github.com/aws/aws-sdk-go-v2/feature/ec2/imds/internal/config
github.com/aws/aws-sdk-go-v2/feature/s3/manager
github.com/aws/aws-sdk-go-v2/internal/auth
github.com/aws/aws-sdk-go-v2/internal/auth/smithy
github.com/aws/aws-sdk-go-v2/internal/awsutil
github.com/aws/aws-sdk-go-v2/internal/configsources
github.com/aws/aws-sdk-go-v2/internal/context
github.com/aws/aws-sdk-go-v2/internal/endpoints
github.com/aws/aws-sdk-go-v2/internal/endpoints/awsrulesfn
github.com/aws/aws-sdk-go-v2/internal/endpoints/v2
github.com/aws/aws-sdk-go-v2/internal/ini
github.com/aws/aws-sdk-go-v2/internal/rand
github.com/aws/aws-sdk-go-v2/internal/sdk
github.com/aws/aws-sdk-go-v2/internal/sdkio
github.com/aws/aws-sdk-go-v2/internal/shareddefaults
github.com/aws/aws-sdk-go-v2/internal/strings
github.com/aws/aws-sdk-go-v2/internal/sync/singleflight
github.com/aws/aws-sdk-go-v2/internal/timeconv
github.com/aws/aws-sdk-go-v2/internal/v4a
github.com/aws/aws-sdk-go-v2/internal/v4a/internal/crypto
github.com/aws/aws-sdk-go-v2/internal/v4a/internal/v4
github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding
github.com/aws/aws-sdk-go-v2/service/internal/checksum
github.com/aws/aws-sdk-go-v2/service/internal/presigned-url
github.com/aws/aws-sdk-go-v2/service/internal/s3shared
github.com/aws/aws-sdk-go-v2/service/internal/s3shared/arn
github.com/aws/aws-sdk-go-v2/service/internal/s3shared/config
github.com/aws/aws-sdk-go-v2/service/s3
github.com/aws/aws-sdk-go-v2/service/s3/internal/arn
github.com/aws/aws-sdk-go-v2/service/s3/internal/customizations
github.com/aws/aws-sdk-go-v2/service/s3/internal/endpoints
github.com/aws/aws-sdk-go-v2/service/s3/types
github.com/aws/aws-sdk-go-v2/service/sso
github.com/aws/aws-sdk-go-v2/service/sso/internal/endpoints
github.com/aws/aws-sdk-go-v2/service/sso/types
github.com/aws/aws-sdk-go-v2/service/ssooidc
github.com/aws/aws-sdk-go-v2/service/ssooidc/internal/endpoints
github.com/aws/aws-sdk-go-v2/service/ssooidc/types
github.com/aws/aws-sdk-go-v2/service/sts
github.com/aws/aws-sdk-go-v2/service/sts/internal/endpoints
github.com/aws/aws-sdk-go-v2/service/sts/types
github.com/aws/smithy-go
github.com/aws/smithy-go/auth
github.com/aws/smithy-go/auth/bearer
github.com/aws/smithy-go/container/private/cache
github.com/aws/smithy-go/container/private/cache/lru
github.com/aws/smithy-go/context
github.com/aws/smithy-go/document
github.com/aws/smithy-go/encoding
github.com/aws/smithy-go/encoding/httpbinding
github.com/aws/smithy-go/encoding/json
github.com/aws/smithy-go/encoding/xml
github.com/aws/smithy-go/endpoints
github.com/aws/smithy-go/endpoints/private/rulesfn
github.com/aws/smithy-go/internal/sync/singleflight
github.com/aws/smithy-go/io
github.com/aws/smithy-go/logging
github.com/aws/smithy-go/middleware
github.com/aws/smithy-go/private/requestcompression
github.com/aws/smithy-go/ptr
github.com/aws/smithy-go/rand
github.com/aws/smithy-go/sync
github.com/aws/smithy-go/time
github.com/aws/smithy-go/transport/http
github.com/aws/smithy-go/transport/http/internal/io
github.com/aws/smithy-go/waiter
github.com/kopia/kopia/repo/blob/azure
github.com/kopia/kopia/repo/blob/s3
github.com/minio/minio-go/v7/pkg/s3utils
github.com/vmware-tanzu/velero/pkg/repository/udmrepo/kopialib/backend/azure
github.com/vmware-tanzu/velero/pkg/util/azure
google.golang.org/grpc/credentials/alts/internal/proto/grpc_gcp
k8s.io/client-go/plugin/pkg/client/auth/azure
k8s.io/client-go/plugin/pkg/client/auth/gcp
```
</p>
</details> 

**After**
```
❯ go list -f {{.Deps}} ./pkg/install/... | sed 's/ /\n/g' | grep -E 'aws|azure|gcp|s3'  

k8s.io/client-go/plugin/pkg/client/auth/azure
k8s.io/client-go/plugin/pkg/client/auth/gcp
```

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.

Related: https://github.com/vmware-tanzu/velero/pull/6484
