### PR TITLE
E2E support sets the --item-block-worker-count.

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -116,6 +116,8 @@ FEATURES ?=
 DEBUG_VELERO_POD_RESTART ?= false
 VELERO_SERVER_DEBUG_MODE ?= false
 
+ITEM_BLOCK_WORKER_COUNT ?= 1
+
 # Parameters to run migration tests along with all other E2E tests, and both of them should
 #   be provided or left them all empty to skip migration tests with no influence to other
 #   E2E tests.
@@ -167,7 +169,8 @@ COMMON_ARGS := --velerocli=$(VELERO_CLI) \
 	--uploader-type=$(UPLOADER_TYPE) \
 	--debug-velero-pod-restart=$(DEBUG_VELERO_POD_RESTART) \
 	--fail-fast=$(FAIL_FAST) \
-	--has-vsphere-plugin=$(HAS_VSPHERE_PLUGIN)
+	--has-vsphere-plugin=$(HAS_VSPHERE_PLUGIN) \
+	--item-block-worker-count=$(ITEM_BLOCK_WORKER_COUNT)
 
 # Make sure ginkgo is in $GOBIN
 .PHONY:ginkgo

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -343,6 +343,12 @@ func init() {
 		false,
 		"a switch for installing vSphere plugin.",
 	)
+	flag.IntVar(
+		&test.VeleroCfg.ItemBlockWorkerCount,
+		"item-block-worker-count",
+		1,
+		"Velero backup's item block worker count.",
+	)
 }
 
 // Add label [SkipVanillaZfs]:

--- a/test/util/velero/install.go
+++ b/test/util/velero/install.go
@@ -367,6 +367,10 @@ func installVeleroServer(ctx context.Context, cli, cloudProvider string, options
 		args = append(args, fmt.Sprintf("--uploader-type=%v", options.UploaderType))
 	}
 
+	if options.ItemBlockWorkerCount > 1 {
+		args = append(args, fmt.Sprintf("--item-block-worker-count=%d", options.ItemBlockWorkerCount))
+	}
+
 	if err := createVeleroResources(ctx, cli, namespace, args, options); err != nil {
 		return err
 	}

--- a/test/util/velero/velero_utils.go
+++ b/test/util/velero/velero_utils.go
@@ -280,6 +280,7 @@ func getProviderVeleroInstallOptions(veleroCfg *VeleroConfig,
 	io.VeleroPodMemLimit = veleroCfg.VeleroPodMemLimit
 	io.VeleroPodMemRequest = veleroCfg.VeleroPodMemRequest
 	io.DisableInformerCache = veleroCfg.DisableInformerCache
+	io.ItemBlockWorkerCount = veleroCfg.ItemBlockWorkerCount
 
 	return io, nil
 }


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
