### PR TITLE
Call WaitGroup.Done() once only when PVB changes to fianl status the first time to avoid panic

### DIFF
--- a/changelogs/CHANGELOG-1.16.md
+++ b/changelogs/CHANGELOG-1.16.md
@@ -13,6 +13,7 @@ https://velero.io/docs/v1.16/
 https://velero.io/docs/v1.16/upgrade-to-1.16/
 
 ### All Changes
+  * Call WaitGroup.Done() once only when PVB changes to final status the first time to avoid panic (#8940, @ywk253100)
   * Add VolumeSnapshotContent into the RIA and the mustHave resource list. (#8926, @blackpiglet)
   * Warn for not found error in patching managed fields (#8916, @sseago)
   * Fix issue 8878, relief node os deduction error checks (#8911, @Lyndon-Li)


### PR DESCRIPTION
Call WaitGroup.Done() once only when PVB changes to fianl status the first time to avoid panic

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
