### PR TITLE
fix upgrade instruction link

### DIFF
--- a/site/config.yaml
+++ b/site/config.yaml
@@ -12,7 +12,7 @@ params:
   hero:
     backgroundColor: med-blue
   versioning: true
-  latest: v1.15
+  latest: v1.16
   versions:
     - main
     - v1.16

--- a/site/data/docs/v1-16-toc.yml
+++ b/site/data/docs/v1-16-toc.yml
@@ -13,8 +13,8 @@ toc:
         url: /basic-install
       - page: Customize Installation
         url: /customize-installation
-      - page: Upgrade to 1.15
-        url: /upgrade-to-1.15
+      - page: Upgrade to 1.16
+        url: /upgrade-to-1.16
       - page: Supported providers
         url: /supported-providers
       - page: Evaluation install


### PR DESCRIPTION
The link wasn't updated after the new release
![image](https://github.com/user-attachments/assets/479fc8e3-fcaf-4c5c-a133-d6a75f8179f4)
cc @lyndon-li
