### PR TITLE
chore: update Go to 1.23 and toolchain to 1.23.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Velero binary build section
-FROM --platform=$BUILDPLATFORM golang:1.22-bookworm AS velero-builder
+FROM --platform=$BUILDPLATFORM golang:1.23-bookworm AS velero-builder
 
 ARG GOPROXY
 ARG BIN
@@ -49,7 +49,7 @@ RUN mkdir -p /output/usr/bin && \
     go clean -modcache -cache
 
 # Restic binary build section
-FROM --platform=$BUILDPLATFORM golang:1.22-bookworm AS restic-builder
+FROM --platform=$BUILDPLATFORM golang:1.23-bookworm AS restic-builder
 
 ARG GOPROXY
 ARG BIN

--- a/Dockerfile-Windows
+++ b/Dockerfile-Windows
@@ -15,7 +15,7 @@
 ARG OS_VERSION=1809
 
 # Velero binary build section
-FROM --platform=$BUILDPLATFORM golang:1.22-bookworm AS velero-builder
+FROM --platform=$BUILDPLATFORM golang:1.23-bookworm AS velero-builder
 
 ARG GOPROXY
 ARG BIN

--- a/Tiltfile
+++ b/Tiltfile
@@ -52,7 +52,7 @@ git_sha = str(local("git rev-parse HEAD", quiet = True, echo_off = True)).strip(
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.22 as tilt-helper
+FROM golang:1.23 as tilt-helper
 
 # Support live reloading with Tilt
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/vmware-tanzu/velero
 
-go 1.22.0
+go 1.23
 
-toolchain go1.22.11
+toolchain go1.23.6
 
 require (
 	cloud.google.com/go/storage v1.50.0

--- a/hack/build-image/Dockerfile
+++ b/hack/build-image/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$TARGETPLATFORM golang:1.22-bookworm
+FROM --platform=$TARGETPLATFORM golang:1.23-bookworm
 
 ARG GOPROXY
 


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

[Go 1.24.0](https://go.dev/blog/go1.24) has been released on since 11 February 2025

This updates Go version from 1.22 to 1.23 and toolchain to 1.23.6

# Does your change fix a particular issue?


# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
