### PR TITLE
Validate `--from-schedule` flag in create backup command

### DIFF
--- a/changelogs/unreleased/8665-aj-2000
+++ b/changelogs/unreleased/8665-aj-2000
@@ -1,0 +1,1 @@
+Fixes issue #8214, validate `--from-schedule` flag in create backup command to prevent empty or whitespace-only values.

--- a/pkg/cmd/cli/backup/create.go
+++ b/pkg/cmd/cli/backup/create.go
@@ -179,6 +179,11 @@ func (o *CreateOptions) Validate(c *cobra.Command, args []string, f client.Facto
 		return fmt.Errorf("either a 'selector' or an 'or-selector' can be specified, but not both")
 	}
 
+	// Ensure if FromSchedule is set, it has a non-empty value
+	if err := o.validateFromScheduleFlag(c); err != nil {
+		return err
+	}
+
 	// Ensure that unless FromSchedule is set, args contains a backup name
 	if o.FromSchedule == "" && len(args) != 1 {
 		return fmt.Errorf("a backup name is required, unless you are creating based on a schedule")
@@ -211,6 +216,23 @@ func (o *CreateOptions) Validate(c *cobra.Command, args []string, f client.Facto
 			return err
 		}
 	}
+
+	return nil
+}
+
+func (o *CreateOptions) validateFromScheduleFlag(c *cobra.Command) error {
+	fromSchedule, err := c.Flags().GetString("from-schedule")
+	if err != nil {
+		return err
+	}
+
+	trimmed := strings.TrimSpace(fromSchedule)
+	if c.Flags().Changed("from-schedule") && trimmed == "" {
+		return fmt.Errorf("flag must have a non-empty value: --from-schedule")
+	}
+
+	// Assign the trimmed value back
+	o.FromSchedule = trimmed
 
 	return nil
 }

--- a/pkg/cmd/cli/backup/create.go
+++ b/pkg/cmd/cli/backup/create.go
@@ -221,19 +221,13 @@ func (o *CreateOptions) Validate(c *cobra.Command, args []string, f client.Facto
 }
 
 func (o *CreateOptions) validateFromScheduleFlag(c *cobra.Command) error {
-	fromSchedule, err := c.Flags().GetString("from-schedule")
-	if err != nil {
-		return err
-	}
-
-	trimmed := strings.TrimSpace(fromSchedule)
+	trimmed := strings.TrimSpace(o.FromSchedule)
 	if c.Flags().Changed("from-schedule") && trimmed == "" {
 		return fmt.Errorf("flag must have a non-empty value: --from-schedule")
 	}
 
 	// Assign the trimmed value back
 	o.FromSchedule = trimmed
-
 	return nil
 }
 

--- a/pkg/cmd/cli/backup/create_test.go
+++ b/pkg/cmd/cli/backup/create_test.go
@@ -88,10 +88,9 @@ func TestCreateOptions_BuildBackup(t *testing.T) {
 }
 
 func TestCreateOptions_ValidateFromScheduleFlag(t *testing.T) {
-	o := &CreateOptions{}
 	cmd := &cobra.Command{}
-
-	cmd.Flags().String("from-schedule", "", "Test from-schedule flag")
+	o := NewCreateOptions()
+	o.BindFromSchedule(cmd.Flags())
 
 	t.Run("from-schedule with empty or no value", func(t *testing.T) {
 		cmd.Flags().Set("from-schedule", "")
@@ -104,6 +103,7 @@ func TestCreateOptions_ValidateFromScheduleFlag(t *testing.T) {
 	t.Run("from-schedule with spaces only", func(t *testing.T) {
 		cmd.Flags().Set("from-schedule", " ")
 		err := o.validateFromScheduleFlag(cmd)
+		require.True(t, cmd.Flags().Changed("from-schedule"))
 		require.Error(t, err)
 		require.Equal(t, "flag must have a non-empty value: --from-schedule", err.Error())
 	})


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
- **Added validation** for the `--from-schedule` flag to ensure non-empty, trimmed values.
- **Added tests** for different `--from-schedule` scenarios (empty, space-only, valid, and trimmed).

**Old behaviour**
<img width="692" alt="image" src="https://github.com/user-attachments/assets/ac81db68-de85-456f-85c5-adb7c8af34a3" />

**New behaviour**
<img width="738" alt="image" src="https://github.com/user-attachments/assets/8bd0862d-2558-4034-bd06-4a05ab36f821" />

**Unit tests**
<img width="809" alt="image" src="https://github.com/user-attachments/assets/a8f3cfe5-1653-428c-99d3-683dbb2d9437" />

# Does your change fix a particular issue?

Fixes #8214 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
