### PR TITLE
Issue 8391: check ErrCancelled from suffix

### DIFF
--- a/changelogs/unreleased/8396-Lyndon-Li
+++ b/changelogs/unreleased/8396-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix issue #8391, check ErrCancelled from suffix of data mover pod's termination message

--- a/pkg/datapath/micro_service_watcher.go
+++ b/pkg/datapath/micro_service_watcher.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -321,7 +322,7 @@ func (ms *microServiceBRWatcher) startWatch() {
 		if lastPod.Status.Phase == v1.PodSucceeded {
 			ms.callbacks.OnCompleted(ms.ctx, ms.namespace, ms.taskName, funcGetResultFromMessage(ms.taskType, terminateMessage, ms.log))
 		} else {
-			if terminateMessage == ErrCancelled {
+			if strings.HasSuffix(terminateMessage, ErrCancelled) {
 				ms.callbacks.OnCancelled(ms.ctx, ms.namespace, ms.taskName)
 			} else {
 				ms.callbacks.OnFailed(ms.ctx, ms.namespace, ms.taskName, errors.New(terminateMessage))

--- a/pkg/datapath/micro_service_watcher_test.go
+++ b/pkg/datapath/micro_service_watcher_test.go
@@ -360,7 +360,7 @@ func TestStartWatch(t *testing.T) {
 					event: &v1.Event{Reason: EventReasonStopped},
 				},
 			},
-			terminationMessage:   ErrCancelled,
+			terminationMessage:   fmt.Sprintf("Failed to init data path service for DataUpload %s: %v", "fake-du-name", errors.New(ErrCancelled)),
 			expectStartEvent:     true,
 			expectTerminateEvent: true,
 			expectCancel:         true,


### PR DESCRIPTION
Fix issue #8391, check ErrCancelled from suffix of data mover pod's termination message