### PR TITLE
Typo: ebs.csi.aws.com instead of aws.ebs.csi.driver

### DIFF
--- a/design/Implemented/handle-backup-of-volumes-by-resources-filters.md
+++ b/design/Implemented/handle-backup-of-volumes-by-resources-filters.md
@@ -86,7 +86,7 @@ volumePolicies:
     # capacity condition matches the volumes whose capacity falls into the range
     capacity: "0,100Gi"
     csi:
-      driver: aws.ebs.csi.driver
+      driver: ebs.csi.aws.com
       fsType: ext4
     storageClass:
     - gp2
@@ -174,7 +174,7 @@ data:
   - conditions:
       capacity: "0,100Gi"
       csi:
-        driver: aws.ebs.csi.driver
+        driver: ebs.csi.aws.com
         fsType: ext4
       storageClass:
       - gp2

--- a/internal/resourcepolicies/resource_policies_test.go
+++ b/internal/resourcepolicies/resource_policies_test.go
@@ -276,7 +276,7 @@ volumePolicies:
 			vol: &v1.PersistentVolume{
 				Spec: v1.PersistentVolumeSpec{
 					PersistentVolumeSource: v1.PersistentVolumeSource{
-						CSI: &v1.CSIPersistentVolumeSource{Driver: "aws.ebs.csi.driver"},
+						CSI: &v1.CSIPersistentVolumeSource{Driver: "ebs.csi.aws.com"},
 					}},
 			},
 			skip: true,
@@ -311,7 +311,7 @@ volumePolicies:
 						v1.ResourceStorage: resource.MustParse("1Gi"),
 					},
 					PersistentVolumeSource: v1.PersistentVolumeSource{
-						CSI: &v1.CSIPersistentVolumeSource{Driver: "aws.ebs.csi.driver"},
+						CSI: &v1.CSIPersistentVolumeSource{Driver: "ebs.csi.aws.com"},
 					}},
 			},
 			skip: true,

--- a/site/content/docs/main/resource-filtering.md
+++ b/site/content/docs/main/resource-filtering.md
@@ -264,7 +264,7 @@ The policies YAML config file would look like this:
         capacity: "10,100Gi"
         # pv matches specific csi driver
         csi:
-          driver: aws.ebs.csi.driver
+          driver: ebs.csi.aws.com
         # pv matches one of the storage class list
         storageClass:
           - gp2

--- a/site/content/docs/v1.11/resource-filtering.md
+++ b/site/content/docs/v1.11/resource-filtering.md
@@ -241,7 +241,7 @@ Velero only support volume resource policies currently, other kinds of resource 
         capacity: "10,100Gi"
         # pv matches specific csi driver
         csi:
-          driver: aws.ebs.csi.driver
+          driver: ebs.csi.aws.com
         # pv matches one of the storage class list
         storageClass:
         - gp2

--- a/site/content/docs/v1.12/resource-filtering.md
+++ b/site/content/docs/v1.12/resource-filtering.md
@@ -241,7 +241,7 @@ Velero only support volume resource policies currently, other kinds of resource 
         capacity: "10,100Gi"
         # pv matches specific csi driver
         csi:
-          driver: aws.ebs.csi.driver
+          driver: ebs.csi.aws.com
         # pv matches one of the storage class list
         storageClass:
         - gp2

--- a/site/content/docs/v1.13/resource-filtering.md
+++ b/site/content/docs/v1.13/resource-filtering.md
@@ -259,7 +259,7 @@ Velero only support volume resource policies currently, other kinds of resource 
         capacity: "10,100Gi"
         # pv matches specific csi driver
         csi:
-          driver: aws.ebs.csi.driver
+          driver: ebs.csi.aws.com
         # pv matches one of the storage class list
         storageClass:
           - gp2

--- a/site/content/docs/v1.14/resource-filtering.md
+++ b/site/content/docs/v1.14/resource-filtering.md
@@ -264,7 +264,7 @@ The policies YAML config file would look like this:
         capacity: "10,100Gi"
         # pv matches specific csi driver
         csi:
-          driver: aws.ebs.csi.driver
+          driver: ebs.csi.aws.com
         # pv matches one of the storage class list
         storageClass:
           - gp2

--- a/site/content/docs/v1.15/resource-filtering.md
+++ b/site/content/docs/v1.15/resource-filtering.md
@@ -264,7 +264,7 @@ The policies YAML config file would look like this:
         capacity: "10,100Gi"
         # pv matches specific csi driver
         csi:
-          driver: aws.ebs.csi.driver
+          driver: ebs.csi.aws.com
         # pv matches one of the storage class list
         storageClass:
           - gp2


### PR DESCRIPTION
Per driver [code](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/966da33cffbd3813846ff0463b6bf31d6a9d91d1/pkg/driver/driver.go#L49C30-L49C45)

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?
Avoids perhaps causing user error like [here](https://github.com/vmware-tanzu/velero/discussions/8372#discussioncomment-11175466:~:text=%3A%0A%20%20%20%20csi%3A-,driver%3A%20aws.efs.csi.driver,-storageClass%3A%0A%20%20%20%20%20%20%2D%20efs).


# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
