### PR TITLE
Repo maintenance for windows

### DIFF
--- a/changelogs/unreleased/8626-Lyndon-Li
+++ b/changelogs/unreleased/8626-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix issue #8419, support repo maintenance job to run on Windows nodes

--- a/pkg/util/velero/velero.go
+++ b/pkg/util/velero/velero.go
@@ -87,3 +87,12 @@ func GetVeleroServerLables(deployment *appsv1.Deployment) map[string]string {
 func GetVeleroServerAnnotations(deployment *appsv1.Deployment) map[string]string {
 	return deployment.Spec.Template.Annotations
 }
+
+// GetVeleroServerLabelValue returns the value of specified label of Velero server deployment
+func GetVeleroServerLabelValue(deployment *appsv1.Deployment, key string) string {
+	if deployment.Spec.Template.Labels == nil {
+		return ""
+	}
+
+	return deployment.Spec.Template.Labels[key]
+}

--- a/pkg/util/velero/velero_test.go
+++ b/pkg/util/velero/velero_test.go
@@ -711,3 +711,51 @@ func TestGetVeleroServerAnnotations(t *testing.T) {
 		})
 	}
 }
+
+func TestGetVeleroServerLabelValue(t *testing.T) {
+	tests := []struct {
+		name       string
+		deployment *appsv1.Deployment
+		expected   string
+	}{
+		{
+			name:       "nil Labels",
+			deployment: &appsv1.Deployment{},
+			expected:   "",
+		},
+		{
+			name: "no label key",
+			deployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{},
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "with label key",
+			deployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"fake-key": "fake-value"},
+						},
+					},
+				},
+			},
+			expected: "fake-value",
+		},
+	}
+
+	// Run tests
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetVeleroServerLabelValue(tt.deployment, "fake-key")
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
Fix issue #8419, support repo maintenance job to run on Windows nodes:

- Add toleration and labels to repo maintenance job pods
- Add retry to wait pod network ready
- Change repo maintenance job pod's `TerminationMessagePolicy` to `TerminationMessageFallbackToLogsOnError`, as kubelet has a bug to support `TerminationMessageReadFile` on Windows
