### PR TITLE
chore: enable early-return, if-return and superfluous-else from revive

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -206,10 +206,12 @@ linters:
         - name: context-keys-type
         - name: dot-imports
           disabled: true
+        # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#early-return
+        # In Go it is idiomatic to minimize nesting statements, a typical example is to avoid if-then-else constructions. 
         - name: early-return
           disabled: true
           arguments:
-            - "preserveScope"
+            - preserve-scope # do not suggest refactorings that would increase variable scope
         - name: empty-block
           disabled: true
         - name: error-naming
@@ -220,18 +222,27 @@ linters:
           disabled: true
         - name: errorf
           disabled: true
+        # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#if-return
+        # Checking if an error is nil to just after return the error or nil is redundant.
+        - name: if-return
         - name: increment-decrement
+        # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#indent-error-flow
+        # To improve the readability of code, it is recommended to reduce the indentation as much as possible.
+        # This rule highlights redundant else-blocks that can be eliminated from the code.
         - name: indent-error-flow
-          disabled: true
+          arguments:
+            - preserve-scope # do not suggest refactorings that would increase variable scope.
         - name: range
         - name: receiver-naming
           disabled: true
         - name: redefines-builtin-id
           disabled: true
+        # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#superfluous-else
+        # To improve the readability of code, it is recommended to reduce the indentation as much as possible.
+        # This rule highlights redundant else-blocks that can be eliminated from the code.
         - name: superfluous-else
-          disabled: true
           arguments:
-            - "preserveScope"
+            - preserve-scope # do not suggest refactorings that would increase variable scope.
         - name: time-naming
         - name: unexported-return
           disabled: true

--- a/internal/resourcemodifiers/strategic_merge_patch.go
+++ b/internal/resourcemodifiers/strategic_merge_patch.go
@@ -74,10 +74,7 @@ func strategicPatchObject(
 		return apierrors.NewBadRequest(err.Error())
 	}
 
-	if err := applyPatchToObject(originalObjMap, patchMap, objToUpdate, schemaReferenceObj, strictErrs); err != nil {
-		return err
-	}
-	return nil
+	return applyPatchToObject(originalObjMap, patchMap, objToUpdate, schemaReferenceObj, strictErrs)
 }
 
 // applyPatchToObject applies a strategic merge patch of <patchMap> to

--- a/internal/volumehelper/volume_policy_helper.go
+++ b/internal/volumehelper/volume_policy_helper.go
@@ -95,10 +95,9 @@ func (v *volumeHelperImpl) ShouldPerformSnapshot(obj runtime.Unstructured, group
 			if action.Type == resourcepolicies.Snapshot {
 				v.logger.Infof(fmt.Sprintf("performing snapshot action for pv %s", pv.Name))
 				return true, nil
-			} else {
-				v.logger.Infof("Skip snapshot action for pv %s as the action type is %s", pv.Name, action.Type)
-				return false, nil
 			}
+			v.logger.Infof("Skip snapshot action for pv %s as the action type is %s", pv.Name, action.Type)
+			return false, nil
 		}
 	}
 
@@ -178,11 +177,10 @@ func (v volumeHelperImpl) ShouldPerformFSBackup(volume corev1api.Volume, pod cor
 				v.logger.Infof("Perform fs-backup action for volume %s of pod %s due to volume policy match",
 					volume.Name, pod.Namespace+"/"+pod.Name)
 				return true, nil
-			} else {
-				v.logger.Infof("Skip fs-backup action for volume %s for pod %s because the action type is %s",
-					volume.Name, pod.Namespace+"/"+pod.Name, action.Type)
-				return false, nil
 			}
+			v.logger.Infof("Skip fs-backup action for volume %s for pod %s because the action type is %s",
+				volume.Name, pod.Namespace+"/"+pod.Name, action.Type)
+			return false, nil
 		}
 	}
 
@@ -190,11 +188,10 @@ func (v volumeHelperImpl) ShouldPerformFSBackup(volume corev1api.Volume, pod cor
 		v.logger.Infof("Perform fs-backup action for volume %s of pod %s due to opt-in/out way",
 			volume.Name, pod.Namespace+"/"+pod.Name)
 		return true, nil
-	} else {
-		v.logger.Infof("Skip fs-backup action for volume %s of pod %s due to opt-in/out way",
-			volume.Name, pod.Namespace+"/"+pod.Name)
-		return false, nil
 	}
+	v.logger.Infof("Skip fs-backup action for volume %s of pod %s due to opt-in/out way",
+		volume.Name, pod.Namespace+"/"+pod.Name)
+	return false, nil
 }
 
 func (v volumeHelperImpl) shouldPerformFSBackupLegacy(
@@ -211,17 +208,16 @@ func (v volumeHelperImpl) shouldPerformFSBackupLegacy(
 		}
 
 		return false
-	} else {
-		// Check volume in opt-out way
-		optOutVolumeNames := podvolumeutil.GetVolumesToExclude(&pod)
-		for _, volumeName := range optOutVolumeNames {
-			if volume.Name == volumeName {
-				return false
-			}
-		}
-
-		return true
 	}
