### PR TITLE
[Cherrypick-1.15]fix(pkg/repository/maintenance): don't panic when there's no container statuses

### DIFF
--- a/changelogs/unreleased/8568-mcluseau
+++ b/changelogs/unreleased/8568-mcluseau
@@ -1,0 +1,1 @@
+fix(pkg/repository/maintenance): don't panic when there's no container statuses


### PR DESCRIPTION
Cherrypicks #8271 to fix #8562 

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
