### PR TITLE
hide restic deprecation warning for install with crd-only

### DIFF
--- a/changelogs/unreleased/8538-Lyndon-Li
+++ b/changelogs/unreleased/8538-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix issue #8539, validate uploader types when o.CRDsOnly is set to false only since CRD installation doesn't rely on uploader types

--- a/pkg/cmd/cli/install/install.go
+++ b/pkg/cmd/cli/install/install.go
@@ -429,15 +429,15 @@ func (o *Options) Validate(c *cobra.Command, args []string, f client.Factory) er
 		return err
 	}
 
+	// If we're only installing CRDs, we can skip the rest of the validation.
+	if o.CRDsOnly {
+		return nil
+	}
+
 	if msg, err := uploader.ValidateUploaderType(o.UploaderType); err != nil {
 		return err
 	} else if msg != "" {
 		fmt.Printf("⚠️  %s\n", msg)
-	}
-
-	// If we're only installing CRDs, we can skip the rest of the validation.
-	if o.CRDsOnly {
-		return nil
 	}
 
 	// Our main 3 providers don't support bucket names starting with a dash, and a bucket name starting with one


### PR DESCRIPTION
Fix issue #8539, validate uploader types when `o.CRDsOnly` is set to `false` only since CRD installation doesn't rely on uploader types
