### PR TITLE
Fix v1.15.0 migration case error

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -197,7 +197,7 @@ run-e2e: ginkgo
 		--standby-cluster-name=$(STANDBY_CLUSTER_NAME) \
 		--eks-policy-arn=$(EKS_POLICY_ARN) \
 		--default-cls-service-account-name=$(DEFAULT_CLS_SERVICE_ACCOUNT_NAME) \
-		--standby-cls-service-account-name=$(STANDBY_CLS_SERVICE_ACCOUNT_NAME)
+		--standby-cls-service-account-name=$(STANDBY_CLS_SERVICE_ACCOUNT_NAME) \
 		--kibishii-directory=$(KIBISHII_DIRECTORY) \
 		--disable-informer-cache=$(DISABLE_INFORMER_CACHE)
 

--- a/test/e2e/migration/migration.go
+++ b/test/e2e/migration/migration.go
@@ -164,11 +164,10 @@ func MigrationTest(useVolumeSnapshots bool, veleroCLI2Version VeleroCLI2Version)
 							semver.Compare(versionWithoutPatch, "v1.14") < 0 {
 							OriginVeleroCfg.Plugins = OriginVeleroCfg.Plugins + "," + migrationNeedPlugins[CSI][0]
 						}
-						if OriginVeleroCfg.SnapshotMoveData {
-							if OriginVeleroCfg.CloudProvider == Azure {
-								OriginVeleroCfg.Plugins = OriginVeleroCfg.Plugins + "," + migrationNeedPlugins[AWS][0]
-							}
+						if OriginVeleroCfg.SnapshotMoveData && OriginVeleroCfg.CloudProvider == Azure {
+							OriginVeleroCfg.Plugins = OriginVeleroCfg.Plugins + "," + migrationNeedPlugins[AWS][0]
 						}
+
 						veleroCLI2Version.VeleroCLI, err = InstallVeleroCLI(veleroCLI2Version.VeleroVersion)
 						Expect(err).To(Succeed())
 					}

--- a/test/types.go
+++ b/test/types.go
@@ -35,12 +35,13 @@ const Azure = "azure"
 const AzureCSI = "azure-csi"
 const AwsCSI = "aws-csi"
 const AWS = "aws"
-const Gcp = "gcp"
+const GCP = "gcp"
 const Vsphere = "vsphere"
+const CSI = "csi"
 
 const UploaderTypeRestic = "restic"
 
-var PublicCloudProviders = []string{AWS, Azure, Gcp, Vsphere}
+var PublicCloudProviders = []string{AWS, Azure, GCP, Vsphere}
 var LocalCloudProviders = []string{Kind, VanillaZFS}
 var CloudProviders = append(PublicCloudProviders, LocalCloudProviders...)
 

