### PR TITLE
Fix WaitGroup panic issue

### DIFF
--- a/changelogs/unreleased/8679-ywk253100
+++ b/changelogs/unreleased/8679-ywk253100
@@ -1,0 +1,1 @@
+Fix #8657: WaitGroup panic issue

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -780,7 +780,7 @@ func (kb *kubernetesBackupper) waitUntilPVBsProcessed(ctx context.Context, log l
 			if processed {
 				continue
 			}
-			updatedPVB, err := itemBlock.itemBackupper.podVolumeBackupper.GetPodVolumeBackup(pvb.Namespace, pvb.Name)
+			updatedPVB, err := itemBlock.itemBackupper.podVolumeBackupper.GetPodVolumeBackupByPodAndVolume(pvb.Spec.Pod.Namespace, pvb.Spec.Pod.Name, pvb.Spec.Volume)
 			if err != nil {
 				allProcessed = false
 				log.Infof("failed to get PVB: %v", err)

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -3978,9 +3978,9 @@ func (b *fakePodVolumeBackupper) WaitAllPodVolumesProcessed(log logrus.FieldLogg
 	return b.pvbs
 }
 
-func (b *fakePodVolumeBackupper) GetPodVolumeBackup(namespace, name string) (*velerov1.PodVolumeBackup, error) {
+func (b *fakePodVolumeBackupper) GetPodVolumeBackupByPodAndVolume(podNamespace, podName, volume string) (*velerov1.PodVolumeBackup, error) {
 	for _, pvb := range b.pvbs {
-		if pvb.Namespace == namespace && pvb.Name == name {
+		if pvb.Spec.Pod.Namespace == podNamespace && pvb.Spec.Pod.Name == podName && pvb.Spec.Volume == volume {
 			return pvb, nil
 		}
 	}

--- a/pkg/podvolume/backupper_test.go
+++ b/pkg/podvolume/backupper_test.go
@@ -620,37 +620,44 @@ func TestBackupPodVolumes(t *testing.T) {
 	}
 }
 
-func TestGetPodVolumeBackup(t *testing.T) {
+func TestGetPodVolumeBackupByPodAndVolume(t *testing.T) {
 	backupper := &backupper{
-		pvbIndexer: cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		pvbIndexer: cache.NewIndexer(podVolumeBackupKey, cache.Indexers{
 			indexNamePod: podIndexFunc,
 		}),
 	}
 
 	obj := &velerov1api.PodVolumeBackup{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "velero",
-			Name:      "pvb",
-		},
 		Spec: velerov1api.PodVolumeBackupSpec{
 			Pod: corev1api.ObjectReference{
 				Kind:      "Pod",
 				Namespace: "default",
 				Name:      "pod",
 			},
+			Volume: "volume",
 		},
 	}
 
 	err := backupper.pvbIndexer.Add(obj)
 	require.NoError(t, err)
 
-	// not exist PVB
-	pvb, err := backupper.GetPodVolumeBackup("invalid-namespace", "invalid-name")
+	// incorrect pod namespace
+	pvb, err := backupper.GetPodVolumeBackupByPodAndVolume("invalid-namespace", "pod", "volume")
 	require.NoError(t, err)
 	assert.Nil(t, pvb)
 
-	// exist PVB
-	pvb, err = backupper.GetPodVolumeBackup("velero", "pvb")
+	// incorrect pod name
+	pvb, err = backupper.GetPodVolumeBackupByPodAndVolume("default", "invalid-pod", "volume")
+	require.NoError(t, err)
+	assert.Nil(t, pvb)
+
+	// incorrect volume
+	pvb, err = backupper.GetPodVolumeBackupByPodAndVolume("default", "pod", "invalid-volume")
+	require.NoError(t, err)
+	assert.Nil(t, pvb)
+
+	// correct pod namespace, name and volume
+	pvb, err = backupper.GetPodVolumeBackupByPodAndVolume("default", "pod", "volume")
 	require.NoError(t, err)
 	assert.NotNil(t, pvb)
 }


### PR DESCRIPTION
Make sure WaitGroup.Add() is called before WaitGroup.Done() to avoid WaitGroup panic issue

Fixes #8657

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
