### PR TITLE
Bump the E2E migration and upgrade Velero and plugin versions for 1.15

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -59,7 +59,7 @@ VELERO_IMAGE ?= velero/velero:main
 PLUGINS ?=
 RESTORE_HELPER_IMAGE ?=
 #Released version only
-UPGRADE_FROM_VELERO_VERSION ?= v1.12.3,v1.13.2
+UPGRADE_FROM_VELERO_VERSION ?= v1.13.2,v1.14.1
 # UPGRADE_FROM_VELERO_CLI can has the same format(a list divided by comma) with UPGRADE_FROM_VELERO_VERSION
 # Upgrade tests will be executed sequently according to the list by UPGRADE_FROM_VELERO_VERSION
 # So although length of UPGRADE_FROM_VELERO_CLI list is not equal with UPGRADE_FROM_VELERO_VERSION
@@ -67,7 +67,7 @@ UPGRADE_FROM_VELERO_VERSION ?= v1.12.3,v1.13.2
 # to the end, nil string will be set if UPGRADE_FROM_VELERO_CLI is shorter than UPGRADE_FROM_VELERO_VERSION
 UPGRADE_FROM_VELERO_CLI ?=
 
-MIGRATE_FROM_VELERO_VERSION ?= v1.13.2,self
+MIGRATE_FROM_VELERO_VERSION ?= v1.14.1,self
 MIGRATE_FROM_VELERO_CLI ?=
 
 VELERO_NAMESPACE ?= velero

--- a/test/util/velero/velero_utils.go
+++ b/test/util/velero/velero_utils.go
@@ -112,6 +112,13 @@ var pluginsMatrix = map[string]map[string][]string{
 		"gcp":       {"velero/velero-plugin-for-gcp:v1.10.1"},
 		"datamover": {"velero/velero-plugin-for-aws:v1.10.1"},
 	},
+	"v1.15": {
+		"aws":       {"velero/velero-plugin-for-aws:v1.11.0"},
+		"azure":     {"velero/velero-plugin-for-microsoft-azure:v1.11.0"},
+		"vsphere":   {"vsphereveleroplugin/velero-plugin-for-vsphere:v1.5.2"},
+		"gcp":       {"velero/velero-plugin-for-gcp:v1.11.0"},
+		"datamover": {"velero/velero-plugin-for-aws:v1.11.0"},
+	},
 	"main": {
 		"aws":       {"velero/velero-plugin-for-aws:main"},
 		"azure":     {"velero/velero-plugin-for-microsoft-azure:main"},


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
