### PR TITLE
Change udmrepo config file location to tmp

### DIFF
--- a/changelogs/unreleased/8602-Lyndon-Li
+++ b/changelogs/unreleased/8602-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix issue #8067, add tmp folder (/tmp for linux, C:\Windows\Temp for Windows) as an alternative of udmrepo's config file location

--- a/pkg/repository/udmrepo/repo_options.go
+++ b/pkg/repository/udmrepo/repo_options.go
@@ -200,7 +200,12 @@ func GetRepoDomain() string {
 
 func getRepoConfigFile(workPath string, repoID string) string {
 	if workPath == "" {
-		workPath = filepath.Join(os.Getenv("HOME"), "udmrepo")
+		home := os.Getenv("HOME")
+		if home != "" {
+			workPath = filepath.Join(home, "udmrepo")
+		} else {
+			workPath = filepath.Join(os.TempDir(), "udmrepo")
+		}
 	}
 
 	name := "repo-" + strings.ToLower(repoID) + ".conf"


### PR DESCRIPTION
Fix issue #8067, add tmp folder (/tmp for linux, C:\Windows\Temp for Windows) as an alternative of udmrepo's config file location