### PR TITLE
fix: use Contains or ErrorContains with testify

### DIFF
--- a/pkg/client/factory_test.go
+++ b/pkg/client/factory_test.go
@@ -129,7 +129,7 @@ func TestFactory(t *testing.T) {
 					LabelSelector: "none",
 				},
 			)
-			assert.Contains(t, e.Error(), fmt.Sprintf("Get \"%s/apis/%s/%s/namespaces/%s", test.expectedHost, resource.Group, resource.Version, namespace))
+			assert.ErrorContains(t, e, fmt.Sprintf("Get \"%s/apis/%s/%s/namespaces/%s", test.expectedHost, resource.Group, resource.Version, namespace))
 			assert.Nil(t, list)
 			assert.NotNil(t, dynamicClient)
 

--- a/pkg/cmd/cli/backup/create_test.go
+++ b/pkg/cmd/cli/backup/create_test.go
@@ -225,8 +225,8 @@ func TestCreateCommand(t *testing.T) {
 
 		//Validate
 		e = o.Validate(cmd, args, f)
-		require.Contains(t, e.Error(), "include-resources, exclude-resources and include-cluster-resources are old filter parameters")
-		require.Contains(t, e.Error(), "include-cluster-scoped-resources, exclude-cluster-scoped-resources, include-namespace-scoped-resources and exclude-namespace-scoped-resources are new filter parameters.\nThey cannot be used together")
+		require.ErrorContains(t, e, "include-resources, exclude-resources and include-cluster-resources are old filter parameters")
+		require.ErrorContains(t, e, "include-cluster-scoped-resources, exclude-cluster-scoped-resources, include-namespace-scoped-resources and exclude-namespace-scoped-resources are new filter parameters.\nThey cannot be used together")
 
 		//cmd
 		e = o.Run(cmd, f)
@@ -292,7 +292,7 @@ func TestCreateCommand(t *testing.T) {
 
 		// Validate
 		e = o.Validate(cmd, args, f)
-		assert.Contains(t, e.Error(), fmt.Sprintf("backupstoragelocations.velero.io \"%s\" not found", bsl))
+		assert.ErrorContains(t, e, fmt.Sprintf("backupstoragelocations.velero.io \"%s\" not found", bsl))
 	})
 
 	t.Run("create a backup create command with specific volume-snapshot-locations setting", func(t *testing.T) {

--- a/pkg/cmd/cli/backuplocation/create_test.go
+++ b/pkg/cmd/cli/backuplocation/create_test.go
@@ -151,7 +151,7 @@ func TestCreateCommand_Run(t *testing.T) {
 	assert.NoError(t, e)
 
 	e = o.Run(c, f)
-	assert.Contains(t, e.Error(), fmt.Sprintf("%s: no such file or directory", caCertFile))
+	assert.ErrorContains(t, e, fmt.Sprintf("%s: no such file or directory", caCertFile))
 
 	// verify all options are set as expected
 	assert.Equal(t, name, o.Name)

--- a/pkg/cmd/cli/backuplocation/delete_test.go
+++ b/pkg/cmd/cli/backuplocation/delete_test.go
@@ -103,7 +103,7 @@ func TestDeleteFunctions(t *testing.T) {
 		bkList.Items = append(bkList.Items, bk)
 		errList := deleteBackups(kbclient, bkList)
 		assert.Len(t, errList, 1)
-		assert.Contains(t, errList[0].Error(), fmt.Sprintf("delete backup \"%s\" associated with deleted BSL: backups.velero.io \"%s\" not found", bk.Name, bk.Name))
+		assert.ErrorContains(t, errList[0], fmt.Sprintf("delete backup \"%s\" associated with deleted BSL: backups.velero.io \"%s\" not found", bk.Name, bk.Name))
 	})
 	t.Run("deleteBackupRepos", func(t *testing.T) {
 		bkrepo := velerov1api.BackupRepository{}
@@ -111,6 +111,6 @@ func TestDeleteFunctions(t *testing.T) {
 		bkrepoList.Items = append(bkrepoList.Items, bkrepo)
 		errList := deleteBackupRepos(kbclient, bkrepoList)
 		assert.Len(t, errList, 1)
-		assert.Contains(t, errList[0].Error(), fmt.Sprintf("delete backup repository \"%s\" associated with deleted BSL: backuprepositories.velero.io \"%s\" not found", bkrepo.Name, bkrepo.Name))
+		assert.ErrorContains(t, errList[0], fmt.Sprintf("delete backup repository \"%s\" associated with deleted BSL: backuprepositories.velero.io \"%s\" not found", bkrepo.Name, bkrepo.Name))
 	})
 }

--- a/pkg/cmd/cli/backuplocation/set_test.go
+++ b/pkg/cmd/cli/backuplocation/set_test.go
@@ -69,7 +69,7 @@ func TestNewSetCommand(t *testing.T) {
 	assert.NoError(t, e)
 
 	e = o.Run(c, f)
-	assert.Contains(t, e.Error(), fmt.Sprintf("%s: no such file or directory", cacert))
+	assert.ErrorContains(t, e, fmt.Sprintf("%s: no such file or directory", cacert))
 
 	// verify all options are set as expected
 	assert.Equal(t, backupName, o.Name)
@@ -77,7 +77,7 @@ func TestNewSetCommand(t *testing.T) {
 	assert.Equal(t, defaultBackupStorageLocation, boolptr.IsSetToTrue(o.DefaultBackupStorageLocation.Value))
 	assert.True(t, reflect.DeepEqual(credential, o.Credential))
 
-	assert.Contains(t, e.Error(), fmt.Sprintf("%s: no such file or directory", cacert))
+	assert.ErrorContains(t, e, fmt.Sprintf("%s: no such file or directory", cacert))
 }
 
 func TestSetCommand_Execute(t *testing.T) {

--- a/pkg/cmd/cli/restore/create_test.go
+++ b/pkg/cmd/cli/restore/create_test.go
@@ -113,7 +113,7 @@ func TestCreateCommand(t *testing.T) {
 
 		//Validate
 		e = o.Validate(cmd, args, f)
-		require.Contains(t, e.Error(), "either a backup or schedule must be specified, but not both")
+		require.ErrorContains(t, e, "either a backup or schedule must be specified, but not both")
 
 		//cmd
 		e = o.Run(cmd, f)

--- a/pkg/datapath/micro_service_watcher_test.go
+++ b/pkg/datapath/micro_service_watcher_test.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"strings"
 	"testing"
 	"time"
 
@@ -617,7 +616,7 @@ func TestRedirectDataMoverLogs(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 
-				assert.True(t, strings.Contains(buffer, test.logMessage))
+				assert.Contains(t, buffer, test.logMessage)
 			}
 		})
 	}

--- a/pkg/repository/maintenance_test.go
+++ b/pkg/repository/maintenance_test.go
@@ -429,7 +429,7 @@ func TestGetMaintenanceJobConfig(t *testing.T) {
 			)
 
 			if tc.expectedError != nil {
-				require.Contains(t, err.Error(), tc.expectedError.Error())
+				require.ErrorContains(t, err, tc.expectedError.Error())
 			} else {
 				require.NoError(t, err)
 			}


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

use Contains or ErrorContains with testify

# Does your change fix a particular issue?

It uses (assert|require).Contains(t,...) or (assert|require).ErrorContains(t, err,...) when possible
It also removes (assert|require).Error(t, err,...) as it is redundant with (assert|require).ErrorContains(t, err,...) behavior

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
