### PR TITLE
[release-1.15] Datamover new ns 1.15

### DIFF
--- a/changelogs/unreleased/8622-sseago
+++ b/changelogs/unreleased/8622-sseago
@@ -1,0 +1,1 @@
+Always create DataUpload configmap in restore namespace

--- a/pkg/restore/actions/dataupload_retrieve_action.go
+++ b/pkg/restore/actions/dataupload_retrieve_action.go
@@ -93,7 +93,7 @@ func (d *DataUploadRetrieveAction) Execute(input *velero.RestoreItemActionExecut
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: dataUpload.Name + "-",
-			Namespace:    dataUpload.Namespace,
+			Namespace:    input.Restore.Namespace,
 			Labels: map[string]string{
 				velerov1api.RestoreUIDLabel:       label.GetValidName(string(input.Restore.UID)),
 				velerov1api.PVCNamespaceNameLabel: label.GetValidName(dataUpload.Spec.SourceNamespace + "." + dataUpload.Spec.SourcePVC),


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
In the DataUpload RIA, always create the ConfigMap in the Restore (velero) ns rather than the NS that the DataUpload was created in.
In most cases these are the same, but they won't be if the backup was done in a cluster with velero installed in namespace1 and the restore is being done with velero installed in namespace2. In this case, we need the configmap created in the namespace that velero is currently running in.

cherry-pick of https://github.com/vmware-tanzu/velero/pull/8621
# Does your change fix a particular issue?

Fixes #8617

# Please indicate you've done the following:

- [x ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x ] Updated the corresponding documentation in `site/content/docs/main`.
