### PR TITLE
Fix: AWS Go SDK URL

### DIFF
--- a/site/content/docs/main/supported-providers.md
+++ b/site/content/docs/main/supported-providers.md
@@ -56,7 +56,7 @@ _Some storage providers, like Quobyte, may need a different [signature algorithm
 
 In the case you want to take volume snapshots but didn't find a plugin for your provider, Velero has support for snapshotting using File System Backup. Please see the [File System Backup][30] documentation.
 
-[0]: https://github.com/aws/aws-sdk-go/aws
+[0]: https://github.com/aws/aws-sdk-go-v2
 [1]: contributions/ibm-config.md
 [2]: contributions/oracle-config.md
 [3]: contributions/minio.md

--- a/site/content/docs/v0.10.0/support-matrix.md
+++ b/site/content/docs/v0.10.0/support-matrix.md
@@ -52,6 +52,6 @@ After you publish your plugin, open a PR that adds your plugin to the appropriat
 [9]: get-started.md
 [10]: https://kubernetes.slack.com/messages/ark-dr
 [11]: https://github.com/heptio/ark/issues
-[12]: https://github.com/aws/aws-sdk-go/aws
+[12]: https://github.com/aws/aws-sdk-go
 [13]: https://portworx.slack.com/messages/px-k8s
 [14]: https://github.com/portworx/ark-plugin/issues

--- a/site/content/docs/v0.11.0/support-matrix.md
+++ b/site/content/docs/v0.11.0/support-matrix.md
@@ -55,7 +55,7 @@ After you publish your plugin, open a PR that adds your plugin to the appropriat
 [9]: get-started.md
 [10]: https://kubernetes.slack.com/messages/velero
 [11]: https://github.com/heptio/velero/issues
-[12]: https://github.com/aws/aws-sdk-go/aws
+[12]: https://github.com/aws/aws-sdk-go
 [13]: https://portworx.slack.com/messages/px-k8s
 [14]: https://github.com/portworx/ark-plugin/issues
 [15]: api-types/backupstoragelocation.md#aws

--- a/site/content/docs/v0.9.0/support-matrix.md
+++ b/site/content/docs/v0.9.0/support-matrix.md
@@ -52,6 +52,6 @@ After you publish your plugin, open a PR that adds your plugin to the appropriat
 [9]: quickstart.md
 [10]: https://kubernetes.slack.com/messages/ark-dr
 [11]: https://github.com/heptio/ark/issues
-[12]: https://github.com/aws/aws-sdk-go/aws
+[12]: https://github.com/aws/aws-sdk-go
 [13]: https://portworx.slack.com/messages/px-k8s
 [14]: https://github.com/portworx/ark-plugin/issues

--- a/site/content/docs/v1.0.0/support-matrix.md
+++ b/site/content/docs/v1.0.0/support-matrix.md
@@ -64,7 +64,7 @@ After you publish your plugin, open a PR that adds your plugin to the appropriat
 [9]: get-started.md
 [10]: https://kubernetes.slack.com/messages/velero
 [11]: https://github.com/vmware-tanzu/velero/issues
-[12]: https://github.com/aws/aws-sdk-go/aws
+[12]: https://github.com/aws/aws-sdk-go
 [13]: https://portworx.slack.com/messages/px-k8s
 [14]: https://github.com/portworx/ark-plugin/issues
 [15]: api-types/backupstoragelocation.md#aws

--- a/site/content/docs/v1.1.0/support-matrix.md
+++ b/site/content/docs/v1.1.0/support-matrix.md
@@ -65,7 +65,7 @@ After you publish your plugin, open a PR that adds your plugin to the appropriat
 [9]: get-started.md
 [10]: https://kubernetes.slack.com/messages/velero
 [11]: https://github.com/vmware-tanzu/velero/issues
-[12]: https://github.com/aws/aws-sdk-go/aws
+[12]: https://github.com/aws/aws-sdk-go
 [13]: https://portworx.slack.com/messages/px-k8s
 [14]: https://github.com/portworx/ark-plugin/issues
 [15]: api-types/backupstoragelocation.md#aws

--- a/site/content/docs/v1.10/supported-providers.md
+++ b/site/content/docs/v1.10/supported-providers.md
@@ -56,7 +56,7 @@ _Some storage providers, like Quobyte, may need a different [signature algorithm
 
 In the case you want to take volume snapshots but didn't find a plugin for your provider, Velero has support for snapshotting using File System Backup. Please see the [File System Backup][30] documentation.
 
-[0]: https://github.com/aws/aws-sdk-go/aws
+[0]: https://github.com/aws/aws-sdk-go
 [1]: contributions/ibm-config.md
 [2]: contributions/oracle-config.md
 [3]: contributions/minio.md

--- a/site/content/docs/v1.11/supported-providers.md
+++ b/site/content/docs/v1.11/supported-providers.md
@@ -56,7 +56,7 @@ _Some storage providers, like Quobyte, may need a different [signature algorithm
 
 In the case you want to take volume snapshots but didn't find a plugin for your provider, Velero has support for snapshotting using File System Backup. Please see the [File System Backup][30] documentation.
 
-[0]: https://github.com/aws/aws-sdk-go/aws
+[0]: https://github.com/aws/aws-sdk-go
 [1]: contributions/ibm-config.md
 [2]: contributions/oracle-config.md
 [3]: contributions/minio.md

--- a/site/content/docs/v1.12/supported-providers.md
+++ b/site/content/docs/v1.12/supported-providers.md
@@ -56,7 +56,7 @@ _Some storage providers, like Quobyte, may need a different [signature algorithm
 
 In the case you want to take volume snapshots but didn't find a plugin for your provider, Velero has support for snapshotting using File System Backup. Please see the [File System Backup][30] documentation.
 
-[0]: https://github.com/aws/aws-sdk-go/aws
+[0]: https://github.com/aws/aws-sdk-go
 [1]: contributions/ibm-config.md
 [2]: contributions/oracle-config.md
 [3]: contributions/minio.md

--- a/site/content/docs/v1.13/supported-providers.md
+++ b/site/content/docs/v1.13/supported-providers.md
@@ -56,7 +56,7 @@ _Some storage providers, like Quobyte, may need a different [signature algorithm
 
 In the case you want to take volume snapshots but didn't find a plugin for your provider, Velero has support for snapshotting using File System Backup. Please see the [File System Backup][30] documentation.
 
-[0]: https://github.com/aws/aws-sdk-go/aws
+[0]: https://github.com/aws/aws-sdk-go
 [1]: contributions/ibm-config.md
 [2]: contributions/oracle-config.md
 [3]: contributions/minio.md

--- a/site/content/docs/v1.14/supported-providers.md
+++ b/site/content/docs/v1.14/supported-providers.md
@@ -55,7 +55,7 @@ _Some storage providers, like Quobyte, may need a different [signature algorithm
 
 In the case you want to take volume snapshots but didn't find a plugin for your provider, Velero has support for snapshotting using File System Backup. Please see the [File System Backup][30] documentation.
 
-[0]: https://github.com/aws/aws-sdk-go/aws
+[0]: https://github.com/aws/aws-sdk-go-v2
 [1]: contributions/ibm-config.md
 [2]: contributions/oracle-config.md
 [3]: contributions/minio.md

--- a/site/content/docs/v1.15/supported-providers.md
+++ b/site/content/docs/v1.15/supported-providers.md
@@ -56,7 +56,7 @@ _Some storage providers, like Quobyte, may need a different [signature algorithm
 
 In the case you want to take volume snapshots but didn't find a plugin for your provider, Velero has support for snapshotting using File System Backup. Please see the [File System Backup][30] documentation.
 
-[0]: https://github.com/aws/aws-sdk-go/aws
+[0]: https://github.com/aws/aws-sdk-go-v2
 [1]: contributions/ibm-config.md
 [2]: contributions/oracle-config.md
 [3]: contributions/minio.md

--- a/site/content/docs/v1.2.0/supported-providers.md
+++ b/site/content/docs/v1.2.0/supported-providers.md
@@ -46,7 +46,7 @@ _Some storage providers, like Quobyte, may need a different [signature algorithm
 
 In the case you want to take volume snapshots but didn't find a plugin for your provider, Velero has support for snapshotting using restic. Please see the [restic integration][30] documentation.
 
-[0]: https://github.com/aws/aws-sdk-go/aws
+[0]: https://github.com/aws/aws-sdk-go
 [1]: contributions/ibm-config.md
 [2]: contributions/oracle-config.md
 [3]: contributions/minio.md

--- a/site/content/docs/v1.3.0/supported-providers.md
+++ b/site/content/docs/v1.3.0/supported-providers.md
@@ -46,7 +46,7 @@ _Some storage providers, like Quobyte, may need a different [signature algorithm
 
 In the case you want to take volume snapshots but didn't find a plugin for your provider, Velero has support for snapshotting using restic. Please see the [restic integration][30] documentation.
 
-[0]: https://github.com/aws/aws-sdk-go/aws
+[0]: https://github.com/aws/aws-sdk-go
 [1]: contributions/ibm-config.md
 [2]: contributions/oracle-config.md
 [3]: contributions/minio.md

--- a/site/content/docs/v1.3.1/supported-providers.md
+++ b/site/content/docs/v1.3.1/supported-providers.md
@@ -46,7 +46,7 @@ _Some storage providers, like Quobyte, may need a different [signature algorithm
 
 In the case you want to take volume snapshots but didn't find a plugin for your provider, Velero has support for snapshotting using restic. Please see the [restic integration][30] documentation.
 
-[0]: https://github.com/aws/aws-sdk-go/aws
+[0]: https://github.com/aws/aws-sdk-go
 [1]: contributions/ibm-config.md
 [2]: contributions/oracle-config.md
 [3]: contributions/minio.md

--- a/site/content/docs/v1.3.2/supported-providers.md
+++ b/site/content/docs/v1.3.2/supported-providers.md
@@ -47,7 +47,7 @@ _Some storage providers, like Quobyte, may need a different [signature algorithm
 
 In the case you want to take volume snapshots but didn't find a plugin for your provider, Velero has support for snapshotting using restic. Please see the [restic integration][30] documentation.
 
-[0]: https://github.com/aws/aws-sdk-go/aws
+[0]: https://github.com/aws/aws-sdk-go
 [1]: contributions/ibm-config.md
 [2]: contributions/oracle-config.md
 [3]: contributions/minio.md

--- a/site/content/docs/v1.4/supported-providers.md
+++ b/site/content/docs/v1.4/supported-providers.md
@@ -55,7 +55,7 @@ _Some storage providers, like Quobyte, may need a different [signature algorithm
 
 In the case you want to take volume snapshots but didn't find a plugin for your provider, Velero has support for snapshotting using restic. Please see the [restic integration][30] documentation.
 
-[0]: https://github.com/aws/aws-sdk-go/aws
+[0]: https://github.com/aws/aws-sdk-go
 [1]: contributions/ibm-config.md
 [2]: contributions/oracle-config.md
 [3]: contributions/minio.md

--- a/site/content/docs/v1.7/supported-providers.md
+++ b/site/content/docs/v1.7/supported-providers.md
@@ -56,7 +56,7 @@ _Some storage providers, like Quobyte, may need a different [signature algorithm
 
 In the case you want to take volume snapshots but didn't find a plugin for your provider, Velero has support for snapshotting using restic. Please see the [restic integration][30] documentation.
 
-[0]: https://github.com/aws/aws-sdk-go/aws
+[0]: https://github.com/aws/aws-sdk-go
 [1]: contributions/ibm-config.md
 [2]: contributions/oracle-config.md
 [3]: contributions/minio.md

--- a/site/content/docs/v1.9/supported-providers.md
+++ b/site/content/docs/v1.9/supported-providers.md
@@ -56,7 +56,7 @@ _Some storage providers, like Quobyte, may need a different [signature algorithm
 
 In the case you want to take volume snapshots but didn't find a plugin for your provider, Velero has support for snapshotting using restic. Please see the [restic integration][30] documentation.
 
-[0]: https://github.com/aws/aws-sdk-go/aws
+[0]: https://github.com/aws/aws-sdk-go
 [1]: contributions/ibm-config.md
 [2]: contributions/oracle-config.md
 [3]: contributions/minio.md


### PR DESCRIPTION
# Please add a summary of your change
Fixes the dead link from the Velero docs
- AWS Go SDK v1 for releases until v1.13
- AWS Go SDK v2 for releases v1.14 and v.15

# Does your change fix a particular issue?
No

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
