### PR TITLE
For not found errors on managed fields, add restore warning

### DIFF
--- a/changelogs/unreleased/8902-sseago
+++ b/changelogs/unreleased/8902-sseago
@@ -1,0 +1,1 @@
+Warn for not found error in patching managed fields

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1704,11 +1704,13 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 	}
 	if patchBytes != nil {
 		if _, err = resourceClient.Patch(obj.GetName(), patchBytes); err != nil {
-			restoreLogger.Errorf("error patch for managed fields %s: %s", kube.NamespaceAndName(obj), err.Error())
 			if !apierrors.IsNotFound(err) {
+				restoreLogger.Errorf("error patch for managed fields %s: %s", kube.NamespaceAndName(obj), err.Error())
 				errs.Add(namespace, err)
 				return warnings, errs, itemExists
 			}
+			restoreLogger.Warnf("item not found when patching managed fields %s: %s", kube.NamespaceAndName(obj), err.Error())
+			warnings.Add(namespace, err)
 		} else {
 			restoreLogger.Infof("the managed fields for %s is patched", kube.NamespaceAndName(obj))
 		}


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
When there's an error patching an item's managedFields struct during restore, a recent change stopped treating it as a restore error when the item wasn't found -- the usual cause for this was some other controller deleted the item post-restore (managed by something else, pod rollout, etc.), so it no longer fails the restore. However, it still logs the failure as an error-level log.

This commit changes the log message to a warn level log, and adds it to the restore warnings. That way a user will be able to see more easily that an object was deleted soon after restore, but it still won't fail the restore.


# Does your change fix a particular issue?

Fixes #8901 

# Please indicate you've done the following:

- [x ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x ] Updated the corresponding documentation in `site/content/docs/main`.
