### PR TITLE
[E2E] Fix the non data mover migration failure.

### DIFF
--- a/test/e2e/migration/migration.go
+++ b/test/e2e/migration/migration.go
@@ -356,26 +356,24 @@ func (m *migrationE2E) Restore() error {
 	})
 
 	By(fmt.Sprintf("Restore %s", m.CaseBaseName), func() {
-		if m.VeleroCfg.SnapshotMoveData {
-			cmName := "datamover-storage-class-config"
-			labels := map[string]string{"velero.io/change-storage-class": "RestoreItemAction",
-				"velero.io/plugin-config": ""}
-			data := map[string]string{kibishii.KibishiiStorageClassName: test.StorageClassName}
+		cmName := "datamover-storage-class-config"
+		labels := map[string]string{"velero.io/change-storage-class": "RestoreItemAction",
+			"velero.io/plugin-config": ""}
+		data := map[string]string{kibishii.KibishiiStorageClassName: test.StorageClassName}
 
-			By(fmt.Sprintf("Create ConfigMap %s in namespace %s",
-				cmName, StandbyVeleroCfg.VeleroNamespace), func() {
-				_, err := k8sutil.CreateConfigMap(
-					StandbyVeleroCfg.StandbyClient.ClientGo,
-					StandbyVeleroCfg.VeleroNamespace,
-					cmName,
-					labels,
-					data,
-				)
-				Expect(err).To(Succeed(), fmt.Sprintf(
-					"failed to create ConfigMap in the namespace %q",
-					StandbyVeleroCfg.VeleroNamespace))
-			})
-		}
+		By(fmt.Sprintf("Create ConfigMap %s in namespace %s",
+			cmName, StandbyVeleroCfg.VeleroNamespace), func() {
+			_, err := k8sutil.CreateConfigMap(
+				StandbyVeleroCfg.StandbyClient.ClientGo,
+				StandbyVeleroCfg.VeleroNamespace,
+				cmName,
+				labels,
+				data,
+			)
+			Expect(err).To(Succeed(), fmt.Sprintf(
+				"failed to create ConfigMap in the namespace %q",
+				StandbyVeleroCfg.VeleroNamespace))
+		})
 
 		Expect(veleroutil.VeleroRestore(
 			m.Ctx,


### PR DESCRIPTION
Migration cases use the Kibishii as the workload, and SC mapping ConfigMap was needed for all scenarios, because standby cluster doesn't have the Kibishii SC after setting up.

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
