### PR TITLE
Adding Support For VolumeAttributes in Resource Policy

### DIFF
--- a/changelogs/unreleased/8382-mayankagg9722
+++ b/changelogs/unreleased/8382-mayankagg9722
@@ -1,0 +1,1 @@
+Adding support in velero Resource Policies for filtering PVs based on additional VolumeAttributes properties under CSI PVs

--- a/internal/resourcepolicies/volume_resources.go
+++ b/internal/resourcepolicies/volume_resources.go
@@ -153,7 +153,11 @@ func (c *csiCondition) match(v *structuredVolume) bool {
 	}
 
 	if c.csi.Driver == "" { // match csi: {}
-		return v.csi != nil
+		if v.csi != nil {
+			return true
+		} 
+
+		return false
 	}
 
 	if v.csi == nil {

--- a/internal/resourcepolicies/volume_resources.go
+++ b/internal/resourcepolicies/volume_resources.go
@@ -172,8 +172,8 @@ func (c *csiCondition) match(v *structuredVolume) bool {
 		return false
 	}
 
-	for key, value := range c.csi.VolumeAttributes { // match csi: {driver: "csi", volumeAttributes: {key: value}}
-		if value != v.csi.VolumeAttributes[key] { // if the value of the key does not match, return false
+	for key, value := range c.csi.VolumeAttributes {
+		if value != v.csi.VolumeAttributes[key] {
 			return false
 		}
 	}

--- a/internal/resourcepolicies/volume_resources.go
+++ b/internal/resourcepolicies/volume_resources.go
@@ -60,7 +60,7 @@ func (s *structuredVolume) parsePV(pv *corev1api.PersistentVolume) {
 
 	csi := pv.Spec.CSI
 	if csi != nil {
-		s.csi = &csiVolumeSource{Driver: csi.Driver}
+		s.csi = &csiVolumeSource{Driver: csi.Driver, VolumeAttributes: csi.VolumeAttributes}
 	}
 
 	s.volumeType = getVolumeTypeFromPV(pv)
@@ -74,7 +74,7 @@ func (s *structuredVolume) parsePodVolume(vol *corev1api.Volume) {
 
 	csi := vol.CSI
 	if csi != nil {
-		s.csi = &csiVolumeSource{Driver: csi.Driver}
+		s.csi = &csiVolumeSource{Driver: csi.Driver, VolumeAttributes: csi.VolumeAttributes}
 	}
 
 	s.volumeType = getVolumeTypeFromVolume(vol)
@@ -160,7 +160,25 @@ func (c *csiCondition) match(v *structuredVolume) bool {
 		return false
 	}
 
-	return c.csi.Driver == v.csi.Driver
+	if c.csi.Driver != v.csi.Driver {
+		return false
+	}
+
+	if c.csi.VolumeAttributes == nil || len(c.csi.VolumeAttributes) == 0 {
+		return true
+	}
+
+	if v.csi.VolumeAttributes == nil || len(v.csi.VolumeAttributes) == 0 {
+		return false
+	}
+
+	for key, value := range c.csi.VolumeAttributes { // match csi: {driver: "csi", volumeAttributes: {key: value}}
+		if value != v.csi.VolumeAttributes[key] { // if the value of the key does not match, return false
+			return false
+		}
+	}
+
+	return true
 }
 
 // parseCapacity parse string into capacity format

--- a/internal/resourcepolicies/volume_resources_test.go
+++ b/internal/resourcepolicies/volume_resources_test.go
@@ -231,13 +231,13 @@ func TestCSIConditionMatch(t *testing.T) {
 			expectedMatch: true,
 		},
 		{
-			name:          "empty csi volumeAttributes volume // SMB volumes",
+			name:          "empty csi volumeAttributes volume",
 			condition:     &csiCondition{&csiVolumeSource{Driver: "test", VolumeAttributes: map[string]string{"protocol": "nfs"}}},
 			volume:        setStructuredVolume(*resource.NewQuantity(0, resource.BinarySI), "", nil, &csiVolumeSource{Driver: "test", VolumeAttributes: map[string]string{"protocol": ""}}),
 			expectedMatch: false,
 		},
 		{
-			name:          "empty csi volumeAttributes volume // SMB volumes",
+			name:          "empty csi volumeAttributes volume",
 			condition:     &csiCondition{&csiVolumeSource{Driver: "test", VolumeAttributes: map[string]string{"protocol": "nfs"}}},
 			volume:        setStructuredVolume(*resource.NewQuantity(0, resource.BinarySI), "", nil, &csiVolumeSource{Driver: "test"}),
 			expectedMatch: false,
@@ -326,7 +326,8 @@ func TestParsePodVolume(t *testing.T) {
 	}
 	csiVolume := corev1api.Volume{}
 	csiVolume.CSI = &corev1api.CSIVolumeSource{
-		Driver: "csi.example.com",
+		Driver:           "csi.example.com",
+		VolumeAttributes: map[string]string{"protocol": "nfs"},
 	}
 	emptyVolume := corev1api.Volume{}
 
@@ -345,7 +346,7 @@ func TestParsePodVolume(t *testing.T) {
 		{
 			name:        "CSI volume",
 			inputVolume: &csiVolume,
-			expectedCSI: &csiVolumeSource{Driver: "csi.example.com"},
+			expectedCSI: &csiVolumeSource{Driver: "csi.example.com", VolumeAttributes: map[string]string{"protocol": "nfs"}},
 		},
 		{
 			name:        "Empty volume",
@@ -397,7 +398,7 @@ func TestParsePV(t *testing.T) {
 	nfsVolume.Spec.NFS = &corev1api.NFSVolumeSource{Server: "nfs.example.com", Path: "/exports/data"}
 	csiVolume := corev1api.PersistentVolume{}
 	csiVolume.Spec.Capacity = corev1api.ResourceList{corev1api.ResourceStorage: resource.MustParse("2Gi")}
-	csiVolume.Spec.CSI = &corev1api.CSIPersistentVolumeSource{Driver: "csi.example.com"}
+	csiVolume.Spec.CSI = &corev1api.CSIPersistentVolumeSource{Driver: "csi.example.com", VolumeAttributes: map[string]string{"protocol": "nfs"}}
 	emptyVolume := corev1api.PersistentVolume{}
 
 	// Test cases
@@ -417,7 +418,7 @@ func TestParsePV(t *testing.T) {
 			name:        "CSI volume",
 			inputVolume: &csiVolume,
 			expectedNFS: nil,
-			expectedCSI: &csiVolumeSource{Driver: "csi.example.com"},
+			expectedCSI: &csiVolumeSource{Driver: "csi.example.com", VolumeAttributes: map[string]string{"protocol": "nfs"}},
 		},
 		{
 			name:        "Empty volume",

--- a/internal/resourcepolicies/volume_resources_validator.go
+++ b/internal/resourcepolicies/volume_resources_validator.go
@@ -70,7 +70,10 @@ func (c *nfsCondition) validate() error {
 }
 
 func (c *csiCondition) validate() error {
-	// validate by yamlv3
+	if c != nil && c.csi != nil && c.csi.Driver == "" && c.csi.VolumeAttributes != nil {
+		return errors.New("csi driver should not be empty")
+	}
+	
 	return nil
 }
 

--- a/internal/resourcepolicies/volume_resources_validator.go
+++ b/internal/resourcepolicies/volume_resources_validator.go
@@ -27,6 +27,8 @@ const currentSupportDataVersion = "v1"
 
 type csiVolumeSource struct {
 	Driver string `yaml:"driver,omitempty"`
+	// CSI volume attributes
+	VolumeAttributes map[string]string `yaml:"volumeAttributes,omitempty"`
 }
 
 type nFSVolumeSource struct {

--- a/internal/resourcepolicies/volume_resources_validator_test.go
+++ b/internal/resourcepolicies/volume_resources_validator_test.go
@@ -166,6 +166,47 @@ func TestValidate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "error format of csi driver",
+			res: &ResourcePolicies{
+				Version: "v1",
+				VolumePolicies: []VolumePolicy{
+					{
+						Action: Action{Type: "skip"},
+						Conditions: map[string]interface{}{
+							"capacity":     "0,10Gi",
+							"storageClass": []string{"gp2", "ebs-sc"},
+							"csi": interface{}(
+								map[string]interface{}{
+									"driver": []string{"aws.efs.csi.driver"},
+								}),
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error format of csi driver volumeAttributes",
+			res: &ResourcePolicies{
+				Version: "v1",
+				VolumePolicies: []VolumePolicy{
+					{
+						Action: Action{Type: "skip"},
+						Conditions: map[string]interface{}{
+							"capacity":     "0,10Gi",
+							"storageClass": []string{"gp2", "ebs-sc"},
+							"csi": interface{}(
+								map[string]interface{}{
+									"driver":           "aws.efs.csi.driver",
+									"volumeAttributes": "test",
+								}),
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "unsupported version",
 			res: &ResourcePolicies{
 				Version: "v2",
@@ -219,6 +260,65 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			wantErr: true,
+		},
+		{
+			name: "supported format volume policies only csi driver",
+			res: &ResourcePolicies{
+				Version: "v1",
+				VolumePolicies: []VolumePolicy{
+					{
+						Action: Action{Type: "skip"},
+						Conditions: map[string]interface{}{
+							"csi": interface{}(
+								map[string]interface{}{
+									"driver": "aws.efs.csi.driver",
+								}),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "supported format volume policies only csi volumeattributes",
+			res: &ResourcePolicies{
+				Version: "v1",
+				VolumePolicies: []VolumePolicy{
+					{
+						Action: Action{Type: "skip"},
+						Conditions: map[string]interface{}{
+							"csi": interface{}(
+								map[string]interface{}{
+									"volumeAttributes": map[string]string{
+										"key1": "value1",
+									},
+								}),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "supported format volume policies with csi driver and volumeattributes",
+			res: &ResourcePolicies{
+				Version: "v1",
+				VolumePolicies: []VolumePolicy{
+					{
+						Action: Action{Type: "skip"},
+						Conditions: map[string]interface{}{
+							"csi": interface{}(
+								map[string]interface{}{
+									"driver": "aws.efs.csi.driver",
+									"volumeAttributes": map[string]string{
+										"key1": "value1",
+									},
+								}),
+						},
+					},
+				},
+			},
+			wantErr: false,
 		},
 		{
 			name: "supported format volume policies",

--- a/internal/resourcepolicies/volume_resources_validator_test.go
+++ b/internal/resourcepolicies/volume_resources_validator_test.go
@@ -297,7 +297,7 @@ func TestValidate(t *testing.T) {
 					},
 				},
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "supported format volume policies with csi driver and volumeattributes",


### PR DESCRIPTION
Thank you for contributing to Velero!

# Summary of your changes
Currently [Velero Resource policies](https://velero.io/docs/main/resource-filtering/#creating-resource-policies) are only supporting "Driver" to be filtered in [CSI volume conditions](https://github.com/vmware-tanzu/velero/blob/a46fef8f2f494f1218e4c4421cad644258f34b01/internal/resourcepolicies/volume_resources_validator.go#L28)

We are adding support for filtering Persistent Volumes (PVs) based on additional **[VolumeAttributes](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#csi-ephemeral-volumes)** properties under CSI PVs.

**Use Case:** 
Customers asked to back up AFS (Azure file shares) and want to only backup SMB type of file share volumes and not NFS file share volumes.

**How Provisioning happens:**
Define the Storage class with `protocol: nfs`  under storage class **parameters** to provision CSI NFS Azure File Shares.

**Link:** https://learn.microsoft.com/en-us/azure/aks/azure-files-csi#nfs-file-shares

The same `protocol:nfs` property will be floated to the PersistentVolumes as part of CSI VolumeAttributes.

**Constraints with current Velero Resource Policies:**
As the current resource policies only offer to filter based on the driver type, we are bringing an additional filter **VolumeAttributes** to extend and allow customer to skip/snapshot only certain types of persistent volumes for the same driver.

**Sample AFS NFS PV attached below:**

![image](https://github.com/user-attachments/assets/afdaf981-e1c9-4766-b6ef-49550ac12b3f)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
