### PR TITLE
Implement parallel ItemBlock processing via backup_controller goroutines

### DIFF
--- a/changelogs/unreleased/8659-sseago
+++ b/changelogs/unreleased/8659-sseago
@@ -1,0 +1,1 @@
+Implement parallel ItemBlock processing via backup_controller goroutines

--- a/pkg/backup/backed_up_items_map.go
+++ b/pkg/backup/backed_up_items_map.go
@@ -26,12 +26,14 @@ import (
 type backedUpItemsMap struct {
 	*sync.RWMutex
 	backedUpItems map[itemKey]struct{}
+	totalItems    map[itemKey]struct{}
 }
 
 func NewBackedUpItemsMap() *backedUpItemsMap {
 	return &backedUpItemsMap{
 		RWMutex:       &sync.RWMutex{},
 		backedUpItems: make(map[itemKey]struct{}),
+		totalItems:    make(map[itemKey]struct{}),
 	}
 }
 
@@ -75,6 +77,12 @@ func (m *backedUpItemsMap) Len() int {
 	return len(m.backedUpItems)
 }
 
+func (m *backedUpItemsMap) BackedUpAndTotalLen() (int, int) {
+	m.RLock()
+	defer m.RUnlock()
+	return len(m.backedUpItems), len(m.totalItems)
+}
+
 func (m *backedUpItemsMap) Has(key itemKey) bool {
 	m.RLock()
 	defer m.RUnlock()
@@ -87,4 +95,11 @@ func (m *backedUpItemsMap) AddItem(key itemKey) {
 	m.Lock()
 	defer m.Unlock()
 	m.backedUpItems[key] = struct{}{}
+	m.totalItems[key] = struct{}{}
+}
+
+func (m *backedUpItemsMap) AddItemToTotal(key itemKey) {
+	m.Lock()
+	defer m.Unlock()
+	m.totalItems[key] = struct{}{}
 }

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -71,6 +71,7 @@ type itemBackupper struct {
 	podVolumeBackupper       podvolume.Backupper
 	podVolumeSnapshotTracker *podvolume.Tracker
 	volumeSnapshotterGetter  VolumeSnapshotterGetter
+	kubernetesBackupper      *kubernetesBackupper
 
 	itemHookHandler                    hook.ItemHookHandler
 	snapshotLocationVolumeSnapshotters map[string]vsv1.VolumeSnapshotter
@@ -95,6 +96,8 @@ func (ib *itemBackupper) backupItem(logger logrus.FieldLogger, obj runtime.Unstr
 	if !selectedForBackup || err != nil || len(files) == 0 || finalize {
 		return selectedForBackup, files, err
 	}
+	ib.tarWriter.Lock()
+	defer ib.tarWriter.Unlock()
 	for _, file := range files {
 		if err := ib.tarWriter.WriteHeader(file.Header); err != nil {
 			return false, []FileForArchive{}, errors.WithStack(err)

--- a/pkg/backup/item_block_worker_pool.go
+++ b/pkg/backup/item_block_worker_pool.go
@@ -1,0 +1,99 @@
+/*
+Copyright the Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backup
+
+import (
+	"context"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type ItemBlockWorkerPool struct {
+	inputChannel chan ItemBlockInput
+	wg           *sync.WaitGroup
+	logger       logrus.FieldLogger
+	cancelFunc   context.CancelFunc
+}
+
+type ItemBlockInput struct {
+	itemBlock  *BackupItemBlock
+	returnChan chan ItemBlockReturn
+}
+
+type ItemBlockReturn struct {
+	itemBlock *BackupItemBlock
+	resources []schema.GroupResource
+	err       error
+}
+
+func (p *ItemBlockWorkerPool) GetInputChannel() chan ItemBlockInput {
+	return p.inputChannel
+}
+
+func StartItemBlockWorkerPool(ctx context.Context, workers int, log logrus.FieldLogger) *ItemBlockWorkerPool {
+	// Buffer will hold up to 10 ItemBlocks waiting for processing
+	inputChannel := make(chan ItemBlockInput, max(workers, 10))
+
+	ctx, cancelFunc := context.WithCancel(ctx)
+	wg := &sync.WaitGroup{}
+
+	for i := 0; i < workers; i++ {
+		logger := log.WithField("worker", i)
+		wg.Add(1)
+		go processItemBlockWorker(ctx, inputChannel, logger, wg)
+	}
+
+	pool := &ItemBlockWorkerPool{
+		inputChannel: inputChannel,
+		cancelFunc:   cancelFunc,
+		logger:       log,
+		wg:           wg,
+	}
+	return pool
+}
+
+func (p *ItemBlockWorkerPool) Stop() {
+	p.cancelFunc()
+	p.logger.Info("ItemBlock worker stopping")
+	p.wg.Wait()
+	p.logger.Info("ItemBlock worker stopped")
+}
+
+func processItemBlockWorker(ctx context.Context,
+	inputChannel chan ItemBlockInput,
+	logger logrus.FieldLogger,
+	wg *sync.WaitGroup) {
+	for {
+		select {
+		case m := <-inputChannel:
+			logger.Infof("processing ItemBlock for backup %v", m.itemBlock.itemBackupper.backupRequest.Name)
+			grList := m.itemBlock.itemBackupper.kubernetesBackupper.backupItemBlock(m.itemBlock)
+			logger.Infof("finished processing ItemBlock for backup %v", m.itemBlock.itemBackupper.backupRequest.Name)
+			m.returnChan <- ItemBlockReturn{
+				itemBlock: m.itemBlock,
+				resources: grList,
+				err:       nil,
+			}
+		case <-ctx.Done():
+			logger.Info("stopping ItemBlock worker")
+			wg.Done()
+			return
+		}
+	}
+}

--- a/pkg/backup/item_collector.go
+++ b/pkg/backup/item_collector.go
@@ -179,6 +179,8 @@ type kubernetesResource struct {
 	// set to true during backup processing when added to an ItemBlock
 	// or if the item is excluded from backup.
 	inItemBlockOrExcluded bool
+	// Kind is added to facilitate creating an itemKey for progress tracking
+	kind string
 }
 
 // getItemsFromResourceIdentifiers get the kubernetesResources
@@ -407,6 +409,7 @@ func (r *itemCollector) getResourceItems(
 				namespace:     resourceID.Namespace,
 				name:          resourceID.Name,
 				path:          path,
+				kind:          resource.Kind,
 			})
 		}
 
@@ -480,6 +483,7 @@ func (r *itemCollector) getResourceItems(
 				namespace:     item.GetNamespace(),
 				name:          item.GetName(),
 				path:          path,
+				kind:          resource.Kind,
 			})
 
 			if item.GetNamespace() != "" {
@@ -806,6 +810,7 @@ func (r *itemCollector) collectNamespaces(
 			preferredGVR:  preferredGVR,
 			name:          unstructuredList.Items[index].GetName(),
 			path:          path,
+			kind:          resource.Kind,
 		})
 	}
 

--- a/pkg/backup/request.go
+++ b/pkg/backup/request.go
@@ -51,6 +51,7 @@ type Request struct {
 	ResPolicies               *resourcepolicies.Policies
 	SkippedPVTracker          *skipPVTracker
 	VolumesInformation        volume.BackupVolumesInformation
+	ItemBlockChannel          chan ItemBlockInput
 }
 
 // BackupVolumesInformation contains the information needs by generating

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -87,6 +87,7 @@ type backupReconciler struct {
 	defaultSnapshotMoveData     bool
 	globalCRClient              kbclient.Client
 	itemBlockWorkerCount        int
+	workerPool                  *pkgbackup.ItemBlockWorkerPool
 }
 
 func NewBackupReconciler(
@@ -139,6 +140,7 @@ func NewBackupReconciler(
 		defaultSnapshotMoveData:     defaultSnapshotMoveData,
 		itemBlockWorkerCount:        itemBlockWorkerCount,
 		globalCRClient:              globalCRClient,
+		workerPool:                  pkgbackup.StartItemBlockWorkerPool(ctx, itemBlockWorkerCount, logger),
 	}
 	b.updateTotalBackupMetric()
 	return b
@@ -329,6 +331,7 @@ func (b *backupReconciler) prepareBackupRequest(backup *velerov1api.Backup, logg
 		Backup:           backup.DeepCopy(), // don't modify items in the cache
 		SkippedPVTracker: pkgbackup.NewSkipPVTracker(),
 		BackedUpItems:    pkgbackup.NewBackedUpItemsMap(),
+		ItemBlockChannel: b.workerPool.GetInputChannel(),
 	}
 	request.VolumesInformation.Init()
 

--- a/pkg/controller/backup_controller_test.go
+++ b/pkg/controller/backup_controller_test.go
@@ -137,7 +137,9 @@ func TestProcessBackupNonProcessedItems(t *testing.T) {
 				kbClient:   velerotest.NewFakeControllerRuntimeClient(t),
 				formatFlag: formatFlag,
 				logger:     logger,
+				workerPool: pkgbackup.StartItemBlockWorkerPool(context.Background(), 1, logger),
 			}
+			defer c.workerPool.Stop()
 			if test.backup != nil {
 				require.NoError(t, c.kbClient.Create(context.Background(), test.backup))
 			}
@@ -226,7 +228,9 @@ func TestProcessBackupValidationFailures(t *testing.T) {
 				clock:                 &clock.RealClock{},
 				formatFlag:            formatFlag,
 				metrics:               metrics.NewServerMetrics(),
+				workerPool:            pkgbackup.StartItemBlockWorkerPool(context.Background(), 1, logger),
 			}
+			defer c.workerPool.Stop()
 
 			require.NotNil(t, test.backup)
 			require.NoError(t, c.kbClient.Create(context.Background(), test.backup))
@@ -289,7 +293,9 @@ func TestBackupLocationLabel(t *testing.T) {
 				defaultBackupLocation: test.backupLocation.Name,
 				clock:                 &clock.RealClock{},
 				formatFlag:            formatFlag,
+				workerPool:            pkgbackup.StartItemBlockWorkerPool(context.Background(), 1, logger),
 			}
+			defer c.workerPool.Stop()
 
 			res := c.prepareBackupRequest(test.backup, logger)
 			assert.NotNil(t, res)
@@ -384,7 +390,9 @@ func Test_prepareBackupRequest_BackupStorageLocation(t *testing.T) {
 				defaultBackupTTL:      defaultBackupTTL.Duration,
 				clock:                 testclocks.NewFakeClock(now),
 				formatFlag:            formatFlag,
+				workerPool:            pkgbackup.StartItemBlockWorkerPool(context.Background(), 1, logger),
 			}
+			defer c.workerPool.Stop()
 
 			test.backup.Spec.StorageLocation = test.backupLocationNameInBackup
 
@@ -460,7 +468,9 @@ func TestDefaultBackupTTL(t *testing.T) {
 				defaultBackupTTL: defaultBackupTTL.Duration,
 				clock:            testclocks.NewFakeClock(now),
 				formatFlag:       formatFlag,
+				workerPool:       pkgbackup.StartItemBlockWorkerPool(context.Background(), 1, logger),
 			}
+			defer c.workerPool.Stop()
 
 			res := c.prepareBackupRequest(test.backup, logger)
 			assert.NotNil(t, res)
@@ -560,7 +570,9 @@ func TestDefaultVolumesToResticDeprecation(t *testing.T) {
 				clock:                    &clock.RealClock{},
 				formatFlag:               formatFlag,
 				defaultVolumesToFsBackup: test.globalVal,
+				workerPool:               pkgbackup.StartItemBlockWorkerPool(context.Background(), 1, logger),
 			}
+			defer c.workerPool.Stop()
 
 			res := c.prepareBackupRequest(test.backup, logger)
 			assert.NotNil(t, res)
@@ -1345,7 +1357,9 @@ func TestProcessBackupCompletions(t *testing.T) {
 				backupper:                backupper,
 				formatFlag:               formatFlag,
 				globalCRClient:           fakeGlobalClient,
+				workerPool:               pkgbackup.StartItemBlockWorkerPool(context.Background(), 1, logger),
 			}
+			defer c.workerPool.Stop()
 
 			pluginManager.On("GetBackupItemActionsV2").Return(nil, nil)
 			pluginManager.On("GetItemBlockActions").Return(nil, nil)
@@ -1539,7 +1553,9 @@ func TestValidateAndGetSnapshotLocations(t *testing.T) {
 				logger:                   logger,
 				defaultSnapshotLocations: test.defaultLocations,
 				kbClient:                 velerotest.NewFakeControllerRuntimeClient(t),
+				workerPool:               pkgbackup.StartItemBlockWorkerPool(context.Background(), 1, logger),
 			}
+			defer c.workerPool.Stop()
 
 			// set up a Backup object to represent what we expect to be passed to backupper.Backup()
 			backup := test.backup.DeepCopy()


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Parallel ItemBlock processing via backup_controller goroutines as described in phase 2 of https://github.com/vmware-tanzu/velero/blob/main/design/backup-performance-improvements.md

# Does your change fix a particular issue?

Fixes #8334

# Please indicate you've done the following:

- [x ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
