### PR TITLE
Copy "envFrom" from Velero server when creating maintenance jobs

### DIFF
--- a/changelogs/unreleased/8343-evhan
+++ b/changelogs/unreleased/8343-evhan
@@ -1,0 +1,1 @@
+Copy "envFrom" from Velero server when creating maintenance jobs

--- a/pkg/exposer/csi_snapshot.go
+++ b/pkg/exposer/csi_snapshot.go
@@ -553,6 +553,7 @@ func (e *csiSnapshotExposer) createBackupPod(
 					VolumeMounts:  volumeMounts,
 					VolumeDevices: volumeDevices,
 					Env:           podInfo.env,
+					EnvFrom:       podInfo.envFrom,
 					Resources:     resources,
 				},
 			},

--- a/pkg/exposer/generic_restore.go
+++ b/pkg/exposer/generic_restore.go
@@ -370,6 +370,7 @@ func (e *genericRestoreExposer) createRestorePod(ctx context.Context, ownerObjec
 					VolumeMounts:  volumeMounts,
 					VolumeDevices: volumeDevices,
 					Env:           podInfo.env,
+					EnvFrom:       podInfo.envFrom,
 					Resources:     resources,
 				},
 			},

--- a/pkg/exposer/image.go
+++ b/pkg/exposer/image.go
@@ -31,6 +31,7 @@ type inheritedPodInfo struct {
 	image          string
 	serviceAccount string
 	env            []v1.EnvVar
+	envFrom        []v1.EnvFromSource
 	volumeMounts   []v1.VolumeMount
 	volumes        []v1.Volume
 	logLevelArgs   []string
@@ -53,6 +54,7 @@ func getInheritedPodInfo(ctx context.Context, client kubernetes.Interface, veler
 	podInfo.serviceAccount = podSpec.ServiceAccountName
 
 	podInfo.env = podSpec.Containers[0].Env
+	podInfo.envFrom = podSpec.Containers[0].EnvFrom
 	podInfo.volumeMounts = podSpec.Containers[0].VolumeMounts
 	podInfo.volumes = podSpec.Volumes
 

--- a/pkg/exposer/image_test.go
+++ b/pkg/exposer/image_test.go
@@ -67,6 +67,22 @@ func TestGetInheritedPodInfo(t *testing.T) {
 									Value: "value-2",
 								},
 							},
+							EnvFrom: []v1.EnvFromSource{
+								{
+									ConfigMapRef: &v1.ConfigMapEnvSource{
+										LocalObjectReference: v1.LocalObjectReference{
+											Name: "test-configmap",
+										},
+									},
+								},
+								{
+									SecretRef: &v1.SecretEnvSource{
+										LocalObjectReference: v1.LocalObjectReference{
+											Name: "test-secret",
+										},
+									},
+								},
+							},
 							VolumeMounts: []v1.VolumeMount{
 								{
 									Name: "volume-1",
@@ -114,6 +130,22 @@ func TestGetInheritedPodInfo(t *testing.T) {
 								{
 									Name:  "env-2",
 									Value: "value-2",
+								},
+							},
+							EnvFrom: []v1.EnvFromSource{
+								{
+									ConfigMapRef: &v1.ConfigMapEnvSource{
+										LocalObjectReference: v1.LocalObjectReference{
+											Name: "test-configmap",
+										},
+									},
+								},
+								{
+									SecretRef: &v1.SecretEnvSource{
+										LocalObjectReference: v1.LocalObjectReference{
+											Name: "test-secret",
+										},
+									},
 								},
 							},
 							VolumeMounts: []v1.VolumeMount{
@@ -191,6 +223,22 @@ func TestGetInheritedPodInfo(t *testing.T) {
 						Value: "value-2",
 					},
 				},
+				envFrom: []v1.EnvFromSource{
+					{
+						ConfigMapRef: &v1.ConfigMapEnvSource{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "test-configmap",
+							},
+						},
+					},
+					{
+						SecretRef: &v1.SecretEnvSource{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "test-secret",
+							},
+						},
+					},
+				},
 				volumeMounts: []v1.VolumeMount{
 					{
 						Name: "volume-1",
@@ -226,6 +274,22 @@ func TestGetInheritedPodInfo(t *testing.T) {
 					{
 						Name:  "env-2",
 						Value: "value-2",
+					},
+				},
+				envFrom: []v1.EnvFromSource{
+					{
+						ConfigMapRef: &v1.ConfigMapEnvSource{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "test-configmap",
+							},
+						},
+					},
+					{
+						SecretRef: &v1.SecretEnvSource{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "test-secret",
+							},
+						},
 					},
 				},
 				volumeMounts: []v1.VolumeMount{

--- a/pkg/repository/manager/manager.go
+++ b/pkg/repository/manager/manager.go
@@ -368,6 +368,9 @@ func (m *manager) buildMaintenanceJob(
 	// Get the environment variables from the Velero server deployment
 	envVars := veleroutil.GetEnvVarsFromVeleroServer(deployment)
 
+	// Get the referenced storage from the Velero server deployment
+	envFromSources := veleroutil.GetEnvFromSourcesFromVeleroServer(deployment)
+
 	// Get the volume mounts from the Velero server deployment
 	volumeMounts := veleroutil.GetVolumeMountsFromVeleroServer(deployment)
 
@@ -433,6 +436,7 @@ func (m *manager) buildMaintenanceJob(
 							Args:            args,
 							ImagePullPolicy: v1.PullIfNotPresent,
 							Env:             envVars,
+							EnvFrom:         envFromSources,
 							VolumeMounts:    volumeMounts,
 							Resources:       resources,
 						},

--- a/pkg/util/velero/velero.go
+++ b/pkg/util/velero/velero.go
@@ -45,6 +45,15 @@ func GetEnvVarsFromVeleroServer(deployment *appsv1.Deployment) []v1.EnvVar {
 	return nil
 }
 
+// GetEnvFromSourcesFromVeleroServer get the environment sources from the Velero server deployment
+func GetEnvFromSourcesFromVeleroServer(deployment *appsv1.Deployment) []v1.EnvFromSource {
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		// We only have one container in the Velero server deployment
+		return container.EnvFrom
+	}
+	return nil
+}
+
 // GetVolumeMountsFromVeleroServer get the volume mounts from the Velero server deployment
 func GetVolumeMountsFromVeleroServer(deployment *appsv1.Deployment) []v1.VolumeMount {
 	for _, container := range deployment.Spec.Template.Spec.Containers {

--- a/pkg/util/velero/velero_test.go
+++ b/pkg/util/velero/velero_test.go
@@ -312,6 +312,105 @@ func TestGetEnvVarsFromVeleroServer(t *testing.T) {
 	}
 }
 
+func TestGetEnvFromSourcesFromVeleroServer(t *testing.T) {
+	tests := []struct {
+		name     string
+		deploy   *appsv1.Deployment
+		expected []v1.EnvFromSource
+	}{
+		{
+			name: "no env vars",
+			deploy: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									EnvFrom: []v1.EnvFromSource{},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []v1.EnvFromSource{},
+		},
+		{
+			name: "configmap",
+			deploy: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									EnvFrom: []v1.EnvFromSource{
+										{
+											ConfigMapRef: &v1.ConfigMapEnvSource{
+												LocalObjectReference: v1.LocalObjectReference{
+													Name: "foo",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []v1.EnvFromSource{
+				{
+					ConfigMapRef: &v1.ConfigMapEnvSource{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: "foo",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "secret",
+			deploy: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									EnvFrom: []v1.EnvFromSource{
+										{
+											SecretRef: &v1.SecretEnvSource{
+												LocalObjectReference: v1.LocalObjectReference{
+													Name: "foo",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []v1.EnvFromSource{
+				{
+					SecretRef: &v1.SecretEnvSource{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: "foo",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := GetEnvFromSourcesFromVeleroServer(test.deploy)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
 func TestGetVolumeMountsFromVeleroServer(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

When the Velero server creates a maintenance job, it copies its own `env` into the newly-created Pod spec. However, Velero's environment may be populated via `envFrom` in addition to `env`, in which case the maintenance job may fail since it will be missing potentially-important variables.

We ran into this while using the [OpenStack plugin](https://github.com/Lirt/velero-plugin-for-openstack), but the issue is not specific to that provider. We worked around the problem in the meantime by moving all variables that were previously stored in a Secret into the Deployment itself.

The documentation already says:

> Maintenance jobs will inherit the labels, annotations, toleration, nodeSelector, service account, image, environment variables, cloud-credentials etc. from Velero deployment.

This would appear to be covered by that, and the change is just bringing the implementation in line with the docs.

# Does your change fix a particular issue?

No existing issue in GitHub from what I can see.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] ~~Updated the corresponding documentation in `site/content/docs/main`.~~
