### PR TITLE
Configure Node Agent DaemonSet for k0s

### DIFF
--- a/site/content/docs/main/file-system-backup.md
+++ b/site/content/docs/main/file-system-backup.md
@@ -78,7 +78,7 @@ backup which created the backup repository, then Velero will not be able to conn
 ### Configure Node Agent DaemonSet spec
 
 After installation, some PaaS/CaaS platforms based on Kubernetes also require modifications the node-agent DaemonSet spec. 
-The steps in this section are only needed if you are installing on RancherOS, Nutanix, OpenShift, VMware Tanzu Kubernetes Grid 
+The steps in this section are only needed if you are installing on RancherOS, k0s, Nutanix, OpenShift, VMware Tanzu Kubernetes Grid 
 Integrated Edition (formerly VMware Enterprise PKS), or Microsoft Azure.  
 
 
@@ -98,6 +98,25 @@ to
 ```yaml
 hostPath:
   path: /opt/rke/var/lib/kubelet/pods
+```
+
+
+**k0s**
+
+
+Update the host path for volumes in the node-agent DaemonSet in the Velero namespace from `/var/lib/kubelet/pods` to 
+`/var/lib/k0s/kubelet/pods/`.  
+
+```yaml
+hostPath:
+  path: /var/lib/kubelet/pods
+```
+
+to
+
+```yaml
+hostPath:
+  path: /var/lib/k0s/kubelet/pods/
 ```
 
 **Nutanix**


### PR DESCRIPTION
Like RancherOS, Nutanix, etc. k0s need to update the host path for volumes in the node-agent DaemonSet



# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
