### PR TITLE
issue8294: inherit k8s default volumeSnapshotClass

### DIFF
--- a/changelogs/unreleased/8719-hu-keyu
+++ b/changelogs/unreleased/8719-hu-keyu
@@ -1,0 +1,1 @@
+Inherit k8s default volumeSnapshotClass.

--- a/pkg/apis/velero/v1/labels_annotations.go
+++ b/pkg/apis/velero/v1/labels_annotations.go
@@ -127,6 +127,9 @@ const (
 	VolumeSnapshotClassDriverBackupAnnotationPrefix = "velero.io/csi-volumesnapshot-class"
 	VolumeSnapshotClassDriverPVCAnnotation          = "velero.io/csi-volumesnapshot-class"
 
+	// https://kubernetes.io/zh-cn/docs/concepts/storage/volume-snapshot-classes/
+	VolumeSnapshotClassKubernetesAnnotation = "snapshot.storage.kubernetes.io/is-default-class"
+
 	// There is no release w/ these constants exported. Using the strings for now.
 	// CSI Annotation volumesnapshotclass
 	// https://github.com/kubernetes-csi/external-snapshotter/blob/master/pkg/utils/util.go#L59-L60

--- a/pkg/util/csi/volume_snapshot.go
+++ b/pkg/util/csi/volume_snapshot.go
@@ -432,13 +432,23 @@ func GetVolumeSnapshotClassForStorageClass(
 			}
 		}
 	}
+	// not found by label, pick by annotation
+	for _, sc := range snapshotClasses.Items {
+		_, hasDefaultAnnotation := sc.Annotations[velerov1api.VolumeSnapshotClassKubernetesAnnotation]
+		if sc.Driver == provisioner {
+			vsClass = sc
+			if hasDefaultAnnotation {
+				return &sc, nil
+			}
+		}
+	}
 	// If there's only one volumesnapshotclass for the driver, return it.
 	if n == 1 {
 		return &vsClass, nil
 	}
 	return nil, fmt.Errorf(
-		"failed to get VolumeSnapshotClass for provisioner %s, ensure that the desired VolumeSnapshot class has the %s label",
-		provisioner, velerov1api.VolumeSnapshotClassSelectorLabel)
+		"failed to get VolumeSnapshotClass for provisioner %s, ensure that the desired VolumeSnapshot class has the %s label or %s annotation",
+		provisioner, velerov1api.VolumeSnapshotClassSelectorLabel, velerov1api.VolumeSnapshotClassKubernetesAnnotation)
 }
 
 // IsVolumeSnapshotClassHasListerSecret returns whether a volumesnapshotclass has a snapshotlister secret


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

Make compatible changes based on the GetVolumeSnapshotClassForStorageClass method，not break existing behaviour.


# Does your change fix a particular issue?

Fixes https://github.com/vmware-tanzu/velero/issues/8294

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
