### PR TITLE
Ephemeral-storage documentation update for plugin requirements

### DIFF
--- a/site/content/docs/main/customize-installation.md
+++ b/site/content/docs/main/customize-installation.md
@@ -178,6 +178,12 @@ Additionally, you may want to update the the default File System Backup operatio
             - --fs-backup-timeout=240m
     ```
 
+### Ephemeral-storage Requests and Limits
+
+Velero does not set ephemeral-storage limits during installation. Limits and requests can be edited after install for clusters that monitor and restrict ephemeral-storage usage. 
+
+Plugins will use ephemeral-storage. There needs to be a sufficient requests and limit set to account for plugins and the additional ephemeral-storage used to maintain credentials and cache space for datamovers. Object storage plugins will fit comfortably into an allocation of 100MB of ephemeral-storage.
+
 ## Configure more than one storage location for backups or volume snapshots
 
 Velero supports any number of backup storage locations and volume snapshot locations. For more details, see [about locations](locations.md).

--- a/site/content/docs/v1.14/customize-installation.md
+++ b/site/content/docs/v1.14/customize-installation.md
@@ -178,6 +178,12 @@ Additionally, you may want to update the the default File System Backup operatio
             - --fs-backup-timeout=240m
     ```
 
+### Ephemeral-storage Requests and Limits
+
+Velero does not set ephemeral-storage limits during installation. Limits and requests can be edited after install for clusters that monitor and restrict ephemeral-storage usage. 
+
+Plugins will use ephemeral-storage. There needs to be a sufficient requests and limit set to account for plugins and the additional ephemeral-storage used to maintain credentials and cache space for datamovers. Object storage plugins will fit comfortably into an allocation of 100MB of ephemeral-storage.
+
 ## Configure more than one storage location for backups or volume snapshots
 
 Velero supports any number of backup storage locations and volume snapshot locations. For more details, see [about locations](locations.md).


### PR DESCRIPTION
# Please add a summary of your change

I hit an interesting issue with ephemeral-storage as of late with OCP 4.16. 

OCP and similar Kubernetes variations add ephemeral-storage to kubernetes resourceAllocations as options besides CPU and memory. Ignored in most Kubernetes clusters.

Previous versions of OCP did not notice ephemeral-storage usage from plugins as they are finished setting up in the container at startup time. As a result, ephemeral-storage could be set as low as limits of 25Mi or less. 

With new installs, ephemeral-storage violations on installation. And eventually tracked down the issue to the /plugins directory.

These estimates are based on current object storage providers. It is entirely possible some plugins will exceed the estimated 100MB per plugin, but this seems to a comfortable estimate at current for some of the more common plugins.

From our own testing of Velero 1.14.1 object storage plugins and a couple of item transformation plugins.

```
sh-5.1$ du -h plugins/*
63M     plugins/kubevirt-velero-plugin <--- kubevirt item transformation plugin
83M     plugins/velero-plugin-for-aws <--- Amazon AWS object storage and snapshotter plugin
62M     plugins/velero-plugin-for-gcp <--- Google Cloud object storage and snapshotter plugin
52M     plugins/velero-plugin-for-microsoft-azure <-- Microsoft Azure storage and snapshotter plugin
91M     plugins/velero-plugins <--- OpenShift item transformation plugin
sh-5.1$ du -h  plugins 
348M    plugins
```

# Does your change fix a particular issue?

Documentation for resolving ephemeral-storage plugin requirements seen in OpenShift 4.16 and any other Kubernetes cluster or environment that monitors and restricts ephemeral-storage usage.

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.


/kind changelog-not-required
