### PR TITLE
Clean up leaked CSI snapshot for incomplete backup

### DIFF
--- a/.github/workflows/pr-codespell.yml
+++ b/.github/workflows/pr-codespell.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Codespell
       uses: codespell-project/actions-codespell@master
       with:
-        # ignore the config/.../crd.go file as it's generated binary data that is edited elswhere.
+        # ignore the config/.../crd.go file as it's generated binary data that is edited elsewhere.
         skip: .git,*.png,*.jpg,*.woff,*.ttf,*.gif,*.ico,./config/crd/v1beta1/crds/crds.go,./config/crd/v1/crds/crds.go,./config/crd/v2alpha1/crds/crds.go,./go.sum,./LICENSE
         ignore_words_list: iam,aks,ist,bridget,ue,shouldnot,atleast,notin,sme,optin
         check_filenames: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -333,7 +333,7 @@ linters-settings:
     force-case-trailing-whitespace: 0
     # Force cuddling of err checks with err var assignment
     force-err-cuddling: false
-    # Allow leading comments to be separated with empty liens
+    # Allow leading comments to be separated with empty lines
     allow-separated-leading-comment: false
 
 linters:

--- a/changelogs/unreleased/8637-raesonerjt
+++ b/changelogs/unreleased/8637-raesonerjt
@@ -1,0 +1,1 @@
+Clean up leaked CSI snapshot for incomplete backup

--- a/pkg/util/csi/volume_snapshot.go
+++ b/pkg/util/csi/volume_snapshot.go
@@ -490,6 +490,8 @@ func SetVolumeSnapshotContentDeletionPolicy(
 	return crClient.Patch(context.TODO(), vsc, crclient.MergeFrom(originVSC))
 }
 
+// CleanupVolumeSnapshot deletes the VolumeSnapshot and the associated VolumeSnapshotContent.  It will make sure the
+// physical snapshot is also deleted.
 func CleanupVolumeSnapshot(
 	volSnap *snapshotv1api.VolumeSnapshot,
 	crClient crclient.Client,
@@ -528,7 +530,8 @@ func CleanupVolumeSnapshot(
 	}
 }
 
-// DeleteVolumeSnapshot handles the VolumeSnapshot instance deletion.
+// DeleteVolumeSnapshot handles the VolumeSnapshot instance deletion.  It will make sure the VolumeSnapshotContent is
+// recreated so that the physical snapshot is retained.
 func DeleteVolumeSnapshot(
 	vs snapshotv1api.VolumeSnapshot,
 	vsc snapshotv1api.VolumeSnapshotContent,


### PR DESCRIPTION
This commit makes sure when a backup is deleted the controller will delete the CSI snapshot even when the bakckup tarball is not uploaded.

fixes #8160

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
