### PR TITLE
Automatically bump go patch version in main branch go.mod

### DIFF
--- a/.github/workflows/auto_bump_golang.yml
+++ b/.github/workflows/auto_bump_golang.yml
@@ -1,0 +1,56 @@
+name: Auto Update Go Patch
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs every day at midnight UTC
+  workflow_dispatch: # Allows manual triggering of the workflow
+  pull_request:
+    paths: # only run on pull requests that modify this workflow
+    - '.github/workflows/auto_bump_golang.yml'
+permissions: 
+  pull-requests: write
+  contents: write
+  actions: write # needed if branch 'actions/update-go-mod-patch' is not pre-created and action is pushing .github/workflows/... to the repo
+env:
+  GH_TOKEN: ${{ github.token }}
+jobs:
+  bump-golang-patch-main:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Update to latest go version allowable from current Dockerfile
+      id: update-go-mod-patch
+      run: |
+        CONTAINER_NAME=$(cat Dockerfile | grep golang: | head -n 1 | cut -d ' ' -f 3)
+        GO_VERSION=$(docker run --rm $CONTAINER_NAME go version | cut -d ' ' -f 3 | cut -d 'o' -f 2)
+        echo "Latest golang version allowed by image: $GO_VERSION"
+        echo "Updating go.mod go version to latest patch version"
+        go get go@$GO_VERSION toolchain@none
+        go mod tidy
+        echo "container=$CONTAINER_NAME" >> $GITHUB_ENV
+        echo "goversion=$GO_VERSION" >> $GITHUB_ENV
+    - name: Create PR with updated go.mod if needed
+      # if not a PR, (ie. schedule or manual trigger by maintainer) then create a PR
+      # For review purposes, PR authors who make changes to this workflow file should push to their main branch to demonstrate the workflow and link to the PR.
+      if: github.event_name != 'pull_request'
+      run: |
+        if ! git diff --exit-code -- go.mod go.sum; then
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Action"
+          git checkout -B actions/update-go-mod-patch
+          git add go.mod go.sum
+          git commit -m "Update Go in go.mod to $goversion"
+          echo "Pushing to $GITHUB_REPOSITORY at actions/update-go-mod-patch"
+          git push --force --set-upstream origin actions/update-go-mod-patch || echo "Please ensure your fork's actions/update-go-mod-patch branch is up to date with upstream/main first."
+          echo "PR to $GITHUB_REPOSITORY main"
+          gh pr create --title "Update Go in go.mod to $goversion" --body "Updated Go in go.mod to match latest patch available from Dockerfile image: $container" --base main --repo $GITHUB_REPOSITORY
+        fi;
+        cat go.mod


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Add new action that creates PR to bump version of golang used based on golang version in container image.
https://go.dev/doc/toolchain introduced toolchain to go.mod and we wanted to avoid go mod tidy triggering adding this line.

This PR adds new action that creates PR to bump version of golang used based on golang version in container image and avoids main branch using older golang than release branch (ie. release-1.15 branch uses golang 1.22.8, when main is using older golang 1.22.0).

It is practically impossible to run go mod tidy with just `go 1.22` as [some user have requested](https://kubernetes.slack.com/archives/C6VCGP4MT/p1731232368836579?thread_ts=1730991728.424729&cid=C6VCGP4MT). A patch version of golang always end up in a separate toolchain line which defeats the purpose of using generic `1.22`.

At least with this PR, go.mod of main branch will be latest possible golang patch version.

We would expect upon merging that next day or upon manual trigger, a PR with go.mod updated to latest go patch matching container image is created.

See manual runs from this workflow here https://github.com/kaovilai/velero/actions/workflows/auto_bump_golang.yml

PRs created by this workflow: https://github.com/kaovilai/velero/pulls?q=is%3Apr+author%3Aapp%2Fgithub-actions+base%3Amain+head%3Aactions%2Fupdate-go-mod-patch+

This is similar to dependabot updating deps. However, [dependabot do not currently updates golang version in go.mod](https://github.com/dependabot/dependabot-core/issues/9057).

Lookout for following [log](https://github.com/vmware-tanzu/velero/actions/runs/11791679553/job/32844097761?pr=8392#step:4:39) in this PR's action run.
```
go: upgraded go 1.22.0 => 1.22.9
```
# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
