### PR TITLE
release-1.15: Reduce minimum go toolchain in go.mod.

### DIFF
--- a/changelogs/unreleased/8399-kaovilai
+++ b/changelogs/unreleased/8399-kaovilai
@@ -1,0 +1,1 @@
+Reduce minimum required go toolchain in release-1.15 go.mod

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,12 @@
 module github.com/vmware-tanzu/velero
 
-go 1.22.8
+// Do not pin patch version here. Leave patch at X.Y.0
+// Unset GOTOOLCHAIN to assume GOTOOLCHAIN=local where go cli version in path is used.
+// Use env GOTOOLCHAIN=auto to allow go to decide whichever is newer from go.mod or cli in path.
+// or GOTOOLCHAIN=goX.Y.Z to use a specific toolchain version
+// See: https://go.dev/doc/toolchain#select and https://github.com/vmware-tanzu/velero/issues/8397
+// To bump minor version, run `go get go@X.Y.0 toolchain@none` (ie. `go get go@1.23.0 toolchain@none`)
+go 1.22.0
 
 require (
 	cloud.google.com/go/storage v1.40.0


### PR DESCRIPTION
TL;DR: this change keeps 1.22.8 as go toolchain for this repo without enforcing it as minimum version on others.
<details><summary>Verification (click me!) prior to #8398 review</summary>
<p>

```
make container && docker run --rm velero/velero:main /velero version --client-only
[+] Building 60.0s (18/18) FINISHED                                                                                                        docker-container:colima-multiplat
 => [internal] load build definition from Dockerfile                                                                                                                    0.0s
 => => transferring dockerfile: 2.37kB                                                                                                                                  0.0s
 => [internal] load metadata for docker.io/paketobuildpacks/run-jammy-tiny:0.2.52                                                                                       3.6s
 => [internal] load metadata for docker.io/library/golang:1.22.8-bookworm                                                                                               3.4s
 => [auth] paketobuildpacks/run-jammy-tiny:pull token for registry-1.docker.io                                                                                          0.0s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                       0.0s
 => => transferring context: 60B                                                                                                                                        0.0s
 => CACHED [stage-2 1/3] FROM docker.io/paketobuildpacks/run-jammy-tiny:0.2.52@sha256:402b925a81a4c6985438fd37d0b22022ca688e528bbd46a38831a3702067cced                  0.0s
 => => resolve docker.io/paketobuildpacks/run-jammy-tiny:0.2.52@sha256:402b925a81a4c6985438fd37d0b22022ca688e528bbd46a38831a3702067cced                                 0.0s
 => CACHED [restic-builder 1/3] FROM docker.io/library/golang:1.22.8-bookworm@sha256:3f0457a0a56a926d93c2baf4cf0057a645e8ff69ff31314080fcc62389643b8e                   0.0s
 => => resolve docker.io/library/golang:1.22.8-bookworm@sha256:3f0457a0a56a926d93c2baf4cf0057a645e8ff69ff31314080fcc62389643b8e                                         0.0s
 => [internal] load build context                                                                                                                                       0.2s
 => => transferring context: 883.86kB                                                                                                                                   0.2s
 => CACHED [velero-builder 2/4] WORKDIR /go/src/github.com/vmware-tanzu/velero                                                                                          0.0s
 => [velero-builder 3/4] COPY . /go/src/github.com/vmware-tanzu/velero                                                                                                  1.6s
 => [restic-builder 2/3] COPY . /go/src/github.com/vmware-tanzu/velero                                                                                                  1.6s
 => [velero-builder 4/4] RUN mkdir -p /output/usr/bin &&     export GOARM=$( echo "" | cut -c2-) &&     go build -o /output/velero     -ldflags "-X github.com/vmware  49.7s
 => [restic-builder 3/3] RUN mkdir -p /output/usr/bin &&     export GOARM=$(echo "" | cut -c2-) &&     /go/src/github.com/vmware-tanzu/velero/hack/build-restic.sh &&  34.6s
 => [stage-2 2/3] COPY --from=velero-builder /output /                                                                                                                  0.2s
 => [stage-2 3/3] COPY --from=restic-builder /output /                                                                                                                  0.1s
 => exporting to docker image format                                                                                                                                    4.1s
 => => exporting layers                                                                                                                                                 2.7s
 => => exporting manifest sha256:5387d1a59b10970f9d0800ba960c4eb0f008e0d2bba5a9498b009ac478e5f4d4                                                                       0.0s
 => => exporting config sha256:f29cee5131777c8dc47571fc475f1abb2984ff1657b51c3a720c8aa453b195f2                                                                         0.0s
 => => sending tarball                                                                                                                                                  1.4s
 => importing to docker                                                                                                                                                 0.5s
 => => loading layer 4e2166c05ab9 491.52kB / 45.94MB                                                                                                                    0.5s
 => => loading layer dd8fc23784d7 98.30kB / 8.82MB                                                                                                                      0.1s

 1 warning found (use --debug to expand):
 - UndefinedVar: Usage of undefined variable '$GOPROXY' (line 58)
container: velero/velero:main
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
Client:
        Version: main
        Git commit: 303d239819259b54ecd264eef176b9dc55db3871-dirty
        Go version: go1.22.8
```


</p>
</details> 

Thank you for contributing to Velero!

# Please add a summary of your change
Reduce minimum go toolchain + add verification from #8398 

Update: verification was removed per review in #8398, but we did validated this pr earlier that the correct toolchain was applied.

# Does your change fix a particular issue?

Fixes #8397

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
