### PR TITLE
Fix the context choosing error after migration case.

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -53,7 +53,7 @@ GINKGO_LABELS ?=
 # When --fail-fast is set, the entire suite will stop when the first failure occurs.
 # Enable --fail-fast by default.
 # https://onsi.github.io/ginkgo/#mental-model-how-ginkgo-handles-failure
-FAIL_FAST ?= true
+FAIL_FAST ?= false
 VELERO_CLI ?=$$(pwd)/../_output/bin/$(GOOS)/$(GOARCH)/velero
 VELERO_IMAGE ?= velero/velero:main
 PLUGINS ?=

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -233,7 +233,7 @@ var _ = Describe("Velero test on parallel files upload",
 var _ = Describe("Velero test on parallel files download",
 	Label("UploaderConfig", "ParallelFilesDownload"), ParallelFilesDownloadTest)
 
-func GetKubeconfigContext() error {
+func GetKubeConfigContext() error {
 	var err error
 	var tcDefault, tcStandby TestClient
 	tcDefault, err = NewTestClient(VeleroCfg.DefaultClusterContext)
@@ -287,7 +287,7 @@ func TestE2e(t *testing.T) {
 	}
 
 	var err error
-	if err = GetKubeconfigContext(); err != nil {
+	if err = GetKubeConfigContext(); err != nil {
 		fmt.Println(err)
 		t.FailNow()
 	}

--- a/test/e2e/migration/migration.go
+++ b/test/e2e/migration/migration.go
@@ -81,12 +81,6 @@ func MigrationTest(useVolumeSnapshots bool, veleroCLI2Version VeleroCLI2Version)
 		}
 	})
 	AfterEach(func() {
-		By(fmt.Sprintf("Switch to default kubeconfig context %s", veleroCfg.DefaultClusterContext), func() {
-			Expect(KubectlConfigUseContext(context.Background(), veleroCfg.DefaultClusterContext)).To(Succeed())
-			veleroCfg.ClientToInstallVelero = veleroCfg.DefaultClient
-			veleroCfg.ClusterToInstallVelero = veleroCfg.DefaultClusterName
-		})
-
 		if CurrentSpecReport().Failed() && veleroCfg.FailFast {
 			fmt.Println("Test case failed and fail fast is enabled. Skip resource clean up.")
 		} else {
@@ -113,6 +107,12 @@ func MigrationTest(useVolumeSnapshots bool, veleroCLI2Version VeleroCLI2Version)
 					DeleteNamespace(context.Background(), *veleroCfg.StandbyClient, migrationNamespace, true)
 				})
 			}
+
+			By(fmt.Sprintf("Switch to default kubeconfig context %s", veleroCfg.DefaultClusterContext), func() {
+				Expect(KubectlConfigUseContext(context.Background(), veleroCfg.DefaultClusterContext)).To(Succeed())
+				veleroCfg.ClientToInstallVelero = veleroCfg.DefaultClient
+				veleroCfg.ClusterToInstallVelero = veleroCfg.DefaultClusterName
+			})
 		}
 	})
 	When("kibishii is the sample workload", func() {


### PR DESCRIPTION
Try to use the normal import way in ginkgo tests.
Change the FAIL_FAST default value to false.

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
