### PR TITLE
Use '"' rather than '`' in the log to avoid unexpected new line

### DIFF
--- a/pkg/backup/item_collector.go
+++ b/pkg/backup/item_collector.go
@@ -116,8 +116,7 @@ func (nt *nsTracker) init(
 	for _, namespace := range unstructuredNSs {
 		if nt.singleLabelSelector != nil &&
 			nt.singleLabelSelector.Matches(labels.Set(namespace.GetLabels())) {
-			nt.logger.Debugf(`Track namespace %s, 
-				because its labels match backup LabelSelector.`,
+			nt.logger.Debugf("Track namespace %s, because its labels match backup LabelSelector.",
 				namespace.GetName(),
 			)
 
@@ -128,8 +127,7 @@ func (nt *nsTracker) init(
 		if len(nt.orLabelSelector) > 0 {
 			for _, selector := range nt.orLabelSelector {
 				if selector.Matches(labels.Set(namespace.GetLabels())) {
-					nt.logger.Debugf(`Track namespace %s",
-						"because its labels match the backup OrLabelSelector.`,
+					nt.logger.Debugf("Track namespace %s, because its labels match the backup OrLabelSelector.",
 						namespace.GetName(),
 					)
 					nt.track(namespace.GetName())
@@ -148,8 +146,7 @@ func (nt *nsTracker) init(
 		}
 
 		if nt.namespaceFilter.ShouldInclude(namespace.GetName()) {
-			nt.logger.Debugf(`Track namespace %s,
-				because its name match the backup namespace filter.`,
+			nt.logger.Debugf("Track namespace %s, because its name match the backup namespace filter.",
 				namespace.GetName(),
 			)
 			nt.track(namespace.GetName())

--- a/pkg/util/csi/volume_snapshot.go
+++ b/pkg/util/csi/volume_snapshot.go
@@ -424,8 +424,7 @@ func GetVolumeSnapshotClassForStorageClass(
 		return &vsClass, nil
 	}
 	return nil, fmt.Errorf(
-		`failed to get VolumeSnapshotClass for provisioner %s, 
-		ensure that the desired VolumeSnapshot class has the %s label`,
+		"failed to get VolumeSnapshotClass for provisioner %s, ensure that the desired VolumeSnapshot class has the %s label",
 		provisioner, velerov1api.VolumeSnapshotClassSelectorLabel)
 }
 


### PR DESCRIPTION
Use '"' rather than '`' in the log to avoid unexpected new line

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
