### PR TITLE
Configurable Kopia Maintenance Interval

### DIFF
--- a/changelogs/unreleased/8581-kaovilai
+++ b/changelogs/unreleased/8581-kaovilai
@@ -1,0 +1,1 @@
+Configurable Kopia Maintenance Interval. backup-repository-configmap adds an option for configurable`fullMaintenanceInterval` where fastGC (12 hours), and eagerGC (6 hours) allowing for faster removal of deleted velero backups from kopia repo.

--- a/pkg/controller/backup_repository_controller_test.go
+++ b/pkg/controller/backup_repository_controller_test.go
@@ -694,7 +694,7 @@ func TestGetBackupRepositoryConfig(t *testing.T) {
 			Namespace: velerov1api.DefaultNamespace,
 		},
 		Data: map[string]string{
-			"fake-repo-type":   "{\"cacheLimitMB\": 1000, \"enableCompression\": true}",
+			"fake-repo-type":   "{\"cacheLimitMB\": 1000, \"enableCompression\": true, \"fullMaintenanceInterval\": \"fastGC\"}",
 			"fake-repo-type-1": "{\"cacheLimitMB\": 1, \"enableCompression\": false}",
 		},
 	}
@@ -744,8 +744,9 @@ func TestGetBackupRepositoryConfig(t *testing.T) {
 				configWithData,
 			},
 			expectedResult: map[string]string{
-				"cacheLimitMB":      "1000",
-				"enableCompression": "true",
+				"cacheLimitMB":            "1000",
+				"enableCompression":       "true",
+				"fullMaintenanceInterval": "fastGC",
 			},
 		},
 	}

--- a/pkg/repository/provider/unified_repo.go
+++ b/pkg/repository/provider/unified_repo.go
@@ -592,7 +592,6 @@ func getStorageVariables(backupLocation *velerov1api.BackupStorageLocation, repo
 				result[param] = v
 			}
 		}
-
 	}
 
 	return result, nil

