### PR TITLE
testifylint: enable and fix go-require rule

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -238,7 +238,6 @@ linters-settings:
   testifylint:
       # TODO: enable them all
       disable:
-        - go-require
         - float-compare
         - require-error
       enable-all: true

--- a/pkg/backup/actions/csi/pvc_action_test.go
+++ b/pkg/backup/actions/csi/pvc_action_test.go
@@ -27,6 +27,7 @@ import (
 	snapshotv1api "github.com/kubernetes-csi/external-snapshotter/client/v7/apis/volumesnapshot/v1"
 	v1 "github.com/kubernetes-csi/external-snapshotter/client/v7/apis/volumesnapshot/v1"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -176,7 +177,7 @@ func TestExecute(t *testing.T) {
 					err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 						err = pvcBIA.crClient.List(ctx, &vsList, &crclient.ListOptions{Namespace: tc.pvc.Namespace})
 
-						require.NoError(t, err)
+						assert.NoError(t, err)
 						if err != nil || len(vsList.Items) == 0 {
 							//lint:ignore nilerr reason
 							return false, nil // ignore
@@ -184,7 +185,7 @@ func TestExecute(t *testing.T) {
 						return true, nil
 					})
 
-					require.NoError(t, err)
+					assert.NoError(t, err)
 					vscName := "testVSC"
 					readyToUse := true
 					vsList.Items[0].Status = &v1.VolumeSnapshotStatus{
@@ -192,12 +193,12 @@ func TestExecute(t *testing.T) {
 						ReadyToUse:                     &readyToUse,
 					}
 					err = pvcBIA.crClient.Update(context.Background(), &vsList.Items[0])
-					require.NoError(t, err)
+					assert.NoError(t, err)
 
 					handleName := "testHandle"
 					vsc := builder.ForVolumeSnapshotContent("testVSC").Status(&snapshotv1api.VolumeSnapshotContentStatus{SnapshotHandle: &handleName}).Result()
 					err = pvcBIA.crClient.Create(context.Background(), vsc)
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}()
 			}
 

--- a/pkg/cmd/cli/backup/logs_test.go
+++ b/pkg/cmd/cli/backup/logs_test.go
@@ -136,7 +136,7 @@ func TestNewLogsCommand(t *testing.T) {
 		done := make(chan bool)
 		go func() {
 			err = l.Run(c, f)
-			require.Error(t, err)
+			assert.Error(t, err)
 		}()
 
 		select {


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

Enable and fixes [go-require](https://github.com/Antonboom/testifylint?tab=readme-ov-file#go-require) rule of [testifylint](https://github.com/Antonboom/testifylint) linter.

Also update golangci-lint version

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