--- a/test/util/providers/common.go
+++ b/test/util/providers/common.go
@@ -78,7 +78,7 @@ func getProvider(cloudProvider string) (ObjectsInStorage, error) {
 	case AWS, Vsphere:
 		aws := AWSStorage("")
 		s = &aws
-	case Gcp:
+	case GCP:
 		gcs := GCSStorage("")
 		s = &gcs
 	case Azure:

--- a/test/util/velero/velero_utils.go
+++ b/test/util/velero/velero_utils.go
@@ -54,77 +54,56 @@ const BackupObjectsPrefix = "backups"
 const RestoreObjectsPrefix = "restores"
 const PluginsObjectsPrefix = "plugins"
 
-var pluginsMatrix = map[string]map[string][]string{
-	"v1.7": {
-		"aws":     {"velero/velero-plugin-for-aws:v1.3.0"},
-		"azure":   {"velero/velero-plugin-for-microsoft-azure:v1.3.0"},
-		"vsphere": {"vsphereveleroplugin/velero-plugin-for-vsphere:v1.3.0"},
-		"gcp":     {"velero/velero-plugin-for-gcp:v1.3.0"},
-		"csi":     {"velero/velero-plugin-for-csi:v0.2.0"},
-	},
-	"v1.8": {
-		"aws":     {"velero/velero-plugin-for-aws:v1.4.0"},
-		"azure":   {"velero/velero-plugin-for-microsoft-azure:v1.4.0"},
-		"vsphere": {"vsphereveleroplugin/velero-plugin-for-vsphere:v1.3.1"},
-		"gcp":     {"velero/velero-plugin-for-gcp:v1.4.0"},
-		"csi":     {"velero/velero-plugin-for-csi:v0.2.0"},
-	},
-	"v1.9": {
-		"aws":     {"velero/velero-plugin-for-aws:v1.5.0"},
-		"azure":   {"velero/velero-plugin-for-microsoft-azure:v1.5.0"},
-		"vsphere": {"vsphereveleroplugin/velero-plugin-for-vsphere:v1.4.0"},
-		"gcp":     {"velero/velero-plugin-for-gcp:v1.5.0"},
-		"csi":     {"velero/velero-plugin-for-csi:v0.3.0"},
-	},
+var PluginsMatrix = map[string]map[string][]string{
 	"v1.10": {
-		"aws":     {"velero/velero-plugin-for-aws:v1.6.0"},
-		"azure":   {"velero/velero-plugin-for-microsoft-azure:v1.6.0"},
-		"vsphere": {"vsphereveleroplugin/velero-plugin-for-vsphere:v1.5.1"},
-		"gcp":     {"velero/velero-plugin-for-gcp:v1.6.0"},
-		"csi":     {"velero/velero-plugin-for-csi:v0.4.0"},
+		"aws":     {"gcr.io/velero-gcp/velero-plugin-for-aws:v1.6.0"},
+		"azure":   {"gcr.io/velero-gcp/velero-plugin-for-microsoft-azure:v1.6.0"},
+		"vsphere": {"gcr.io/velero-gcp/velero-plugin-for-vsphere:v1.5.1"},
+		"gcp":     {"gcr.io/velero-gcp/velero-plugin-for-gcp:v1.6.0"},
+		"csi":     {"gcr.io/velero-gcp/velero-plugin-for-csi:v0.4.0"},
 	},
 	"v1.11": {
-		"aws":     {"velero/velero-plugin-for-aws:v1.7.0"},
-		"azure":   {"velero/velero-plugin-for-microsoft-azure:v1.7.0"},
-		"vsphere": {"vsphereveleroplugin/velero-plugin-for-vsphere:v1.5.1"},
-		"gcp":     {"velero/velero-plugin-for-gcp:v1.7.0"},
-		"csi":     {"velero/velero-plugin-for-csi:v0.5.0"},
+		"aws":     {"gcr.io/velero-gcp/velero-plugin-for-aws:v1.7.0"},
+		"azure":   {"gcr.io/velero-gcp/velero-plugin-for-microsoft-azure:v1.7.0"},
+		"vsphere": {"gcr.io/velero-gcp/velero-plugin-for-vsphere:v1.5.1"},
+		"gcp":     {"gcr.io/velero-gcp/velero-plugin-for-gcp:v1.7.0"},
+		"csi":     {"gcr.io/velero-gcp/velero-plugin-for-csi:v0.5.0"},
 	},
 	"v1.12": {
-		"aws":     {"velero/velero-plugin-for-aws:v1.8.0"},
-		"azure":   {"velero/velero-plugin-for-microsoft-azure:v1.8.0"},
-		"vsphere": {"vsphereveleroplugin/velero-plugin-for-vsphere:v1.5.1"},
-		"gcp":     {"velero/velero-plugin-for-gcp:v1.8.0"},
-		"csi":     {"velero/velero-plugin-for-csi:v0.6.0"},
+		"aws":     {"gcr.io/velero-gcp/velero-plugin-for-aws:v1.8.0"},
+		"azure":   {"gcr.io/velero-gcp/velero-plugin-for-microsoft-azure:v1.8.0"},
+		"vsphere": {"gcr.io/velero-gcp/velero-plugin-for-vsphere:v1.5.1"},
+		"gcp":     {"gcr.io/velero-gcp/velero-plugin-for-gcp:v1.8.0"},
+		"csi":     {"gcr.io/velero-gcp/velero-plugin-for-csi:v0.6.0"},
 	},
 	"v1.13": {
-		"aws":       {"velero/velero-plugin-for-aws:v1.9.2"},
-		"azure":     {"velero/velero-plugin-for-microsoft-azure:v1.9.2"},
-		"vsphere":   {"vsphereveleroplugin/velero-plugin-for-vsphere:v1.5.2"},
-		"gcp":       {"velero/velero-plugin-for-gcp:v1.9.2"},
-		"csi":       {"velero/velero-plugin-for-csi:v0.7.1"},
-		"datamover": {"velero/velero-plugin-for-aws:v1.9.2"},
+		"aws":       {"gcr.io/velero-gcp/velero-plugin-for-aws:v1.9.2"},
+		"azure":     {"gcr.io/velero-gcp/velero-plugin-for-microsoft-azure:v1.9.2"},
+		"vsphere":   {"gcr.io/velero-gcp/velero-plugin-for-vsphere:v1.5.2"},
+		"gcp":       {"gcr.io/velero-gcp/velero-plugin-for-gcp:v1.9.2"},
+		"csi":       {"gcr.io/velero-gcp/velero-plugin-for-csi:v0.7.1"},
+		"datamover": {"gcr.io/velero-gcp/velero-plugin-for-aws:v1.9.2"},
 	},
 	"v1.14": {
-		"aws":       {"velero/velero-plugin-for-aws:v1.10.1"},
-		"azure":     {"velero/velero-plugin-for-microsoft-azure:v1.10.1"},
-		"vsphere":   {"vsphereveleroplugin/velero-plugin-for-vsphere:v1.5.2"},
-		"gcp":       {"velero/velero-plugin-for-gcp:v1.10.1"},
-		"datamover": {"velero/velero-plugin-for-aws:v1.10.1"},
+		"aws":       {"gcr.io/velero-gcp/velero-plugin-for-aws:v1.10.1"},
+		"azure":     {"gcr.io/velero-gcp/velero-plugin-for-microsoft-azure:v1.10.1"},
+		"vsphere":   {"gcr.io/velero-gcp/velero-plugin-for-vsphere:v1.5.2"},
+		"gcp":       {"gcr.io/velero-gcp/velero-plugin-for-gcp:v1.10.1"},
+		"datamover": {"gcr.io/velero-gcp/velero-plugin-for-aws:v1.10.1"},
 	},
 	"v1.15": {
-		"aws":       {"velero/velero-plugin-for-aws:v1.11.0"},
-		"azure":     {"velero/velero-plugin-for-microsoft-azure:v1.11.0"},
-		"vsphere":   {"vsphereveleroplugin/velero-plugin-for-vsphere:v1.5.2"},
-		"gcp":       {"velero/velero-plugin-for-gcp:v1.11.0"},
-		"datamover": {"velero/velero-plugin-for-aws:v1.11.0"},
+		"aws":       {"gcr.io/velero-gcp/velero-plugin-for-aws:v1.11.0"},
+		"azure":     {"gcr.io/velero-gcp/velero-plugin-for-microsoft-azure:v1.11.0"},
+		"vsphere":   {"gcr.io/velero-gcp/velero-plugin-for-vsphere:v1.5.2"},
+		"gcp":       {"gcr.io/velero-gcp/velero-plugin-for-gcp:v1.11.0"},
+		"datamover": {"gcr.io/velero-gcp/velero-plugin-for-aws:v1.11.0"},
 	},
 	"main": {
-		"aws":       {"velero/velero-plugin-for-aws:main"},
-		"azure":     {"velero/velero-plugin-for-microsoft-azure:main"},
-		"vsphere":   {"vsphereveleroplugin/velero-plugin-for-vsphere:v1.5.2"},
-		"gcp":       {"velero/velero-plugin-for-gcp:main"},
-		"datamover": {"velero/velero-plugin-for-aws:main"},
+		"aws":       {"gcr.io/velero-gcp/velero-plugin-for-aws:main"},
+		"azure":     {"gcr.io/velero-gcp/velero-plugin-for-microsoft-azure:main"},
+		"vsphere":   {"gcr.io/velero-gcp/velero-plugin-for-vsphere:v1.5.2"},
+		"gcp":       {"gcr.io/velero-gcp/velero-plugin-for-gcp:main"},
+		"datamover": {"gcr.io/velero-gcp/velero-plugin-for-aws:main"},
 	},
 }
 
@@ -132,10 +111,10 @@ func getPluginsByVersion(version, cloudProvider, objectStoreProvider string, nee
 	var cloudMap map[string][]string
 	arr := strings.Split(version, ".")
 	if len(arr) >= 3 {
-		cloudMap = pluginsMatrix[arr[0]+"."+arr[1]]
+		cloudMap = PluginsMatrix[arr[0]+"."+arr[1]]
 	}
 	if len(cloudMap) == 0 {
-		cloudMap = pluginsMatrix["main"]
+		cloudMap = PluginsMatrix["main"]
 		if len(cloudMap) == 0 {
 			return nil, errors.Errorf("fail to get plugins by version: main")
 		}


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
This PR is used to fix the E2E migration E2E error after bumping to v1.15.
The error was introduced in v1.14, which added hard-code logic to add the CSI plugin for the migration case's Velero install CLI. That works because the Velero v1.14 migration E2E test covers the v1.13 to the v1.14 migration. v1.13 still needs to install the CSI plugin. 

The CSI plugin was integrated into Velero in v1.14. Add adding the CSI plugin for Velero no older than v1.14 will cause the same plugin to register twice error, which causes the Velero server to exit.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:
Remove the hard-code logic.
Read the should used plugins and their version from the Velero E2E default value.

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
