### PR TITLE
[1.15] hide restic deprecation warning for install with crd-only

### DIFF
--- a/changelogs/CHANGELOG-1.15.md
+++ b/changelogs/CHANGELOG-1.15.md
@@ -23,6 +23,7 @@ https://velero.io/docs/v1.15/upgrade-to-1.15/
   * Fix issue #8391, check ErrCancelled from suffix of data mover pod's termination message (#8404, @Lyndon-Li)
   * Fix issue #8394, don't call closeDataPath in VGDP callbacks, otherwise, the VGDP cleanup will hang (#8402, @Lyndon-Li)
   * Reduce minimum required go toolchain in release-1.15 go.mod (#8399, @kaovilai)
+  * Fix issue #8539, validate uploader types when o.CRDsOnly is set to false only since CRD installation doesn't rely on uploader types (#8540, @Lyndon-Li)
 
 
 ## v1.15

--- a/pkg/cmd/cli/install/install.go
+++ b/pkg/cmd/cli/install/install.go
@@ -413,15 +413,15 @@ func (o *Options) Validate(c *cobra.Command, args []string, f client.Factory) er
 		return err
 	}
 
+	// If we're only installing CRDs, we can skip the rest of the validation.
+	if o.CRDsOnly {
+		return nil
+	}
+
 	if msg, err := uploader.ValidateUploaderType(o.UploaderType); err != nil {
 		return err
 	} else if msg != "" {
 		fmt.Printf("⚠️  %s\n", msg)
-	}
-
-	// If we're only installing CRDs, we can skip the rest of the validation.
-	if o.CRDsOnly {
-		return nil
 	}
 
 	// Our main 3 providers don't support bucket names starting with a dash, and a bucket name starting with one


### PR DESCRIPTION
Fix issue https://github.com/vmware-tanzu/velero/issues/8539, validate uploader types when o.CRDsOnly is set to false only since CRD installation doesn't rely on uploader types