### PR TITLE
Make BackedUpItems thread safe

### DIFF
--- a/changelogs/unreleased/8366-sseago
+++ b/changelogs/unreleased/8366-sseago
@@ -1,0 +1,1 @@
+Make BackedUpItems thread safe

--- a/pkg/backup/backed_up_items_map.go
+++ b/pkg/backup/backed_up_items_map.go
@@ -1,0 +1,90 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backup
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// backedUpItemsMap keeps track of the items already backed up for the current Velero Backup
+type backedUpItemsMap struct {
+	*sync.RWMutex
+	backedUpItems map[itemKey]struct{}
+}
+
+func NewBackedUpItemsMap() *backedUpItemsMap {
+	return &backedUpItemsMap{
+		RWMutex:       &sync.RWMutex{},
+		backedUpItems: make(map[itemKey]struct{}),
+	}
+}
+
+func (m *backedUpItemsMap) CopyItemMap() map[itemKey]struct{} {
+	m.RLock()
+	defer m.RUnlock()
+	returnMap := make(map[itemKey]struct{}, len(m.backedUpItems))
+	for key, val := range m.backedUpItems {
+		returnMap[key] = val
+	}
+	return returnMap
+}
+
+// ResourceMap returns a map of the backed up items.
+// For each map entry, the key is the resource type,
+// and the value is a list of namespaced names for the resource.
+func (m *backedUpItemsMap) ResourceMap() map[string][]string {
+	m.RLock()
+	defer m.RUnlock()
+
+	resources := map[string][]string{}
+	for i := range m.backedUpItems {
+		entry := i.name
+		if i.namespace != "" {
+			entry = fmt.Sprintf("%s/%s", i.namespace, i.name)
+		}
+		resources[i.resource] = append(resources[i.resource], entry)
+	}
+
+	// sort namespace/name entries for each GVK
+	for _, v := range resources {
+		sort.Strings(v)
+	}
+
+	return resources
+}
+
+func (m *backedUpItemsMap) Len() int {
+	m.RLock()
+	defer m.RUnlock()
+	return len(m.backedUpItems)
+}
+
+func (m *backedUpItemsMap) Has(key itemKey) bool {
+	m.RLock()
+	defer m.RUnlock()
+
+	_, exists := m.backedUpItems[key]
+	return exists
+}
+
+func (m *backedUpItemsMap) AddItem(key itemKey) {
+	m.Lock()
+	defer m.Unlock()
+	m.backedUpItems[key] = struct{}{}
+}

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -76,6 +76,7 @@ func TestBackedUpItemsMatchesTarballContents(t *testing.T) {
 	req := &Request{
 		Backup:           defaultBackup().Result(),
 		SkippedPVTracker: NewSkipPVTracker(),
+		BackedUpItems:    NewBackedUpItemsMap(),
 	}
 
 	backupFile := bytes.NewBuffer([]byte{})
@@ -103,7 +104,7 @@ func TestBackedUpItemsMatchesTarballContents(t *testing.T) {
 	// go through BackedUpItems after the backup to assemble the list of files we
 	// expect to see in the tarball and compare to see if they match
 	var expectedFiles []string
-	for item := range req.BackedUpItems {
+	for item := range req.BackedUpItems.CopyItemMap() {
 		file := "resources/" + gvkToResource[item.resource]
 		if item.namespace != "" {
 			file = file + "/namespaces/" + item.namespace
@@ -135,6 +136,7 @@ func TestBackupProgressIsUpdated(t *testing.T) {
 	req := &Request{
 		Backup:           defaultBackup().Result(),
 		SkippedPVTracker: NewSkipPVTracker(),
+		BackedUpItems:    NewBackedUpItemsMap(),
 	}
 	backupFile := bytes.NewBuffer([]byte{})
 
@@ -159,8 +161,8 @@ func TestBackupProgressIsUpdated(t *testing.T) {
 	h.backupper.Backup(h.log, req, backupFile, nil, nil, nil)
 
 	require.NotNil(t, req.Status.Progress)
-	assert.Len(t, req.BackedUpItems, req.Status.Progress.TotalItems)
-	assert.Len(t, req.BackedUpItems, req.Status.Progress.ItemsBackedUp)
+	assert.Equal(t, req.BackedUpItems.Len(), req.Status.Progress.TotalItems)
+	assert.Equal(t, req.BackedUpItems.Len(), req.Status.Progress.ItemsBackedUp)
 }
 
 // TestBackupOldResourceFiltering runs backups with different combinations
@@ -871,6 +873,7 @@ func TestBackupOldResourceFiltering(t *testing.T) {
 				req = &Request{
 					Backup:           tc.backup,
 					SkippedPVTracker: NewSkipPVTracker(),
+					BackedUpItems:    NewBackedUpItemsMap(),
 				}
 				backupFile = bytes.NewBuffer([]byte{})
 			)
@@ -1048,6 +1051,7 @@ func TestCRDInclusion(t *testing.T) {
 				req = &Request{
 					Backup:           tc.backup,
 					SkippedPVTracker: NewSkipPVTracker(),
+					BackedUpItems:    NewBackedUpItemsMap(),
 				}
 				backupFile = bytes.NewBuffer([]byte{})
 			)
@@ -1143,6 +1147,7 @@ func TestBackupResourceCohabitation(t *testing.T) {
 				req = &Request{
 					Backup:           tc.backup,
 					SkippedPVTracker: NewSkipPVTracker(),
+					BackedUpItems:    NewBackedUpItemsMap(),
 				}
 				backupFile = bytes.NewBuffer([]byte{})
 			)
@@ -1169,6 +1174,7 @@ func TestBackupUsesNewCohabitatingResourcesForEachBackup(t *testing.T) {
 	backup1 := &Request{
 		Backup:           defaultBackup().Result(),
 		SkippedPVTracker: NewSkipPVTracker(),
+		BackedUpItems:    NewBackedUpItemsMap(),
 	}
 	backup1File := bytes.NewBuffer([]byte{})
 
@@ -1183,6 +1189,7 @@ func TestBackupUsesNewCohabitatingResourcesForEachBackup(t *testing.T) {
 	backup2 := &Request{
 		Backup:           defaultBackup().Result(),
 		SkippedPVTracker: NewSkipPVTracker(),
+		BackedUpItems:    NewBackedUpItemsMap(),
 	}
 	backup2File := bytes.NewBuffer([]byte{})
 
@@ -1233,6 +1240,7 @@ func TestBackupResourceOrdering(t *testing.T) {
 				req = &Request{
 					Backup:           tc.backup,
 					SkippedPVTracker: NewSkipPVTracker(),
+					BackedUpItems:    NewBackedUpItemsMap(),
 				}
 				backupFile = bytes.NewBuffer([]byte{})
 			)
@@ -1349,6 +1357,7 @@ func TestBackupItemActionsForSkippedPV(t *testing.T) {
 			backupReq: &Request{
 				Backup:           defaultBackup().SnapshotVolumes(false).Result(),
 				SkippedPVTracker: NewSkipPVTracker(),
+				BackedUpItems:    NewBackedUpItemsMap(),
 			},
 			resPolicies: &resourcepolicies.ResourcePolicies{
 				Version: "v1",
@@ -1395,6 +1404,7 @@ func TestBackupItemActionsForSkippedPV(t *testing.T) {
 					},
 					includedPVs: map[string]struct{}{},
 				},
+				BackedUpItems: NewBackedUpItemsMap(),
 			},
 			apiResources: []*test.APIResource{
 				test.PVCs(
@@ -1641,6 +1651,7 @@ func TestBackupActionsRunForCorrectItems(t *testing.T) {
 				req = &Request{
 					Backup:           tc.backup,
 					SkippedPVTracker: NewSkipPVTracker(),
+					BackedUpItems:    NewBackedUpItemsMap(),
 				}
 				backupFile = bytes.NewBuffer([]byte{})
 			)
@@ -1722,6 +1733,7 @@ func TestBackupWithInvalidActions(t *testing.T) {
 				req = &Request{
 					Backup:           tc.backup,
 					SkippedPVTracker: NewSkipPVTracker(),
+					BackedUpItems:    NewBackedUpItemsMap(),
 				}
 				backupFile = bytes.NewBuffer([]byte{})
 			)
@@ -1872,6 +1884,7 @@ func TestBackupActionModifications(t *testing.T) {
 				req = &Request{
 					Backup:           tc.backup,
 					SkippedPVTracker: NewSkipPVTracker(),
+					BackedUpItems:    NewBackedUpItemsMap(),
 				}
 				backupFile = bytes.NewBuffer([]byte{})
 			)
@@ -2128,6 +2141,7 @@ func TestBackupActionAdditionalItems(t *testing.T) {
 				req = &Request{
 					Backup:           tc.backup,
 					SkippedPVTracker: NewSkipPVTracker(),
+					BackedUpItems:    NewBackedUpItemsMap(),
 				}
 				backupFile = bytes.NewBuffer([]byte{})
 			)
@@ -2385,6 +2399,7 @@ func TestItemBlockActionsRunForCorrectItems(t *testing.T) {
 				req = &Request{
 					Backup:           tc.backup,
 					SkippedPVTracker: NewSkipPVTracker(),
+					BackedUpItems:    NewBackedUpItemsMap(),
 				}
 				backupFile = bytes.NewBuffer([]byte{})
 			)
@@ -2466,6 +2481,7 @@ func TestBackupWithInvalidItemBlockActions(t *testing.T) {
 				req = &Request{
 					Backup:           tc.backup,
 					SkippedPVTracker: NewSkipPVTracker(),
+					BackedUpItems:    NewBackedUpItemsMap(),
 				}
 				backupFile = bytes.NewBuffer([]byte{})
 			)
@@ -2718,6 +2734,7 @@ func TestItemBlockActionRelatedItems(t *testing.T) {
 				req = &Request{
 					Backup:           tc.backup,
 					SkippedPVTracker: NewSkipPVTracker(),
+					BackedUpItems:    NewBackedUpItemsMap(),
 				}
 				backupFile = bytes.NewBuffer([]byte{})
 			)
@@ -2882,6 +2899,7 @@ func TestBackupWithSnapshots(t *testing.T) {
 					newSnapshotLocation("velero", "default", "default"),
 				},
 				SkippedPVTracker: NewSkipPVTracker(),
+				BackedUpItems:    NewBackedUpItemsMap(),
 			},
 			apiResources: []*test.APIResource{
 				test.PVs(
@@ -2916,6 +2934,7 @@ func TestBackupWithSnapshots(t *testing.T) {
 					newSnapshotLocation("velero", "default", "default"),
 				},
 				SkippedPVTracker: NewSkipPVTracker(),
+				BackedUpItems:    NewBackedUpItemsMap(),
 			},
 			apiResources: []*test.APIResource{
 				test.PVs(
@@ -2951,6 +2970,7 @@ func TestBackupWithSnapshots(t *testing.T) {
 					newSnapshotLocation("velero", "default", "default"),
 				},
 				SkippedPVTracker: NewSkipPVTracker(),
+				BackedUpItems:    NewBackedUpItemsMap(),
 			},
 			apiResources: []*test.APIResource{
 				test.PVs(
@@ -2986,6 +3006,7 @@ func TestBackupWithSnapshots(t *testing.T) {
 					newSnapshotLocation("velero", "default", "default"),
 				},
 				SkippedPVTracker: NewSkipPVTracker(),
+				BackedUpItems:    NewBackedUpItemsMap(),
 			},
 			apiResources: []*test.APIResource{
 				test.PVs(
@@ -3021,6 +3042,7 @@ func TestBackupWithSnapshots(t *testing.T) {
 					newSnapshotLocation("velero", "default", "default"),
 				},
 				SkippedPVTracker: NewSkipPVTracker(),
+				BackedUpItems:    NewBackedUpItemsMap(),
 			},
 			apiResources: []*test.APIResource{
 				test.PVs(
@@ -3054,6 +3076,7 @@ func TestBackupWithSnapshots(t *testing.T) {
 					newSnapshotLocation("velero", "default", "default"),
 				},
 				SkippedPVTracker: NewSkipPVTracker(),
+				BackedUpItems:    NewBackedUpItemsMap(),
 			},
 			apiResources: []*test.APIResource{
 				test.PVs(
@@ -3070,6 +3093,7 @@ func TestBackupWithSnapshots(t *testing.T) {
 			req: &Request{
 				Backup:           defaultBackup().Result(),
 				SkippedPVTracker: NewSkipPVTracker(),
+				BackedUpItems:    NewBackedUpItemsMap(),
 			},
 			apiResources: []*test.APIResource{
 				test.PVs(
@@ -3089,6 +3113,7 @@ func TestBackupWithSnapshots(t *testing.T) {
 					newSnapshotLocation("velero", "default", "default"),
 				},
 				SkippedPVTracker: NewSkipPVTracker(),
+				BackedUpItems:    NewBackedUpItemsMap(),
 			},
 			apiResources: []*test.APIResource{
 				test.PVs(
@@ -3106,6 +3131,7 @@ func TestBackupWithSnapshots(t *testing.T) {
 					newSnapshotLocation("velero", "default", "default"),
 				},
 				SkippedPVTracker: NewSkipPVTracker(),
+				BackedUpItems:    NewBackedUpItemsMap(),
 			},
 			apiResources: []*test.APIResource{
 				test.PVs(
@@ -3126,6 +3152,7 @@ func TestBackupWithSnapshots(t *testing.T) {
 					newSnapshotLocation("velero", "another", "another"),
 				},
 				SkippedPVTracker: NewSkipPVTracker(),
+				BackedUpItems:    NewBackedUpItemsMap(),
 			},
 			apiResources: []*test.APIResource{
 				test.PVs(
@@ -3256,6 +3283,7 @@ func TestBackupWithAsyncOperations(t *testing.T) {
 			req: &Request{
 				Backup:           defaultBackup().Result(),
 				SkippedPVTracker: NewSkipPVTracker(),
+				BackedUpItems:    NewBackedUpItemsMap(),
 			},
 			apiResources: []*test.APIResource{
 				test.Pods(
@@ -3286,6 +3314,7 @@ func TestBackupWithAsyncOperations(t *testing.T) {
 			req: &Request{
 				Backup:           defaultBackup().Result(),
 				SkippedPVTracker: NewSkipPVTracker(),
+				BackedUpItems:    NewBackedUpItemsMap(),
 			},
 			apiResources: []*test.APIResource{
 				test.Pods(
@@ -3316,6 +3345,7 @@ func TestBackupWithAsyncOperations(t *testing.T) {
 			req: &Request{
 				Backup:           defaultBackup().Result(),
 				SkippedPVTracker: NewSkipPVTracker(),
+				BackedUpItems:    NewBackedUpItemsMap(),
 			},
 			apiResources: []*test.APIResource{
 				test.Pods(
@@ -3398,6 +3428,7 @@ func TestBackupWithInvalidHooks(t *testing.T) {
 				req = &Request{
 					Backup:           tc.backup,
 					SkippedPVTracker: NewSkipPVTracker(),
+					BackedUpItems:    NewBackedUpItemsMap(),
 				}
 				backupFile = bytes.NewBuffer([]byte{})
 			)
@@ -3868,6 +3899,7 @@ func TestBackupWithHooks(t *testing.T) {
 				req = &Request{
 					Backup:           tc.backup,
 					SkippedPVTracker: NewSkipPVTracker(),
+					BackedUpItems:    NewBackedUpItemsMap(),
 				}
 				backupFile         = bytes.NewBuffer([]byte{})
 				podCommandExecutor = new(test.MockPodCommandExecutor)
@@ -4071,6 +4103,7 @@ func TestBackupWithPodVolume(t *testing.T) {
 					Backup:            tc.backup,
 					SnapshotLocations: []*velerov1.VolumeSnapshotLocation{tc.vsl},
 					SkippedPVTracker:  NewSkipPVTracker(),
+					BackedUpItems:     NewBackedUpItemsMap(),
 				}
 				backupFile = bytes.NewBuffer([]byte{})
 			)
@@ -5181,6 +5214,7 @@ func TestBackupNewResourceFiltering(t *testing.T) {
 				req = &Request{
 					Backup:           tc.backup,
 					SkippedPVTracker: NewSkipPVTracker(),
+					BackedUpItems:    NewBackedUpItemsMap(),
 				}
 				backupFile = bytes.NewBuffer([]byte{})
 			)
@@ -5342,6 +5376,7 @@ func TestBackupNamespaces(t *testing.T) {
 				req = &Request{
 					Backup:           tc.backup,
 					SkippedPVTracker: NewSkipPVTracker(),
+					BackedUpItems:    NewBackedUpItemsMap(),
 				}
 				backupFile = bytes.NewBuffer([]byte{})
 			)

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -175,12 +175,12 @@ func (ib *itemBackupper) backupItemInternal(logger logrus.FieldLogger, obj runti
 		name:      name,
 	}
 
-	if _, exists := ib.backupRequest.BackedUpItems[key]; exists {
+	if ib.backupRequest.BackedUpItems.Has(key) {
 		log.Info("Skipping item because it's already been backed up.")
 		// returning true since this item *is* in the backup, even though we're not backing it up here
 		return true, itemFiles, nil
 	}
-	ib.backupRequest.BackedUpItems[key] = struct{}{}
+	ib.backupRequest.BackedUpItems.AddItem(key)
 	log.Info("Backing up item")
 
 	var (

--- a/pkg/backup/request.go
+++ b/pkg/backup/request.go
@@ -17,9 +17,6 @@ limitations under the License.
 package backup
 
 import (
-	"fmt"
-	"sort"
-
 	"github.com/vmware-tanzu/velero/internal/hook"
 	"github.com/vmware-tanzu/velero/internal/resourcepolicies"
 	"github.com/vmware-tanzu/velero/internal/volume"
@@ -49,7 +46,7 @@ type Request struct {
 	ResolvedItemBlockActions  []framework.ItemBlockResolvedAction
 	VolumeSnapshots           []*volume.Snapshot
 	PodVolumeBackups          []*velerov1api.PodVolumeBackup
-	BackedUpItems             map[itemKey]struct{}
+	BackedUpItems             *backedUpItemsMap
 	itemOperationsList        *[]*itemoperation.BackupOperation
 	ResPolicies               *resourcepolicies.Policies
 	SkippedPVTracker          *skipPVTracker
@@ -71,21 +68,7 @@ func (r *Request) GetItemOperationsList() *[]*itemoperation.BackupOperation {
 // BackupResourceList returns the list of backed up resources grouped by the API
 // Version and Kind
 func (r *Request) BackupResourceList() map[string][]string {
-	resources := map[string][]string{}
-	for i := range r.BackedUpItems {
-		entry := i.name
-		if i.namespace != "" {
-			entry = fmt.Sprintf("%s/%s", i.namespace, i.name)
-		}
-		resources[i.resource] = append(resources[i.resource], entry)
-	}
-
-	// sort namespace/name entries for each GVK
-	for _, v := range resources {
-		sort.Strings(v)
-	}
-
-	return resources
+	return r.BackedUpItems.ResourceMap()
 }
 
 func (r *Request) FillVolumesInformation() {

--- a/pkg/backup/request_test.go
+++ b/pkg/backup/request_test.go
@@ -44,9 +44,9 @@ func TestRequest_BackupResourceList(t *testing.T) {
 			name:     "my-pv",
 		},
 	}
-	backedUpItems := map[itemKey]struct{}{}
+	backedUpItems := NewBackedUpItemsMap()
 	for _, it := range items {
-		backedUpItems[it] = struct{}{}
+		backedUpItems.AddItem(it)
 	}
 
 	req := Request{BackedUpItems: backedUpItems}
@@ -70,9 +70,9 @@ func TestRequest_BackupResourceListEntriesSorted(t *testing.T) {
 			namespace: "ns1",
 		},
 	}
-	backedUpItems := map[itemKey]struct{}{}
+	backedUpItems := NewBackedUpItemsMap()
 	for _, it := range items {
-		backedUpItems[it] = struct{}{}
+		backedUpItems.AddItem(it)
 	}
 
 	req := Request{BackedUpItems: backedUpItems}

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -328,6 +328,7 @@ func (b *backupReconciler) prepareBackupRequest(backup *velerov1api.Backup, logg
 	request := &pkgbackup.Request{
 		Backup:           backup.DeepCopy(), // don't modify items in the cache
 		SkippedPVTracker: pkgbackup.NewSkipPVTracker(),
+		BackedUpItems:    pkgbackup.NewBackedUpItemsMap(),
 	}
 	request.VolumesInformation.Init()
 

--- a/pkg/controller/backup_finalizer_controller.go
+++ b/pkg/controller/backup_finalizer_controller.go
@@ -160,6 +160,7 @@ func (r *backupFinalizerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		Backup:           backup,
 		StorageLocation:  location,
 		SkippedPVTracker: pkgbackup.NewSkipPVTracker(),
+		BackedUpItems:    pkgbackup.NewBackedUpItemsMap(),
 	}
 	var outBackupFile *os.File
 	if len(operations) > 0 {


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
This PR synchronizes access to backupRequest.BackedUpItems with an RWMutex so that multiple ItemBlock processing goroutines will be able to access it.
 
# Does your change fix a particular issue?

Fixes #7148 

# Please indicate you've done the following:

- [ x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ x] Updated the corresponding documentation in `site/content/docs/main`.
