### PR TITLE
Don't include excluded items in ItemBlocks

### DIFF
--- a/changelogs/unreleased/8572-sseago
+++ b/changelogs/unreleased/8572-sseago
@@ -1,0 +1,1 @@
+Don't include excluded items in ItemBlocks

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -455,8 +455,8 @@ func (kb *kubernetesBackupper) BackupWithResolvers(
 			"name":      items[i].name,
 		}).Infof("Processing item")
 
-		// Skip if this item has already been added to an ItemBlock
-		if items[i].inItemBlock {
+		// Skip if this item has already been processed (in a block or previously excluded)
+		if items[i].inItemBlockOrExcluded {
 			log.Debugf("Not creating new ItemBlock for %s %s/%s because it's already in an ItemBlock", items[i].groupResource.String(), items[i].namespace, items[i].name)
 		} else {
 			if itemBlock == nil {
@@ -639,12 +639,23 @@ func (kb *kubernetesBackupper) executeItemBlockActions(
 				continue
 			}
 			itemsMap[relatedItem] = append(itemsMap[relatedItem], &kubernetesResource{
-				groupResource: relatedItem.GroupResource,
-				preferredGVR:  gvr,
-				namespace:     relatedItem.Namespace,
-				name:          relatedItem.Name,
-				inItemBlock:   true,
+				groupResource:         relatedItem.GroupResource,
+				preferredGVR:          gvr,
+				namespace:             relatedItem.Namespace,
+				name:                  relatedItem.Name,
+				inItemBlockOrExcluded: true,
 			})
+
+			relatedItemMetadata, err := meta.Accessor(item)
+			if err != nil {
+				log.WithError(errors.WithStack(err)).Warn("Failed to get object metadata.")
+				continue
+			}
+			// Don't add to ItemBlock if item is excluded
+			// itemInclusionChecks logs the reason
+			if !itemBlock.itemBackupper.itemInclusionChecks(log, false, relatedItemMetadata, item, relatedItem.GroupResource) {
+				continue
+			}
 			log.Infof("adding %s %s/%s to ItemBlock", relatedItem.GroupResource, relatedItem.Namespace, relatedItem.Name)
 			itemBlock.AddUnstructured(relatedItem.GroupResource, item, gvr)
 			kb.executeItemBlockActions(log, item, relatedItem.GroupResource, relatedItem.Name, relatedItem.Namespace, itemsMap, itemBlock)
@@ -660,13 +671,9 @@ func (kb *kubernetesBackupper) backupItemBlock(ctx context.Context, itemBlock Ba
 	itemBlock.Log.Debug("Executing pre hooks")
 	for _, item := range itemBlock.Items {
 		if item.Gr == kuberesource.Pods {
-			metadata, key, err := kb.itemMetadataAndKey(item)
+			key, err := kb.getItemKey(item)
 			if err != nil {
 				itemBlock.Log.WithError(errors.WithStack(err)).Error("Error accessing pod metadata")
-				continue
-			}
-			// Don't run hooks if pod is excluded
-			if !itemBlock.itemBackupper.itemInclusionChecks(itemBlock.Log, false, metadata, item.Item, item.Gr) {
 				continue
 			}
 			// Don't run hooks if pod has already been backed up
@@ -679,7 +686,7 @@ func (kb *kubernetesBackupper) backupItemBlock(ctx context.Context, itemBlock Ba
 	for i, pod := range failedPods {
 		itemBlock.Log.WithError(errs[i]).WithField("name", pod.Item.GetName()).Error("Error running pre hooks for pod")
 		// if pre hook fails, flag pod as backed-up and move on
-		_, key, err := kb.itemMetadataAndKey(pod)
+		key, err := kb.getItemKey(pod)
 		if err != nil {
 			itemBlock.Log.WithError(errors.WithStack(err)).Error("Error accessing pod metadata")
 			continue
@@ -704,17 +711,17 @@ func (kb *kubernetesBackupper) backupItemBlock(ctx context.Context, itemBlock Ba
 	return grList
 }
 
-func (kb *kubernetesBackupper) itemMetadataAndKey(item itemblock.ItemBlockItem) (metav1.Object, itemKey, error) {
+func (kb *kubernetesBackupper) getItemKey(item itemblock.ItemBlockItem) (itemKey, error) {
 	metadata, err := meta.Accessor(item.Item)
 	if err != nil {
-		return nil, itemKey{}, err
+		return itemKey{}, err
 	}
 	key := itemKey{
 		resource:  resourceKey(item.Item),
 		namespace: metadata.GetNamespace(),
 		name:      metadata.GetName(),
 	}
-	return metadata, key, nil
+	return key, nil
 }
 
 func (kb *kubernetesBackupper) handleItemBlockPreHooks(itemBlock BackupItemBlock, hookPods []itemblock.ItemBlockItem) ([]itemblock.ItemBlockItem, []itemblock.ItemBlockItem, []error) {

--- a/pkg/backup/item_collector.go
+++ b/pkg/backup/item_collector.go
@@ -176,7 +176,9 @@ type kubernetesResource struct {
 	preferredGVR          schema.GroupVersionResource
 	namespace, name, path string
 	orderedResource       bool
-	inItemBlock           bool // set to true during backup processing when added to an ItemBlock
+	// set to true during backup processing when added to an ItemBlock
+	// or if the item is excluded from backup.
+	inItemBlockOrExcluded bool
 }
 
 // getItemsFromResourceIdentifiers get the kubernetesResources


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Run itemExclusionChecks before adding items to ItemBlocks. Fixes a regression in 1.15 where excluding PVCs from backup no longer excludes associated PVs.

# Does your change fix a particular issue?

Fixes #8510

# Please indicate you've done the following:

- [x ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x ] Updated the corresponding documentation in `site/content/docs/main`.
