### PR TITLE
issue 8649: host_pods should not be mandatory to node-agent

### DIFF
--- a/changelogs/unreleased/8774-mpryc
+++ b/changelogs/unreleased/8774-mpryc
@@ -1,0 +1,1 @@
+host_pods should not be mandatory to node-agent

--- a/pkg/cmd/cli/nodeagent/server.go
+++ b/pkg/cmd/cli/nodeagent/server.go
@@ -80,6 +80,8 @@ const (
 	// files will be written to
 	defaultCredentialsDirectory = "/tmp/credentials"
 
+	defaultHostPodsPath = "/host_pods"
+
 	defaultResourceTimeout         = 10 * time.Minute
 	defaultDataMoverPrepareTimeout = 30 * time.Minute
 	defaultDataPathConcurrentNum   = 1
@@ -414,8 +416,12 @@ func (s *nodeAgentServer) waitCacheForResume() error {
 // validatePodVolumesHostPath validates that the pod volumes path contains a
 // directory for each Pod running on this node
 func (s *nodeAgentServer) validatePodVolumesHostPath(client kubernetes.Interface) error {
-	files, err := s.fileSystem.ReadDir("/host_pods/")
+	files, err := s.fileSystem.ReadDir(defaultHostPodsPath)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			s.logger.Warnf("Pod volumes host path [%s] doesn't exist, fs-backup is disabled", defaultHostPodsPath)
+			return nil
+		}
 		return errors.Wrap(err, "could not read pod volumes host path")
 	}
 
@@ -446,7 +452,7 @@ func (s *nodeAgentServer) validatePodVolumesHostPath(client kubernetes.Interface
 			valid = false
 			s.logger.WithFields(logrus.Fields{
 				"pod":  fmt.Sprintf("%s/%s", pod.GetNamespace(), pod.GetName()),
-				"path": "/host_pods/" + dirName,
+				"path": defaultHostPodsPath + "/" + dirName,
 			}).Debug("could not find volumes for pod in host path")
 		}
 	}


### PR DESCRIPTION
Fixes #8649. The host_pods path should not be mandatory for node-agent.

This update enables the node-agent to start even if the /host_pods path does not exist. If the path is present, the existing logic remains unchanged, ensuring it is readable.

This PR does not address mounting (or omitting) the /host_pods directory.

Additionally, this change specifically resolves #8649 and not #8185, which requires further design work and will be handled in a separate PR.