+	// Check volume in opt-out way
+	optOutVolumeNames := podvolumeutil.GetVolumesToExclude(&pod)
+	for _, volumeName := range optOutVolumeNames {
+		if volume.Name == volumeName {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (v *volumeHelperImpl) shouldIncludeVolumeInBackup(vol corev1api.Volume) bool {

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -838,12 +838,11 @@ func zoneFromPVNodeAffinity(res *corev1api.PersistentVolume, topologyKeys ...str
 		}
 		for _, exp := range term.MatchExpressions {
 			if keySet.Has(exp.Key) && exp.Operator == "In" && len(exp.Values) > 0 {
-				if exp.Key == gkeCsiZoneKey {
-					providerGke = true
-					zones = append(zones, exp.Values[0])
-				} else {
+				if exp.Key != gkeCsiZoneKey {
 					return exp.Key, exp.Values[0]
 				}
+				providerGke = true
+				zones = append(zones, exp.Values[0])
 			}
 		}
 	}

--- a/pkg/client/retry.go
+++ b/pkg/client/retry.go
@@ -35,9 +35,8 @@ func CreateRetryGenerateName(client kbclient.Client, ctx context.Context, obj kb
 	}
 	if obj.GetGenerateName() != "" && obj.GetName() == "" {
 		return retry.OnError(retry.DefaultRetry, apierrors.IsAlreadyExists, retryCreateFn)
-	} else {
-		return client.Create(ctx, obj, &kbclient.CreateOptions{})
 	}
+	return client.Create(ctx, obj, &kbclient.CreateOptions{})
 }
 
 // CapBackoff provides a backoff with a set backoff cap

--- a/pkg/cmd/cli/backup/download.go
+++ b/pkg/cmd/cli/backup/download.go
@@ -89,11 +89,7 @@ func (o *DownloadOptions) Validate(c *cobra.Command, args []string, f client.Fac
 	cmd.CheckError(err)
 
 	backup := new(velerov1api.Backup)
-	if err := kbClient.Get(context.Background(), controllerclient.ObjectKey{Namespace: f.Namespace(), Name: o.Name}, backup); err != nil {
-		return err
-	}
-
-	return nil
+	return kbClient.Get(context.Background(), controllerclient.ObjectKey{Namespace: f.Namespace(), Name: o.Name}, backup)
 }
 
 func (o *DownloadOptions) Complete(args []string) error {

--- a/pkg/cmd/cli/datamover/backup_test.go
+++ b/pkg/cmd/cli/datamover/backup_test.go
@@ -55,9 +55,8 @@ func (fr *fakeRunHelper) Init() error {
 func (fr *fakeRunHelper) RunCancelableDataPath(_ context.Context) (string, error) {
 	if fr.runCancelableDataPathErr != nil {
 		return "", fr.runCancelableDataPathErr
-	} else {
-		return fr.runCancelableDataPathResult, nil
 	}
+	return fr.runCancelableDataPathResult, nil
 }
 
 func (fr *fakeRunHelper) Shutdown() {

--- a/pkg/cmd/cli/podvolume/backup_test.go
+++ b/pkg/cmd/cli/podvolume/backup_test.go
@@ -55,9 +55,8 @@ func (fr *fakeRunHelper) Init() error {
 func (fr *fakeRunHelper) RunCancelableDataPath(_ context.Context) (string, error) {
 	if fr.runCancelableDataPathErr != nil {
 		return "", fr.runCancelableDataPathErr
-	} else {
-		return fr.runCancelableDataPathResult, nil
 	}
+	return fr.runCancelableDataPathResult, nil
 }
 
 func (fr *fakeRunHelper) Shutdown() {

--- a/pkg/cmd/util/downloadrequest/downloadrequest.go
+++ b/pkg/cmd/util/downloadrequest/downloadrequest.go
@@ -75,11 +75,7 @@ func StreamWithBSLCACert(
 		return err
 	}
 
-	if err := download(ctx, downloadURL, kind, w, insecureSkipTLSVerify, caCertFile, bslCACert); err != nil {
-		return err
-	}
-
-	return nil
+	return download(ctx, downloadURL, kind, w, insecureSkipTLSVerify, caCertFile, bslCACert)
 }
 
 func getDownloadURL(

--- a/pkg/cmd/util/output/backup_describer.go
+++ b/pkg/cmd/util/output/backup_describer.go
@@ -794,12 +794,11 @@ func describePodVolumeBackups(d *Describer, details bool, podVolumeBackups []vel
 	// Get the type of pod volume uploader. Since the uploader only comes from a single source, we can
 	// take the uploader type from the first element of the array.
 	var uploaderType string
-	if len(podVolumeBackups) > 0 {
-		uploaderType = podVolumeBackups[0].Spec.UploaderType
-	} else {
+	if len(podVolumeBackups) == 0 {
 		d.Printf("\tPod Volume Backups: <none included>\n")
 		return
 	}
+	uploaderType = podVolumeBackups[0].Spec.UploaderType
 
 	if details {
 		d.Printf("\tPod Volume Backups - %s:\n", uploaderType)

--- a/pkg/cmd/util/output/backup_structured_describer.go
+++ b/pkg/cmd/util/output/backup_structured_describer.go
@@ -499,12 +499,11 @@ func describePodVolumeBackupsInSF(backups []velerov1api.PodVolumeBackup, details
 	// Get the type of pod volume uploader. Since the uploader only comes from a single source, we can
 	// take the uploader type from the first element of the array.
 	var uploaderType string
-	if len(backups) > 0 {
-		uploaderType = backups[0].Spec.UploaderType
-	} else {
+	if len(backups) == 0 {
 		backupVolumes["podVolumeBackups"] = "<none included>"
 		return
 	}
+	uploaderType = backups[0].Spec.UploaderType
 	// type display the type of pod volume backups
 	podVolumeBackupsInfo["uploderType"] = uploaderType
 

--- a/pkg/cmd/util/output/output.go
+++ b/pkg/cmd/util/output/output.go
@@ -88,10 +88,7 @@ func GetShowLabelsValue(cmd *cobra.Command) bool {
 // ValidateFlags returns an error if any of the output-related flags
 // were specified with invalid values, or nil otherwise.
 func ValidateFlags(cmd *cobra.Command) error {
-	if err := validateOutputFlag(cmd); err != nil {
-		return err
-	}
-	return nil
+	return validateOutputFlag(cmd)
 }
 
 func validateOutputFlag(cmd *cobra.Command) error {

--- a/pkg/cmd/util/output/restore_describer.go
+++ b/pkg/cmd/util/output/restore_describer.go
@@ -369,11 +369,10 @@ func describePodVolumeRestores(d *Describer, restores []velerov1api.PodVolumeRes
 	// Get the type of pod volume uploader. Since the uploader only comes from a single source, we can
 	// take the uploader type from the first element of the array.
 	var uploaderType string
-	if len(restores) > 0 {
-		uploaderType = restores[0].Spec.UploaderType
-	} else {
+	if len(restores) == 0 {
 		return
 	}
+	uploaderType = restores[0].Spec.UploaderType
 
 	if details {
 		d.Printf("%s Restores:\n", uploaderType)

--- a/pkg/controller/backup_deletion_controller.go
+++ b/pkg/controller/backup_deletion_controller.go
@@ -398,9 +398,8 @@ func (r *backupDeletionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 			if cnt > 0 {
 				return false, nil
-			} else {
-				return true, nil
 			}
+			return true, nil
 		})
 		if err != nil {
 			log.WithError(err).Error("Error polling for deletion of restores")

--- a/pkg/controller/data_download_controller.go
+++ b/pkg/controller/data_download_controller.go
@@ -327,9 +327,8 @@ func (r *DataDownloadReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			if err == datapath.ConcurrentLimitExceed {
 				log.Debug("Data path instance is concurrent limited requeue later")
 				return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
-			} else {
-				return r.errorOut(ctx, dd, err, "error to create data path", log)
 			}
+			return r.errorOut(ctx, dd, err, "error to create data path", log)
 		}
 
 		if err := r.initCancelableDataPath(ctx, asyncBR, result, log); err != nil {
@@ -817,9 +816,8 @@ func exclusiveUpdateDataDownload(ctx context.Context, cli client.Client, dd *vel
 	// it won't rollback dd in memory when error
 	if apierrors.IsConflict(err) {
 		return false, nil
-	} else {
-		return false, err
 	}
+	return false, err
 }
 
 func (r *DataDownloadReconciler) getTargetPVC(ctx context.Context, dd *velerov2alpha1api.DataDownload) (*corev1api.PersistentVolumeClaim, error) {
@@ -943,9 +941,8 @@ func UpdateDataDownloadWithRetry(ctx context.Context, client client.Client, name
 				if apierrors.IsConflict(err) {
 					log.Debugf("failed to update datadownload for %s/%s and will retry it", dd.Namespace, dd.Name)
 					return false, nil
-				} else {
-					return false, errors.Wrapf(err, "error updating datadownload %s/%s", dd.Namespace, dd.Name)
 				}
+				return false, errors.Wrapf(err, "error updating datadownload %s/%s", dd.Namespace, dd.Name)
 			}
 		}
 

--- a/pkg/controller/data_upload_controller.go
+++ b/pkg/controller/data_upload_controller.go
@@ -346,9 +346,8 @@ func (r *DataUploadReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			if err == datapath.ConcurrentLimitExceed {
 				log.Debug("Data path instance is concurrent limited requeue later")
 				return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
-			} else {
-				return r.errorOut(ctx, du, err, "error to create data path", log)
 			}
+			return r.errorOut(ctx, du, err, "error to create data path", log)
 		}
 
 		if err := r.initCancelableDataPath(ctx, asyncBR, res, log); err != nil {
@@ -887,9 +886,8 @@ func exclusiveUpdateDataUpload(ctx context.Context, cli client.Client, du *veler
 	// warn we won't rollback du values in memory when error
 	if apierrors.IsConflict(err) {
 		return false, nil
-	} else {
-		return false, err
 	}
+	return false, err
 }
 
 func (r *DataUploadReconciler) closeDataPath(ctx context.Context, duName string) {
@@ -1036,9 +1034,8 @@ func UpdateDataUploadWithRetry(ctx context.Context, client client.Client, namesp
 				if apierrors.IsConflict(err) {
 					log.Debugf("failed to update dataupload for %s/%s and will retry it", du.Namespace, du.Name)
 					return false, nil
-				} else {
-					return false, errors.Wrapf(err, "error updating dataupload with error %s/%s", du.Namespace, du.Name)
 				}
+				return false, errors.Wrapf(err, "error updating dataupload with error %s/%s", du.Namespace, du.Name)
 			}
 		}
 

--- a/pkg/controller/pod_volume_backup_controller.go
+++ b/pkg/controller/pod_volume_backup_controller.go
@@ -289,9 +289,8 @@ func (r *PodVolumeBackupReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			if err == datapath.ConcurrentLimitExceed {
 				log.Debug("Data path instance is concurrent limited requeue later")
 				return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
-			} else {
-				return r.errorOut(ctx, pvb, err, "error to create data path", log)
 			}
+			return r.errorOut(ctx, pvb, err, "error to create data path", log)
 		}
 
 		r.metrics.RegisterPodVolumeBackupEnqueue(r.nodeName)
@@ -433,9 +432,8 @@ func exclusiveUpdatePodVolumeBackup(ctx context.Context, cli client.Client, pvb 
 
 	if apierrors.IsConflict(err) {
 		return false, nil
-	} else {
-		return false, err
 	}
+	return false, err
 }
 
 func (r *PodVolumeBackupReconciler) onPrepareTimeout(ctx context.Context, pvb *velerov1api.PodVolumeBackup) {
@@ -885,9 +883,8 @@ func UpdatePVBWithRetry(ctx context.Context, client client.Client, namespacedNam
 				if apierrors.IsConflict(err) {
 					log.Debugf("failed to update PVB for %s/%s and will retry it", pvb.Namespace, pvb.Name)
 					return false, nil
-				} else {
-					return false, errors.Wrapf(err, "error updating PVB with error %s/%s", pvb.Namespace, pvb.Name)
 				}
+				return false, errors.Wrapf(err, "error updating PVB with error %s/%s", pvb.Namespace, pvb.Name)
 			}
 		}
 

--- a/pkg/controller/pod_volume_restore_controller.go
+++ b/pkg/controller/pod_volume_restore_controller.go
@@ -293,9 +293,8 @@ func (r *PodVolumeRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			if err == datapath.ConcurrentLimitExceed {
 				log.Debug("Data path instance is concurrent limited requeue later")
 				return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
-			} else {
-				return r.errorOut(ctx, pvr, err, "error to create data path", log)
 			}
+			return r.errorOut(ctx, pvr, err, "error to create data path", log)
 		}
 
 		if err := r.initCancelableDataPath(ctx, asyncBR, res, log); err != nil {
@@ -438,9 +437,8 @@ func exclusiveUpdatePodVolumeRestore(ctx context.Context, cli client.Client, pvr
 	// warn we won't rollback pvr values in memory when error
 	if apierrors.IsConflict(err) {
 		return false, nil
-	} else {
-		return false, err
 	}
+	return false, err
 }
 
 func (r *PodVolumeRestoreReconciler) onPrepareTimeout(ctx context.Context, pvr *velerov1api.PodVolumeRestore) {
@@ -944,9 +942,8 @@ func UpdatePVRWithRetry(ctx context.Context, client client.Client, namespacedNam
 				if apierrors.IsConflict(err) {
 					log.Debugf("failed to update PVR for %s/%s and will retry it", pvr.Namespace, pvr.Name)
 					return false, nil
-				} else {
-					return false, errors.Wrapf(err, "error updating PVR %s/%s", pvr.Namespace, pvr.Name)
 				}
+				return false, errors.Wrapf(err, "error updating PVR %s/%s", pvr.Namespace, pvr.Name)
 			}
 		}
 

--- a/pkg/controller/pod_volume_restore_controller_legacy.go
+++ b/pkg/controller/pod_volume_restore_controller_legacy.go
@@ -151,9 +151,8 @@ func (c *PodVolumeRestoreReconcilerLegacy) Reconcile(ctx context.Context, req ct
 	if err != nil {
 		if err == datapath.ConcurrentLimitExceed {
 			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
-		} else {
-			return c.errorOut(ctx, pvr, err, "error to create data path", log)
 		}
+		return c.errorOut(ctx, pvr, err, "error to create data path", log)
 	}
 
 	original := pvr.DeepCopy()

--- a/pkg/controller/server_status_request_controller_test.go
+++ b/pkg/controller/server_status_request_controller_test.go
@@ -77,12 +77,11 @@ var _ = Describe("Server Status Request Reconciler", func() {
 			})
 
 			Expect(actualResult).To(BeEquivalentTo(test.expectedRequeue))
-			if test.expectedErrMsg == "" {
-				Expect(err).ToNot(HaveOccurred())
-			} else {
+			if test.expectedErrMsg != "" {
 				Expect(err.Error()).To(BeEquivalentTo(test.expectedErrMsg))
 				return
 			}
+			Expect(err).ToNot(HaveOccurred())
 
 			instance := &velerov1api.ServerStatusRequest{}
 			err = r.client.Get(ctx, kbclient.ObjectKey{Name: test.req.Name, Namespace: test.req.Namespace}, instance)

--- a/pkg/datamover/backup_micro_service.go
+++ b/pkg/datamover/backup_micro_service.go
@@ -149,9 +149,8 @@ func (r *BackupMicroService) RunCancelableDataPath(ctx context.Context) (string,
 
 		if du.Status.Phase == velerov2alpha1api.DataUploadPhaseInProgress {
 			return true, nil
-		} else {
-			return false, nil
 		}
+		return false, nil
 	})
 
 	if err != nil {

--- a/pkg/datamover/restore_micro_service.go
+++ b/pkg/datamover/restore_micro_service.go
@@ -137,9 +137,8 @@ func (r *RestoreMicroService) RunCancelableDataPath(ctx context.Context) (string
 
 		if dd.Status.Phase == velerov2alpha1api.DataDownloadPhaseInProgress {
 			return true, nil
-		} else {
-			return false, nil
 		}
+		return false, nil
 	})
 	if err != nil {
 		log.WithError(err).Error("Failed to wait dd")

--- a/pkg/datamover/util.go
+++ b/pkg/datamover/util.go
@@ -21,9 +21,8 @@ import "fmt"
 func GetUploaderType(dataMover string) string {
 	if dataMover == "" || dataMover == "velero" {
 		return "kopia"
-	} else {
-		return dataMover
 	}
+	return dataMover
 }
 
 func IsBuiltInUploader(dataMover string) bool {

--- a/pkg/datapath/manager.go
+++ b/pkg/datapath/manager.go
@@ -91,7 +91,6 @@ func (m *Manager) GetAsyncBR(jobName string) AsyncBR {
 
 	if async, exist := m.tracker[jobName]; exist {
 		return async
-	} else {
-		return nil
 	}
+	return nil
 }

--- a/pkg/exposer/csi_snapshot.go
+++ b/pkg/exposer/csi_snapshot.go
@@ -268,9 +268,8 @@ func (e *csiSnapshotExposer) GetExposed(ctx context.Context, ownerObject corev1a
 		if apierrors.IsNotFound(err) {
 			curLog.WithField("backup pod", backupPodName).Debugf("Backup pod is not running in the current node %s", exposeWaitParam.NodeName)
 			return nil, nil
-		} else {
-			return nil, errors.Wrapf(err, "error to get backup pod %s", backupPodName)
 		}
+		return nil, errors.Wrapf(err, "error to get backup pod %s", backupPodName)
 	}
 
 	curLog.WithField("pod", pod.Name).Infof("Backup pod is in running state in node %s", pod.Spec.NodeName)

--- a/pkg/exposer/generic_restore.go
+++ b/pkg/exposer/generic_restore.go
@@ -210,9 +210,8 @@ func (e *genericRestoreExposer) GetExposed(ctx context.Context, ownerObject core
 		if apierrors.IsNotFound(err) {
 			curLog.WithField("restore pod", restorePodName).Debug("Restore pod is not running in the current node")
 			return nil, nil
-		} else {
-			return nil, errors.Wrapf(err, "error to get restore pod %s", restorePodName)
 		}
+		return nil, errors.Wrapf(err, "error to get restore pod %s", restorePodName)
 	}
 
 	curLog.WithField("pod", pod.Name).Infof("Restore pod is in running state in node %s", pod.Spec.NodeName)

--- a/pkg/exposer/generic_restore_test.go
+++ b/pkg/exposer/generic_restore_test.go
@@ -390,9 +390,8 @@ func TestRebindVolume(t *testing.T) {
 						if hookCount == 0 {
 							hookCount++
 							return false, nil, nil
-						} else {
-							return true, nil, errors.New("fake-patch-error")
 						}
+						return true, nil, errors.New("fake-patch-error")
 					},
 				},
 			},

--- a/pkg/exposer/host_path.go
+++ b/pkg/exposer/host_path.go
@@ -89,7 +89,6 @@ func ExtractPodVolumeHostPath(ctx context.Context, path string, kubeClient kuber
 
 	if osType == kube.NodeOSWindows {
 		return strings.Replace(path, nodeagent.HostPodVolumeMountPathWin(), podPath, 1), nil
-	} else {
-		return strings.Replace(path, nodeagent.HostPodVolumeMountPath(), podPath, 1), nil
 	}
+	return strings.Replace(path, nodeagent.HostPodVolumeMountPath(), podPath, 1), nil
 }

--- a/pkg/exposer/pod_volume.go
+++ b/pkg/exposer/pod_volume.go
@@ -199,9 +199,8 @@ func (e *podVolumeExposer) GetExposed(ctx context.Context, ownerObject corev1api
 		if apierrors.IsNotFound(err) {
 			curLog.WithField("hosting pod", hostingPodName).Debug("Hosting pod is not running in the current node")
 			return nil, nil
-		} else {
-			return nil, errors.Wrapf(err, "error to wait for rediness of pod %s", hostingPodName)
 		}
+		return nil, errors.Wrapf(err, "error to wait for rediness of pod %s", hostingPodName)
 	}
 
 	curLog.WithField("pod", updated.Name).Infof("Hosting pod is in running state in node %s", updated.Spec.NodeName)

--- a/pkg/itemoperationmap/backup_operation_map.go
+++ b/pkg/itemoperationmap/backup_operation_map.go
@@ -107,10 +107,7 @@ func (m *BackupItemOperationsMap) UpdateForBackup(backupStore persistence.Backup
 	if !ok || (!operations.ChangesSinceUpdate && len(operations.ErrsSinceUpdate) == 0) {
 		return nil
 	}
-	if err := operations.uploadProgress(backupStore, backupName); err != nil {
-		return err
-	}
-	return nil
+	return operations.uploadProgress(backupStore, backupName)
 }
 
 type OperationsForBackup struct {

--- a/pkg/itemoperationmap/restore_operation_map.go
+++ b/pkg/itemoperationmap/restore_operation_map.go
@@ -107,10 +107,7 @@ func (m *RestoreItemOperationsMap) UpdateForRestore(backupStore persistence.Back
 	if !ok || (!operations.ChangesSinceUpdate && len(operations.ErrsSinceUpdate) == 0) {
 		return nil
 	}
-	if err := operations.uploadProgress(backupStore, restoreName); err != nil {
-		return err
-	}
-	return nil
+	return operations.uploadProgress(backupStore, restoreName)
 }
 
 type OperationsForRestore struct {

--- a/pkg/nodeagent/node_agent.go
+++ b/pkg/nodeagent/node_agent.go
@@ -130,9 +130,8 @@ func isRunning(ctx context.Context, kubeClient kubernetes.Interface, namespace s
 		return ErrDaemonSetNotFound
 	} else if err != nil {
 		return err
-	} else {
-		return nil
 	}
+	return nil
 }
 
 // KbClientIsRunningInNode checks if the node agent pod is running properly in a specified node through kube client. If not, return the error found

--- a/pkg/podvolume/backup_micro_service.go
+++ b/pkg/podvolume/backup_micro_service.go
@@ -148,9 +148,8 @@ func (r *BackupMicroService) RunCancelableDataPath(ctx context.Context) (string,
 
 		if pvb.Status.Phase == velerov1api.PodVolumeBackupPhaseInProgress {
 			return true, nil
-		} else {
-			return false, nil
 		}
+		return false, nil
 	})
 
 	if err != nil {

--- a/pkg/podvolume/restore_micro_service.go
+++ b/pkg/podvolume/restore_micro_service.go
@@ -139,9 +139,8 @@ func (r *RestoreMicroService) RunCancelableDataPath(ctx context.Context) (string
 
 		if pvr.Status.Phase == velerov1api.PodVolumeRestorePhaseInProgress {
 			return true, nil
-		} else {
-			return false, nil
 		}
+		return false, nil
 	})
 	if err != nil {
 		log.WithError(err).Error("Failed to wait PVR")

--- a/pkg/podvolume/util.go
+++ b/pkg/podvolume/util.go
@@ -153,9 +153,8 @@ func GetRealSource(pvb *velerov1api.PodVolumeBackup) string {
 
 	if pvcName != "" {
 		return fmt.Sprintf("%s/%s/%s", pvb.Spec.Pod.Namespace, pvb.Spec.Pod.Name, pvcName)
-	} else {
-		return fmt.Sprintf("%s/%s/%s", pvb.Spec.Pod.Namespace, pvb.Spec.Pod.Name, pvb.Spec.Volume)
 	}
+	return fmt.Sprintf("%s/%s/%s", pvb.Spec.Pod.Namespace, pvb.Spec.Pod.Name, pvb.Spec.Volume)
 }
 
 func getUploaderTypeOrDefault(uploaderType string) string {

--- a/pkg/repository/config/config.go
+++ b/pkg/repository/config/config.go
@@ -103,9 +103,8 @@ func GetBackendType(provider string, config map[string]string) BackendType {
 		return bt
 	} else if config != nil && config["s3Url"] != "" {
 		return AWSBackend
-	} else {
-		return bt
 	}
+	return bt
 }
 
 func IsBackendTypeValid(backendType BackendType) bool {

--- a/pkg/repository/ensurer.go
+++ b/pkg/repository/ensurer.go
@@ -89,9 +89,8 @@ func (r *Ensurer) EnsureRepo(ctx context.Context, namespace, volumeNamespace, ba
 
 		// no repo found: create one and wait for it to be ready
 		return r.createBackupRepositoryAndWait(ctx, namespace, backupRepoKey)
-	} else {
-		return nil, errors.WithStack(err)
 	}
+	return nil, errors.WithStack(err)
 }
 
 func (r *Ensurer) repoLock(key BackupRepositoryKey) *sync.Mutex {
@@ -126,9 +125,8 @@ func (r *Ensurer) waitBackupRepository(ctx context.Context, namespace string, ba
 		} else if isBackupRepositoryNotFoundError(err) || isBackupRepositoryNotProvisionedError(err) {
 			checkErr = err
 			return false, nil
-		} else {
-			return false, err
 		}
+		return false, err
 	}
 
 	err := wait.PollUntilContextTimeout(ctx, time.Millisecond*500, r.resourceTimeout, true, checkFunc)

--- a/pkg/repository/maintenance/maintenance.go
+++ b/pkg/repository/maintenance/maintenance.go
@@ -227,11 +227,10 @@ func getJobConfig(
 	); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nil
-		} else {
-			return nil, errors.Wrapf(
-				err,
-				"fail to get repo maintenance job configs %s", repoMaintenanceJobConfig)
 		}
+		return nil, errors.Wrapf(
+			err,
+			"fail to get repo maintenance job configs %s", repoMaintenanceJobConfig)
 	}
 
 	if cm.Data == nil {

--- a/pkg/restore/actions/csi/volumesnapshotcontent_action.go
+++ b/pkg/restore/actions/csi/volumesnapshotcontent_action.go
@@ -100,13 +100,12 @@ func (p *volumeSnapshotContentRestoreItemAction) Execute(
 	// Set the DeletionPolicy to Retain to avoid VS deletion will not trigger snapshot deletion
 	vsc.Spec.DeletionPolicy = snapshotv1api.VolumeSnapshotContentRetain
 
-	if vscFromBackup.Status != nil && vscFromBackup.Status.SnapshotHandle != nil {
-		vsc.Spec.Source.VolumeHandle = nil
-		vsc.Spec.Source.SnapshotHandle = vscFromBackup.Status.SnapshotHandle
-	} else {
+	if vscFromBackup.Status == nil || vscFromBackup.Status.SnapshotHandle == nil {
 		p.log.Errorf("fail to get snapshot handle from VSC %s status", vsc.Name)
 		return nil, errors.Errorf("fail to get snapshot handle from VSC %s status", vsc.Name)
 	}
+	vsc.Spec.Source.VolumeHandle = nil
+	vsc.Spec.Source.SnapshotHandle = vscFromBackup.Status.SnapshotHandle
 
 	additionalItems := []velero.ResourceIdentifier{}
 	if csi.IsVolumeSnapshotContentHasDeleteSecret(&vsc) {

--- a/pkg/restore/actions/service_account_action.go
+++ b/pkg/restore/actions/service_account_action.go
@@ -65,9 +65,8 @@ func (a *ServiceAccountAction) Execute(input *velero.RestoreItemActionExecuteInp
 			log.Debug("Match found - excluding this secret")
 			serviceAccount.Secrets = append(serviceAccount.Secrets[:i], serviceAccount.Secrets[i+1:]...)
 			break
-		} else {
-			log.Debug("No match found - including this secret")
 		}
+		log.Debug("No match found - including this secret")
 	}
 
 	res, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&serviceAccount)

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1245,12 +1245,11 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 					// Return early because we don't want to restore the PV itself, we
 					// want to dynamically re-provision it.
 					return warnings, errs, itemExists
-				} else {
-					obj, err = ctx.handleSkippedPVHasRetainPolicy(obj, restoreLogger)
-					if err != nil {
-						errs.Add(namespace, err)
-						return warnings, errs, itemExists
-					}
+				}
+				obj, err = ctx.handleSkippedPVHasRetainPolicy(obj, restoreLogger)
+				if err != nil {
+					errs.Add(namespace, err)
+					return warnings, errs, itemExists
 				}
 			}
 		} else {

--- a/pkg/uploader/kopia/block_restore.go
+++ b/pkg/uploader/kopia/block_restore.go
@@ -69,13 +69,13 @@ func (o *BlockOutput) WriteFile(ctx context.Context, relativePath string, remote
 		if bytesToWrite > 0 {
 			offset := 0
 			for bytesToWrite > 0 {
-				if bytesWritten, err := targetFile.Write(buffer[offset:bytesToWrite]); err == nil {
-					progressCb(int64(bytesWritten))
-					bytesToWrite -= bytesWritten
-					offset += bytesWritten
-				} else {
+				bytesWritten, err := targetFile.Write(buffer[offset:bytesToWrite])
+				if err != nil {
 					return errors.Wrapf(err, "failed to write data to file %s", o.targetFileName)
 				}
+				progressCb(int64(bytesWritten))
+				bytesToWrite -= bytesWritten
+				offset += bytesWritten
 			}
 		}
 	}

--- a/pkg/uploader/provider/provider.go
+++ b/pkg/uploader/provider/provider.go
@@ -86,7 +86,6 @@ func NewUploaderProvider(
 	}
 	if uploaderType == uploader.KopiaType {
 		return NewKopiaUploaderProvider(requesterType, ctx, credGetter, backupRepo, log)
-	} else {
-		return NewResticUploaderProvider(repoIdentifier, bsl, credGetter, repoKeySelector, log)
 	}
+	return NewResticUploaderProvider(repoIdentifier, bsl, credGetter, repoKeySelector, log)
 }

--- a/pkg/util/csi/volume_snapshot.go
+++ b/pkg/util/csi/volume_snapshot.go
@@ -185,9 +185,8 @@ func EnsureDeleteVS(ctx context.Context, snapshotClient snapshotter.SnapshotV1In
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			return errors.Errorf("timeout to assure VolumeSnapshot %s is deleted, finalizers in VS %v", vsName, updated.Finalizers)
-		} else {
-			return errors.Wrapf(err, "error to assure VolumeSnapshot is deleted, %s", vsName)
 		}
+		return errors.Wrapf(err, "error to assure VolumeSnapshot is deleted, %s", vsName)
 	}
 
 	return nil
@@ -244,9 +243,8 @@ func EnsureDeleteVSC(ctx context.Context, snapshotClient snapshotter.SnapshotV1I
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			return errors.Errorf("timeout to assure VolumeSnapshotContent %s is deleted, finalizers in VSC %v", vscName, updated.Finalizers)
-		} else {
-			return errors.Wrapf(err, "error to assure VolumeSnapshotContent is deleted, %s", vscName)
 		}
+		return errors.Wrapf(err, "error to assure VolumeSnapshotContent is deleted, %s", vscName)
 	}
 
 	return nil
@@ -672,11 +670,10 @@ func WaitUntilVSCHandleIsReady(
 				return nil,
 					errors.Errorf("CSI got timed out with error: %v",
 						*vsc.Status.Error.Message)
-			} else {
-				log.Errorf(
-					"Timed out awaiting reconciliation of volumesnapshot %s/%s",
-					volSnap.Namespace, volSnap.Name)
 			}
+			log.Errorf(
+				"Timed out awaiting reconciliation of volumesnapshot %s/%s",
+				volSnap.Namespace, volSnap.Name)
 		}
 		return nil, err
 	}

--- a/pkg/util/kube/pod.go
+++ b/pkg/util/kube/pod.go
@@ -127,9 +127,8 @@ func EnsureDeletePod(ctx context.Context, podGetter corev1client.CoreV1Interface
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			return errors.Errorf("timeout to assure pod %s is deleted, finalizers in pod %v", pod, updated.Finalizers)
-		} else {
-			return errors.Wrapf(err, "error to assure pod is deleted, %s", pod)
 		}
+		return errors.Wrapf(err, "error to assure pod is deleted, %s", pod)
 	}
 
 	return nil

--- a/pkg/util/kube/pod_test.go
+++ b/pkg/util/kube/pod_test.go
@@ -956,9 +956,8 @@ func (em *exitWithMessageMock) CreateFile(name string) (*os.File, error) {
 
 	if em.writeFail {
 		return os.OpenFile(em.filePath, os.O_CREATE|os.O_RDONLY, 0500)
-	} else {
-		return os.Create(em.filePath)
 	}
+	return os.Create(em.filePath)
 }
 
 func TestExitPodWithMessage(t *testing.T) {

--- a/pkg/util/kube/pvc_pv.go
+++ b/pkg/util/kube/pvc_pv.go
@@ -51,10 +51,9 @@ func DeletePVAndPVCIfAny(ctx context.Context, client corev1client.CoreV1Interfac
 		if apierrors.IsNotFound(err) {
 			log.WithError(err).Debugf("Abort deleting PV and PVC, for related PVC doesn't exist, %s/%s", pvcNamespace, pvcName)
 			return
-		} else {
-			log.Warnf("failed to get pvc %s/%s with err %v", pvcNamespace, pvcName, err)
-			return
 		}
+		log.Warnf("failed to get pvc %s/%s with err %v", pvcNamespace, pvcName, err)
+		return
 	}
 
 	if pvcObj.Spec.VolumeName == "" {
@@ -153,9 +152,8 @@ func EnsureDeletePVC(ctx context.Context, pvcGetter corev1client.CoreV1Interface
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			return errors.Errorf("timeout to assure pvc %s is deleted, finalizers in pvc %v", pvcName, updated.Finalizers)
-		} else {
-			return errors.Wrapf(err, "error to ensure pvc deleted for %s", pvcName)
 		}
+		return errors.Wrapf(err, "error to ensure pvc deleted for %s", pvcName)
 	}
 
 	return nil
@@ -184,9 +182,8 @@ func EnsurePVDeleted(ctx context.Context, pvGetter corev1client.CoreV1Interface,
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			return errors.Errorf("timeout to assure pv %s is deleted", pvName)
-		} else {
-			return errors.Wrapf(err, "error to ensure pv is deleted for %s", pvName)
 		}
+		return errors.Wrapf(err, "error to ensure pv is deleted for %s", pvName)
 	}
 
 	return nil
@@ -385,9 +382,8 @@ func WaitPVBound(ctx context.Context, pvGetter corev1client.CoreV1Interface, pvN
 
 	if err != nil {
 		return nil, errors.Wrap(err, "error to wait for bound of PV")
-	} else {
-		return updated, nil
 	}
+	return updated, nil
 }
 
 // IsPVCBound returns true if the specified PVC has been bound

--- a/pkg/util/logging/error_location_hook.go
+++ b/pkg/util/logging/error_location_hook.go
@@ -140,10 +140,9 @@ func getInnermostTrace(err error) stackTracer {
 		}
 
 		c, isCauser := err.(causer)
-		if isCauser {
-			err = c.Cause()
-		} else {
+		if !isCauser {
 			return tracer
 		}
+		err = c.Cause()
 	}
 }

--- a/pkg/util/stringptr/stringptr.go
+++ b/pkg/util/stringptr/stringptr.go
@@ -21,7 +21,6 @@ const NilString = "<nil>"
 func GetString(str *string) string {
 	if str == nil {
 		return NilString
-	} else {
-		return *str
 	}
+	return *str
 }

--- a/test/e2e/backups/deletion.go
+++ b/test/e2e/backups/deletion.go
@@ -305,9 +305,8 @@ func runBackupDeletionTests(client TestClient, veleroCfg VeleroConfig, backupLoc
 	err = DeleteBackup(context.Background(), backupName, &veleroCfg)
 	if err != nil {
 		return errors.Wrapf(err, "|| UNEXPECTED || - Failed to delete backup %q", backupName)
-	} else {
-		fmt.Printf("|| EXPECTED || - Success to delete backup %s locally\n", backupName)
 	}
+	fmt.Printf("|| EXPECTED || - Success to delete backup %s locally\n", backupName)
 	fmt.Printf("|| EXPECTED || - Backup deletion test completed successfully\n")
 	return nil
 }

--- a/test/e2e/basic/api-group/enable_api_group_versions.go
+++ b/test/e2e/basic/api-group/enable_api_group_versions.go
@@ -389,9 +389,8 @@ func rerenderTestYaml(index int, group, path string) (string, error) {
 			return fmt.Sprintf("RockBand%dList", index)
 		} else if s == "rockbands" {
 			return fmt.Sprintf("rockband%ds", index)
-		} else {
-			return fmt.Sprintf("rockband%d", index)
 		}
+		return fmt.Sprintf("rockband%d", index)
 	})
 
 	// replace group name to new value

--- a/test/e2e/basic/namespace-mapping.go
+++ b/test/e2e/basic/namespace-mapping.go
@@ -131,9 +131,7 @@ func (n *NamespaceMapping) Verify() error {
 }
 
 func (n *NamespaceMapping) Clean() error {
-	if CurrentSpecReport().Failed() && n.VeleroCfg.FailFast {
-		fmt.Println("Test case failed and fail fast is enabled. Skip resource clean up.")
-	} else {
+	if !(CurrentSpecReport().Failed() && n.VeleroCfg.FailFast) {
 		if err := DeleteStorageClass(context.Background(), n.Client, KibishiiStorageClassName); err != nil {
 			return err
 		}
@@ -145,6 +143,7 @@ func (n *NamespaceMapping) Clean() error {
 
 		return n.GetTestCase().Clean()
 	}
+	fmt.Println("Test case failed and fail fast is enabled. Skip resource clean up.")
 
 	return nil
 }

--- a/test/e2e/basic/resources-check/rbac.go
+++ b/test/e2e/basic/resources-check/rbac.go
@@ -177,11 +177,10 @@ func (r *RBACCase) Destroy() error {
 }
 
 func (r *RBACCase) Clean() error {
-	if CurrentSpecReport().Failed() && r.VeleroCfg.FailFast {
-		fmt.Println("Test case failed and fail fast is enabled. Skip resource clean up.")
-	} else {
+	if !(CurrentSpecReport().Failed() && r.VeleroCfg.FailFast) {
 		return r.Destroy()
 	}
+	fmt.Println("Test case failed and fail fast is enabled. Skip resource clean up.")
 
 	return nil
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -677,14 +677,13 @@ func GetKubeConfigContext() error {
 		if err != nil {
 			return err
 		}
-		if test.VeleroCfg.StandbyClusterContext != "" {
-			tcStandby, err = k8s.NewTestClient(test.VeleroCfg.StandbyClusterContext)
-			test.VeleroCfg.StandbyClient = &tcStandby
-			if err != nil {
-				return err
-			}
-		} else {
+		if test.VeleroCfg.StandbyClusterContext == "" {
 			return errors.New("migration test needs 2 clusters to run")
+		}
+		tcStandby, err = k8s.NewTestClient(test.VeleroCfg.StandbyClusterContext)
+		test.VeleroCfg.StandbyClient = &tcStandby
+		if err != nil {
+			return err
 		}
 	}
 

--- a/test/e2e/pv-backup/pv-backup-filter.go
+++ b/test/e2e/pv-backup/pv-backup-filter.go
@@ -216,10 +216,9 @@ func fileExist(
 	origin_content := strings.Replace(CreateFileContent(namespace, podName, volume), "\n", "", -1)
 	if c == origin_content {
 		return nil
-	} else {
-		return errors.New(fmt.Sprintf("UNEXPECTED: File %s does not exist in volume %s of pod %s in namespace %s.",
-			FILE_NAME, volume, podName, namespace))
 	}
+	return errors.New(fmt.Sprintf("UNEXPECTED: File %s does not exist in volume %s of pod %s in namespace %s.",
+		FILE_NAME, volume, podName, namespace))
 }
 func fileNotExist(
 	ctx context.Context,
@@ -231,8 +230,7 @@ func fileNotExist(
 	_, _, err := ReadFileFromPodVolume(ctx, namespace, podName, podName, volume, FILE_NAME, workerOS)
 	if err != nil {
 		return nil
-	} else {
-		return errors.New(fmt.Sprintf("UNEXPECTED: File %s exist in volume %s of pod %s in namespace %s.",
-			FILE_NAME, volume, podName, namespace))
 	}
+	return errors.New(fmt.Sprintf("UNEXPECTED: File %s exist in volume %s of pod %s in namespace %s.",
+		FILE_NAME, volume, podName, namespace))
 }

--- a/test/e2e/resourcemodifiers/resource_modifiers.go
+++ b/test/e2e/resourcemodifiers/resource_modifiers.go
@@ -131,15 +131,14 @@ func (r *ResourceModifiersCase) Verify() error {
 
 func (r *ResourceModifiersCase) Clean() error {
 	// If created some resources which is not in current test namespace, we NEED to override the base Clean function
-	if CurrentSpecReport().Failed() && r.VeleroCfg.FailFast {
-		fmt.Println("Test case failed and fail fast is enabled. Skip resource clean up.")
-	} else {
+	if !(CurrentSpecReport().Failed() && r.VeleroCfg.FailFast) {
 		if err := DeleteConfigMap(r.Client.ClientGo, r.VeleroCfg.VeleroNamespace, r.cmName); err != nil {
 			return err
 		}
 
 		return r.GetTestCase().Clean() // only clean up resources in test namespace
 	}
+	fmt.Println("Test case failed and fail fast is enabled. Skip resource clean up.")
 
 	return nil
 }

--- a/test/e2e/resourcepolicies/resource_policies.go
+++ b/test/e2e/resourcepolicies/resource_policies.go
@@ -182,15 +182,14 @@ func (r *ResourcePoliciesCase) Verify() error {
 
 func (r *ResourcePoliciesCase) Clean() error {
 	// If created some resources which is not in current test namespace, we NEED to override the base Clean function
-	if CurrentSpecReport().Failed() && r.VeleroCfg.FailFast {
-		fmt.Println("Test case failed and fail fast is enabled. Skip resource clean up.")
-	} else {
+	if !(CurrentSpecReport().Failed() && r.VeleroCfg.FailFast) {
 		if err := DeleteConfigMap(r.Client.ClientGo, r.VeleroCfg.VeleroNamespace, r.cmName); err != nil {
 			return err
 		}
 
 		return r.GetTestCase().Clean() // only clean up resources in test namespace
 	}
+	fmt.Println("Test case failed and fail fast is enabled. Skip resource clean up.")
 
 	return nil
 }

--- a/test/util/csi/common.go
+++ b/test/util/csi/common.go
@@ -149,12 +149,11 @@ func CheckVolumeSnapshotCR(client TestClient, index map[string]string, expectedC
 		return nil, errors.New("Fail to get APIVersion")
 	}
 
-	if apiVersion[0] == "v1" {
-		if snapshotContentNameList, err = GetCsiSnapshotHandle(client, apiVersion[0], index); err != nil {
-			return nil, errors.Wrap(err, "Fail to get CSI snapshot content")
-		}
-	} else {
+	if apiVersion[0] != "v1" {
 		return nil, errors.New("API version is invalid")
+	}
+	if snapshotContentNameList, err = GetCsiSnapshotHandle(client, apiVersion[0], index); err != nil {
+		return nil, errors.Wrap(err, "Fail to get CSI snapshot content")
 	}
 	if expectedCount >= 0 {
 		if len(snapshotContentNameList) != expectedCount {

--- a/test/util/k8s/common.go
+++ b/test/util/k8s/common.go
@@ -372,23 +372,13 @@ func FileExistInPV(
 	if strings.Contains(output, fmt.Sprintf("/%s/%s: No such file or directory", volume, filename)) {
 		return false, nil
 	}
-
 	if err == nil {
 		return true, nil
-	} else {
-		return false, errors.Wrap(err, fmt.Sprintf("Fail to read file %s from volume %s of pod %s in %s",
-			filename, volume, podName, namespace))
 	}
+	return false, errors.Wrap(err, fmt.Sprintf("Fail to read file %s from volume %s of pod %s in %s",
+		filename, volume, podName, namespace))
 }
-func ReadFileFromPodVolume(
-	ctx context.Context,
-	namespace string,
-	podName string,
-	containerName string,
-	volume string,
-	filename string,
-	workerOS string,
-) (string, string, error) {
+func ReadFileFromPodVolume(ctx context.Context, namespace, podName, containerName, volume, filename, workerOS string) (string, string, error) {
 	arg := []string{"exec", "-n", namespace, "-c", containerName, podName,
 		"--", "cat", fmt.Sprintf("/%s/%s", volume, filename)}
 	if workerOS == common.WorkerOSWindows {

--- a/test/util/k8s/namespace.go
+++ b/test/util/k8s/namespace.go
@@ -115,10 +115,9 @@ func DeleteNamespace(ctx context.Context, client TestClient, namespace string, w
 			if err != nil {
 				fmt.Printf("Get namespace %s err: %v", namespace, err)
 				return false, err
-			} else {
-				if !slices.Contains(nsList, namespace) {
-					return true, nil
-				}
+			}
+			if !slices.Contains(nsList, namespace) {
+				return true, nil
 			}
 			fmt.Printf("namespace %q is still being deleted...\n", namespace)
 			logrus.Debugf("namespace %q is still being deleted...", namespace)
@@ -190,16 +189,16 @@ func CleanupNamespaces(ctx context.Context, client TestClient, CaseBaseName stri
 func WaitAllSelectedNSDeleted(ctx context.Context, client TestClient, label string) error {
 	return waitutil.PollImmediateInfinite(5*time.Second,
 		func() (bool, error) {
-			if ns, err := client.ClientGo.CoreV1().Namespaces().List(ctx, metav1.ListOptions{LabelSelector: label}); err != nil {
+			ns, err := client.ClientGo.CoreV1().Namespaces().List(ctx, metav1.ListOptions{LabelSelector: label})
+			if err != nil {
 				return false, err
 			} else if ns == nil {
 				return true, nil
 			} else if len(ns.Items) == 0 {
 				return true, nil
-			} else {
-				logrus.Debugf("%d namespaces is still being deleted...\n", len(ns.Items))
-				return false, nil
 			}
+			logrus.Debugf("%d namespaces is still being deleted...\n", len(ns.Items))
+			return false, nil
 		})
 }
 

--- a/test/util/kibishii/kibishii_utils.go
+++ b/test/util/kibishii/kibishii_utils.go
@@ -540,11 +540,7 @@ spec:
 		return err
 	}
 
-	if err := patchTemplate.Execute(file, patchImageData{Image: kibishiiImage}); err != nil {
-		return err
-	}
-
-	return nil
+	return patchTemplate.Execute(file, patchImageData{Image: kibishiiImage})
 }
 
 func generateJumpPadPatch(jumpPadImage string, patchDirectory string) error {
@@ -569,11 +565,7 @@ spec:
 		return err
 	}
 
-	if err := patchTemplate.Execute(file, patchImageData{Image: jumpPadImage}); err != nil {
-		return err
-	}
-
-	return nil
+	return patchTemplate.Execute(file, patchImageData{Image: jumpPadImage})
 }
 
 func generateEtcdImagePatch(etcdImage string, patchPath string) error {
@@ -617,11 +609,7 @@ spec:
 		return err
 	}
 
-	if err := patchTemplate.Execute(file, patchImageData{Image: etcdImage}); err != nil {
-		return err
-	}
-
-	return nil
+	return patchTemplate.Execute(file, patchImageData{Image: etcdImage})
 }
 
 func generateData(ctx context.Context, namespace string, kibishiiData *KibishiiData) error {

--- a/test/util/metrics/minio.go
+++ b/test/util/metrics/minio.go
@@ -27,7 +27,6 @@ func GetMinioDiskUsage(cloudCredentialsFile string, bslBucket string, bslPrefix 
 	toatalSize, err := aws.GetMinioBucketSize(cloudCredentialsFile, bslBucket, bslPrefix, bslConfig)
 	if err != nil {
 		return 0, errors.Errorf("a Failed to get minio bucket size with err %v", err)
-	} else {
-		return toatalSize, nil
 	}
+	return toatalSize, nil
 }

--- a/test/util/providers/aws_utils.go
+++ b/test/util/providers/aws_utils.go
@@ -362,10 +362,9 @@ func (s AWSStorage) IsSnapshotExisted(cloudCredentialsFile, bslConfig, backupObj
 	}
 	if actualCount != snapshotCheck.ExpectCount {
 		return errors.New(fmt.Sprintf("Snapshot count %d is not as expected %d", actualCount, snapshotCheck.ExpectCount))
-	} else {
-		fmt.Printf("Snapshot count %d is as expected %d\n", actualCount, snapshotCheck.ExpectCount)
-		return nil
 	}
+	fmt.Printf("Snapshot count %d is as expected %d\n", actualCount, snapshotCheck.ExpectCount)
+	return nil
 }
 
 func (s AWSStorage) GetMinioBucketSize(cloudCredentialsFile, bslBucket, bslPrefix, bslConfig string) (int64, error) {

--- a/test/util/providers/azure_utils.go
+++ b/test/util/providers/azure_utils.go
@@ -157,9 +157,8 @@ func getStorageAccountKey(credentialsFile, accountName, subscriptionID, resource
 	if os.Getenv(resourceGroupEnvVar) == "" {
 		if resourceGroupCfg == "" {
 			return "", errors.New("Credential file should contain AZURE_RESOURCE_GROUP or AZURE_STORAGE_ACCOUNT_ACCESS_KEY")
-		} else {
-			resourceGroup = resourceGroupCfg
 		}
+		resourceGroup = resourceGroupCfg
 	} else {
 		resourceGroup = os.Getenv(resourceGroupEnvVar)
 	}
@@ -405,10 +404,9 @@ func (s AzureStorage) IsSnapshotExisted(cloudCredentialsFile, bslConfig, backupN
 	}
 	if snapshotCountFound != snapshotCheck.ExpectCount {
 		return errors.New(fmt.Sprintf("Snapshot count %d is not as expected %d\n", snapshotCountFound, snapshotCheck.ExpectCount))
-	} else {
-		fmt.Printf("Snapshot count %d is as expected %d\n", snapshotCountFound, snapshotCheck.ExpectCount)
-		return nil
 	}
+	fmt.Printf("Snapshot count %d is as expected %d\n", snapshotCountFound, snapshotCheck.ExpectCount)
+	return nil
 }
 
 func (s AzureStorage) GetObject(cloudCredentialsFile, bslBucket, bslPrefix, bslConfig, objectKey string) (io.ReadCloser, error) {

--- a/test/util/providers/gcloud_utils.go
+++ b/test/util/providers/gcloud_utils.go
@@ -138,10 +138,9 @@ func (s GCSStorage) IsSnapshotExisted(cloudCredentialsFile, bslConfig, backupObj
 
 	if snapshotCountFound != snapshotCheck.ExpectCount {
 		return errors.New(fmt.Sprintf("Snapshot count %d is not as expected %d\n", snapshotCountFound, len(snapshotCheck.SnapshotIDList)))
-	} else {
-		fmt.Printf("Snapshot count %d is as expected %d\n", snapshotCountFound, len(snapshotCheck.SnapshotIDList))
-		return nil
 	}
+	fmt.Printf("Snapshot count %d is as expected %d\n", snapshotCountFound, len(snapshotCheck.SnapshotIDList))
+	return nil
 }
 
 func (s GCSStorage) GetObject(cloudCredentialsFile, bslBucket, bslPrefix, bslConfig, objectKey string) (io.ReadCloser, error) {

--- a/test/util/velero/velero_utils.go
+++ b/test/util/velero/velero_utils.go
@@ -389,9 +389,8 @@ func CheckScheduleWithResourceOrder(ctx context.Context, veleroCLI, veleroNamesp
 	}
 	if reflect.DeepEqual(schedule.Spec.Template.OrderedResources, order) {
 		return nil
-	} else {
-		return fmt.Errorf("resource order %v set in schedule command is not equal with order %v stored in schedule cr", order, schedule.Spec.Template.OrderedResources)
 	}
+	return fmt.Errorf("resource order %v set in schedule command is not equal with order %v stored in schedule cr", order, schedule.Spec.Template.OrderedResources)
 }
 
 func CheckBackupWithResourceOrder(ctx context.Context, veleroCLI, veleroNamespace, backupName string, orderResources map[string]string) error {
@@ -410,9 +409,8 @@ func CheckBackupWithResourceOrder(ctx context.Context, veleroCLI, veleroNamespac
 	}
 	if reflect.DeepEqual(backup.Spec.OrderedResources, orderResources) {
 		return nil
-	} else {
-		return fmt.Errorf("resource order %v set in backup command is not equal with order %v stored in backup cr", orderResources, backup.Spec.OrderedResources)
 	}
+	return fmt.Errorf("resource order %v set in backup command is not equal with order %v stored in backup cr", orderResources, backup.Spec.OrderedResources)
 }
 
 // VeleroBackupNamespace uses the veleroCLI to backup a namespace.
@@ -660,10 +658,7 @@ func VeleroVersion(ctx context.Context, veleroCLI, veleroNamespace string) error
 	args := []string{
 		"version", "--namespace", veleroNamespace,
 	}
-	if err := VeleroCmdExec(ctx, veleroCLI, args); err != nil {
-		return err
-	}
-	return nil
+	return VeleroCmdExec(ctx, veleroCLI, args)
 }
 
 // GetPlugins will collect all kinds plugins for VeleroInstall, such as provider
@@ -1048,37 +1043,35 @@ func IsBackupExist(ctx context.Context, backupName string, veleroCfg *VeleroConf
 
 func WaitBackupDeleted(ctx context.Context, backupName string, timeout time.Duration, veleroCfg *VeleroConfig) error {
 	return wait.PollImmediate(10*time.Second, timeout, func() (bool, error) {
-		if exist, err := IsBackupExist(ctx, backupName, veleroCfg); err != nil {
+		exist, err := IsBackupExist(ctx, backupName, veleroCfg)
+		if err != nil {
 			return false, err
-		} else {
-			if exist {
-				return false, nil
-			} else {
-				fmt.Printf("Backup %s does not exist\n", backupName)
-				return true, nil
-			}
 		}
+		if exist {
+			return false, nil
+		}
+		fmt.Printf("Backup %s does not exist\n", backupName)
+		return true, nil
 	})
 }
 
 func WaitForExpectedStateOfBackup(ctx context.Context, backupName string,
 	timeout time.Duration, existing bool, veleroCfg *VeleroConfig) error {
 	return wait.PollImmediate(10*time.Second, timeout, func() (bool, error) {
-		if exist, err := IsBackupExist(ctx, backupName, veleroCfg); err != nil {
+		exist, err := IsBackupExist(ctx, backupName, veleroCfg)
+		if err != nil {
 			return false, err
-		} else {
-			msg := "does not exist as expect"
-			if exist {
-				msg = "was found as expect"
-			}
-			if exist == existing {
-				fmt.Println("Backup <" + backupName + "> " + msg)
-				return true, nil
-			} else {
-				fmt.Println("Backup <" + backupName + "> " + msg)
-				return false, nil
-			}
 		}
+		msg := "does not exist as expect"
+		if exist {
+			msg = "was found as expect"
+		}
+		if exist == existing {
+			fmt.Println("Backup <" + backupName + "> " + msg)
+			return true, nil
+		}
+		fmt.Println("Backup <" + backupName + "> " + msg)
+		return false, nil
 	})
 }
 
@@ -1239,9 +1232,8 @@ func SnapshotCRsCountShouldBe(ctx context.Context, namespace, backupName string,
 	}
 	if count == expectedCount {
 		return nil
-	} else {
-		return errors.New(fmt.Sprintf("SnapshotCR count %d of backup %s in namespace %s is not as expected %d", count, backupName, namespace, expectedCount))
 	}
+	return errors.New(fmt.Sprintf("SnapshotCR count %d of backup %s in namespace %s is not as expected %d", count, backupName, namespace, expectedCount))
 }
 
 func BackupRepositoriesCountShouldBe(ctx context.Context, veleroNamespace, targetNamespace string, expectedCount int) error {
@@ -1251,9 +1243,8 @@ func BackupRepositoriesCountShouldBe(ctx context.Context, veleroNamespace, targe
 	}
 	if len(resticArr) == expectedCount {
 		return nil
-	} else {
-		return errors.New(fmt.Sprintf("BackupRepositories count %d in namespace %s is not as expected %d", len(resticArr), targetNamespace, expectedCount))
 	}
+	return errors.New(fmt.Sprintf("BackupRepositories count %d in namespace %s is not as expected %d", len(resticArr), targetNamespace, expectedCount))
 }
 
 func GetRepositories(ctx context.Context, veleroNamespace, targetNamespace string) ([]string, error) {
@@ -1568,9 +1559,8 @@ func IsSupportUploaderType(version string) (bool, error) {
 	}
 	if v.AtLeast(verSupportUploaderType) {
 		return true, nil
-	} else {
-		return false, nil
 	}
+	return false, nil
 }
 
 func GetVeleroPodName(ctx context.Context) ([]string, error) {


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

enables and fixes this rules  from revive

* [early-return](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#early-return)
* [if-return](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#if-return)
* [superfluous-else](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#superfluous-else)

Enable preserveScope for [indent-error-flow](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#indent-error-flow) to not suggest refactorings that would increase variable scope.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
