### PR TITLE
Propagate dns settings to backup pods

### DIFF
--- a/changelogs/unreleased/8845-flx5
+++ b/changelogs/unreleased/8845-flx5
@@ -1,0 +1,2 @@
+Inherit the dnsPolicy and dnsConfig from the node agent pod.
+This is done so that the kopia task uses the same configuration.

--- a/pkg/exposer/csi_snapshot.go
+++ b/pkg/exposer/csi_snapshot.go
@@ -681,6 +681,8 @@ func (e *csiSnapshotExposer) createBackupPod(
 			RestartPolicy:                 corev1.RestartPolicyNever,
 			SecurityContext:               securityCtx,
 			Tolerations:                   toleration,
+			DNSPolicy:                     podInfo.dnsPolicy,
+			DNSConfig:                     podInfo.dnsConfig,
 		},
 	}
 

--- a/pkg/exposer/generic_restore.go
+++ b/pkg/exposer/generic_restore.go
@@ -510,6 +510,8 @@ func (e *genericRestoreExposer) createRestorePod(ctx context.Context, ownerObjec
 			RestartPolicy:                 corev1.RestartPolicyNever,
 			SecurityContext:               securityCtx,
 			Tolerations:                   toleration,
+			DNSPolicy:                     podInfo.dnsPolicy,
+			DNSConfig:                     podInfo.dnsConfig,
 		},
 	}
 

--- a/pkg/exposer/image.go
+++ b/pkg/exposer/image.go
@@ -36,6 +36,8 @@ type inheritedPodInfo struct {
 	volumes        []v1.Volume
 	logLevelArgs   []string
 	logFormatArgs  []string
+	dnsPolicy      v1.DNSPolicy
+	dnsConfig      *v1.PodDNSConfig
 }
 
 func getInheritedPodInfo(ctx context.Context, client kubernetes.Interface, veleroNamespace string, osType string) (inheritedPodInfo, error) {
@@ -57,6 +59,9 @@ func getInheritedPodInfo(ctx context.Context, client kubernetes.Interface, veler
 	podInfo.envFrom = podSpec.Containers[0].EnvFrom
 	podInfo.volumeMounts = podSpec.Containers[0].VolumeMounts
 	podInfo.volumes = podSpec.Volumes
+
+	podInfo.dnsPolicy = podSpec.DNSPolicy
+	podInfo.dnsConfig = podSpec.DNSConfig
 
 	args := podSpec.Containers[0].Args
 	for i, arg := range args {


### PR DESCRIPTION
The dnsPolicy and dnsConfig field of the node-agent should be inherited. Otherwise a S3 server that is only available by using the indicated dns server will be unreachable in the upload pod.

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
