### PR TITLE
Bump the KinD version to v0.26.0 to support containerd v2.

### DIFF
--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -91,7 +91,7 @@ jobs:
           docker run -d --rm -p 9000:9000 -e "MINIO_ACCESS_KEY=minio" -e "MINIO_SECRET_KEY=minio123" -e "MINIO_DEFAULT_BUCKETS=bucket,additional-bucket" bitnami/minio:2021.6.17-debian-10-r7
       - uses: engineerd/setup-kind@v0.5.0
         with:
-          version: "v0.21.0"
+          version: "v0.26.0"
           image: "kindest/node:v${{ matrix.k8s }}"
       - name: Fetch built CLI
         id: cli-cache


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
