### PR TITLE
Refactor pod volume context

### DIFF
--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -309,9 +309,9 @@ func (kb *kubernetesBackupper) BackupWithResolvers(
 		}
 	}
 
-	var cancelFunc context.CancelFunc
-	kb.podVolumeContext, cancelFunc = context.WithTimeout(context.Background(), podVolumeTimeout)
-	defer cancelFunc()
+	var podVolumeCancelFunc context.CancelFunc
+	kb.podVolumeContext, podVolumeCancelFunc = context.WithTimeout(context.Background(), podVolumeTimeout)
+	defer podVolumeCancelFunc()
 
 	var podVolumeBackupper podvolume.Backupper
 	if kb.podVolumeBackupperFactory != nil {

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -250,9 +250,9 @@ func (kr *kubernetesRestorer) RestoreWithResolvers(
 		}
 	}
 
-	var cancelFunc go_context.CancelFunc
-	kr.podVolumeContext, cancelFunc = go_context.WithTimeout(go_context.Background(), podVolumeTimeout)
-	defer cancelFunc()
+	var podVolumeCancelFunc go_context.CancelFunc
+	kr.podVolumeContext, podVolumeCancelFunc = go_context.WithTimeout(go_context.Background(), podVolumeTimeout)
+	defer podVolumeCancelFunc()
 
 	var podVolumeRestorer podvolume.Restorer
 	if kr.podVolumeRestorerFactory != nil {

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -108,6 +108,7 @@ type kubernetesRestorer struct {
 	namespaceClient               corev1.NamespaceInterface
 	podVolumeRestorerFactory      podvolume.RestorerFactory
 	podVolumeTimeout              time.Duration
+	podVolumeContext              go_context.Context
 	resourceTerminatingTimeout    time.Duration
 	resourceTimeout               time.Duration
 	resourcePriorities            types.Priorities
@@ -249,12 +250,13 @@ func (kr *kubernetesRestorer) RestoreWithResolvers(
 		}
 	}
 
-	ctx, cancelFunc := go_context.WithTimeout(go_context.Background(), podVolumeTimeout)
+	var cancelFunc go_context.CancelFunc
+	kr.podVolumeContext, cancelFunc = go_context.WithTimeout(go_context.Background(), podVolumeTimeout)
 	defer cancelFunc()
 
 	var podVolumeRestorer podvolume.Restorer
 	if kr.podVolumeRestorerFactory != nil {
-		podVolumeRestorer, err = kr.podVolumeRestorerFactory.NewRestorer(ctx, req.Restore)
+		podVolumeRestorer, err = kr.podVolumeRestorerFactory.NewRestorer(kr.podVolumeContext, req.Restore)
 		if err != nil {
 			return results.Result{}, results.Result{Velero: []string{err.Error()}}
 		}


### PR DESCRIPTION
Refactor pod volume context code to avoid misuse of podVolumeTimeout which is integrated to a context with a general name `ctx`