### PR TITLE
Fix a warning during make container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN mkdir -p /output/usr/bin && \
 # Restic binary build section
 FROM --platform=$BUILDPLATFORM golang:1.22-bookworm AS restic-builder
 
+ARG GOPROXY
 ARG BIN
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Fix a warning during make container:
```
 1 warning found (use docker --debug to expand):                                                                                                             
 - UndefinedVar: Usage of undefined variable '$GOPROXY' (line 58)
```