### PR TITLE
Restore VolumeSnapshot,  VolumeSnapshotcontent and dataupload associated with a PVC  during a CSI Restore even if it is excluded  from the restore due to label(s) selector

### DIFF
--- a/pkg/cmd/server/plugin/plugin.go
+++ b/pkg/cmd/server/plugin/plugin.go
@@ -50,6 +50,10 @@ func NewCommand(f client.Factory) *cobra.Command {
 			f.SetClientQPS(config.ClientQPS)
 			f.SetClientBurst(config.ClientBurst)
 			pluginServer = pluginServer.
+				RegisterRestoreItemActionV2(
+					constant.PluginCSIPVCVSDURestoreRIA,
+					newPvcVSDVRestoreItemAction(f),
+				).
 				RegisterBackupItemAction(
 					"velero.io/pv",
 					newPVBackupItemAction,
@@ -425,6 +429,9 @@ func newVolumeSnapshotContentDeleteItemAction(f client.Factory) plugincommon.Han
 }
 
 // RestoreItemAction plugins
+func newPvcVSDVRestoreItemAction(f client.Factory) plugincommon.HandlerInitializer {
+	return csiria.NewPvcVSDVRestoreItemAction(f)
+} 
 
 func newPvcRestoreItemAction(f client.Factory) plugincommon.HandlerInitializer {
 	return csiria.NewPvcRestoreItemAction(f)

--- a/pkg/cmd/server/plugin/plugin.go
+++ b/pkg/cmd/server/plugin/plugin.go
@@ -50,7 +50,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 			f.SetClientQPS(config.ClientQPS)
 			f.SetClientBurst(config.ClientBurst)
 			pluginServer = pluginServer.
-				RegisterRestoreItemActionV2(
+				RegisterRestoreItemAction(
 					constant.PluginCSIPVCVSDURestoreRIA,
 					newPvcVSDVRestoreItemAction(f),
 				).

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -21,5 +21,6 @@ const (
 	ControllerRestoreFinalizer      = "restore-finalizer"
 
 	PluginCSIPVCRestoreRIA            = "velero.io/csi-pvc-restorer"
+	PluginCSIPVCVSDURestoreRIA            = "velero.io/csi-pvc-vs-dv-restorer"
 	PluginCsiVolumeSnapshotRestoreRIA = "velero.io/csi-volumesnapshot-restorer"
 )

--- a/pkg/restore/actions/csi/pvc_action.go
+++ b/pkg/restore/actions/csi/pvc_action.go
@@ -229,6 +229,11 @@ func (p *pvcRestoreItemAction) Execute(
 							Name:          pvcFromBackup.Annotations[velerov1api.VolumeSnapshotLabel],
 							Namespace:     newNamespace,
 						},
+						{
+							GroupResource: kuberesource.PersistentVolumeClaims,
+							Name:          pvc.Name,
+							Namespace:     newNamespace,
+						},
 					}
 					return &velero.RestoreItemActionExecuteOutput{
 						UpdatedItem:     input.Item,

--- a/pkg/restore/actions/csi/pvc_action.go
+++ b/pkg/restore/actions/csi/pvc_action.go
@@ -24,6 +24,7 @@ import (
 	snapshotv1api "github.com/kubernetes-csi/external-snapshotter/client/v7/apis/volumesnapshot/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	kuberesource "github.com/vmware-tanzu/velero/pkg/kuberesource"
 	corev1api "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -198,11 +199,45 @@ func (p *pvcRestoreItemAction) Execute(
 				}, nil
 			}
 
-			if err := restoreFromVolumeSnapshot(
-				&pvc, newNamespace, p.crClient, targetVSName, logger,
-			); err != nil {
-				logger.Errorf("Failed to restore PVC from VolumeSnapshot.")
+			exists, err := pvcVolumeSnapshotResourceExists(newNamespace, p.crClient, targetVSName)
+			if err != nil {
+				logger.Errorf("Failed to verify if VolumeSnapshot exists.")
 				return nil, errors.WithStack(err)
+			}
+			if exists { // TODO: rename the function restoreFromVolumeSnapshot so it reflects the action (patching the pvc requst size to the vs's restore size if needed.)
+				if err := restoreFromVolumeSnapshot(
+					&pvc, newNamespace, p.crClient, targetVSName, logger,
+				); err != nil {
+					logger.Errorf("Failed to restore PVC from VolumeSnapshot.")
+					return nil, errors.WithStack(err)
+				}
+			} else {
+
+				// TODD: find the proper place for this consotant
+				const waitVSAnnotation = "velero.io/csi-volumesnapshot-waiting"
+				if _, waiting := pvc.Annotations[waitVSAnnotation]; !waiting {
+					logger.Warning("PVC's VolumeSnapshot was not found, queuing it for restore and will try again next time.")
+					// Not waiting yet, so add the annotation and queue the VS and PVC.
+					if pvc.Annotations == nil {
+						pvc.Annotations = make(map[string]string)
+					}
+					pvc.Annotations[waitVSAnnotation] = "true"
+
+					additionalItems := []velero.ResourceIdentifier{
+						{
+							GroupResource: kuberesource.VolumeSnapshots,
+							Name:          pvcFromBackup.Annotations[velerov1api.VolumeSnapshotLabel],
+							Namespace:     newNamespace,
+						},
+					}
+					return &velero.RestoreItemActionExecuteOutput{
+						UpdatedItem:     input.Item,
+						AdditionalItems: additionalItems,
+					}, nil
+				} else {
+					logger.Error("PVC's VolumeSnapshot was not found again.")
+					return nil, errors.WithStack(err)
+				}
 			}
 		}
 	}
@@ -470,7 +505,7 @@ func restoreFromVolumeSnapshot(
 			Name:      volumeSnapshotName,
 		},
 		vs,
-	); err != nil {
+	); err != nil { //TODO: check if we can remove this error check soince we already checked for the existence of the volumesnapshot.
 		return errors.Wrapf(err, "Failed to get Volumesnapshot %s/%s to restore PVC %s/%s",
 			newNamespace, volumeSnapshotName, newNamespace, pvc.Name)
 	}
