### PR TITLE
Mounted cloud credentials should not be world-readable

### DIFF
--- a/changelogs/unreleased/8919-sseago
+++ b/changelogs/unreleased/8919-sseago
@@ -1,0 +1,1 @@
+Mounted cloud credentials should not be world-readable

--- a/internal/credentials/file_store.go
+++ b/internal/credentials/file_store.go
@@ -71,7 +71,8 @@ func (n *namespacedFileStore) Path(selector *corev1api.SecretKeySelector) (strin
 
 	keyFilePath := filepath.Join(n.fsRoot, fmt.Sprintf("%s-%s", selector.Name, selector.Key))
 
-	file, err := n.fs.OpenFile(keyFilePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	// owner RW perms, group R perms, no public perms
+	file, err := n.fs.OpenFile(keyFilePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0640)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to open credentials file for writing")
 	}

--- a/pkg/install/daemonset.go
+++ b/pkg/install/daemonset.go
@@ -23,6 +23,7 @@ import (
 	appsv1api "k8s.io/api/apps/v1"
 	corev1api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/vmware-tanzu/velero/internal/velero"
 	"github.com/vmware-tanzu/velero/pkg/nodeagent"
@@ -188,7 +189,9 @@ func DaemonSet(namespace string, opts ...podTemplateOption) *appsv1api.DaemonSet
 				Name: "cloud-credentials",
 				VolumeSource: corev1api.VolumeSource{
 					Secret: &corev1api.SecretVolumeSource{
-						SecretName: "cloud-credentials",
+						// read-only for Owner, Group, Public
+						DefaultMode: ptr.To(int32(0444)),
+						SecretName:  "cloud-credentials",
 					},
 				},
 			},

--- a/pkg/install/deployment.go
+++ b/pkg/install/deployment.go
@@ -24,6 +24,7 @@ import (
 	appsv1api "k8s.io/api/apps/v1"
 	corev1api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/vmware-tanzu/velero/internal/velero"
 	"github.com/vmware-tanzu/velero/pkg/builder"
@@ -411,7 +412,9 @@ func Deployment(namespace string, opts ...podTemplateOption) *appsv1api.Deployme
 				Name: "cloud-credentials",
 				VolumeSource: corev1api.VolumeSource{
 					Secret: &corev1api.SecretVolumeSource{
-						SecretName: "cloud-credentials",
+						// read-only for Owner, Group, Public
+						DefaultMode: ptr.To(int32(0444)),
+						SecretName:  "cloud-credentials",
 					},
 				},
 			},


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Cloud credentials (both default and BSL-named) should not be world-readable. This PR makes the file access permissions more restrictive.
```
sh-5.1$ ls -l /tmp/credentials/openshift-adp 
total 4
-rw-r-----. 1 1000740000 root 112 May  8 16:36 cloud-credentials-cloud
```
# Does your change fix a particular issue?

Fixes #8906 

# Please indicate you've done the following:

- [x ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x ] Updated the corresponding documentation in `site/content/docs/main`.
