### PR TITLE
Expose VSC SourceVolumeMode

### DIFF
--- a/changelogs/unreleased/8261-msfrucht
+++ b/changelogs/unreleased/8261-msfrucht
@@ -1,0 +1,1 @@
+Expose VSC SourceVolumeMode

--- a/pkg/exposer/csi_snapshot.go
+++ b/pkg/exposer/csi_snapshot.go
@@ -368,6 +368,7 @@ func (e *csiSnapshotExposer) createBackupVSC(ctx context.Context, ownerObject co
 			DeletionPolicy:          snapshotv1api.VolumeSnapshotContentDelete,
 			Driver:                  snapshotVSC.Spec.Driver,
 			VolumeSnapshotClassName: snapshotVSC.Spec.VolumeSnapshotClassName,
+			SourceVolumeMode:        snapshotVSC.Spec.SourceVolumeMode,
 		},
 	}
 

--- a/pkg/exposer/csi_snapshot_test.go
+++ b/pkg/exposer/csi_snapshot_test.go
@@ -109,6 +109,7 @@ func TestExpose(t *testing.T) {
 	}
 
 	snapshotHandle := "fake-handle"
+	sourceVolumeMode := corev1.PersistentVolumeFilesystem
 	vscObj := &snapshotv1api.VolumeSnapshotContent{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: vscName,
@@ -121,6 +122,7 @@ func TestExpose(t *testing.T) {
 			DeletionPolicy:          snapshotv1api.VolumeSnapshotContentDelete,
 			Driver:                  "fake-driver",
 			VolumeSnapshotClassName: &snapshotClass,
+			SourceVolumeMode:        &sourceVolumeMode,
 		},
 		Status: &snapshotv1api.VolumeSnapshotContentStatus{
 			RestoreSize:    &restoreSize,
@@ -522,6 +524,7 @@ func TestExpose(t *testing.T) {
 				assert.Equal(t, expectedVSC.Spec.DeletionPolicy, vscObj.Spec.DeletionPolicy)
 				assert.Equal(t, expectedVSC.Spec.Driver, vscObj.Spec.Driver)
 				assert.Equal(t, *expectedVSC.Spec.VolumeSnapshotClassName, *vscObj.Spec.VolumeSnapshotClassName)
+				assert.Equal(t, *expectedVSC.Spec.SourceVolumeMode, *vscObj.Spec.SourceVolumeMode)
 
 				if test.expectedVolumeSize != nil {
 					assert.Equal(t, *test.expectedVolumeSize, backupPVC.Spec.Resources.Requests[corev1.ResourceStorage])


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Copies the VolumeSnapshotContent SourceVolumeMode during DataUpload. Recent versions of the snapshot-controller do not allow the field to be changed from "Filesystem" or "Block" to nil resulting in a failure to move the VolumeSnapshot into the local namespace.

This was found in Kubernetes 1.29/OpenShift 4.16

@shubham-pampattiwar identified the underlying source of the behavior changes to https://kubernetes.io/blog/2024/04/30/prevent-unauthorized-volume-mode-conversion-ga/ and shows up in external-provisioner v4.0.0 and external-snapshotter v7.0.0.

This field is typically nil to begin with in other environments which doesn't trigger this error.

# Does your change fix a particular issue?
https://github.com/vmware-tanzu/velero/issues/8259

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
