### PR TITLE
Fix issue: backup schedule pause/unpause doesn't work

### DIFF
--- a/changelogs/unreleased/8512-ywk253100
+++ b/changelogs/unreleased/8512-ywk253100
@@ -1,0 +1,1 @@
+Fix issue: backup schedule pause/unpause doesn't work


### PR DESCRIPTION
The issue is caused by the changes of controller-runtime: WithEventFilter() doesn't apply to WatchesRawSource(), this commit set Predicate for WatchesRawSource() seperatedly

Fixes #8437

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
