### PR TITLE
fix(pkg/repository/maintenance): handle when there's no container status

### DIFF
--- a/changelogs/unreleased/8271-mcluseau
+++ b/changelogs/unreleased/8271-mcluseau
@@ -1,0 +1,1 @@
+fix(pkg/repository/maintenance): don't panic when there's no container statuses


### PR DESCRIPTION
Fixes a crash in this case.

```
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0

goroutine 562 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:116 +0x1e5
panic({0x2ae2cc0?, 0xc001a084b0?})
	/usr/local/go/src/runtime/panic.go:770 +0x132
github.com/vmware-tanzu/velero/pkg/repository.GetMaintenanceResultFromJob({0x318cd00, 0xc0009be3f0}, 0xc0025ae508)
	/go/src/github.com/vmware-tanzu/velero/pkg/repository/maintenance.go:120 +0x229
```
