### PR TITLE
issue8827: When initializing or creating an Azure repository, adjust the log output to JSON format

### DIFF
--- a/changelogs/unreleased/8864-hu-keyu
+++ b/changelogs/unreleased/8864-hu-keyu
@@ -1,0 +1,1 @@
+When initializing or creating an Azure repository, adjust the log output to JSON format

--- a/pkg/repository/udmrepo/kopialib/backend/azure/azure_storage_wrapper.go
+++ b/pkg/repository/udmrepo/kopialib/backend/azure/azure_storage_wrapper.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/azure"
 	"github.com/kopia/kopia/repo/blob/throttling"
+
 	"github.com/vmware-tanzu/velero/pkg/repository/udmrepo"
 	azureutil "github.com/vmware-tanzu/velero/pkg/util/azure"
 )

--- a/pkg/repository/udmrepo/kopialib/backend/azure/azure_storage_wrapper.go
+++ b/pkg/repository/udmrepo/kopialib/backend/azure/azure_storage_wrapper.go
@@ -22,8 +22,6 @@ import (
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/azure"
 	"github.com/kopia/kopia/repo/blob/throttling"
-	"github.com/sirupsen/logrus"
-
 	"github.com/vmware-tanzu/velero/pkg/repository/udmrepo"
 	azureutil "github.com/vmware-tanzu/velero/pkg/util/azure"
 )
@@ -56,7 +54,7 @@ func (s *Storage) ConnectionInfo() blob.ConnectionInfo {
 func NewStorage(ctx context.Context, option *Option, isCreate bool) (blob.Storage, error) {
 	cfg := option.Config
 
-	client, _, err := azureutil.NewStorageClient(logrus.New(), cfg)
+	client, _, err := azureutil.NewStorageClient(newLogger(), cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/repository/udmrepo/kopialib/backend/azure/logger.go
+++ b/pkg/repository/udmrepo/kopialib/backend/azure/logger.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2017, 2019 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"github.com/sirupsen/logrus"
+
+	"github.com/vmware-tanzu/velero/pkg/util/logging"
+)
+
+// newLogger returns a logger that is suitable for use within an kopia backend
+func newLogger() *logrus.Logger {
+	logger := logrus.New()
+	/*
+		!!!DO NOT SET THE OUTPUT TO STDOUT!!!
+
+		go-plugin uses stdout for a communications protocol between client and server.
+
+		stderr is used for log messages from server to client. The velero server makes sure they are logged to stdout.
+	*/
+
+	// we use the JSON formatter because go-plugin will parse incoming
+	// JSON on stderr and use it to create structured log entries.
+	logger.Formatter = &logrus.JSONFormatter{
+		FieldMap: logrus.FieldMap{
+			// this is the hclog-compatible message field
+			logrus.FieldKeyMsg: "@message",
+		},
+		// Velero server already adds timestamps when emitting logs, so
+		// don't do it within the plugin.
+		DisableTimestamp: false,
+	}
+
+	// set a logger name for the location hook which will signal to the Velero
+	// server logger that the location has been set within a hook.
+	logger.Hooks.Add((&logging.LogLocationHook{}).WithLoggerName("kopialib"))
+
+	// make sure we attempt to record the error location
+	logger.Hooks.Add(&logging.ErrorLocationHook{})
+
+	// this hook adjusts the string representation of WarnLevel to "warn"
+	// rather than "warning" to make it parseable by go-plugin within the
+	// Velero server code
+	logger.Hooks.Add(&logging.HcLogLevelHook{})
+
+	return logger
+}

--- a/pkg/repository/udmrepo/kopialib/backend/azure/logger.go
+++ b/pkg/repository/udmrepo/kopialib/backend/azure/logger.go
@@ -24,38 +24,5 @@ import (
 
 // newLogger returns a logger that is suitable for use within an kopia backend
 func newLogger() *logrus.Logger {
-	logger := logrus.New()
-	/*
-		!!!DO NOT SET THE OUTPUT TO STDOUT!!!
-
-		go-plugin uses stdout for a communications protocol between client and server.
-
-		stderr is used for log messages from server to client. The velero server makes sure they are logged to stdout.
-	*/
-
-	// we use the JSON formatter because go-plugin will parse incoming
-	// JSON on stderr and use it to create structured log entries.
-	logger.Formatter = &logrus.JSONFormatter{
-		FieldMap: logrus.FieldMap{
-			// this is the hclog-compatible message field
-			logrus.FieldKeyMsg: "@message",
-		},
-		// Velero server already adds timestamps when emitting logs, so
-		// don't do it within the plugin.
-		DisableTimestamp: false,
-	}
-
-	// set a logger name for the location hook which will signal to the Velero
-	// server logger that the location has been set within a hook.
-	logger.Hooks.Add((&logging.LogLocationHook{}).WithLoggerName("kopialib"))
-
-	// make sure we attempt to record the error location
-	logger.Hooks.Add(&logging.ErrorLocationHook{})
-
-	// this hook adjusts the string representation of WarnLevel to "warn"
-	// rather than "warning" to make it parseable by go-plugin within the
-	// Velero server code
-	logger.Hooks.Add(&logging.HcLogLevelHook{})
-
-	return logger
+	return logging.DefaultLogger(logrus.InfoLevel, logging.FormatJSON)
 }

--- a/pkg/repository/udmrepo/kopialib/backend/azure/logger_test.go
+++ b/pkg/repository/udmrepo/kopialib/backend/azure/logger_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2018, 2019 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package azure
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware-tanzu/velero/pkg/util/logging"
+)
+
+func TestNewLogger(t *testing.T) {
+	l := newLogger()
+
+	expectedFormatter := &logrus.JSONFormatter{
+		FieldMap: logrus.FieldMap{
+			logrus.FieldKeyMsg: "@message",
+		},
+		DisableTimestamp: false,
+	}
+	assert.Equal(t, expectedFormatter, l.Formatter)
+
+	expectedHooks := []logrus.Hook{
+		(&logging.LogLocationHook{}).WithLoggerName("kopialib"),
+		&logging.ErrorLocationHook{},
+		&logging.HcLogLevelHook{},
+	}
+
+	for _, level := range logrus.AllLevels {
+		assert.Equal(t, expectedHooks, l.Hooks[level])
+	}
+}

--- a/pkg/repository/udmrepo/kopialib/backend/azure/logger_test.go
+++ b/pkg/repository/udmrepo/kopialib/backend/azure/logger_test.go
@@ -20,28 +20,11 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/vmware-tanzu/velero/pkg/util/logging"
 )
 
 func TestNewLogger(t *testing.T) {
 	l := newLogger()
-
-	expectedFormatter := &logrus.JSONFormatter{
-		FieldMap: logrus.FieldMap{
-			logrus.FieldKeyMsg: "@message",
-		},
-		DisableTimestamp: false,
-	}
+	expectedFormatter := &logrus.JSONFormatter{}
 	assert.Equal(t, expectedFormatter, l.Formatter)
-
-	expectedHooks := []logrus.Hook{
-		(&logging.LogLocationHook{}).WithLoggerName("kopialib"),
-		&logging.ErrorLocationHook{},
-		&logging.HcLogLevelHook{},
-	}
-
-	for _, level := range logrus.AllLevels {
-		assert.Equal(t, expectedHooks, l.Hooks[level])
-	}
+	assert.Equal(t, logrus.InfoLevel, l.Level)
 }


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

When initializing or creating an Azure repository, adjust the log output to JSON format.



# Does your change fix a particular issue?

Fixes https://github.com/vmware-tanzu/velero/issues/8827

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