--- a/pkg/repository/provider/unified_repo.go
+++ b/pkg/repository/provider/unified_repo.go
@@ -576,9 +576,13 @@ func getStorageVariables(backupLocation *velerov1api.BackupStorageLocation, repo
 	result[udmrepo.StoreOptionOssRegion] = strings.Trim(region, "/")
 	result[udmrepo.StoreOptionFsPath] = config["fspath"]
 
-	if backupRepoConfig != nil {
-		if v, found := backupRepoConfig[udmrepo.StoreOptionCacheLimit]; found {
-			result[udmrepo.StoreOptionCacheLimit] = v
+	// Write all backupRepoConfig to results if not exists, otherwise error on conflict
+	for k, v := range backupRepoConfig { // if nil, this would be skipped
+		if _, ok := result[k]; !ok {
+			// TODO: validation of allowed values for each key?
+			result[k] = v
+		} else {
+			return result, errors.Errorf("backupRepoConfig contains key %s that would override storage variables", k)
 		}
 	}
 

--- a/pkg/repository/udmrepo/kopialib/lib_repo.go
+++ b/pkg/repository/udmrepo/kopialib/lib_repo.go
@@ -622,7 +622,9 @@ func writeInitParameters(ctx context.Context, repoOption udmrepo.RepoOptions, lo
 		default:
 			return errors.Errorf("invalid full maintenance interval option %s", fullMaintIntervalOption)
 		}
-		logger.Infof("Full maintenance interval change from %v to %v", priorMaintInterval, p.FullCycle.Interval)
+		if priorMaintInterval != p.FullCycle.Interval {
+			logger.Infof("Full maintenance interval change from %v to %v", priorMaintInterval, p.FullCycle.Interval)
+		}
 
 		p.Owner = r.ClientOptions().UsernameAtHost()
 

--- a/pkg/repository/udmrepo/kopialib/lib_repo.go
+++ b/pkg/repository/udmrepo/kopialib/lib_repo.go
@@ -611,18 +611,18 @@ func writeInitParameters(ctx context.Context, repoOption udmrepo.RepoOptions, lo
 		// repoOption.StorageOptions[udmrepo.StoreOptionKeyFullMaintenanceInterval] would for example look like
 		// configMapName.data.kopia: {"fullMaintenanceInterval": "eagerGC"}
 		fullMaintIntervalOption := udmrepo.FullMaintenanceIntervalOptions(repoOption.StorageOptions[udmrepo.StoreOptionKeyFullMaintenanceInterval])
-		if fullMaintIntervalOption == udmrepo.FastGC {
-			logger.Infof("Full maintenance interval change from %v to %v", p.FullCycle.Interval, udmrepo.FastGCInterval)
+		priorMaintInterval := p.FullCycle.Interval
+		switch fullMaintIntervalOption {
+		case udmrepo.FastGC:
 			p.FullCycle.Interval = udmrepo.FastGCInterval
-		}
-		if fullMaintIntervalOption == udmrepo.EagerGC {
-			logger.Infof("Full maintenance interval change from %v to %v", p.FullCycle.Interval, udmrepo.EagerGCInterval)
+		case udmrepo.EagerGC:
 			p.FullCycle.Interval = udmrepo.EagerGCInterval
-		}
-		if fullMaintIntervalOption == udmrepo.NormalGC {
-			logger.Infof("Full maintenance interval change from %v to %v", p.FullCycle.Interval, udmrepo.NormalGCInterval)
+		case udmrepo.NormalGC:
 			p.FullCycle.Interval = udmrepo.NormalGCInterval
+		default:
+			return errors.Errorf("invalid full maintenance interval option %s", fullMaintIntervalOption)
 		}
+		logger.Infof("Full maintenance interval change from %v to %v", priorMaintInterval, p.FullCycle.Interval)
 
 		p.Owner = r.ClientOptions().UsernameAtHost()
 

--- a/pkg/repository/udmrepo/kopialib/lib_repo.go
+++ b/pkg/repository/udmrepo/kopialib/lib_repo.go
@@ -619,6 +619,7 @@ func writeInitParameters(ctx context.Context, repoOption udmrepo.RepoOptions, lo
 			p.FullCycle.Interval = udmrepo.EagerGCInterval
 		case udmrepo.NormalGC:
 			p.FullCycle.Interval = udmrepo.NormalGCInterval
+		case "": // do nothing
 		default:
 			return errors.Errorf("invalid full maintenance interval option %s", fullMaintIntervalOption)
 		}

--- a/pkg/repository/udmrepo/repo_options.go
+++ b/pkg/repository/udmrepo/repo_options.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 const (
@@ -70,7 +71,18 @@ const (
 	ThrottleOptionListOps       = "listOPS"
 	ThrottleOptionUploadBytes   = "uploadBytes"
 	ThrottleOptionDownloadBytes = "downloadBytes"
+	// FullMaintenanceInterval will overwrite kopia maintenance interval
+	// options are fastGC for 12 hours, eagerGC for 6 hours, normalGC for 24 hours
+	StoreOptionKeyFullMaintenanceInterval                                = "fullMaintenanceInterval"
+	FastGC                                FullMaintenanceIntervalOptions = "fastGC"
+	FastGCInterval                        time.Duration                  = 12 * time.Hour
+	EagerGC                               FullMaintenanceIntervalOptions = "eagerGC"
+	EagerGCInterval                       time.Duration                  = 6 * time.Hour
+	NormalGC                              FullMaintenanceIntervalOptions = "normalGC"
+	NormalGCInterval                      time.Duration                  = 24 * time.Hour
 )
+
+type FullMaintenanceIntervalOptions string
 
 const (
 	defaultUsername = "default"

--- a/site/content/docs/main/backup-repository-configuration.md
+++ b/site/content/docs/main/backup-repository-configuration.md
@@ -49,6 +49,33 @@ Below is the supported configurations by Velero and the specific backup reposito
 ***Kopia repository:***  
 `cacheLimitMB`: specifies the size limit(in MB) for the local data cache. The more data is cached locally, the less data may be downloaded from the backup storage, so the better performance may be achieved. Practically, you can specify any size that is smaller than the free space so that the disk space won't run out. This parameter is for repository connection, that is, you could change it before connecting to the repository. E.g., before a backup/restore/maintenance.  
 
+### Full Maintenance Interval customization
+The full maintenance interval defaults to kopia defaults of 24 hours. Velero provide three override options under `fullMaintenanceInterval` configuration using `backup-repository-configmap` ConfigMap provided to velero install commands allowing for faster removal of deleted velero backups from kopia repo.
+- normalGC: 24 hours
+- fastGC: 12 hours
+- eagerGC: 6 hours
+
+Example of the `backup-repository-configmap` ConfigMap for the above scenario is as below:
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-name>
+  namespace: velero
+data:
+  <repository-type-1>: |
+    {
+      "fullMaintenanceInterval": fastGC
+    }
+  <repository-type-2>: |
+    {
+      "fullMaintenanceInterval": normalGC
+    }        
+```
+
+Per kopia [Maintenance Safety](https://kopia.io/docs/advanced/maintenance/#maintenance-safety), it is expected that velero backup deletion will not result in immediate kopia repository data removal. Reducing full maintenance interval using above options should help reduce time taken to remove blobs not in use.
+
+On the other hand, the not-in-use data will be deleted permanently after the full maintenance, so shorter full maintenance intervals may weaken the data safety if they are used incorrectly.
 
 [1]: file-system-backup.md
 [2]: csi-snapshot-data-movement.md

--- a/site/content/docs/main/backup-repository-configuration.md
+++ b/site/content/docs/main/backup-repository-configuration.md
@@ -30,7 +30,8 @@ metadata:
 data:
   <kopia>: |
     {
-      "cacheLimitMB": 2048    
+      "cacheLimitMB": 2048,
+      "fullMaintenanceInterval": "fastGC"
     }
   <other-repository-type>: |
     {
@@ -49,29 +50,10 @@ Below is the supported configurations by Velero and the specific backup reposito
 ***Kopia repository:***  
 `cacheLimitMB`: specifies the size limit(in MB) for the local data cache. The more data is cached locally, the less data may be downloaded from the backup storage, so the better performance may be achieved. Practically, you can specify any size that is smaller than the free space so that the disk space won't run out. This parameter is for repository connection, that is, you could change it before connecting to the repository. E.g., before a backup/restore/maintenance.  
 
-### Full Maintenance Interval customization
-The full maintenance interval defaults to kopia defaults of 24 hours. Velero provide three override options under `fullMaintenanceInterval` configuration using `backup-repository-configmap` ConfigMap provided to velero install commands allowing for faster removal of deleted velero backups from kopia repo.
+`fullMaintenanceInterval`: The full maintenance interval defaults to kopia defaults of 24 hours. Override options below allows for faster removal of deleted velero backups from kopia repo.
 - normalGC: 24 hours
 - fastGC: 12 hours
 - eagerGC: 6 hours
-
-Example of the `backup-repository-configmap` ConfigMap for the above scenario is as below:
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: <config-name>
-  namespace: velero
-data:
-  <repository-type-1>: |
-    {
-      "fullMaintenanceInterval": fastGC
-    }
-  <repository-type-2>: |
-    {
-      "fullMaintenanceInterval": normalGC
-    }        
-```
 
 Per kopia [Maintenance Safety](https://kopia.io/docs/advanced/maintenance/#maintenance-safety), it is expected that velero backup deletion will not result in immediate kopia repository data removal. Reducing full maintenance interval using above options should help reduce time taken to remove blobs not in use.
 

--- a/site/content/docs/main/repository-maintenance.md
+++ b/site/content/docs/main/repository-maintenance.md
@@ -51,7 +51,7 @@ For example, the following BackupRepository's key should be `test-default-kopia`
 
 You can still customize the maintenance job resource requests and limit when using the [velero install][1] CLI command.
 
-The `LoadAffinity` structure is reused from design [node-agent affinity configuration](2).
+The `LoadAffinity` structure is reused from design [node-agent affinity configuration][2].
 
 ### Affinity Example
 It's possible that the users want to choose nodes that match condition A or condition B to run the job.
@@ -131,33 +131,11 @@ velero install --default-repo-maintain-frequency <DURATION>
 For Kopia the default maintenance frequency is 1 hour, and Restic is 7 * 24 hours.
 
 ### Full Maintenance Interval customization
-The full maintenance interval defaults to kopia defaults of 24 hours. Velero provide three override options under `fullMaintenanceInterval` configuration using `backup-repository-configmap` ConfigMap provided to velero install commands allowing for faster removal of deleted velero backups from kopia repo.
-- normalGC: 24 hours
-- fastGC: 12 hours
-- eagerGC: 6 hours
-
-Example of the `backup-repository-configmap` ConfigMap for the above scenario is as below:
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: <config-name>
-  namespace: velero
-data:
-  <repository-type-1>: |
-    {
-      "fullMaintenanceInterval": fastGC
-    }
-  <repository-type-2>: |
-    {
-      "fullMaintenanceInterval": normalGC
-    }        
-```
-
-Per kopia [Maintenance Safety](https://kopia.io/docs/advanced/maintenance/#maintenance-safety), it is expected that velero backup deletion will not result in immediate kopia repository data removal. Reducing full maintenance interval using above options should help reduce time taken to remove blobs not in use.
+See [backup repository configuration][3]
 
 ### Others
 Maintenance jobs will inherit the labels, annotations, toleration, nodeSelector, service account, image, environment variables, cloud-credentials etc. from Velero deployment.
 
 [1]: velero-install.md#usage
 [2]: node-agent-concurrency.md
+[3]: backup-repository-configuration.md#full-maintenance-interval-customization

--- a/site/content/docs/main/repository-maintenance.md
+++ b/site/content/docs/main/repository-maintenance.md
@@ -130,6 +130,32 @@ velero install --default-repo-maintain-frequency <DURATION>
 ```
 For Kopia the default maintenance frequency is 1 hour, and Restic is 7 * 24 hours.
 
+### Full Maintenance Interval customization
+The full maintenance interval defaults to kopia defaults of 24 hours. Velero provide three override options under `fullMaintenanceInterval` configuration using `backup-repository-configmap` ConfigMap provided to velero install commands allowing for faster removal of deleted velero backups from kopia repo.
+- normalGC: 24 hours
+- fastGC: 12 hours
+- eagerGC: 6 hours
+
+Example of the `backup-repository-configmap` ConfigMap for the above scenario is as below:
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-name>
+  namespace: velero
+data:
+  <repository-type-1>: |
+    {
+      "fullMaintenanceInterval": fastGC
+    }
+  <repository-type-2>: |
+    {
+      "fullMaintenanceInterval": normalGC
+    }        
+```
+
+Per kopia [Maintenance Safety](https://kopia.io/docs/advanced/maintenance/#maintenance-safety), it is expected that velero backup deletion will not result in immediate kopia repository data removal. Reducing full maintenance interval using above options should help reduce time taken to remove blobs not in use.
+
 ### Others
 Maintenance jobs will inherit the labels, annotations, toleration, nodeSelector, service account, image, environment variables, cloud-credentials etc. from Velero deployment.
 


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Configurable Kopia Maintenance Interval. repo-maintenance-job-configmap adds an option for `fullMaintenanceInterval` where fastGC (12 hours), and eagerGC (6 hours).
This configmap is loaded in assembleRepoParam that returns RepoParam which now contains the maintenance interval referenced by several repository functions.
The manager functions then call provider functions which read repoParam.FullMaintenanceInterval and add it to repoOption.
Repooption is then passed to repoService, in this case kopiaRepoService.Init
kopiaRepoService.Init calls writeInitParameters which finally set kopia p.FullCycle.Interval

#### Doc previews
https://velero-git-configkopiamaintinterval-kaovilais-projects.vercel.app/docs/main/repository-maintenance#full-maintenance-interval-customization
https://velero-git-configkopiamaintinterval-kaovilais-projects.vercel.app/docs/main/backup-repository-configuration/#full-maintenance-interval-customization

# Does your change fix a particular issue?

Fixes #8364

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
