### PR TITLE
Revert push image tarball to gcs

### DIFF
--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Build Velero Image
         if: steps.image-cache.outputs.cache-hit != 'true'
         run: |
-          SAVE_IMAGE=false IMAGE=velero VERSION=pr-test make container
+          IMAGE=velero VERSION=pr-test make container
           docker save velero:pr-test -o ./velero.tar
   # Create json of k8s versions to test
   # from guide: https://stackoverflow.com/a/65094398/4590470

--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Build Velero Image
         if: steps.image-cache.outputs.cache-hit != 'true'
         run: |
-          IMAGE=velero VERSION=pr-test make container
+          SAVE_IMAGE=false IMAGE=velero VERSION=pr-test make container
           docker save velero:pr-test -o ./velero.tar
   # Create json of k8s versions to test
   # from guide: https://stackoverflow.com/a/65094398/4590470

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -68,24 +68,4 @@ jobs:
               
           # Build and push Velero image to docker registry
           docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
-          VERSION=$(./hack/docker-push.sh | grep 'VERSION:' | awk -F: '{print $2}' | xargs)
-
-          # Upload Velero image package to GCS
-          source hack/ci/build_util.sh
-          BIN=velero
-          RESTORE_HELPER_BIN=velero-restore-helper
-          GCS_BUCKET=velero-builds
-          VELERO_IMAGE=${BIN}-${VERSION}
-          VELERO_RESTORE_HELPER_IMAGE=${RESTORE_HELPER_BIN}-${VERSION}
-          VELERO_IMAGE_FILE=${VELERO_IMAGE}.tar.gz
-          VELERO_RESTORE_HELPER_IMAGE_FILE=${VELERO_RESTORE_HELPER_IMAGE}.tar.gz
-          VELERO_IMAGE_BACKUP_FILE=${VELERO_IMAGE}-'build.'${GITHUB_RUN_NUMBER}.tar.gz
-          VELERO_RESTORE_HELPER_IMAGE_BACKUP_FILE=${VELERO_RESTORE_HELPER_IMAGE}-'build.'${GITHUB_RUN_NUMBER}.tar.gz
-
-          cp ${VELERO_IMAGE_FILE} ${VELERO_IMAGE_BACKUP_FILE}
-          cp ${VELERO_RESTORE_HELPER_IMAGE_FILE} ${VELERO_RESTORE_HELPER_IMAGE_BACKUP_FILE}
-
-          uploader ${VELERO_IMAGE_FILE} ${GCS_BUCKET}
-          uploader ${VELERO_RESTORE_HELPER_IMAGE_FILE} ${GCS_BUCKET}
-          uploader ${VELERO_IMAGE_BACKUP_FILE} ${GCS_BUCKET}
-          uploader ${VELERO_RESTORE_HELPER_IMAGE_BACKUP_FILE} ${GCS_BUCKET}
+          ./hack/docker-push.sh

--- a/Makefile
+++ b/Makefile
@@ -213,11 +213,10 @@ endif
 	--build-arg=RESTIC_VERSION=$(RESTIC_VERSION) \
 	-f $(VELERO_DOCKERFILE) .
 	@echo "container: $(IMAGE):$(VERSION)"
-ifeq ($(BUILDX_OUTPUT_TYPE)_$(REGISTRY), registry_velero)
-	docker pull $(IMAGE):$(VERSION)
-	rm -f $(BIN)-$(VERSION).tar
-	docker save $(IMAGE):$(VERSION) -o $(BIN)-$(VERSION).tar
-	gzip -f $(BIN)-$(VERSION).tar
+ifeq ($(BUILDX_OUTPUT_TYPE), "registry")
+	@docker pull $(IMAGE):$(VERSION)
+	@docker save $(IMAGE):$(VERSION) -o $(BIN)-$(VERSION).tar
+	@gzip $(BIN)-$(VERSION).tar
 endif
 
 SKIP_TESTS ?=

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,6 @@ VERSION ?= main
 
 TAG_LATEST ?= false
 
-SAVE_IMAGE ?= true
 ifeq ($(TAG_LATEST), true)
 	IMAGE_TAGS ?= $(IMAGE):$(VERSION) $(IMAGE):latest
 	GCR_IMAGE_TAGS ?= $(GCR_IMAGE):$(VERSION) $(GCR_IMAGE):latest
@@ -214,11 +213,6 @@ endif
 	--build-arg=RESTIC_VERSION=$(RESTIC_VERSION) \
 	-f $(VELERO_DOCKERFILE) .
 	@echo "container: $(IMAGE):$(VERSION)"
-ifeq ($(SAVE_IMAGE), true)
-	@docker pull $(IMAGE):$(VERSION)
-	@docker save $(IMAGE):$(VERSION) -o $(BIN)-$(VERSION).tar
-	@gzip $(BIN)-$(VERSION).tar
-endif
 
 SKIP_TESTS ?=
 test: build-dirs

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ VERSION ?= main
 
 TAG_LATEST ?= false
 
+SAVE_IMAGE ?= true
 ifeq ($(TAG_LATEST), true)
 	IMAGE_TAGS ?= $(IMAGE):$(VERSION) $(IMAGE):latest
 	GCR_IMAGE_TAGS ?= $(GCR_IMAGE):$(VERSION) $(GCR_IMAGE):latest
@@ -213,7 +214,7 @@ endif
 	--build-arg=RESTIC_VERSION=$(RESTIC_VERSION) \
 	-f $(VELERO_DOCKERFILE) .
 	@echo "container: $(IMAGE):$(VERSION)"
-ifeq ($(BUILDX_OUTPUT_TYPE), "registry")
+ifeq ($(SAVE_IMAGE), true)
 	@docker pull $(IMAGE):$(VERSION)
 	@docker save $(IMAGE):$(VERSION) -o $(BIN)-$(VERSION).tar
 	@gzip $(BIN)-$(VERSION).tar

--- a/hack/ci/build_util.sh
+++ b/hack/ci/build_util.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -x
-
-set -e
-
-function uploader {
-    gsutil cp $1 gs://$2/$1
-    gsutil -D setacl public-read gs://$2/$1 &> /dev/null
-}


### PR DESCRIPTION
Revert git action to push image tarball to GCS in PRs #5565, #5573, #5524, #5581. Reasons:
1. It was used by CVE scan, but it is not being used at present
2. It doesn't support multiple arch build