### PR TITLE
#8878 fix: pv: check sc fstype before node os; allow node os check fail

### DIFF
--- a/changelogs/unreleased/8892-CarlQLange
+++ b/changelogs/unreleased/8892-CarlQLange
@@ -1,0 +1,1 @@
+#8878: pv allow node os check fail and fallback to linux

--- a/pkg/util/kube/pvc_pv_test.go
+++ b/pkg/util/kube/pvc_pv_test.go
@@ -1857,6 +1857,40 @@ func TestGetPVCAttachingNodeOS(t *testing.T) {
 			pvc:            pvcObjBlockMode,
 			expectedNodeOS: NodeOSLinux,
 		},
+		{
+			name: "selected-node non-existent, sc fstype ntfs",
+			pvc: &corev1api.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   "fake-namespace",
+					Name:        "fake-pvc",
+					Annotations: map[string]string{KubeAnnSelectedNode: "non-existent-node"},
+				},
+				Spec: corev1api.PersistentVolumeClaimSpec{
+					StorageClassName: &storageClass,
+				},
+			},
+			kubeClientObj: []runtime.Object{
+				scObjWithFSType,
+			},
+			expectedNodeOS: NodeOSWindows,
+		},
+		{
+			name: "selected-node non-existent, sc no fstype",
+			pvc: &corev1api.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   "fake-namespace",
+					Name:        "fake-pvc",
+					Annotations: map[string]string{KubeAnnSelectedNode: "non-existent-node"},
+				},
+				Spec: corev1api.PersistentVolumeClaimSpec{
+					StorageClassName: &storageClass,
+				},
+			},
+			kubeClientObj: []runtime.Object{
+				scObjWithoutFSType,
+			},
+			expectedNodeOS: NodeOSLinux,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/util/kube/pvc_pv_test.go
+++ b/pkg/util/kube/pvc_pv_test.go
@@ -1783,7 +1783,7 @@ func TestGetPVCAttachingNodeOS(t *testing.T) {
 		{
 			name: "node doesn't exist",
 			pvc:  pvcObjWithNode,
-			err:  "error to get os from node fake-node for PVC fake-namespace/fake-pvc: error getting node fake-node: nodes \"fake-node\" not found",
+			expectedNodeOS: NodeOSLinux,
 		},
 		{
 			name: "node without os label",


### PR DESCRIPTION
Adds tests for cases outlines in #8878 and code to pass those tests: allow the node os check to fail (enabling fallback to linux).

Fixes #8878 

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.