### PR TITLE
golangci-lint: enable int-conversion and fiximports rule of perfsprint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -227,6 +227,12 @@ linters-settings:
     require-explanation: true
     # Enable to require nolint directives to mention the specific linter being suppressed. Default is false.
     require-specific: true
+  perfsprint:
+    strconcat: false
+    sprintf1: false
+    errorf: false
+    int-conversion: true
+    fiximports: true
   revive:
     rules:
       - name: unexported-return
@@ -310,6 +316,7 @@ linters:
     - nilerr
     - noctx
     - nolintlint
+    - perfsprint
     - revive
     - staticcheck
     - stylecheck

--- a/pkg/backup/actions/csi/pvc_action.go
+++ b/pkg/backup/actions/csi/pvc_action.go
@@ -19,6 +19,7 @@ package csi
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	snapshotv1api "github.com/kubernetes-csi/external-snapshotter/client/v7/apis/volumesnapshot/v1"
 	"github.com/pkg/errors"
@@ -484,9 +485,7 @@ func newDataUpload(
 	if backup.Spec.UploaderConfig != nil &&
 		backup.Spec.UploaderConfig.ParallelFilesUpload > 0 {
 		dataUpload.Spec.DataMoverConfig = make(map[string]string)
-		dataUpload.Spec.DataMoverConfig[uploaderUtil.ParallelFilesUpload] = fmt.Sprintf(
-			"%d", backup.Spec.UploaderConfig.ParallelFilesUpload,
-		)
+		dataUpload.Spec.DataMoverConfig[uploaderUtil.ParallelFilesUpload] = strconv.Itoa(backup.Spec.UploaderConfig.ParallelFilesUpload)
 	}
 
 	return dataUpload

--- a/pkg/cmd/cli/backup/create_test.go
+++ b/pkg/cmd/cli/backup/create_test.go
@@ -19,6 +19,7 @@ package backup
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -222,7 +223,7 @@ func TestCreateCommand(t *testing.T) {
 		flags.Parse([]string{"--default-volumes-to-fs-backup", defaultVolumesToFsBackup})
 		flags.Parse([]string{"--resource-policies-configmap", resPoliciesConfigmap})
 		flags.Parse([]string{"--data-mover", dataMover})
-		flags.Parse([]string{"--parallel-files-upload", fmt.Sprintf("%d", parallelFilesUpload)})
+		flags.Parse([]string{"--parallel-files-upload", strconv.Itoa(parallelFilesUpload)})
 		//flags.Parse([]string{"--wait"})
 
 		client := velerotest.NewFakeControllerRuntimeClient(t).(kbclient.WithWatch)

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -18,6 +18,7 @@ package label
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,7 +39,7 @@ func GetValidName(label string) string {
 	}
 
 	sha := sha256.Sum256([]byte(label))
-	strSha := fmt.Sprintf("%x", sha)
+	strSha := hex.EncodeToString(sha[:])
 	charsFromLabel := validation.DNS1035LabelMaxLength - 6
 	if charsFromLabel < 0 {
 		// Derive the label name from sha hash in case the DNS1035LabelMaxLength is less than 6


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

enable int-conversion and fiximports rule of [perfsprint](https://golangci-lint.run/usage/linters/#perfsprinf)
This is to reduce memory consumption

# Does your change fix a particular issue?

No

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
