### PR TITLE
chore: enable revive default rules

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -235,7 +235,57 @@ linters-settings:
     fiximports: true
   revive:
     rules:
+      - name: blank-imports
+        disabled: true
+      - name: context-as-argument
+        disabled: true
+      - name: context-keys-type
+        disabled: false
+      - name: dot-imports
+        disabled: true
+      - name: early-return
+        disabled: true
+        arguments:
+          - "preserveScope"
+      - name: empty-block
+        disabled: true
+      - name: error-naming
+        disabled: true
+      - name: error-return
+        disabled: true
+      - name: error-strings
+        disabled: true
+      - name: errorf
+        disabled: true
+      - name: increment-decrement
+        disabled: true
+      - name: indent-error-flow
+        disabled: true
+      - name: range
+        disabled: false
+      - name: receiver-naming
+        disabled: true
+      - name: redefines-builtin-id
+        disabled: true
+      - name: superfluous-else
+        disabled: true
+        arguments:
+          - "preserveScope"
+      - name: time-naming
+        disabled: false
       - name: unexported-return
+        disabled: true
+      - name: unnecessary-stmt
+        disabled: true
+      - name: unreachable-code
+        disabled: false
+      - name: unused-parameter
+        disabled: true
+      - name: use-any
+        disabled: true
+      - name: var-declaration
+        disabled: true
+      - name: var-naming
         disabled: true
     
   rowserrcheck:


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

chore: enable revive default rules

Precising a rule on revive configuration overrrides the default one, this adds the default rules. 
They will need to be fixed before being activated.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
