### PR TITLE
Run backup post hooks inside ItemBlock synchronously

### DIFF
--- a/changelogs/unreleased/8694-ywk253100
+++ b/changelogs/unreleased/8694-ywk253100
@@ -1,0 +1,1 @@
+Run backup post hooks inside ItemBlock synchronously

--- a/internal/hook/hook_tracker.go
+++ b/internal/hook/hook_tracker.go
@@ -69,16 +69,14 @@ type HookTracker struct {
 	// HookExecutedCnt indicates the number of executed hooks.
 	hookExecutedCnt int
 	// hookErrs records hook execution errors if any.
-	hookErrs        []HookErrInfo
-	AsyncItemBlocks *sync.WaitGroup
+	hookErrs []HookErrInfo
 }
 
 // NewHookTracker creates a hookTracker instance.
 func NewHookTracker() *HookTracker {
 	return &HookTracker{
-		lock:            &sync.RWMutex{},
-		tracker:         make(map[hookKey]hookStatus),
-		AsyncItemBlocks: &sync.WaitGroup{},
+		lock:    &sync.RWMutex{},
+		tracker: make(map[hookKey]hookStatus),
 	}
 }
 
@@ -143,8 +141,6 @@ func (ht *HookTracker) Record(podNamespace, podName, container, source, hookName
 
 // Stat returns the number of attempted hooks and failed hooks
 func (ht *HookTracker) Stat() (hookAttemptedCnt int, hookFailedCnt int) {
-	ht.AsyncItemBlocks.Wait()
-
 	ht.lock.RLock()
 	defer ht.lock.RUnlock()
 

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -759,8 +759,7 @@ func (kb *kubernetesBackupper) backupItemBlock(itemBlock *BackupItemBlock) []sch
 
 	if len(postHookPods) > 0 {
 		itemBlock.Log.Debug("Executing post hooks")
-		itemBlock.itemBackupper.hookTracker.AsyncItemBlocks.Add(1)
-		go kb.handleItemBlockPostHooks(itemBlock, postHookPods)
+		kb.handleItemBlockPostHooks(itemBlock, postHookPods)
 	}
 
 	return grList
@@ -798,7 +797,6 @@ func (kb *kubernetesBackupper) handleItemBlockPreHooks(itemBlock *BackupItemBloc
 // The hooks cannot execute until the PVBs to be processed
 func (kb *kubernetesBackupper) handleItemBlockPostHooks(itemBlock *BackupItemBlock, hookPods []itemblock.ItemBlockItem) {
 	log := itemBlock.Log
-	defer itemBlock.itemBackupper.hookTracker.AsyncItemBlocks.Done()
 
 	// the post hooks will not execute until all PVBs of the item block pods are processed
 	if err := kb.waitUntilPVBsProcessed(kb.podVolumeContext, log, itemBlock, hookPods); err != nil {

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -3995,17 +3995,7 @@ func TestBackupWithHooks(t *testing.T) {
 			require.NoError(t, h.backupper.Backup(h.log, req, backupFile, nil, tc.actions, nil))
 
 			if tc.wantHookExecutionLog != nil {
-				// as the post hook execution in async way, check the existence rather than the exact order
-				assert.Equal(t, len(tc.wantHookExecutionLog), len(podCommandExecutor.HookExecutionLog))
-				m := map[string]struct{}{}
-				for _, entry := range podCommandExecutor.HookExecutionLog {
-					m[entry.String()] = struct{}{}
-				}
-
-				for _, entry := range tc.wantHookExecutionLog {
-					_, exist := m[entry.String()]
-					assert.True(t, exist)
-				}
+				assert.Equal(t, tc.wantHookExecutionLog, podCommandExecutor.HookExecutionLog)
 			}
 			assertTarballContents(t, backupFile, append(tc.wantBackedUp, "metadata/version")...)
 		})


### PR DESCRIPTION
Run backup post hooks inside ItemBlock synchronously as the ItemBlocks are handled asynchronously

Fixes #8516

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
