### PR TITLE
add no-relabeling option to backupPVC configmap

### DIFF
--- a/changelogs/unreleased/8288-sseago
+++ b/changelogs/unreleased/8288-sseago
@@ -1,0 +1,1 @@
+add no-relabeling option to backupPVC configmap

--- a/pkg/nodeagent/node_agent.go
+++ b/pkg/nodeagent/node_agent.go
@@ -68,6 +68,10 @@ type BackupPVC struct {
 
 	// ReadOnly sets the backupPVC's access mode as read only
 	ReadOnly bool `json:"readOnly,omitempty"`
+
+	// SPCNoRelabeling sets Spec.SecurityContext.SELinux.Type to "spc_t" for the pod mounting the backupPVC
+	// ignored if ReadOnly is false
+	SPCNoRelabeling bool `json:"spcNoRelabeling,omitempty"`
 }
 
 type Configs struct {


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
The previous SELinux fix handled podified datamover problems for users who are not setting the readOnly field for their storageclass. When the readOnly field is set (needed for ceph shallow copy), SELinux relabeling can't happen, so datamover backup will fail. This fix adds the `spc_t` SELinux option in cases when users set this field in the backupPVC configmap. This should only be needed for storageclasses that are already setting `readOnly=true`, so a new map key won't be needed, just a new value in the struct.

```json
{
    "backupPVC": {
        "storage-class-1": {
            "readOnly": true,
            "spcNoRelabeling": true
        }
    }
}
```


# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x ] Updated the corresponding documentation in `site/content/docs/main`.
