### PR TITLE
Added ResourceModifier to Velero Documentation

### DIFF
--- a/site/content/docs/main/api-types/restore.md
+++ b/site/content/docs/main/api-types/restore.md
@@ -111,6 +111,11 @@ spec:
   # existingResourcePolicy specifies the restore behaviour
   # for the Kubernetes resource to be restored. Optional
   existingResourcePolicy: none
+  # ResourceModifier specifies the reference to JSON resource patches
+  # that should be applied to resources before restoration. Optional
+  resourceModifier:
+    kind: ConfigMap
+    name: resource-modifier-configmap
   # Actions to perform during or post restore. The only hooks currently supported are
   # adding an init container to a pod before it can be restored and executing a command in a
   # restored pod's container. Optional.

--- a/site/content/docs/v1.15/api-types/restore.md
+++ b/site/content/docs/v1.15/api-types/restore.md
@@ -114,7 +114,6 @@ spec:
   # ResourceModifier specifies the reference to JSON resource patches
   # that should be applied to resources before restoration. Optional
   resourceModifier:
-    apiVersion: v1
     kind: ConfigMap
     name: resource-modifier-config
   # Actions to perform during or post restore. The only hooks currently supported are

--- a/site/content/docs/v1.15/api-types/restore.md
+++ b/site/content/docs/v1.15/api-types/restore.md
@@ -115,7 +115,7 @@ spec:
   # that should be applied to resources before restoration. Optional
   resourceModifier:
     kind: ConfigMap
-    name: resource-modifier-config
+    name: resource-modifier-configmap
   # Actions to perform during or post restore. The only hooks currently supported are
   # adding an init container to a pod before it can be restored and executing a command in a
   # restored pod's container. Optional.

--- a/site/content/docs/v1.15/api-types/restore.md
+++ b/site/content/docs/v1.15/api-types/restore.md
@@ -111,6 +111,12 @@ spec:
   # existingResourcePolicy specifies the restore behaviour
   # for the Kubernetes resource to be restored. Optional
   existingResourcePolicy: none
+  # ResourceModifier specifies the reference to JSON resource patches
+  # that should be applied to resources before restoration. Optional
+  resourceModifier:
+    apiVersion: v1
+    kind: ConfigMap
+    name: resource-modifier-config
   # Actions to perform during or post restore. The only hooks currently supported are
   # adding an init container to a pod before it can be restored and executing a command in a
   # restored pod's container. Optional.


### PR DESCRIPTION
/kind changelog-not-required

The documentation for Restore API Types was missing this parameter for resource modifier. 

Fixes #8463 

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] Updated the corresponding documentation in `site/content/docs/main`.
