### PR TITLE
Copy SecurityContext from Containers[0] if present for PVR

### DIFF
--- a/changelogs/unreleased/8712-sseago
+++ b/changelogs/unreleased/8712-sseago
@@ -1,0 +1,1 @@
+Copy SecurityContext from Containers[0] if present for PVR


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Velero 1.15.1 added a change to set a default SecurityContext on the fs-backup InitContainer to fix a bug related to pod security standards enforcement. In an OpenShift environment, when the pod was created by a non-admin user, using this default SecurityContext with runAsUser set based on the current (velero) user breaks because this forces the openshift.io/scc annotation to the default privileged level of the velero SA.

The fix is to use the SecurityContext from the first pod container if that container has a SecurityContext set, using the default otherwise.

# Does your change fix a particular issue?

Fixes #8711

# Please indicate you've done the following:

- [x ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x ] Updated the corresponding documentation in `site/content/docs/main`.