@@ -562,6 +597,25 @@ func (p *pvcRestoreItemAction) isResourceExist(
 		return true
 	}
 	return false
+}
+
+func pvcVolumeSnapshotResourceExists(
+	newNamespace string,
+	crClient crclient.Client,
+	volumeSnapshotName string,
+	) (bool, error) {
+	vs := &snapshotv1api.VolumeSnapshot{}
+	err := crClient.Get(context.TODO(), crclient.ObjectKey{
+		Namespace: newNamespace,
+		Name:      volumeSnapshotName,
+	}, vs)
+	if err != nil {
+		if crclient.IgnoreNotFound(err) == nil {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func NewPvcRestoreItemAction(f client.Factory) plugincommon.HandlerInitializer {

--- a/pkg/restore/actions/csi/pvc_vs_dv_action.go
+++ b/pkg/restore/actions/csi/pvc_vs_dv_action.go
@@ -1,0 +1,137 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csi
+
+import (
+    "github.com/pkg/errors"
+    "github.com/sirupsen/logrus"
+    corev1api "k8s.io/api/core/v1"
+    "k8s.io/apimachinery/pkg/runtime"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+    velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+    "github.com/vmware-tanzu/velero/pkg/client"
+    plugincommon "github.com/vmware-tanzu/velero/pkg/plugin/framework/common"
+    "github.com/vmware-tanzu/velero/pkg/plugin/velero"
+    kuberesource "github.com/vmware-tanzu/velero/pkg/kuberesource"
+)
+
+// pvcVSDVRestoreItemAction is a restore item action plugin for Velero
+type pvcVSDVRestoreItemAction struct {
+	log      logrus.FieldLogger
+	crClient crclient.Client
+}
+
+// AppliesTo returns information indicating that the
+func (p *pvcVSDVRestoreItemAction) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+		IncludedResources: []string{"persistentvolumeclaims"},
+
+	}, nil
+}
+
+
+// Execute modifies the PVC's spec to use the VolumeSnapshot object as the
+// data source ensuring that the newly provisioned volume can be pre-populated
+// with data from the VolumeSnapshot.
+func (p *pvcVSDVRestoreItemAction) Execute(
+	input *velero.RestoreItemActionExecuteInput,
+) (*velero.RestoreItemActionExecuteOutput, error) {
+	var pvcFromBackup corev1api.PersistentVolumeClaim
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(
+		input.ItemFromBackup.UnstructuredContent(), &pvcFromBackup); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	logger := p.log.WithFields(logrus.Fields{
+		"Action":  "PVCVSDVRestoreItemAction",
+		"PVC":     pvcFromBackup.Namespace + "/" + pvcFromBackup.Name,
+		"Restore": input.Restore.Namespace + "/" + input.Restore.Name,
+	})
+	logger.Info("Starting PVCVSDVRestoreItemAction for PVC")
+
+	var pvc corev1api.PersistentVolumeClaim
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(input.Item.UnstructuredContent(), &pvc); err != nil {
+		return nil, errors.Wrap(err, "failed to convert PVC from unstructured")
+	}
+
+	additionalItems := []velero.ResourceIdentifier{}
+
+	// Check for VolumeSnapshot annotation.
+	// Velero uses velerov1api.VolumeSnapshotLabel to store the snapshot name.
+	if pvc.Annotations != nil {
+		if vsName, ok := pvc.Annotations[velerov1api.VolumeSnapshotLabel]; ok && vsName != "" {
+			additionalItems = append(additionalItems, velero.ResourceIdentifier{
+				GroupResource: kuberesource.VolumeSnapshots,
+				Name:          vsName,
+				Namespace:     pvc.Namespace,
+			})
+		}
+
+		// Check for DataVolume annotation.
+		if dvName, ok := pvc.Annotations[velerov1api.DataUploadNameAnnotation]; ok && dvName != "" {
+			additionalItems = append(additionalItems, velero.ResourceIdentifier{
+				GroupResource: schema.GroupResource{
+					Group:    "cdi.kubevirt.io",
+					Resource: "datavolumes",
+				},
+				Name:      dvName,
+				Namespace: pvc.Namespace,
+			})
+		}
+	}
+
+	return &velero.RestoreItemActionExecuteOutput{
+		UpdatedItem:     input.Item,
+		AdditionalItems: additionalItems,
+	}, nil
+}
+
+
+
+func (p *pvcVSDVRestoreItemAction) Name() string {
+	return "PVCRestoreItemAction"
+}
+
+
+func (p *pvcVSDVRestoreItemAction) Cancel(
+	operationID string, restore *velerov1api.Restore) error {
+	return nil
+}
+
+func (p *pvcVSDVRestoreItemAction) AreAdditionalItemsReady(
+	additionalItems []velero.ResourceIdentifier,
+	restore *velerov1api.Restore,
+) (bool, error) {
+	return true, nil
+}
+
+// NewPvcVSDVRestoreItemAction returns a new instance of PVCVSDVRestoreItemAction.
+func NewPvcVSDVRestoreItemAction(f client.Factory) plugincommon.HandlerInitializer {
+	return func(logger logrus.FieldLogger) (any, error) {
+		crClient, err := f.KubebuilderClient()
+		if err != nil {
+			return nil, err
+		}
+
+		return &pvcVSDVRestoreItemAction{
+			log:      logger,
+			crClient: crClient,
+		}, nil
+	}
+}

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1375,6 +1375,8 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 		obj = unstructuredObj
 
 		var filteredAdditionalItems []velero.ResourceIdentifier
+		ctx.log.Debugf("Will Restore the following AdditionalItems: %+v", executeOutput.AdditionalItems)
+
 		for _, additionalItem := range executeOutput.AdditionalItems {
 			itemPath := archive.GetItemFilePath(ctx.restoreDir, additionalItem.GroupResource.String(), additionalItem.Namespace, additionalItem.Name)
 


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Issue

During a CSI restore, if the VolumeSnapshot is missing for any reason, the PVC remains in a pending state with the error:

error getting snapshot your-snapshot-name from api server: volumesnapshots.snapshot.storage.k8s.io "your-snapshot-name" not found.

In Addition,
The CSI  PVC Restore Action fails because restore size is required from the VolumeSnapshot resource to patch the PVC's request size if too small. 

To handle cases , in which the volumesnapshot was initially excluded  due to label(s) selector,
PVC Restore Action will now return the required VolumeSnapshot in additional items if not found. We annotate the PVC (if not already annotated) and return both the VolumeSnapshot and the PVC in additional items. This allows Velero to restore the VolumeSnapshot and retry the PVC action. If the VolumeSnapshot is missing and the PVC already has the annotation, the restore action will fail.

Note: this only handles cases where the VS is excluded sue to label(s) selector, other cases (like excluding by resource type) are not handled.


# Does your change fix a particular issue?

Fixes #(issue)



# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.