### PR TITLE
Add SecurityContext to restore-helper

### DIFF
--- a/changelogs/unreleased/8491-reasonerjt
+++ b/changelogs/unreleased/8491-reasonerjt
@@ -1,0 +1,1 @@
+Add SecurityContext to restore-helper

--- a/pkg/restore/actions/pod_volume_restore_action_test.go
+++ b/pkg/restore/actions/pod_volume_restore_action_test.go
@@ -20,6 +20,8 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/vmware-tanzu/velero/pkg/util/boolptr"
+
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -113,8 +115,18 @@ func TestPodVolumeRestoreActionExecute(t *testing.T) {
 		defaultCPURequestLimit, defaultMemRequestLimit, // requests
 		defaultCPURequestLimit, defaultMemRequestLimit, // limits
 	)
-
-	securityContext, _ := kube.ParseSecurityContext("", "", "", "")
+	id := int64(1000)
+	securityContext := corev1api.SecurityContext{
+		AllowPrivilegeEscalation: boolptr.False(),
+		Capabilities: &corev1api.Capabilities{
+			Drop: []corev1api.Capability{"ALL"},
+		},
+		SeccompProfile: &corev1api.SeccompProfile{
+			Type: corev1api.SeccompProfileTypeRuntimeDefault,
+		},
+		RunAsUser:    &id,
+		RunAsNonRoot: boolptr.True(),
+	}
 
 	var (
 		restoreName = "my-restore"


### PR DESCRIPTION
This commit adds SecurityContext which complies with "restricted" level per Pod Security Standards

Fixes #8229 

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
