### PR TITLE
Include --annotations flag in backup and restore create commands

### DIFF
--- a/changelogs/unreleased/8354-alromeros
+++ b/changelogs/unreleased/8354-alromeros
@@ -1,0 +1,1 @@
+Include --annotations flag in backup and restore create commands

--- a/pkg/cmd/cli/backup/create.go
+++ b/pkg/cmd/cli/backup/create.go
@@ -94,6 +94,7 @@ type CreateOptions struct {
 	IncludeNamespaceScopedResources flag.StringArray
 	ExcludeNamespaceScopedResources flag.StringArray
 	Labels                          flag.Map
+	Annotations                     flag.Map
 	Selector                        flag.LabelSelector
 	OrSelector                      flag.OrLabelSelector
 	IncludeClusterResources         flag.OptionalBool
@@ -113,6 +114,7 @@ func NewCreateOptions() *CreateOptions {
 	return &CreateOptions{
 		IncludeNamespaces:       flag.NewStringArray("*"),
 		Labels:                  flag.NewMap(),
+		Annotations:             flag.NewMap(),
 		SnapshotVolumes:         flag.NewOptionalBool(nil),
 		IncludeClusterResources: flag.NewOptionalBool(nil),
 	}
@@ -129,6 +131,7 @@ func (o *CreateOptions) BindFlags(flags *pflag.FlagSet) {
 	flags.Var(&o.IncludeNamespaceScopedResources, "include-namespace-scoped-resources", "Namespaced resources to include in the backup, formatted as resource.group, such as deployments.apps(use '*' for all resources). Cannot work with include-resources, exclude-resources and include-cluster-resources.")
 	flags.Var(&o.ExcludeNamespaceScopedResources, "exclude-namespace-scoped-resources", "Namespaced resources to exclude from the backup, formatted as resource.group, such as deployments.apps(use '*' for all resources). Cannot work with include-resources, exclude-resources and include-cluster-resources.")
 	flags.Var(&o.Labels, "labels", "Labels to apply to the backup.")
+	flags.Var(&o.Annotations, "annotations", "Annotations to apply to the backup.")
 	flags.StringVar(&o.StorageLocation, "storage-location", "", "Location in which to store the backup.")
 	flags.StringSliceVar(&o.SnapshotLocations, "volume-snapshot-locations", o.SnapshotLocations, "List of locations (at most one per provider) where volume snapshots should be stored.")
 	flags.VarP(&o.Selector, "selector", "l", "Only back up resources matching this label selector.")
@@ -403,7 +406,7 @@ func (o *CreateOptions) BuildBackup(namespace string) (*velerov1api.Backup, erro
 		}
 	}
 
-	backup := backupBuilder.ObjectMeta(builder.WithLabelsMap(o.Labels.Data())).Result()
+	backup := backupBuilder.ObjectMeta(builder.WithLabelsMap(o.Labels.Data()), builder.WithAnnotationsMap(o.Annotations.Data())).Result()
 	return backup, nil
 }
 

--- a/pkg/cmd/cli/restore/create.go
+++ b/pkg/cmd/cli/restore/create.go
@@ -84,6 +84,7 @@ type CreateOptions struct {
 	RestoreVolumes            flag.OptionalBool
 	PreserveNodePorts         flag.OptionalBool
 	Labels                    flag.Map
+	Annotations               flag.Map
 	IncludeNamespaces         flag.StringArray
 	ExcludeNamespaces         flag.StringArray
 	ExistingResourcePolicy    string
@@ -107,6 +108,7 @@ type CreateOptions struct {
 func NewCreateOptions() *CreateOptions {
 	return &CreateOptions{
 		Labels:                  flag.NewMap(),
+		Annotations:             flag.NewMap(),
 		IncludeNamespaces:       flag.NewStringArray("*"),
 		NamespaceMappings:       flag.NewMap().WithEntryDelimiter(',').WithKeyValueDelimiter(':'),
 		RestoreVolumes:          flag.NewOptionalBool(nil),
@@ -123,6 +125,7 @@ func (o *CreateOptions) BindFlags(flags *pflag.FlagSet) {
 	flags.Var(&o.ExcludeNamespaces, "exclude-namespaces", "Namespaces to exclude from the restore.")
 	flags.Var(&o.NamespaceMappings, "namespace-mappings", "Namespace mappings from name in the backup to desired restored name in the form src1:dst1,src2:dst2,...")
 	flags.Var(&o.Labels, "labels", "Labels to apply to the restore.")
+	flags.Var(&o.Annotations, "annotations", "Annotations to apply to the restore.")
 	flags.Var(&o.IncludeResources, "include-resources", "Resources to include in the restore, formatted as resource.group, such as storageclasses.storage.k8s.io (use '*' for all resources).")
 	flags.Var(&o.ExcludeResources, "exclude-resources", "Resources to exclude from the restore, formatted as resource.group, such as storageclasses.storage.k8s.io.")
 	flags.StringVar(&o.ExistingResourcePolicy, "existing-resource-policy", "", "Restore Policy to be used during the restore workflow, can be - none or update")
@@ -309,9 +312,10 @@ func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
 
 	restore := &api.Restore{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: f.Namespace(),
-			Name:      o.RestoreName,
-			Labels:    o.Labels.Data(),
+			Namespace:   f.Namespace(),
+			Name:        o.RestoreName,
+			Labels:      o.Labels.Data(),
+			Annotations: o.Annotations.Data(),
 		},
 		Spec: api.RestoreSpec{
 			BackupName:              o.BackupName,

--- a/pkg/cmd/cli/restore/create_test.go
+++ b/pkg/cmd/cli/restore/create_test.go
@@ -65,6 +65,7 @@ func TestCreateCommand(t *testing.T) {
 		restoreVolumes := "true"
 		preserveNodePorts := "true"
 		labels := "c=foo"
+		annotations := "ann=foo"
 		includeNamespaces := "app1,app2"
 		excludeNamespaces := "pod1,pod2,pod3"
 		existingResourcePolicy := "none"
@@ -88,6 +89,7 @@ func TestCreateCommand(t *testing.T) {
 		flags.Parse([]string{"--restore-volumes", restoreVolumes})
 		flags.Parse([]string{"--preserve-nodeports", preserveNodePorts})
 		flags.Parse([]string{"--labels", labels})
+		flags.Parse([]string{"--annotations", annotations})
 		flags.Parse([]string{"--existing-resource-policy", existingResourcePolicy})
 		flags.Parse([]string{"--include-namespaces", includeNamespaces})
 		flags.Parse([]string{"--exclude-namespaces", excludeNamespaces})
@@ -124,6 +126,7 @@ func TestCreateCommand(t *testing.T) {
 		require.Equal(t, restoreVolumes, o.RestoreVolumes.String())
 		require.Equal(t, preserveNodePorts, o.PreserveNodePorts.String())
 		require.Equal(t, labels, o.Labels.String())
+		require.Equal(t, annotations, o.Annotations.String())
 		require.Equal(t, includeNamespaces, o.IncludeNamespaces.String())
 		require.Equal(t, excludeNamespaces, o.ExcludeNamespaces.String())
 		require.Equal(t, existingResourcePolicy, o.ExistingResourcePolicy)


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

This Pull Request implements a new `--annotations` flag in the backup and restore create commands.

This allows users to specify key-value pairs for annotations directly at the time of backup and restore creation, in the same way as the `--labels` flag.

Usage example:

```sh
velero backup create my-backup --include-namespaces default --annotations AnnMetadataBackup=true
```
For restore:
```sh
velero restore create my-restore --include-namespaces default --annotations AnnIgnoreChecks=true
```

# Does your change fix a particular issue?

Fixes #8350

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
