### PR TITLE
Add configurable selinux options for datamover backup:

### DIFF
--- a/changelogs/unreleased/8255-sseago
+++ b/changelogs/unreleased/8255-sseago
@@ -1,0 +1,1 @@
+Add configurable selinux options for datamover backup

--- a/pkg/controller/data_upload_controller.go
+++ b/pkg/controller/data_upload_controller.go
@@ -76,6 +76,7 @@ type DataUploadReconciler struct {
 	podResources        corev1.ResourceRequirements
 	preparingTimeout    time.Duration
 	metrics             *metrics.ServerMetrics
+	selinuxDatamover    string
 }
 
 func NewDataUploadReconciler(
@@ -92,6 +93,7 @@ func NewDataUploadReconciler(
 	preparingTimeout time.Duration,
 	log logrus.FieldLogger,
 	metrics *metrics.ServerMetrics,
+	selinuxDatamover string,
 ) *DataUploadReconciler {
 	return &DataUploadReconciler{
 		client:            client,
@@ -114,6 +116,7 @@ func NewDataUploadReconciler(
 		podResources:     podResources,
 		preparingTimeout: preparingTimeout,
 		metrics:          metrics,
+		selinuxDatamover: selinuxDatamover,
 	}
 }
 
@@ -816,6 +819,7 @@ func (r *DataUploadReconciler) setupExposeParam(du *velerov2alpha1api.DataUpload
 			Affinity:         r.loadAffinity,
 			BackupPVCConfig:  r.backupPVCConfig,
 			Resources:        r.podResources,
+			SELinuxDatamover: r.selinuxDatamover,
 		}, nil
 	}
 	return nil, nil

--- a/pkg/controller/data_upload_controller_test.go
+++ b/pkg/controller/data_upload_controller_test.go
@@ -245,6 +245,7 @@ func initDataUploaderReconcilerWithError(needError ...error) (*DataUploadReconci
 		time.Minute*5,
 		velerotest.NewLogger(),
 		metrics.NewServerMetrics(),
+		"",
 	), nil
 }
 

--- a/pkg/exposer/types.go
+++ b/pkg/exposer/types.go
@@ -17,6 +17,9 @@ limitations under the License.
 package exposer
 
 import (
+	"fmt"
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -25,6 +28,9 @@ const (
 	AccessModeBlock      = "by-block-device"
 	podGroupLabel        = "velero.io/exposer-pod-group"
 	podGroupSnapshot     = "snapshot-exposer"
+	SELinuxNone          = "none"
+	SELinuxNoRelabeling  = "no-relabeling"
+	SELinuxNoReadOnly    = "no-readonly"
 )
 
 // ExposeResult defines the result of expose.
@@ -38,4 +44,15 @@ type ExposeByPod struct {
 	HostingPod       *corev1.Pod
 	HostingContainer string
 	VolumeName       string
+}
+
+// ValidateSelinuxDatamover validates if the input param is a valid SELinux approach for data mover.
+// It will return an error if it's invalid.
+func ValidateSELinuxDatamover(t string) error {
+	t = strings.TrimSpace(t)
+	if t != "" && t != SELinuxNone && t != SELinuxNoRelabeling && t != SELinuxNoReadOnly {
+		return fmt.Errorf("invalid SELinux datamover option '%s', valid options are: '%s', '%s', '%s'", t, SELinuxNone, SELinuxNoRelabeling, SELinuxNoReadOnly)
+	}
+
+	return nil
 }

--- a/pkg/install/daemonset.go
+++ b/pkg/install/daemonset.go
@@ -54,6 +54,10 @@ func DaemonSet(namespace string, opts ...podTemplateOption) *appsv1.DaemonSet {
 		daemonSetArgs = append(daemonSetArgs, fmt.Sprintf("--node-agent-configmap=%s", c.nodeAgentConfigMap))
 	}
 
+	if len(c.selinuxDatamover) > 0 {
+		daemonSetArgs = append(daemonSetArgs, fmt.Sprintf("--selinux-datamover=%s", c.selinuxDatamover))
+	}
+
 	userID := int64(0)
 	mountPropagationMode := corev1.MountPropagationHostToContainer
 

--- a/pkg/install/deployment.go
+++ b/pkg/install/deployment.go
@@ -57,6 +57,7 @@ type podTemplateConfig struct {
 	backupRepoConfigMap             string
 	repoMaintenanceJobConfigMap     string
 	nodeAgentConfigMap              string
+	selinuxDatamover                string
 }
 
 func WithImage(image string) podTemplateOption {
@@ -180,6 +181,12 @@ func WithPrivilegedNodeAgent(b bool) podTemplateOption {
 func WithNodeAgentConfigMap(nodeAgentConfigMap string) podTemplateOption {
 	return func(c *podTemplateConfig) {
 		c.nodeAgentConfigMap = nodeAgentConfigMap
+	}
+}
+
+func WithSELinuxDatamover(selinuxDatamover string) podTemplateOption {
+	return func(c *podTemplateConfig) {
+		c.selinuxDatamover = selinuxDatamover
 	}
 }
 

--- a/pkg/install/resources.go
+++ b/pkg/install/resources.go
@@ -267,6 +267,7 @@ type VeleroOptions struct {
 	BackupRepoConfigMap             string
 	RepoMaintenanceJobConfigMap     string
 	NodeAgentConfigMap              string
+	SELinuxDatamover                string
 }
 
 func AllCRDs() *unstructured.UnstructuredList {
@@ -410,6 +411,9 @@ func AllResources(o *VeleroOptions) *unstructured.UnstructuredList {
 		}
 		if len(o.NodeAgentConfigMap) > 0 {
 			dsOpts = append(dsOpts, WithNodeAgentConfigMap(o.NodeAgentConfigMap))
+		}
+		if len(o.SELinuxDatamover) > 0 {
+			dsOpts = append(dsOpts, WithSELinuxDatamover(o.SELinuxDatamover))
 		}
 
 		ds := DaemonSet(o.Namespace, dsOpts...)


### PR DESCRIPTION

Thank you for contributing to Velero!

# Please add a summary of your change
Current podified datamover fails on backup in clusters with SELinux enabled because the default relabeling behavior on volume mount fails for readonly volumes, and then SELinux prevents the pod user from accessing the `unlabeled_t` files.

This provides user-configurable options via a new installer and node-agent server flag `--selinux-datamover` to configure the behavior, since there is no one-size-fits-all solution. The three valid non-empty values for this flag are:

- none: no changes (won't work in SELinux environments). Default value if field is empty.
- no-relabeling: Sets securityContext.SELinuxOptions.Type=spc_t. Preferred configuration for SELinux with some performance improvements for volumes with many files, but won't work with Restricted pods.
- no-readonly: Removes volumes.volumeSource.PVC.ReadOnly=true. For SELinux environments where spc_t is not allowed, but may break shallow copy.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x ] Updated the corresponding documentation in `site/content/docs/main`.
