### PR TITLE
Issue 8706: for immediate volumes, get node from volumeattachment

### DIFF
--- a/changelogs/unreleased/8715-Lyndon-Li
+++ b/changelogs/unreleased/8715-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix issue #8706, for immediate volumes, there is no selected-node annotation on PVC, so deduce the attached node from VolumeAttachment CRs


### PR DESCRIPTION
Fix issue #8706, for immediate volumes, there is no `selected-node` annotation on PVC, so deduce the attached node from `VolumeAttachment` CRs