### PR TITLE
Skip namespace in terminating state in backup resource collection.

### DIFF
--- a/changelogs/unreleased/8890-blackpiglet
+++ b/changelogs/unreleased/8890-blackpiglet
@@ -1,0 +1,1 @@
+Skip namespace in terminating state in backup resource collection.

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -5341,9 +5341,9 @@ func TestBackupNamespaces(t *testing.T) {
 				Result(),
 			apiResources: []*test.APIResource{
 				test.Namespaces(
-					builder.ForNamespace("ns-1").Result(),
-					builder.ForNamespace("ns-2").Result(),
-					builder.ForNamespace("ns-3").Result(),
+					builder.ForNamespace("ns-1").Phase(corev1api.NamespaceActive).Result(),
+					builder.ForNamespace("ns-2").Phase(corev1api.NamespaceActive).Result(),
+					builder.ForNamespace("ns-3").Phase(corev1api.NamespaceActive).Result(),
 				),
 				test.Deployments(
 					builder.ForDeployment("ns-1", "deploy-1").ObjectMeta(builder.WithLabels("a", "b")).Result(),
@@ -5364,9 +5364,9 @@ func TestBackupNamespaces(t *testing.T) {
 			}).Result(),
 			apiResources: []*test.APIResource{
 				test.Namespaces(
-					builder.ForNamespace("ns-1").Result(),
-					builder.ForNamespace("ns-2").Result(),
-					builder.ForNamespace("ns-3").Result(),
+					builder.ForNamespace("ns-1").Phase(corev1api.NamespaceActive).Result(),
+					builder.ForNamespace("ns-2").Phase(corev1api.NamespaceActive).Result(),
+					builder.ForNamespace("ns-3").Phase(corev1api.NamespaceActive).Result(),
 				),
 				test.Deployments(
 					builder.ForDeployment("ns-1", "deploy-1").ObjectMeta(builder.WithLabels("a", "b")).Result(),
@@ -5390,9 +5390,9 @@ func TestBackupNamespaces(t *testing.T) {
 				Result(),
 			apiResources: []*test.APIResource{
 				test.Namespaces(
-					builder.ForNamespace("ns-1").Result(),
-					builder.ForNamespace("ns-2").Result(),
-					builder.ForNamespace("ns-3").Result(),
+					builder.ForNamespace("ns-1").Phase(corev1api.NamespaceActive).Result(),
+					builder.ForNamespace("ns-2").Phase(corev1api.NamespaceActive).Result(),
+					builder.ForNamespace("ns-3").Phase(corev1api.NamespaceActive).Result(),
 				),
 				test.Deployments(
 					builder.ForDeployment("ns-1", "deploy-1").ObjectMeta(builder.WithLabels("a", "b")).Result(),
@@ -5411,9 +5411,9 @@ func TestBackupNamespaces(t *testing.T) {
 				Result(),
 			apiResources: []*test.APIResource{
 				test.Namespaces(
-					builder.ForNamespace("ns-1").ObjectMeta(builder.WithLabels("a", "b")).Result(),
-					builder.ForNamespace("ns-2").Result(),
-					builder.ForNamespace("ns-3").Result(),
+					builder.ForNamespace("ns-1").ObjectMeta(builder.WithLabels("a", "b")).Phase(corev1api.NamespaceActive).Result(),
+					builder.ForNamespace("ns-2").Phase(corev1api.NamespaceActive).Result(),
+					builder.ForNamespace("ns-3").Phase(corev1api.NamespaceActive).Result(),
 				),
 				test.Deployments(
 					builder.ForDeployment("ns-1", "deploy-1").ObjectMeta(builder.WithLabels("a", "b")).Result(),
@@ -5431,9 +5431,9 @@ func TestBackupNamespaces(t *testing.T) {
 			backup: defaultBackup().IncludedNamespaces("invalid*").Result(),
 			apiResources: []*test.APIResource{
 				test.Namespaces(
-					builder.ForNamespace("ns-1").Result(),
-					builder.ForNamespace("ns-2").Result(),
-					builder.ForNamespace("ns-3").Result(),
+					builder.ForNamespace("ns-1").Phase(corev1api.NamespaceActive).Result(),
+					builder.ForNamespace("ns-2").Phase(corev1api.NamespaceActive).Result(),
+					builder.ForNamespace("ns-3").Phase(corev1api.NamespaceActive).Result(),
 				),
 				test.Deployments(
 					builder.ForDeployment("ns-1", "deploy-1").ObjectMeta(builder.WithLabels("a", "b")).Result(),
@@ -5446,9 +5446,9 @@ func TestBackupNamespaces(t *testing.T) {
 			backup: defaultBackup().Result(),
 			apiResources: []*test.APIResource{
 				test.Namespaces(
-					builder.ForNamespace("ns-1").Result(),
-					builder.ForNamespace("ns-2").Result(),
-					builder.ForNamespace("ns-3").Result(),
+					builder.ForNamespace("ns-1").Phase(corev1api.NamespaceActive).Result(),
+					builder.ForNamespace("ns-2").Phase(corev1api.NamespaceActive).Result(),
+					builder.ForNamespace("ns-3").Phase(corev1api.NamespaceActive).Result(),
 				),
 				test.Deployments(
 					builder.ForDeployment("ns-1", "deploy-1").ObjectMeta(builder.WithLabels("a", "b")).Result(),


### PR DESCRIPTION
To make sure resources in terminating namespaces are not included.

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #8888 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
