### PR TITLE
[1.15] Issue 8394: move closeDataPath outside callbacks

### DIFF
--- a/changelogs/unreleased/8402-Lyndon-Li
+++ b/changelogs/unreleased/8402-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix issue #8394, don't call closeDataPath in VGDP callbacks, otherwise, the VGDP cleanup will hang


### PR DESCRIPTION
Fix issue https://github.com/vmware-tanzu/velero/issues/8394, don't call closeDataPath in VGDP callbacks, otherwise, the VGDP cleanup will hang