### PR TITLE
Revert "Expose VSC SourceVolumeMode" 1.14

### DIFF
--- a/changelogs/unreleased/8280-msfrucht
+++ b/changelogs/unreleased/8280-msfrucht
@@ -1,1 +1,0 @@
-Expose VSC SourceVolumeMode

--- a/pkg/exposer/csi_snapshot.go
+++ b/pkg/exposer/csi_snapshot.go
@@ -332,7 +332,6 @@ func (e *csiSnapshotExposer) createBackupVSC(ctx context.Context, ownerObject co
 			DeletionPolicy:          snapshotv1api.VolumeSnapshotContentDelete,
 			Driver:                  snapshotVSC.Spec.Driver,
 			VolumeSnapshotClassName: snapshotVSC.Spec.VolumeSnapshotClassName,
-			SourceVolumeMode:        snapshotVSC.Spec.SourceVolumeMode,
 		},
 	}
 

--- a/pkg/exposer/csi_snapshot_test.go
+++ b/pkg/exposer/csi_snapshot_test.go
@@ -110,7 +110,6 @@ func TestExpose(t *testing.T) {
 	}
 
 	snapshotHandle := "fake-handle"
-	sourceVolumeMode := corev1.PersistentVolumeFilesystem
 	vscObj := &snapshotv1api.VolumeSnapshotContent{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: vscName,
@@ -123,7 +122,6 @@ func TestExpose(t *testing.T) {
 			DeletionPolicy:          snapshotv1api.VolumeSnapshotContentDelete,
 			Driver:                  "fake-driver",
 			VolumeSnapshotClassName: &snapshotClass,
-			SourceVolumeMode:        &sourceVolumeMode,
 		},
 		Status: &snapshotv1api.VolumeSnapshotContentStatus{
 			RestoreSize:    &restoreSize,
@@ -435,7 +433,6 @@ func TestExpose(t *testing.T) {
 				assert.Equal(t, expectedVSC.Spec.DeletionPolicy, vscObj.Spec.DeletionPolicy)
 				assert.Equal(t, expectedVSC.Spec.Driver, vscObj.Spec.Driver)
 				assert.Equal(t, *expectedVSC.Spec.VolumeSnapshotClassName, *vscObj.Spec.VolumeSnapshotClassName)
-				assert.Equal(t, *expectedVSC.Spec.SourceVolumeMode, *vscObj.Spec.SourceVolumeMode)
 
 				if test.expectedVolumeSize != nil {
 					assert.Equal(t, *test.expectedVolumeSize, backupPVC.Spec.Resources.Requests[corev1.ResourceStorage])


### PR DESCRIPTION
# Please add a summary of your change

This reverts commit 7580538f031a1b998353c660fe0a6501e3866379.

# Does your change fix a particular issue?

At best, this issue should be added to site documentation troubleshooting.

The underlying issue was a downlevel csi-snapshotter container from an ancient Rook install that used inadvertently without much thought.

Changing the SourceVolumeMode fails to fix the issue. It cannot be fixed in Velero as the issue was requests from the csi-snapshotter container.

While I do not believe the existing change will cause problems, the should make it easier for the maintainers to remove.

Fixes #(issue)
See https://github.com/vmware-tanzu/velero/issues/8259#issuecomment-2411819708

# Please indicate you've done the following:

/kind changelog-not-required

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
