### PR TITLE
Add --item-block-worker-count flag to velero install and server

### DIFF
--- a/changelogs/unreleased/8380-sseago
+++ b/changelogs/unreleased/8380-sseago
@@ -1,0 +1,1 @@
+Add --item-block-worker-count flag to velero install and server

--- a/pkg/cmd/cli/install/install.go
+++ b/pkg/cmd/cli/install/install.go
@@ -89,6 +89,7 @@ type Options struct {
 	BackupRepoConfigMap             string
 	RepoMaintenanceJobConfigMap     string
 	NodeAgentConfigMap              string
+	ItemBlockWorkerCount            int
 }
 
 // BindFlags adds command line values to the options struct.
@@ -181,6 +182,12 @@ func (o *Options) BindFlags(flags *pflag.FlagSet) {
 		"node-agent-configmap",
 		o.NodeAgentConfigMap,
 		"The name of ConfigMap containing node-agent configurations.",
+	)
+	flags.IntVar(
+		&o.ItemBlockWorkerCount,
+		"item-block-worker-count",
+		o.ItemBlockWorkerCount,
+		"Number of worker threads to process ItemBlocks. Default is one. Optional.",
 	)
 }
 
@@ -283,6 +290,7 @@ func (o *Options) AsVeleroOptions() (*install.VeleroOptions, error) {
 		BackupRepoConfigMap:             o.BackupRepoConfigMap,
 		RepoMaintenanceJobConfigMap:     o.RepoMaintenanceJobConfigMap,
 		NodeAgentConfigMap:              o.NodeAgentConfigMap,
+		ItemBlockWorkerCount:            o.ItemBlockWorkerCount,
 	}, nil
 }
 

--- a/pkg/cmd/server/config/config.go
+++ b/pkg/cmd/server/config/config.go
@@ -53,6 +53,8 @@ const (
 	DefaultMaintenanceJobCPULimit    = "0"
 	DefaultMaintenanceJobMemRequest  = "0"
 	DefaultMaintenanceJobMemLimit    = "0"
+
+	DefaultItemBlockWorkerCount = 1
 )
 
 var (
@@ -179,6 +181,7 @@ type Config struct {
 	RepoMaintenanceJobConfig       string
 	PodResources                   kube.PodResources
 	KeepLatestMaintenanceJobs      int
+	ItemBlockWorkerCount           int
 }
 
 func GetDefaultConfig() *Config {
@@ -216,6 +219,7 @@ func GetDefaultConfig() *Config {
 			MemoryLimit:   DefaultMaintenanceJobMemLimit,
 		},
 		KeepLatestMaintenanceJobs: DefaultKeepLatestMaintenanceJobs,
+		ItemBlockWorkerCount:      DefaultItemBlockWorkerCount,
 	}
 
 	return config
@@ -293,5 +297,11 @@ func (c *Config) BindFlags(flags *pflag.FlagSet) {
 		"repo-maintenance-job-configmap",
 		c.RepoMaintenanceJobConfig,
 		"The name of ConfigMap containing repository maintenance Job configurations.",
+	)
+	flags.IntVar(
+		&c.ItemBlockWorkerCount,
+		"item-block-worker-count",
+		c.ItemBlockWorkerCount,
+		"Number of worker threads to process ItemBlocks. Default is one. Optional.",
 	)
 }

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -620,6 +620,7 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 			s.credentialFileStore,
 			s.config.MaxConcurrentK8SConnections,
 			s.config.DefaultSnapshotMoveData,
+			s.config.ItemBlockWorkerCount,
 			s.crClient,
 		).SetupWithManager(s.mgr); err != nil {
 			s.logger.Fatal(err, "unable to create controller", "controller", constant.ControllerBackup)

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -86,6 +86,7 @@ type backupReconciler struct {
 	maxConcurrentK8SConnections int
 	defaultSnapshotMoveData     bool
 	globalCRClient              kbclient.Client
+	itemBlockWorkerCount        int
 }
 
 func NewBackupReconciler(
@@ -110,6 +111,7 @@ func NewBackupReconciler(
 	credentialStore credentials.FileStore,
 	maxConcurrentK8SConnections int,
 	defaultSnapshotMoveData bool,
+	itemBlockWorkerCount int,
 	globalCRClient kbclient.Client,
 ) *backupReconciler {
 	b := &backupReconciler{
@@ -135,6 +137,7 @@ func NewBackupReconciler(
 		credentialFileStore:         credentialStore,
 		maxConcurrentK8SConnections: maxConcurrentK8SConnections,
 		defaultSnapshotMoveData:     defaultSnapshotMoveData,
+		itemBlockWorkerCount:        itemBlockWorkerCount,
 		globalCRClient:              globalCRClient,
 	}
 	b.updateTotalBackupMetric()

--- a/pkg/install/deployment.go
+++ b/pkg/install/deployment.go
@@ -57,6 +57,7 @@ type podTemplateConfig struct {
 	backupRepoConfigMap             string
 	repoMaintenanceJobConfigMap     string
 	nodeAgentConfigMap              string
+	itemBlockWorkerCount            int
 }
 
 func WithImage(image string) podTemplateOption {
@@ -212,6 +213,12 @@ func WithRepoMaintenanceJobConfigMap(repoMaintenanceJobConfigMap string) podTemp
 	}
 }
 
+func WithItemBlockWorkerCount(itemBlockWorkerCount int) podTemplateOption {
+	return func(c *podTemplateConfig) {
+		c.itemBlockWorkerCount = itemBlockWorkerCount
+	}
+}
+
 func Deployment(namespace string, opts ...podTemplateOption) *appsv1.Deployment {
 	// TODO: Add support for server args
 	c := &podTemplateConfig{
@@ -295,6 +302,10 @@ func Deployment(namespace string, opts ...podTemplateOption) *appsv1.Deployment 
 
 	if len(c.repoMaintenanceJobConfigMap) > 0 {
 		args = append(args, fmt.Sprintf("--repo-maintenance-job-configmap=%s", c.repoMaintenanceJobConfigMap))
+	}
+
+	if c.itemBlockWorkerCount > 0 {
+		args = append(args, fmt.Sprintf("--item-block-worker-count=%d", c.itemBlockWorkerCount))
 	}
 
 	deployment := &appsv1.Deployment{

--- a/pkg/install/resources.go
+++ b/pkg/install/resources.go
@@ -267,6 +267,7 @@ type VeleroOptions struct {
 	BackupRepoConfigMap             string
 	RepoMaintenanceJobConfigMap     string
 	NodeAgentConfigMap              string
+	ItemBlockWorkerCount            int
 }
 
 func AllCRDs() *unstructured.UnstructuredList {
@@ -353,6 +354,7 @@ func AllResources(o *VeleroOptions) *unstructured.UnstructuredList {
 		WithScheduleSkipImmediately(o.ScheduleSkipImmediately),
 		WithPodResources(o.PodResources),
 		WithKeepLatestMaintenanceJobs(o.KeepLatestMaintenanceJobs),
+		WithItemBlockWorkerCount(o.ItemBlockWorkerCount),
 	}
 
 	if len(o.Features) > 0 {


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
This is the second PR related to phase 2 for backup performance improvements which adds  a new flag `--item-block-worker-count` to velero install and server commands.

Follow-on PRs will use this value to determine the number of goroutines to start for processing ItemBlocks
# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ x] Updated the corresponding documentation in `site/content/docs/main`.
