### PR TITLE
Add go buildinfo to velero to check toolchain version used.

### DIFF
--- a/changelogs/unreleased/8398-kaovilai
+++ b/changelogs/unreleased/8398-kaovilai
@@ -1,0 +1,1 @@
+Add go buildinfo to velero to identify toolchain used to build velero

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/vmware-tanzu/velero
 
+// Do not pin patch version here. Leave patch at X.Y.0
+// Unset GOTOOLCHAIN to assume GOTOOLCHAIN=local where go cli version in path is used.
+// Use env GOTOOLCHAIN=auto to allow go to decide whichever is newer from go.mod or cli in path.
+// or GOTOOLCHAIN=goX.Y.Z to use a specific toolchain version
+// See: https://go.dev/doc/toolchain#select and https://github.com/vmware-tanzu/velero/issues/8397
+// To bump minor version, run `go get go@X.Y.0 toolchain@none` (ie. `go get go@1.23.0 toolchain@none`)
 go 1.22.0
 
 require (

--- a/pkg/buildinfo/buildinfo.go
+++ b/pkg/buildinfo/buildinfo.go
@@ -19,11 +19,17 @@ limitations under the License.
 // worrying about introducing circular dependencies.
 package buildinfo
 
-import "fmt"
+import (
+	"fmt"
+	"runtime/debug"
+)
 
 var (
 	// Version is the current version of Velero, set by the go linker's -X flag at build time.
 	Version string
+
+	// goVersion is the version of Go that was used to build Velero
+	goBuildInfo *debug.BuildInfo
 
 	// GitSHA is the actual commit that is being built, set by the go linker's -X flag at build time.
 	GitSHA string
@@ -43,4 +49,15 @@ func FormattedGitSHA() string {
 		return fmt.Sprintf("%s-%s", GitSHA, GitTreeState)
 	}
 	return GitSHA
+}
+
+func GoVersion() string {
+	if goBuildInfo == nil {
+		var ok bool
+		goBuildInfo, ok = debug.ReadBuildInfo()
+		if !ok {
+			return "cannot read Go BuildInfo"
+		}
+	}
+	return goBuildInfo.GoVersion
 }

--- a/pkg/cmd/cli/version/version.go
+++ b/pkg/cmd/cli/version/version.go
@@ -69,6 +69,7 @@ func printVersion(w io.Writer, clientOnly bool, kbClient kbclient.Client, server
 	fmt.Fprintln(w, "Client:")
 	fmt.Fprintf(w, "\tVersion: %s\n", buildinfo.Version)
 	fmt.Fprintf(w, "\tGit commit: %s\n", buildinfo.FormattedGitSHA())
+	fmt.Fprintf(w, "\tGo version: %s\n", buildinfo.GoVersion())
 
 	if clientOnly {
 		return

--- a/pkg/cmd/cli/version/version_test.go
+++ b/pkg/cmd/cli/version/version_test.go
@@ -49,7 +49,7 @@ func TestPrintVersion(t *testing.T) {
 	buildinfo.GitSHA = "somegitsha"
 	buildinfo.GitTreeState = "dirty"
 
-	clientVersion := fmt.Sprintf("Client:\n\tVersion: %s\n\tGit commit: %s\n", buildinfo.Version, buildinfo.FormattedGitSHA())
+	clientVersion := fmt.Sprintf("Client:\n\tVersion: %s\n\tGit commit: %s\n\tGo version: %s\n", buildinfo.Version, buildinfo.FormattedGitSHA(), buildinfo.GoVersion())
 
 	tests := []struct {
 		name                string

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -109,7 +109,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 
 			logger.Infof("setting log-level to %s", strings.ToUpper(logLevel.String()))
 
-			logger.Infof("Starting Velero server %s (%s)", buildinfo.Version, buildinfo.FormattedGitSHA())
+			logger.Infof("Starting Velero server %s (%s) go-version: %s", buildinfo.Version, buildinfo.FormattedGitSHA(), buildinfo.GoVersion())
 			if len(features.All()) > 0 {
 				logger.Infof("%d feature flags enabled %s", len(features.All()), features.All())
 			} else {


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Facilitates requirements similar to #8397 that may come up in the future.
Helps validate go version used to build given that `go.mod` or commit hash of a built binary do not tell you this information.

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
