### PR TITLE
Add third party annotation support for maintenance job

### DIFF
--- a/changelogs/unreleased/8812-Lyndon-Li
+++ b/changelogs/unreleased/8812-Lyndon-Li
@@ -1,0 +1,1 @@
+Add third party annotation support for maintenance job, so that the declared third party annotations could be added to the maintenance job pods

--- a/pkg/repository/maintenance/maintenance.go
+++ b/pkg/repository/maintenance/maintenance.go
@@ -460,6 +460,13 @@ func buildJob(cli client.Client, ctx context.Context, repo *velerov1api.BackupRe
 		}
 	}
 
+	podAnnotations := map[string]string{}
+	for _, k := range util.ThirdPartyAnnotations {
+		if v := veleroutil.GetVeleroServerAnnotationValue(deployment, k); v != "" {
+			podAnnotations[k] = v
+		}
+	}
+
 	// Set arguments
 	args := []string{"repo-maintenance"}
 	args = append(args, fmt.Sprintf("--repo-name=%s", repo.Spec.VolumeNamespace))
@@ -481,8 +488,9 @@ func buildJob(cli client.Client, ctx context.Context, repo *velerov1api.BackupRe
 			BackoffLimit: new(int32), // Never retry
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "velero-repo-maintenance-pod",
-					Labels: podLabels,
+					Name:        "velero-repo-maintenance-pod",
+					Labels:      podLabels,
+					Annotations: podAnnotations,
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{

--- a/pkg/util/velero/velero.go
+++ b/pkg/util/velero/velero.go
@@ -96,3 +96,12 @@ func GetVeleroServerLabelValue(deployment *appsv1.Deployment, key string) string
 
 	return deployment.Spec.Template.Labels[key]
 }
+
+// GetVeleroServerAnnotationValue returns the value of specified annotation of Velero server deployment
+func GetVeleroServerAnnotationValue(deployment *appsv1.Deployment, key string) string {
+	if deployment.Spec.Template.Annotations == nil {
+		return ""
+	}
+
+	return deployment.Spec.Template.Annotations[key]
+}


### PR DESCRIPTION
Add third party annotation support for maintenance job, so that the declared third party annotations could be added to the maintenance job pods.

Otherwise, there is the same problem for maintenance jobs as #8754 for data movers.
