### PR TITLE
Update design doc and site docs to reflect ItemBlock implementation

### DIFF
--- a/site/content/docs/main/backup-hooks.md
+++ b/site/content/docs/main/backup-hooks.md
@@ -13,6 +13,9 @@ processing ("pre" hooks), or after all custom actions have been completed and an
 specified by custom action have been backed up ("post" hooks). Note that hooks are _not_ executed within a shell
 on the containers.
 
+As of Velero 1.15, related items that must be backed up together are grouped into ItemBlocks, and pod hooks run before and after the ItemBlock is backed up.
+In particular, this means that if an ItemBlock contains more than one pod (such as in a scenario where an RWX volume is mounted by multiple pods), pre hooks are run for all pods in the ItemBlock, then the items are backed up, then all post hooks are run.
+
 There are two ways to specify hooks: annotations on the pod itself, and in the Backup spec.
 
 ### Specifying Hooks As Pod Annotations

--- a/site/content/docs/main/custom-plugins.md
+++ b/site/content/docs/main/custom-plugins.md
@@ -58,6 +58,7 @@ Velero supports the following kinds of plugins:
 - **Backup Item Action** - executes arbitrary logic for individual items prior to storing them in a backup file
 - **Restore Item Action** - executes arbitrary logic for individual items prior to restoring them into a cluster
 - **Delete Item Action** - executes arbitrary logic based on individual items within a backup prior to deleting the backup
+- **Item Block Action** - executes arbitrary logic for individual items to determine which items should be backed up together
 
 Plugin binaries are discovered by recursively reading a directory in no particular order. Hence no guarantee is provided for the
 order in which item action plugins are invoked. However, if a single binary implements multiple item action plugins,


### PR DESCRIPTION
Update design doc and site docs to reflect ItemBlock implementation

Note that for the existing velero plugin types, the site docs do not directly include field-by-field specifications. Instead, the user is linked to the velero-plugin-example repo for examples of each plugin type. Consistent with that, https://github.com/vmware-tanzu/velero-plugin-example/pull/74 should be considered a  companion PR to this one, which makes some minor updates to site docs and modifies the feature design doc to reflect changes made during phase 1 implementation.

# Please add a summary of your change
Note that for the existing velero plugin types, the site docs do not directly include field-by-field specifications. Instead, the user is linked to the velero-plugin-example repo for examples of each plugin type. Consistent with that, https://github.com/vmware-tanzu/velero-plugin-example/pull/74 should be considered a  companion PR to this one, which makes some minor updates to site docs and modifies the feature design doc to reflect changes made during phase 1 implementation.

# Does your change fix a particular issue?

Fixes #7900 

# Please indicate you've done the following:

- [ x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x ] Updated the corresponding documentation in `site/content/docs/main`.
