### PR TITLE
release-1.15: CSI: Make cleanup more verbose, and don't fail get on not exist

### DIFF
--- a/pkg/util/csi/volume_snapshot.go
+++ b/pkg/util/csi/volume_snapshot.go
@@ -490,7 +490,7 @@ func CleanupVolumeSnapshot(
 		vs,
 	)
 	if err != nil {
-		log.Debugf("Failed to get volumesnapshot %s/%s", volSnap.Namespace, volSnap.Name)
+		log.Infof("Failed to get volumesnapshot %s/%s", volSnap.Namespace, volSnap.Name)
 		return
 	}
 
@@ -502,13 +502,13 @@ func CleanupVolumeSnapshot(
 			crClient,
 		)
 		if err != nil {
-			log.Debugf("Failed to patch DeletionPolicy of volume snapshot %s/%s",
+			log.Infof("Failed to patch DeletionPolicy of volume snapshot %s/%s",
 				vs.Namespace, vs.Name)
 		}
 	}
 	err = crClient.Delete(context.TODO(), vs)
 	if err != nil {
-		log.Debugf("Failed to delete volumesnapshot %s/%s: %v", vs.Namespace, vs.Name, err)
+		log.Infof("Failed to delete volumesnapshot %s/%s: %v", vs.Namespace, vs.Name, err)
 	} else {
 		log.Infof("Deleted volumesnapshot with volumesnapshotContent %s/%s",
 			vs.Namespace, vs.Name)
@@ -701,6 +701,10 @@ func WaitUntilVSCHandleIsReady(
 				crclient.ObjectKeyFromObject(volSnap),
 				vs,
 			); err != nil {
+				// if not found, do not error out yet, we want to retry Get until timeout
+				if apierrors.IsNotFound(err) {
+					return false, nil
+				}
 				return false,
 					errors.Wrapf(err, fmt.Sprintf(
 						"failed to get volumesnapshot %s/%s",


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Make velero more verbose when deleting snapshots to help diagnose issues when it does happen.

Test image amd/arm64
```
ghcr.io/kaovilai/velero:verboseCleanup-r1.15-b26183826
```
# Does your change fix a particular issue?

Fixes #8473

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
