### PR TITLE
internal/volumes_information.go: reuse constants from pkg/apis/velero/v1

### DIFF
--- a/internal/volume/volumes_information.go
+++ b/internal/volume/volumes_information.go
@@ -49,13 +49,7 @@ const (
 
 const (
 	FieldValueIsUnknown string = "unknown"
-	kopia               string = "kopia"
 	veleroDatamover     string = "velero"
-
-	//TODO reuse these constants from csi-plugin-for-velero after it's merged into the same repo
-
-	CSIDriverNameAnnotation        = "velero.io/csi-driver-name"
-	VolumeSnapshotHandleAnnotation = "velero.io/csi-volumesnapshot-handle"
 )
 
 type BackupVolumeInfo struct {
@@ -647,7 +641,7 @@ func (v *BackupVolumesInformation) generateVolumeInfoFromDataUpload() {
 				},
 				SnapshotDataMovementInfo: &SnapshotDataMovementInfo{
 					DataMover:    dataMover,
-					UploaderType: kopia,
+					UploaderType: velerov1api.BackupRepositoryTypeKopia,
 					OperationID:  operation.Spec.OperationID,
 					Phase:        dataUpload.Status.Phase,
 				},
@@ -850,9 +844,9 @@ func (t *RestoreVolumeInfoTracker) Result() []*RestoreVolumeInfo {
 			SnapshotDataMoved: false,
 			RestoreMethod:     CSISnapshot,
 			CSISnapshotInfo: &CSISnapshotInfo{
-				SnapshotHandle: csiSnapshot.Annotations[VolumeSnapshotHandleAnnotation],
+				SnapshotHandle: csiSnapshot.Annotations[velerov1api.VolumeSnapshotHandleAnnotation],
 				Size:           restoreSize,
-				Driver:         csiSnapshot.Annotations[CSIDriverNameAnnotation],
+				Driver:         csiSnapshot.Annotations[velerov1api.DriverNameAnnotation],
 				VSCName:        vscName,
 			},
 		}
@@ -889,7 +883,7 @@ func (t *RestoreVolumeInfoTracker) Result() []*RestoreVolumeInfo {
 			RestoreMethod: CSISnapshot,
 			SnapshotDataMovementInfo: &SnapshotDataMovementInfo{
 				DataMover:      dataMover,
-				UploaderType:   kopia,
+				UploaderType:   velerov1api.BackupRepositoryTypeKopia,
 				SnapshotHandle: dd.Spec.SnapshotID,
 				OperationID:    operationID,
 			},

--- a/internal/volume/volumes_information_test.go
+++ b/internal/volume/volumes_information_test.go
@@ -1170,8 +1170,8 @@ func TestRestoreVolumeInfoResult(t *testing.T) {
 				pvcCSISnapshotMap: map[string]snapshotv1api.VolumeSnapshot{
 					"testNS/testPVC": *builder.ForVolumeSnapshot("sourceNS", "testCSISnapshot").
 						ObjectMeta(
-							builder.WithAnnotations(VolumeSnapshotHandleAnnotation, "csi-snap-001",
-								CSIDriverNameAnnotation, "test-csi-driver"),
+							builder.WithAnnotations(velerov1api.VolumeSnapshotHandleAnnotation, "csi-snap-001",
+								velerov1api.DriverNameAnnotation, "test-csi-driver"),
 						).SourceVolumeSnapshotContentName("test-vsc-001").
 						Status().RestoreSize("1Gi").Result(),
 				},
@@ -1269,7 +1269,7 @@ func TestRestoreVolumeInfoResult(t *testing.T) {
 					SnapshotDataMoved: true,
 					SnapshotDataMovementInfo: &SnapshotDataMovementInfo{
 						DataMover:      "velero",
-						UploaderType:   kopia,
+						UploaderType:   velerov1api.BackupRepositoryTypeKopia,
 						SnapshotHandle: "dd-snap-001",
 						OperationID:    "dd-operation-001",
 					},
@@ -1282,7 +1282,7 @@ func TestRestoreVolumeInfoResult(t *testing.T) {
 					SnapshotDataMoved: true,
 					SnapshotDataMovementInfo: &SnapshotDataMovementInfo{
 						DataMover:      "velero",
-						UploaderType:   kopia,
+						UploaderType:   velerov1api.BackupRepositoryTypeKopia,
 						SnapshotHandle: "dd-snap-002",
 						OperationID:    "dd-operation-002",
 					},


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [] Updated the corresponding documentation in `site/content/docs/main`.
