### PR TITLE
Issue 8249: disable selinux relabel for backupPod

### DIFF
--- a/pkg/exposer/csi_snapshot.go
+++ b/pkg/exposer/csi_snapshot.go
@@ -546,6 +546,9 @@ func (e *csiSnapshotExposer) createBackupPod(
 			RestartPolicy:                 corev1.RestartPolicyNever,
 			SecurityContext: &corev1.PodSecurityContext{
 				RunAsUser: &userID,
+				SELinuxOptions: &corev1.SELinuxOptions{
+					Type: "spc_t",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Fix issue #8249, disable selinux relabel for backupPod of data mover