### PR TITLE
DM controller refactor for cancel

### DIFF
--- a/changelogs/unreleased/8952-Lyndon-Li
+++ b/changelogs/unreleased/8952-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix issue #8534, refactor dm controllers to tolerate cancel request in more cases, e.g., node restart, node drain

--- a/pkg/builder/data_download_builder.go
+++ b/pkg/builder/data_download_builder.go
@@ -165,3 +165,15 @@ func (d *DataDownloadBuilder) AcceptedTimestamp(acceptedTimestamp *metav1.Time) 
 	d.object.Status.AcceptedTimestamp = acceptedTimestamp
 	return d
 }
+
+// Finalizers sets the DataDownload's Finalizers.
+func (d *DataDownloadBuilder) Finalizers(finalizers []string) *DataDownloadBuilder {
+	d.object.Finalizers = finalizers
+	return d
+}
+
+// Message sets the DataDownload's Message.
+func (d *DataDownloadBuilder) Message(msg string) *DataDownloadBuilder {
+	d.object.Status.Message = msg
+	return d
+}

--- a/pkg/builder/data_upload_builder.go
+++ b/pkg/builder/data_upload_builder.go
@@ -168,3 +168,15 @@ func (d *DataUploadBuilder) AcceptedTimestamp(acceptedTimestamp *metav1.Time) *D
 	d.object.Status.AcceptedTimestamp = acceptedTimestamp
 	return d
 }
+
+// Finalizers sets the DataUpload's Finalizers.
+func (d *DataUploadBuilder) Finalizers(finalizers []string) *DataUploadBuilder {
+	d.object.Finalizers = finalizers
+	return d
+}
+
+// Message sets the DataUpload's Message.
+func (d *DataUploadBuilder) Message(msg string) *DataUploadBuilder {
+	d.object.Status.Message = msg
+	return d
+}

--- a/pkg/controller/data_upload_controller.go
+++ b/pkg/controller/data_upload_controller.go
@@ -59,6 +59,8 @@ const (
 	dataUploadDownloadRequestor = "snapshot-data-upload-download"
 	DataUploadDownloadFinalizer = "velero.io/data-upload-download-finalizer"
 	preparingMonitorFrequency   = time.Minute
+	cancelDelayInProgress       = time.Hour
+	cancelDelayOthers           = time.Minute * 5
 )
 
 // DataUploadReconciler reconciles a DataUpload object
@@ -77,6 +79,7 @@ type DataUploadReconciler struct {
 	podResources        corev1api.ResourceRequirements
 	preparingTimeout    time.Duration
 	metrics             *metrics.ServerMetrics
+	cancelledDataUpload map[string]time.Time
 }
 
 func NewDataUploadReconciler(
@@ -109,12 +112,13 @@ func NewDataUploadReconciler(
 				log,
 			),
 		},
-		dataPathMgr:      dataPathMgr,
-		loadAffinity:     loadAffinity,
-		backupPVCConfig:  backupPVCConfig,
-		podResources:     podResources,
-		preparingTimeout: preparingTimeout,
-		metrics:          metrics,
+		dataPathMgr:         dataPathMgr,
+		loadAffinity:        loadAffinity,
+		backupPVCConfig:     backupPVCConfig,
+		podResources:        podResources,
+		preparingTimeout:    preparingTimeout,
+		metrics:             metrics,
+		cancelledDataUpload: make(map[string]time.Time),
 	}
 }
 
@@ -144,44 +148,96 @@ func (r *DataUploadReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, nil
 	}
 
+	// Logic for clear resources when dataupload been deleted
+	if !isDataUploadInFinalState(du) {
+		if !controllerutil.ContainsFinalizer(du, DataUploadDownloadFinalizer) {
+			if err := UpdateDataUploadWithRetry(ctx, r.client, req.NamespacedName, log, func(dataUpload *velerov2alpha1api.DataUpload) bool {
+				if controllerutil.ContainsFinalizer(dataUpload, DataUploadDownloadFinalizer) {
+					return false
+				}
+
+				controllerutil.AddFinalizer(dataUpload, DataUploadDownloadFinalizer)
+
+				return true
+			}); err != nil {
+				log.WithError(err).Errorf("failed to add finalizer for du %s/%s", du.Namespace, du.Name)
+				return ctrl.Result{}, err
+			}
+
+			return ctrl.Result{}, nil
+		}
+
+		if !du.DeletionTimestamp.IsZero() {
+			if !du.Spec.Cancel {
+				// when delete cr we need to clear up internal resources created by Velero, here we use the cancel mechanism
+				// to help clear up resources instead of clear them directly in case of some conflict with Expose action
+				log.Warnf("Cancel du under phase %s because it is being deleted", du.Status.Phase)
+
+				if err := UpdateDataUploadWithRetry(ctx, r.client, req.NamespacedName, log, func(dataUpload *velerov2alpha1api.DataUpload) bool {
+					if dataUpload.Spec.Cancel {
+						return false
+					}
+
+					dataUpload.Spec.Cancel = true
+					dataUpload.Status.Message = "Cancel dataupload because it is being deleted"
+
+					return true
+				}); err != nil {
+					log.WithError(err).Errorf("failed to set cancel flag for du %s/%s", du.Namespace, du.Name)
+					return ctrl.Result{}, err
+				}
+
+				return ctrl.Result{}, nil
+			}
+		}
+	} else {
+		delete(r.cancelledDataUpload, du.Name)
+
+		// put the finalizer remove action here for all cr will goes to the final status, we could check finalizer and do remove action in final status
+		// instead of intermediate state.
+		// remove finalizer no matter whether the cr is being deleted or not for it is no longer needed when internal resources are all cleaned up
+		// also in final status cr won't block the direct delete of the velero namespace
+		if controllerutil.ContainsFinalizer(du, DataUploadDownloadFinalizer) {
+			if err := UpdateDataUploadWithRetry(ctx, r.client, req.NamespacedName, log, func(du *velerov2alpha1api.DataUpload) bool {
+				if !controllerutil.ContainsFinalizer(du, DataUploadDownloadFinalizer) {
+					return false
+				}
+
+				controllerutil.RemoveFinalizer(du, DataUploadDownloadFinalizer)
+
+				return true
+			}); err != nil {
+				log.WithError(err).Error("error to remove finalizer")
+				return ctrl.Result{}, err
+			}
+
+			return ctrl.Result{}, nil
+		}
+	}
+
+	if du.Spec.Cancel {
+		if spotted, found := r.cancelledDataUpload[du.Name]; !found {
+			r.cancelledDataUpload[du.Name] = r.Clock.Now()
+		} else {
+			delay := cancelDelayOthers
+			if du.Status.Phase == velerov2alpha1api.DataUploadPhaseInProgress {
+				delay = cancelDelayInProgress
+			}
+
+			if time.Since(spotted) > delay {
+				log.Infof("Data upload %s is canceled in Phase %s but not handled in reasonable time", du.GetName(), du.Status.Phase)
+				if r.tryCancelDataUpload(ctx, du, "") {
+					delete(r.cancelledDataUpload, du.Name)
+				}
+
+				return ctrl.Result{}, nil
+			}
+		}
+	}
+
 	ep, ok := r.snapshotExposerList[du.Spec.SnapshotType]
 	if !ok {
 		return r.errorOut(ctx, du, errors.Errorf("%s type of snapshot exposer is not exist", du.Spec.SnapshotType), "not exist type of exposer", log)
-	}
-
-	// Logic for clear resources when dataupload been deleted
-	if du.DeletionTimestamp.IsZero() { // add finalizer for all cr at beginning
-		if !isDataUploadInFinalState(du) && !controllerutil.ContainsFinalizer(du, DataUploadDownloadFinalizer) {
-			succeeded, err := r.exclusiveUpdateDataUpload(ctx, du, func(du *velerov2alpha1api.DataUpload) {
-				controllerutil.AddFinalizer(du, DataUploadDownloadFinalizer)
-			})
-
-			if err != nil {
-				log.Errorf("failed to add finalizer with error %s for %s/%s", err.Error(), du.Namespace, du.Name)
-				return ctrl.Result{}, err
-			} else if !succeeded {
-				log.Warnf("failed to add finalizer for %s/%s and will requeue later", du.Namespace, du.Name)
-				return ctrl.Result{Requeue: true}, nil
-			}
-		}
-	} else if controllerutil.ContainsFinalizer(du, DataUploadDownloadFinalizer) && !du.Spec.Cancel && !isDataUploadInFinalState(du) {
-		// when delete cr we need to clear up internal resources created by Velero, here we use the cancel mechanism
-		// to help clear up resources instead of clear them directly in case of some conflict with Expose action
-		log.Warnf("Cancel du under phase %s because it is being deleted", du.Status.Phase)
-
-		if err := UpdateDataUploadWithRetry(ctx, r.client, req.NamespacedName, log, func(dataUpload *velerov2alpha1api.DataUpload) bool {
-			if dataUpload.Spec.Cancel {
-				return false
-			}
-
-			dataUpload.Spec.Cancel = true
-			dataUpload.Status.Message = "Cancel dataupload because it is being deleted"
-
-			return true
-		}); err != nil {
-			log.Errorf("failed to set cancel flag with error %s for %s/%s", err.Error(), du.Namespace, du.Name)
-			return ctrl.Result{}, err
-		}
 	}
 
 	if du.Status.Phase == "" || du.Status.Phase == velerov2alpha1api.DataUploadPhaseNew {
@@ -189,7 +245,7 @@ func (r *DataUploadReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 		accepted, err := r.acceptDataUpload(ctx, du)
 		if err != nil {
-			return r.errorOut(ctx, du, err, "error to accept the data upload", log)
+			return ctrl.Result{}, errors.Wrapf(err, "error accepting the data upload %s", du.Name)
 		}
 
 		if !accepted {
@@ -213,48 +269,15 @@ func (r *DataUploadReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// but the pod maybe is not in the same node of the current controller, so we need to return it here.
 		// And then only the controller who is in the same node could do the rest work.
 		if err := ep.Expose(ctx, getOwnerObject(du), exposeParam); err != nil {
-			if err := r.client.Get(ctx, req.NamespacedName, du); err != nil {
-				if !apierrors.IsNotFound(err) {
-					return ctrl.Result{}, errors.Wrap(err, "getting DataUpload")
-				}
-			}
-			if isDataUploadInFinalState(du) {
-				log.Warnf("expose snapshot with err %v but it may caused by clean up resources in cancel action", err)
-				r.cleanUp(ctx, du, log)
-				return ctrl.Result{}, nil
-			} else {
-				return r.errorOut(ctx, du, err, "error to expose snapshot", log)
-			}
+			return r.errorOut(ctx, du, err, "error exposing snapshot", log)
 		}
 
 		log.Info("Snapshot is exposed")
 
-		// we need to get CR again for it may canceled by dataupload controller on other
-		// nodes when doing expose action, if detectd cancel action we need to clear up the internal
-		// resources created by velero during backup.
-		if err := r.client.Get(ctx, req.NamespacedName, du); err != nil {
-			if apierrors.IsNotFound(err) {
-				log.Debug("Unable to find DataUpload")
-				return ctrl.Result{}, nil
-			}
-			return ctrl.Result{}, errors.Wrap(err, "getting DataUpload")
-		}
-
-		// we need to clean up resources as resources created in Expose it may later than cancel action or prepare time
-		// and need to clean up resources again
-		if isDataUploadInFinalState(du) {
-			r.cleanUp(ctx, du, log)
-		}
-
 		return ctrl.Result{}, nil
 	} else if du.Status.Phase == velerov2alpha1api.DataUploadPhaseAccepted {
-		if du.Spec.Cancel {
-			// we don't want to update CR into cancel status forcely as it may conflict with CR update in Expose action
-			// we could retry when the CR requeue in periodcally
-			log.Debugf("Data upload is been canceled %s in Phase %s", du.GetName(), du.Status.Phase)
-			r.tryCancelAcceptedDataUpload(ctx, du, "")
-		} else if peekErr := ep.PeekExposed(ctx, getOwnerObject(du)); peekErr != nil {
-			r.tryCancelAcceptedDataUpload(ctx, du, fmt.Sprintf("found a dataupload %s/%s with expose error: %s. mark it as cancel", du.Namespace, du.Name, peekErr))
+		if peekErr := ep.PeekExposed(ctx, getOwnerObject(du)); peekErr != nil {
+			r.tryCancelDataUpload(ctx, du, fmt.Sprintf("found a du %s/%s with expose error: %s. mark it as cancel", du.Namespace, du.Name, peekErr))
 			log.Errorf("Cancel du %s/%s because of expose error %s", du.Namespace, du.Name, peekErr)
 		} else if du.Status.AcceptedTimestamp != nil {
 			if time.Since(du.Status.AcceptedTimestamp.Time) >= r.preparingTimeout {
@@ -264,9 +287,14 @@ func (r *DataUploadReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 		return ctrl.Result{}, nil
 	} else if du.Status.Phase == velerov2alpha1api.DataUploadPhasePrepared {
-		log.Info("Data upload is prepared")
+		log.Infof("Data upload is prepared and should be processed by %s (%s)", du.Status.Node, r.nodeName)
+
+		if du.Status.Node != r.nodeName {
+			return ctrl.Result{}, nil
+		}
 
 		if du.Spec.Cancel {
+			log.Info("Prepared data upload is being canceled")
 			r.OnDataUploadCancelled(ctx, du.GetNamespace(), du.GetName())
 			return ctrl.Result{}, nil
 		}
@@ -281,8 +309,7 @@ func (r *DataUploadReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if err != nil {
 			return r.errorOut(ctx, du, err, "exposed snapshot is not ready", log)
 		} else if res == nil {
-			log.Debug("Get empty exposer")
-			return ctrl.Result{}, nil
+			return r.errorOut(ctx, du, errors.New("no expose result is available for the current node"), "exposed snapshot is not ready", log)
 		}
 
 		if res.ByPod.NodeOS == nil {
@@ -318,15 +345,29 @@ func (r *DataUploadReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 
 		// Update status to InProgress
-		original := du.DeepCopy()
-		du.Status.Phase = velerov2alpha1api.DataUploadPhaseInProgress
-		du.Status.StartTimestamp = &metav1.Time{Time: r.Clock.Now()}
-		du.Status.NodeOS = velerov2alpha1api.NodeOS(*res.ByPod.NodeOS)
-		if err := r.client.Patch(ctx, du, client.MergeFrom(original)); err != nil {
+		terminated := false
+		if err := UpdateDataUploadWithRetry(ctx, r.client, types.NamespacedName{Namespace: du.Namespace, Name: du.Name}, log, func(du *velerov2alpha1api.DataUpload) bool {
+			if isDataUploadInFinalState(du) {
+				terminated = true
+				return false
+			}
+
+			du.Status.Phase = velerov2alpha1api.DataUploadPhaseInProgress
+			du.Status.StartTimestamp = &metav1.Time{Time: r.Clock.Now()}
+			du.Status.NodeOS = velerov2alpha1api.NodeOS(*res.ByPod.NodeOS)
+
+			return true
+		}); err != nil {
 			log.WithError(err).Warnf("Failed to update dataupload %s to InProgress, will data path close and retry", du.Name)
 
 			r.closeDataPath(ctx, du.Name)
 			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
+		}
+
+		if terminated {
+			log.Warnf("dataupload %s is terminated during transition from prepared", du.Name)
+			r.closeDataPath(ctx, du.Name)
+			return ctrl.Result{}, nil
 		}
 
 		log.Info("Data upload is marked as in progress")
@@ -340,45 +381,39 @@ func (r *DataUploadReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 		return ctrl.Result{}, nil
 	} else if du.Status.Phase == velerov2alpha1api.DataUploadPhaseInProgress {
-		log.Info("Data upload is in progress")
 		if du.Spec.Cancel {
-			log.Info("Data upload is being canceled")
+			if du.Status.Node != r.nodeName {
+				return ctrl.Result{}, nil
+			}
+
+			log.Info("In progress data upload is being canceled")
 
 			asyncBR := r.dataPathMgr.GetAsyncBR(du.Name)
 			if asyncBR == nil {
-				if du.Status.Node == r.nodeName {
-					r.OnDataUploadCancelled(ctx, du.GetNamespace(), du.GetName())
-				} else {
-					log.Info("Data path is not started in this node and will not canceled by current node")
-				}
+				r.OnDataUploadCancelled(ctx, du.GetNamespace(), du.GetName())
 				return ctrl.Result{}, nil
 			}
 
 			// Update status to Canceling
-			original := du.DeepCopy()
-			du.Status.Phase = velerov2alpha1api.DataUploadPhaseCanceling
-			if err := r.client.Patch(ctx, du, client.MergeFrom(original)); err != nil {
+			if err := UpdateDataUploadWithRetry(ctx, r.client, types.NamespacedName{Namespace: du.Namespace, Name: du.Name}, log, func(du *velerov2alpha1api.DataUpload) bool {
+				if isDataUploadInFinalState(du) {
+					log.Warnf("dataupload %s is terminated, abort setting it to canceling", du.Name)
+					return false
+				}
+
+				du.Status.Phase = velerov2alpha1api.DataUploadPhaseCanceling
+				return true
+			}); err != nil {
 				log.WithError(err).Error("error updating data upload into canceling status")
 				return ctrl.Result{}, err
 			}
+
 			asyncBR.Cancel()
 			return ctrl.Result{}, nil
 		}
-		return ctrl.Result{}, nil
-	} else {
-		// put the finalizer remove action here for all cr will goes to the final status, we could check finalizer and do remove action in final status
-		// instead of intermediate state.
-		// remove finalizer no matter whether the cr is being deleted or not for it is no longer needed when internal resources are all cleaned up
-		// also in final status cr won't block the direct delete of the velero namespace
-		if isDataUploadInFinalState(du) && controllerutil.ContainsFinalizer(du, DataUploadDownloadFinalizer) {
-			original := du.DeepCopy()
-			controllerutil.RemoveFinalizer(du, DataUploadDownloadFinalizer)
-			if err := r.client.Patch(ctx, du, client.MergeFrom(original)); err != nil {
-				log.WithError(err).Error("error to remove finalizer")
-			}
-		}
-		return ctrl.Result{}, nil
 	}
+
+	return ctrl.Result{}, nil
 }
 
 func (r *DataUploadReconciler) initCancelableDataPath(ctx context.Context, asyncBR datapath.AsyncBR, res *exposer.ExposeResult, log logrus.FieldLogger) error {
@@ -488,14 +523,14 @@ func (r *DataUploadReconciler) OnDataUploadCancelled(ctx context.Context, namesp
 			log.WithError(err).Error("error updating DataUpload status")
 		} else {
 			r.metrics.RegisterDataUploadCancel(r.nodeName)
+			delete(r.cancelledDataUpload, du.Name)
 		}
 	}
 }
 
-func (r *DataUploadReconciler) tryCancelAcceptedDataUpload(ctx context.Context, du *velerov2alpha1api.DataUpload, message string) {
+func (r *DataUploadReconciler) tryCancelDataUpload(ctx context.Context, du *velerov2alpha1api.DataUpload, message string) bool {
 	log := r.logger.WithField("dataupload", du.Name)
-	log.Warn("Accepted data upload is canceled")
-	succeeded, err := r.exclusiveUpdateDataUpload(ctx, du, func(dataUpload *velerov2alpha1api.DataUpload) {
+	succeeded, err := funcExclusiveUpdateDataUpload(ctx, r.client, du, func(dataUpload *velerov2alpha1api.DataUpload) {
 		dataUpload.Status.Phase = velerov2alpha1api.DataUploadPhaseCanceled
 		if dataUpload.Status.StartTimestamp.IsZero() {
 			dataUpload.Status.StartTimestamp = &metav1.Time{Time: r.Clock.Now()}
@@ -509,16 +544,20 @@ func (r *DataUploadReconciler) tryCancelAcceptedDataUpload(ctx context.Context, 
 
 	if err != nil {
 		log.WithError(err).Error("error updating dataupload status")
-		return
+		return false
 	} else if !succeeded {
 		log.Warn("conflict in updating dataupload status and will try it again later")
-		return
+		return false
 	}
 
 	// success update
 	r.metrics.RegisterDataUploadCancel(r.nodeName)
 	// cleans up any objects generated during the snapshot expose
 	r.cleanUp(ctx, du, log)
+
+	log.Warn("data upload is canceled")
+
+	return true
 }
 
 func (r *DataUploadReconciler) cleanUp(ctx context.Context, du *velerov2alpha1api.DataUpload, log logrus.FieldLogger) {
@@ -538,16 +577,10 @@ func (r *DataUploadReconciler) cleanUp(ctx context.Context, du *velerov2alpha1ap
 func (r *DataUploadReconciler) OnDataUploadProgress(ctx context.Context, namespace string, duName string, progress *uploader.Progress) {
 	log := r.logger.WithField("dataupload", duName)
 
-	var du velerov2alpha1api.DataUpload
-	if err := r.client.Get(ctx, types.NamespacedName{Name: duName, Namespace: namespace}, &du); err != nil {
-		log.WithError(err).Warn("Failed to get dataupload on progress")
-		return
-	}
-
-	original := du.DeepCopy()
-	du.Status.Progress = shared.DataMoveOperationProgress{TotalBytes: progress.TotalBytes, BytesDone: progress.BytesDone}
-
-	if err := r.client.Patch(ctx, &du, client.MergeFrom(original)); err != nil {
+	if err := UpdateDataUploadWithRetry(ctx, r.client, types.NamespacedName{Namespace: namespace, Name: duName}, log, func(du *velerov2alpha1api.DataUpload) bool {
+		du.Status.Progress = shared.DataMoveOperationProgress{TotalBytes: progress.TotalBytes, BytesDone: progress.BytesDone}
+		return true
+	}); err != nil {
 		log.WithError(err).Error("Failed to update progress")
 	}
 }
@@ -560,7 +593,19 @@ func (r *DataUploadReconciler) OnDataUploadProgress(ctx context.Context, namespa
 func (r *DataUploadReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	gp := kube.NewGenericEventPredicate(func(object client.Object) bool {
 		du := object.(*velerov2alpha1api.DataUpload)
-		return (du.Status.Phase == velerov2alpha1api.DataUploadPhaseAccepted)
+		if du.Status.Phase == velerov2alpha1api.DataUploadPhaseAccepted {
+			return true
+		}
+
+		if du.Spec.Cancel && !isDataUploadInFinalState(du) {
+			return true
+		}
+
+		if isDataUploadInFinalState(du) && !du.DeletionTimestamp.IsZero() {
+			return true
+		}
+
+		return false
 	})
 	s := kube.NewPeriodicalEnqueueSource(r.logger.WithField("controller", constant.ControllerDataUpload), r.client, &velerov2alpha1api.DataUploadList{}, preparingMonitorFrequency, kube.PeriodicalEnqueueSourceOption{
 		Predicates: []predicate.Predicate{gp},
@@ -621,10 +666,17 @@ func (r *DataUploadReconciler) findDataUploadForPod(ctx context.Context, podObj 
 
 	if pod.Status.Phase == corev1api.PodRunning {
 		log.Info("Preparing dataupload")
-		// we don't expect anyone else update the CR during the Prepare process
-		updated, err := r.exclusiveUpdateDataUpload(context.Background(), du, r.prepareDataUpload)
-		if err != nil || !updated {
-			log.WithField("updated", updated).WithError(err).Warn("failed to update dataupload, prepare will halt for this dataupload")
+		if err = UpdateDataUploadWithRetry(context.Background(), r.client, types.NamespacedName{Namespace: du.Namespace, Name: du.Name}, log,
+			func(du *velerov2alpha1api.DataUpload) bool {
+				if isDataUploadInFinalState(du) {
+					log.Warnf("dataupload %s is terminated, abort setting it to prepared", du.Name)
+					return false
+				}
+
+				r.prepareDataUpload(du)
+				return true
+			}); err != nil {
+			log.WithError(err).Warn("failed to update dataupload, prepare will halt for this dataupload")
 			return []reconcile.Request{}
 		}
 	} else if unrecoverable, reason := kube.IsPodUnrecoverable(pod, log); unrecoverable { // let the abnormal backup pod failed early
@@ -678,18 +730,26 @@ func (r *DataUploadReconciler) errorOut(ctx context.Context, du *velerov2alpha1a
 }
 
 func (r *DataUploadReconciler) updateStatusToFailed(ctx context.Context, du *velerov2alpha1api.DataUpload, err error, msg string, log logrus.FieldLogger) error {
-	original := du.DeepCopy()
-	du.Status.Phase = velerov2alpha1api.DataUploadPhaseFailed
-	du.Status.Message = errors.WithMessage(err, msg).Error()
-	if du.Status.StartTimestamp.IsZero() {
-		du.Status.StartTimestamp = &metav1.Time{Time: r.Clock.Now()}
-	}
+	log.Info("update data upload status to Failed")
 
-	if dataPathError, ok := err.(datapath.DataPathError); ok {
-		du.Status.SnapshotID = dataPathError.GetSnapshotID()
-	}
-	du.Status.CompletionTimestamp = &metav1.Time{Time: r.Clock.Now()}
-	if patchErr := r.client.Patch(ctx, du, client.MergeFrom(original)); patchErr != nil {
+	if patchErr := UpdateDataUploadWithRetry(ctx, r.client, types.NamespacedName{Namespace: du.Namespace, Name: du.Name}, log, func(du *velerov2alpha1api.DataUpload) bool {
+		if isDataUploadInFinalState(du) {
+			return false
+		}
+
+		du.Status.Phase = velerov2alpha1api.DataUploadPhaseFailed
+		du.Status.Message = errors.WithMessage(err, msg).Error()
+		if du.Status.StartTimestamp.IsZero() {
+			du.Status.StartTimestamp = &metav1.Time{Time: r.Clock.Now()}
+		}
+
+		if dataPathError, ok := err.(datapath.DataPathError); ok {
+			du.Status.SnapshotID = dataPathError.GetSnapshotID()
+		}
+		du.Status.CompletionTimestamp = &metav1.Time{Time: r.Clock.Now()}
+
+		return true
+	}); patchErr != nil {
 		log.WithError(patchErr).Error("error updating DataUpload status")
 	} else {
 		r.metrics.RegisterDataUploadFailure(r.nodeName)
@@ -711,7 +771,7 @@ func (r *DataUploadReconciler) acceptDataUpload(ctx context.Context, du *velerov
 		dataUpload.Status.AcceptedTimestamp = &metav1.Time{Time: r.Clock.Now()}
 	}
 
-	succeeded, err := r.exclusiveUpdateDataUpload(ctx, updated, updateFunc)
+	succeeded, err := funcExclusiveUpdateDataUpload(ctx, r.client, updated, updateFunc)
 
 	if err != nil {
 		return false, err
@@ -732,7 +792,7 @@ func (r *DataUploadReconciler) onPrepareTimeout(ctx context.Context, du *velerov
 
 	log.Info("Timeout happened for preparing dataupload")
 
-	succeeded, err := r.exclusiveUpdateDataUpload(ctx, du, func(du *velerov2alpha1api.DataUpload) {
+	succeeded, err := funcExclusiveUpdateDataUpload(ctx, r.client, du, func(du *velerov2alpha1api.DataUpload) {
 		du.Status.Phase = velerov2alpha1api.DataUploadPhaseFailed
 		du.Status.Message = "timeout on preparing data upload"
 	})
@@ -770,11 +830,13 @@ func (r *DataUploadReconciler) onPrepareTimeout(ctx context.Context, du *velerov
 	r.metrics.RegisterDataUploadFailure(r.nodeName)
 }
 
-func (r *DataUploadReconciler) exclusiveUpdateDataUpload(ctx context.Context, du *velerov2alpha1api.DataUpload,
+var funcExclusiveUpdateDataUpload = exclusiveUpdateDataUpload
+
+func exclusiveUpdateDataUpload(ctx context.Context, cli client.Client, du *velerov2alpha1api.DataUpload,
 	updateFunc func(*velerov2alpha1api.DataUpload)) (bool, error) {
 	updateFunc(du)
 
-	err := r.client.Update(ctx, du)
+	err := cli.Update(ctx, du)
 	if err == nil {
 		return true, nil
 	}
@@ -905,7 +967,7 @@ func isDataUploadInFinalState(du *velerov2alpha1api.DataUpload) bool {
 		du.Status.Phase == velerov2alpha1api.DataUploadPhaseCompleted
 }
 
-func UpdateDataUploadWithRetry(ctx context.Context, client client.Client, namespacedName types.NamespacedName, log *logrus.Entry, updateFunc func(*velerov2alpha1api.DataUpload) bool) error {
+func UpdateDataUploadWithRetry(ctx context.Context, client client.Client, namespacedName types.NamespacedName, log logrus.FieldLogger, updateFunc func(*velerov2alpha1api.DataUpload) bool) error {
 	return wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
 		du := &velerov2alpha1api.DataUpload{}
 		if err := client.Get(ctx, namespacedName, du); err != nil {
@@ -939,11 +1001,7 @@ func (r *DataUploadReconciler) AttemptDataUploadResume(ctx context.Context, logg
 
 	for i := range dataUploads.Items {
 		du := &dataUploads.Items[i]
-		if du.Status.Phase == velerov2alpha1api.DataUploadPhasePrepared {
-			// keep doing nothing let controller re-download the data
-			// the Prepared CR could be still handled by dataupload controller after node-agent restart
-			logger.WithField("dataupload", du.GetName()).Debug("find a dataupload with status prepared")
-		} else if du.Status.Phase == velerov2alpha1api.DataUploadPhaseInProgress {
+		if du.Status.Phase == velerov2alpha1api.DataUploadPhaseInProgress {
 			if du.Status.Node != r.nodeName {
 				logger.WithField("du", du.Name).WithField("current node", r.nodeName).Infof("DU should be resumed by another node %s", du.Status.Node)
 				continue
@@ -972,23 +1030,10 @@ func (r *DataUploadReconciler) AttemptDataUploadResume(ctx context.Context, logg
 			if err != nil {
 				logger.WithField("dataupload", du.GetName()).WithError(errors.WithStack(err)).Error("Failed to trigger dataupload cancel")
 			}
-		} else if du.Status.Phase == velerov2alpha1api.DataUploadPhaseAccepted {
-			r.logger.WithField("dataupload", du.GetName()).Warn("Cancel du under Accepted phase")
-
-			err := UpdateDataUploadWithRetry(ctx, r.client, types.NamespacedName{Namespace: du.Namespace, Name: du.Name}, r.logger.WithField("dataupload", du.Name),
-				func(dataUpload *velerov2alpha1api.DataUpload) bool {
-					if dataUpload.Spec.Cancel {
-						return false
-					}
-
-					dataUpload.Spec.Cancel = true
-					dataUpload.Status.Message = "Dataupload is in Accepted status during the node-agent starting, mark it as cancel"
-
-					return true
-				})
-			if err != nil {
-				r.logger.WithField("dataupload", du.GetName()).WithError(errors.WithStack(err)).Error("Failed to trigger dataupload cancel")
-			}
+		} else {
+			// the Prepared CR could be still handled by dataupload controller after node-agent restart
+			// the accepted CR may also suvived from node-agent restart as long as the intermediate objects are all done
+			logger.WithField("dataupload", du.GetName()).Infof("find a dataupload with status %s", du.Status.Phase)
 		}
 	}
 

--- a/pkg/controller/data_upload_controller_test.go
+++ b/pkg/controller/data_upload_controller_test.go
@@ -45,7 +45,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -270,34 +269,29 @@ type fakeSnapshotExposer struct {
 	clock           clock.WithTickerAndDelayedExecution
 	ambiguousNodeOS bool
 	peekErr         error
+	exposeErr       error
+	getErr          error
+	getNil          bool
 }
 
 func (f *fakeSnapshotExposer) Expose(ctx context.Context, ownerObject corev1api.ObjectReference, param any) error {
-	du := velerov2alpha1api.DataUpload{}
-	err := f.kubeClient.Get(ctx, kbclient.ObjectKey{
-		Name:      dataUploadName,
-		Namespace: velerov1api.DefaultNamespace,
-	}, &du)
-	if err != nil {
-		return err
+	if f.exposeErr != nil {
+		return f.exposeErr
 	}
 
-	original := du
-	du.Status.Phase = velerov2alpha1api.DataUploadPhasePrepared
-	du.Status.StartTimestamp = &metav1.Time{Time: f.clock.Now()}
-	f.kubeClient.Patch(ctx, &du, kbclient.MergeFrom(&original))
 	return nil
 }
 
 func (f *fakeSnapshotExposer) GetExposed(ctx context.Context, du corev1api.ObjectReference, tm time.Duration, para any) (*exposer.ExposeResult, error) {
-	pod := &corev1api.Pod{}
-	err := f.kubeClient.Get(ctx, kbclient.ObjectKey{
-		Name:      dataUploadName,
-		Namespace: velerov1api.DefaultNamespace,
-	}, pod)
-	if err != nil {
-		return nil, err
+	if f.getErr != nil {
+		return nil, f.getErr
 	}
+
+	if f.getNil {
+		return nil, nil
+	}
+
+	pod := &corev1api.Pod{}
 
 	nodeOS := "linux"
 	pNodeOS := &nodeOS
@@ -346,214 +340,265 @@ func (b *fakeDataUploadFSBR) Close(ctx context.Context) {
 
 func TestReconcile(t *testing.T) {
 	tests := []struct {
-		name                string
-		du                  *velerov2alpha1api.DataUpload
-		pod                 *corev1api.Pod
-		pvc                 *corev1api.PersistentVolumeClaim
-		snapshotExposerList map[velerov2alpha1api.SnapshotType]exposer.SnapshotExposer
-		dataMgr             *datapath.Manager
-		expectedProcessed   bool
-		expected            *velerov2alpha1api.DataUpload
-		checkFunc           func(velerov2alpha1api.DataUpload) bool
-		expectedRequeue     ctrl.Result
-		expectedErrMsg      string
-		needErrs            []bool
-		removeNode          bool
-		ambiguousNodeOS     bool
-		peekErr             error
-		notCreateFSBR       bool
-		fsBRInitErr         error
-		fsBRStartErr        error
+		name                     string
+		du                       *velerov2alpha1api.DataUpload
+		notCreateDU              bool
+		needDelete               bool
+		sportTime                *metav1.Time
+		pod                      *corev1api.Pod
+		pvc                      *corev1api.PersistentVolumeClaim
+		snapshotExposerList      map[velerov2alpha1api.SnapshotType]exposer.SnapshotExposer
+		dataMgr                  *datapath.Manager
+		needCreateFSBR           bool
+		needExclusiveUpdateError error
+		expected                 *velerov2alpha1api.DataUpload
+		expectDeleted            bool
+		expectCancelRecord       bool
+		needErrs                 []bool
+		ambiguousNodeOS          bool
+		peekErr                  error
+		exposeErr                error
+		getExposeErr             error
+		getExposeNil             bool
+		fsBRInitErr              error
+		fsBRStartErr             error
+		expectedErr              string
+		expectedResult           *ctrl.Result
+		expectDataPath           bool
 	}{
 		{
-			name:            "Dataupload is not initialized",
-			du:              builder.ForDataUpload("unknown-ns", "unknown-name").Result(),
-			expectedRequeue: ctrl.Result{},
+			name:        "du not found",
+			du:          dataUploadBuilder().Result(),
+			notCreateDU: true,
 		},
 		{
-			name:            "Error get Dataupload",
-			du:              builder.ForDataUpload(velerov1api.DefaultNamespace, "unknown-name").Result(),
-			expectedRequeue: ctrl.Result{},
-			expectedErrMsg:  "getting DataUpload: Get error",
-			needErrs:        []bool{true, false, false, false},
+			name: "du not created in velero default namespace",
+			du:   builder.ForDataUpload("test-ns", dataUploadName).Result(),
 		},
 		{
-			name:            "Unsupported data mover type",
-			du:              dataUploadBuilder().DataMover("unknown type").Result(),
-			expected:        dataUploadBuilder().Phase("").Result(),
-			expectedRequeue: ctrl.Result{},
+			name:        "get du fail",
+			du:          dataUploadBuilder().Result(),
+			needErrs:    []bool{true, false, false, false},
+			expectedErr: "getting DataUpload: Get error",
 		},
 		{
-			name:              "Unknown type of snapshot exposer is not initialized",
-			du:                dataUploadBuilder().SnapshotType("unknown type").Result(),
-			expectedProcessed: true,
-			expected:          dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseFailed).Result(),
-			expectedRequeue:   ctrl.Result{},
-			expectedErrMsg:    "unknown type type of snapshot exposer is not exist",
+			name: "du is not for built-in dm",
+			du:   dataUploadBuilder().DataMover("other").Result(),
 		},
 		{
-			name:            "Dataupload should be accepted",
-			du:              dataUploadBuilder().Result(),
-			pod:             builder.ForPod("fake-ns", dataUploadName).Volumes(&corev1api.Volume{Name: "test-pvc"}).Result(),
-			pvc:             builder.ForPersistentVolumeClaim("fake-ns", "test-pvc").Result(),
-			expected:        dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseAccepted).Result(),
-			expectedRequeue: ctrl.Result{},
+			name:     "add finalizer to du",
+			du:       dataUploadBuilder().Result(),
+			expected: dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).Result(),
 		},
 		{
-			name:              "Dataupload should fail to get PVC information",
-			du:                dataUploadBuilder().Result(),
-			pod:               builder.ForPod("fake-ns", dataUploadName).Volumes(&corev1api.Volume{Name: "wrong-pvc"}).Result(),
-			expectedProcessed: true,
-			expected:          dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseFailed).Result(),
-			expectedRequeue:   ctrl.Result{},
-			expectedErrMsg:    "failed to get PVC",
+			name:        "add finalizer to du failed",
+			du:          dataUploadBuilder().Result(),
+			needErrs:    []bool{false, false, true, false},
+			expectedErr: "error updating dataupload with error velero/dataupload-1: Update error",
 		},
 		{
-			name:              "Dataupload should fail because expected node doesn't exist",
-			du:                dataUploadBuilder().Result(),
-			pod:               builder.ForPod("fake-ns", dataUploadName).Volumes(&corev1api.Volume{Name: "test-pvc"}).Result(),
-			pvc:               builder.ForPersistentVolumeClaim("fake-ns", "test-pvc").Result(),
-			removeNode:        true,
-			expectedProcessed: true,
-			expected:          dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseFailed).Result(),
-			expectedRequeue:   ctrl.Result{},
-			expectedErrMsg:    "no appropriate node to run data upload",
+			name:       "du is under deletion",
+			du:         dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).Result(),
+			needDelete: true,
+			expected:   dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).Cancel(true).Result(),
 		},
 		{
-			name:            "Dataupload should be prepared",
-			du:              dataUploadBuilder().SnapshotType(fakeSnapshotType).Result(),
-			expected:        dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).Result(),
-			expectedRequeue: ctrl.Result{},
+			name:        "du is under deletion but cancel failed",
+			du:          dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).Result(),
+			needErrs:    []bool{false, false, true, false},
+			needDelete:  true,
+			expectedErr: "error updating dataupload with error velero/dataupload-1: Update error",
 		},
 		{
-			name:            "Dataupload prepared should be completed",
-			pod:             builder.ForPod(velerov1api.DefaultNamespace, dataUploadName).Volumes(&corev1api.Volume{Name: "dataupload-1"}).Result(),
-			du:              dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).SnapshotType(fakeSnapshotType).Result(),
-			expected:        dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseInProgress).Result(),
-			expectedRequeue: ctrl.Result{},
+			name:          "du is under deletion and in terminal state",
+			du:            dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).Phase(velerov2alpha1api.DataUploadPhaseFailed).Result(),
+			sportTime:     &metav1.Time{Time: time.Now()},
+			needDelete:    true,
+			expectDeleted: true,
 		},
 		{
-			name:              "Dataupload should fail if expose returns ambiguous nodeOS",
-			pod:               builder.ForPod(velerov1api.DefaultNamespace, dataUploadName).Volumes(&corev1api.Volume{Name: "dataupload-1"}).Result(),
-			du:                dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).SnapshotType(fakeSnapshotType).Result(),
-			ambiguousNodeOS:   true,
-			expectedProcessed: true,
-			expected:          dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseFailed).Result(),
-			expectedErrMsg:    "unsupported ambiguous node OS",
+			name:        "du is under deletion and in terminal state, but remove finalizer failed",
+			du:          dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).Phase(velerov2alpha1api.DataUploadPhaseFailed).Result(),
+			needErrs:    []bool{false, false, true, false},
+			needDelete:  true,
+			expectedErr: "error updating dataupload with error velero/dataupload-1: Update error",
 		},
 		{
-			name:            "Dataupload with not enabled cancel",
-			pod:             builder.ForPod(velerov1api.DefaultNamespace, dataUploadName).Volumes(&corev1api.Volume{Name: "dataupload-1"}).Result(),
-			du:              dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseInProgress).SnapshotType(fakeSnapshotType).Cancel(false).Result(),
-			expected:        dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseInProgress).Result(),
-			expectedRequeue: ctrl.Result{},
+			name:               "delay cancel negative for others",
+			du:                 dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).Cancel(true).Phase(velerov2alpha1api.DataUploadPhasePrepared).Result(),
+			sportTime:          &metav1.Time{Time: time.Now()},
+			expectCancelRecord: true,
 		},
 		{
-			name:            "Dataupload should be cancel",
-			pod:             builder.ForPod(velerov1api.DefaultNamespace, dataUploadName).Volumes(&corev1api.Volume{Name: "dataupload-1"}).Result(),
-			du:              dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseInProgress).SnapshotType(fakeSnapshotType).Cancel(true).Result(),
-			expected:        dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseCanceling).Result(),
-			expectedRequeue: ctrl.Result{},
+			name:               "delay cancel negative for inProgress",
+			du:                 dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).Cancel(true).Phase(velerov2alpha1api.DataUploadPhaseInProgress).Result(),
+			sportTime:          &metav1.Time{Time: time.Now().Add(-time.Minute * 58)},
+			expectCancelRecord: true,
 		},
 		{
-			name: "Dataupload should be cancel with match node",
-			pod:  builder.ForPod(velerov1api.DefaultNamespace, dataUploadName).Volumes(&corev1api.Volume{Name: "dataupload-1"}).Result(),
-			du: func() *velerov2alpha1api.DataUpload {
-				du := dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseInProgress).SnapshotType(fakeSnapshotType).Cancel(true).Result()
-				du.Status.Node = "test-node"
-				return du
-			}(),
-			expectedProcessed: true,
-			expected:          dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseCanceled).Result(),
-			expectedRequeue:   ctrl.Result{},
-			notCreateFSBR:     true,
+			name:      "delay cancel affirmative for others",
+			du:        dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).Cancel(true).Phase(velerov2alpha1api.DataUploadPhasePrepared).Result(),
+			sportTime: &metav1.Time{Time: time.Now().Add(-time.Minute * 5)},
+			expected:  dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).Cancel(true).Phase(velerov2alpha1api.DataUploadPhaseCanceled).Result(),
 		},
 		{
-			name: "Dataupload should not be cancel with mismatch node",
-			pod:  builder.ForPod(velerov1api.DefaultNamespace, dataUploadName).Volumes(&corev1api.Volume{Name: "dataupload-1"}).Result(),
-			du: func() *velerov2alpha1api.DataUpload {
-				du := dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseInProgress).SnapshotType(fakeSnapshotType).Cancel(true).Result()
-				du.Status.Node = "different_node"
-				return du
-			}(),
-			expected:        dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseInProgress).Result(),
-			expectedRequeue: ctrl.Result{},
-			notCreateFSBR:   true,
+			name:      "delay cancel affirmative for inProgress",
+			du:        dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).Cancel(true).Phase(velerov2alpha1api.DataUploadPhaseInProgress).Result(),
+			sportTime: &metav1.Time{Time: time.Now().Add(-time.Hour)},
+			expected:  dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).Cancel(true).Phase(velerov2alpha1api.DataUploadPhaseCanceled).Result(),
 		},
 		{
-			name:            "runCancelableDataUpload is concurrent limited",
-			dataMgr:         datapath.NewManager(0),
-			pod:             builder.ForPod(velerov1api.DefaultNamespace, dataUploadName).Volumes(&corev1api.Volume{Name: "dataupload-1"}).Result(),
-			du:              dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).SnapshotType(fakeSnapshotType).Result(),
-			expected:        dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).Result(),
-			expectedRequeue: ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5},
+			name:               "delay cancel failed",
+			du:                 dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).Cancel(true).Phase(velerov2alpha1api.DataUploadPhaseInProgress).Result(),
+			needErrs:           []bool{false, false, true, false},
+			sportTime:          &metav1.Time{Time: time.Now().Add(-time.Hour)},
+			expected:           dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).Cancel(true).Phase(velerov2alpha1api.DataUploadPhaseInProgress).Result(),
+			expectCancelRecord: true,
 		},
 		{
-			name:              "data path init error",
-			pod:               builder.ForPod(velerov1api.DefaultNamespace, dataUploadName).Volumes(&corev1api.Volume{Name: "dataupload-1"}).Result(),
-			du:                dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).SnapshotType(fakeSnapshotType).Result(),
-			fsBRInitErr:       errors.New("fake-data-path-init-error"),
-			expectedProcessed: true,
-			expected:          dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseFailed).SnapshotType(fakeSnapshotType).Result(),
-			expectedErrMsg:    "error initializing asyncBR: fake-data-path-init-error",
+			name: "Unknown data upload status",
+			du:   dataUploadBuilder().Phase("Unknown").Finalizers([]string{DataUploadDownloadFinalizer}).Result(),
 		},
 		{
-			name:            "Unable to update status to in progress for data download",
-			pod:             builder.ForPod(velerov1api.DefaultNamespace, dataUploadName).Volumes(&corev1api.Volume{Name: "dataupload-1"}).Result(),
-			du:              dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).SnapshotType(fakeSnapshotType).Result(),
-			needErrs:        []bool{false, false, false, true},
-			expected:        dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).SnapshotType(fakeSnapshotType).Result(),
-			expectedRequeue: ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5},
+			name:        "Unknown type of snapshot exposer is not initialized",
+			du:          dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).SnapshotType("unknown type").Result(),
+			expected:    dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).Phase(velerov2alpha1api.DataUploadPhaseFailed).Result(),
+			expectedErr: "unknown type type of snapshot exposer is not exist",
 		},
 		{
-			name:              "data path start error",
-			pod:               builder.ForPod(velerov1api.DefaultNamespace, dataUploadName).Volumes(&corev1api.Volume{Name: "dataupload-1"}).Result(),
-			du:                dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).SnapshotType(fakeSnapshotType).Result(),
-			fsBRStartErr:      errors.New("fake-data-path-start-error"),
-			expectedProcessed: true,
-			expected:          dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseFailed).SnapshotType(fakeSnapshotType).Result(),
-			expectedErrMsg:    "error starting async backup for pod dataupload-1, volume dataupload-1: fake-data-path-start-error",
+			name:                     "new du but accept failed",
+			du:                       dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).Result(),
+			needExclusiveUpdateError: errors.New("exclusive-update-error"),
+			expected:                 dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).Result(),
+			expectedErr:              "error accepting the data upload dataupload-1: exclusive-update-error",
 		},
 		{
-			name:     "prepare timeout",
-			du:       dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseAccepted).SnapshotType(fakeSnapshotType).AcceptedTimestamp(&metav1.Time{Time: time.Now().Add(-time.Minute * 5)}).Result(),
-			expected: dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseFailed).Result(),
+			name:     "du is cancel on accepted",
+			du:       dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).Cancel(true).Result(),
+			expected: dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).Cancel(true).Phase(velerov2alpha1api.DataUploadPhaseCanceled).Result(),
 		},
 		{
-			name:              "peek error",
-			du:                dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseAccepted).SnapshotType(fakeSnapshotType).Result(),
-			peekErr:           errors.New("fake-peek-error"),
-			expectedProcessed: true,
-			expected:          dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseCanceled).Result(),
+			name:        "du is accepted but setup expose param failed on getting PVC",
+			du:          dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).Result(),
+			expected:    dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).Phase(velerov2alpha1api.DataUploadPhaseFailed).Message("failed to set exposer parameters").Result(),
+			expectedErr: "failed to get PVC fake-ns/test-pvc: persistentvolumeclaims \"test-pvc\" not found",
 		},
 		{
-			name: "Dataupload with enabled cancel",
-			pod:  builder.ForPod(velerov1api.DefaultNamespace, dataUploadName).Volumes(&corev1api.Volume{Name: "dataupload-1"}).Result(),
-			du: func() *velerov2alpha1api.DataUpload {
-				du := dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseAccepted).SnapshotType(fakeSnapshotType).Result()
-				controllerutil.AddFinalizer(du, DataUploadDownloadFinalizer)
-				du.DeletionTimestamp = &metav1.Time{Time: time.Now()}
-				return du
-			}(),
-			checkFunc: func(du velerov2alpha1api.DataUpload) bool {
-				return du.Spec.Cancel
-			},
-			expected:        dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseAccepted).Result(),
-			expectedRequeue: ctrl.Result{},
+			name:        "du expose failed",
+			du:          dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).SnapshotType(fakeSnapshotType).Result(),
+			pvc:         builder.ForPersistentVolumeClaim("fake-ns", "test-pvc").Result(),
+			exposeErr:   errors.New("fake-expose-error"),
+			expected:    dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).Phase(velerov2alpha1api.DataUploadPhaseFailed).Message("error exposing snapshot").Result(),
+			expectedErr: "fake-expose-error",
 		},
 		{
-			name: "Dataupload with remove finalizer and should not be retrieved",
-			pod:  builder.ForPod(velerov1api.DefaultNamespace, dataUploadName).Volumes(&corev1api.Volume{Name: "dataupload-1"}).Result(),
-			du: func() *velerov2alpha1api.DataUpload {
-				du := dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseFailed).SnapshotType(fakeSnapshotType).Cancel(true).Result()
-				controllerutil.AddFinalizer(du, DataUploadDownloadFinalizer)
-				du.DeletionTimestamp = &metav1.Time{Time: time.Now()}
-				return du
-			}(),
-			checkFunc: func(du velerov2alpha1api.DataUpload) bool {
-				return !controllerutil.ContainsFinalizer(&du, DataUploadDownloadFinalizer)
-			},
-			expectedRequeue: ctrl.Result{},
+			name:     "du succeeds for accepted",
+			du:       dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).SnapshotType(fakeSnapshotType).Result(),
+			pvc:      builder.ForPersistentVolumeClaim("fake-ns", "test-pvc").Result(),
+			expected: dataUploadBuilder().Finalizers([]string{DataUploadDownloadFinalizer}).Phase(velerov2alpha1api.DataUploadPhaseAccepted).Result(),
+		},
+		{
+			name:     "prepare timeout on accepted",
+			du:       dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseAccepted).Finalizers([]string{DataUploadDownloadFinalizer}).AcceptedTimestamp(&metav1.Time{Time: time.Now().Add(-time.Minute * 30)}).Result(),
+			expected: dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseFailed).Finalizers([]string{DataUploadDownloadFinalizer}).Phase(velerov2alpha1api.DataUploadPhaseFailed).Message("timeout on preparing data upload").Result(),
+		},
+		{
+			name:     "peek error on accepted",
+			du:       dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseAccepted).SnapshotType(fakeSnapshotType).Finalizers([]string{DataUploadDownloadFinalizer}).Result(),
+			peekErr:  errors.New("fake-peak-error"),
+			expected: dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseCanceled).Finalizers([]string{DataUploadDownloadFinalizer}).Phase(velerov2alpha1api.DataUploadPhaseCanceled).Message("found a du velero/dataupload-1 with expose error: fake-peak-error. mark it as cancel").Result(),
+		},
+		{
+			name:     "cancel on prepared",
+			du:       dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).Finalizers([]string{DataUploadDownloadFinalizer}).Node("test-node").Cancel(true).Result(),
+			expected: dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseCanceled).Finalizers([]string{DataUploadDownloadFinalizer}).Cancel(true).Phase(velerov2alpha1api.DataUploadPhaseCanceled).Result(),
+		},
+		{
+			name:         "Failed to get snapshot expose on prepared",
+			du:           dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).SnapshotType(fakeSnapshotType).Finalizers([]string{DataUploadDownloadFinalizer}).Node("test-node").Result(),
+			getExposeErr: errors.New("fake-get-error"),
+			expected:     dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseFailed).Finalizers([]string{DataUploadDownloadFinalizer}).Message("exposed snapshot is not ready: fake-get-error").Result(),
+			expectedErr:  "fake-get-error",
+		},
+		{
+			name:         "Get nil restore expose on prepared",
+			du:           dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).SnapshotType(fakeSnapshotType).Finalizers([]string{DataUploadDownloadFinalizer}).Node("test-node").Result(),
+			getExposeNil: true,
+			expected:     dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseFailed).Finalizers([]string{DataUploadDownloadFinalizer}).Message("exposed snapshot is not ready").Result(),
+			expectedErr:  "no expose result is available for the current node",
+		},
+		{
+			name:            "Dataupload should fail if expose returns ambiguous nodeOS",
+			du:              dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).SnapshotType(fakeSnapshotType).Finalizers([]string{DataUploadDownloadFinalizer}).Node("test-node").Result(),
+			ambiguousNodeOS: true,
+			expected:        dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseFailed).Finalizers([]string{DataUploadDownloadFinalizer}).Result(),
+			expectedErr:     "unsupported ambiguous node OS",
+		},
+		{
+			name:           "Error in data path is concurrent limited",
+			du:             dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).SnapshotType(fakeSnapshotType).Finalizers([]string{DataUploadDownloadFinalizer}).Node("test-node").Result(),
+			dataMgr:        datapath.NewManager(0),
+			expectedResult: &ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5},
+		},
+		{
+			name:        "data path init error",
+			du:          dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).SnapshotType(fakeSnapshotType).Finalizers([]string{DataUploadDownloadFinalizer}).Node("test-node").Result(),
+			fsBRInitErr: errors.New("fake-data-path-init-error"),
+			expected:    dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseFailed).Finalizers([]string{DataUploadDownloadFinalizer}).Message("error initializing data path").Result(),
+			expectedErr: "error initializing asyncBR: fake-data-path-init-error",
+		},
+		{
+			name:           "Unable to update status to in progress for data upload",
+			du:             dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).SnapshotType(fakeSnapshotType).Finalizers([]string{DataUploadDownloadFinalizer}).Node("test-node").Result(),
+			needErrs:       []bool{false, false, true, false},
+			expected:       dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).Finalizers([]string{DataUploadDownloadFinalizer}).Result(),
+			expectedResult: &ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5},
+		},
+		{
+			name:         "data path start error",
+			du:           dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).SnapshotType(fakeSnapshotType).Finalizers([]string{DataUploadDownloadFinalizer}).Node("test-node").Result(),
+			fsBRStartErr: errors.New("fake-data-path-start-error"),
+			expected:     dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseFailed).Finalizers([]string{DataUploadDownloadFinalizer}).Message("error starting data path").Result(),
+			expectedErr:  "error starting async backup for pod , volume dataupload-1: fake-data-path-start-error",
+		},
+		{
+			name:           "Prepare succeeds",
+			du:             dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).SnapshotType(fakeSnapshotType).Finalizers([]string{DataUploadDownloadFinalizer}).Node("test-node").Result(),
+			expected:       dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseInProgress).Finalizers([]string{DataUploadDownloadFinalizer}).Result(),
+			expectDataPath: true,
+		},
+		{
+			name:     "In progress du is not handled by the current node",
+			du:       dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseInProgress).Finalizers([]string{DataUploadDownloadFinalizer}).Result(),
+			expected: dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseInProgress).Finalizers([]string{DataUploadDownloadFinalizer}).Result(),
+		},
+		{
+			name:     "In progress du is not set as cancel",
+			du:       dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseInProgress).Finalizers([]string{DataUploadDownloadFinalizer}).Node("test-node").Result(),
+			expected: dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseInProgress).Finalizers([]string{DataUploadDownloadFinalizer}).Result(),
+		},
+		{
+			name:     "Cancel data upload in progress with empty FSBR",
+			du:       dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseInProgress).Cancel(true).Finalizers([]string{DataUploadDownloadFinalizer}).Node("test-node").Result(),
+			expected: dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseCanceled).Cancel(true).Finalizers([]string{DataUploadDownloadFinalizer}).Result(),
+		},
+		{
+			name:               "Cancel data upload in progress and patch data upload error",
+			du:                 dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseInProgress).Cancel(true).Finalizers([]string{DataUploadDownloadFinalizer}).Node("test-node").Result(),
+			needErrs:           []bool{false, false, true, false},
+			needCreateFSBR:     true,
+			expected:           dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseInProgress).Cancel(true).Finalizers([]string{DataUploadDownloadFinalizer}).Result(),
+			expectedErr:        "error updating dataupload with error velero/dataupload-1: Update error",
+			expectCancelRecord: true,
+			expectDataPath:     true,
+		},
+		{
+			name:               "Cancel data upload in progress succeeds",
+			du:                 dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseInProgress).Cancel(true).Finalizers([]string{DataUploadDownloadFinalizer}).Node("test-node").Result(),
+			needCreateFSBR:     true,
+			expected:           dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseCanceling).Cancel(true).Finalizers([]string{DataUploadDownloadFinalizer}).Result(),
+			expectDataPath:     true,
+			expectCancelRecord: true,
 		},
 	}
 
@@ -561,24 +606,15 @@ func TestReconcile(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			r, err := initDataUploaderReconciler(test.needErrs...)
 			require.NoError(t, err)
-			defer func() {
-				r.client.Delete(ctx, test.du, &kbclient.DeleteOptions{})
-				if test.pod != nil {
-					r.client.Delete(ctx, test.pod, &kbclient.DeleteOptions{})
-				}
-			}()
-			ctx := context.Background()
-			if test.du.Namespace == velerov1api.DefaultNamespace {
-				isDeletionTimestampSet := test.du.DeletionTimestamp != nil
-				err = r.client.Create(ctx, test.du)
+
+			if !test.notCreateDU {
+				err = r.client.Create(context.Background(), test.du)
 				require.NoError(t, err)
-				// because of the changes introduced by https://github.com/kubernetes-sigs/controller-runtime/commit/7a66d580c0c53504f5b509b45e9300cc18a1cc30
-				// the fake client ignores the DeletionTimestamp when calling the Create(),
-				// so call Delete() here
-				if isDeletionTimestampSet {
-					err = r.client.Delete(ctx, test.du)
-					require.NoError(t, err)
-				}
+			}
+
+			if test.needDelete {
+				err = r.client.Delete(context.Background(), test.du)
+				require.NoError(t, err)
 			}
 
 			if test.pod != nil {
@@ -591,38 +627,41 @@ func TestReconcile(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			if test.removeNode {
-				err = r.kubeClient.CoreV1().Nodes().Delete(ctx, "fake-node", metav1.DeleteOptions{})
-				require.NoError(t, err)
-			}
-
 			if test.dataMgr != nil {
 				r.dataPathMgr = test.dataMgr
 			} else {
 				r.dataPathMgr = datapath.NewManager(1)
 			}
 
+			if test.sportTime != nil {
+				r.cancelledDataUpload[test.du.Name] = test.sportTime.Time
+			}
+
 			if test.du.Spec.SnapshotType == fakeSnapshotType {
-				r.snapshotExposerList = map[velerov2alpha1api.SnapshotType]exposer.SnapshotExposer{fakeSnapshotType: &fakeSnapshotExposer{r.client, r.Clock, test.ambiguousNodeOS, test.peekErr}}
+				r.snapshotExposerList = map[velerov2alpha1api.SnapshotType]exposer.SnapshotExposer{fakeSnapshotType: &fakeSnapshotExposer{r.client, r.Clock, test.ambiguousNodeOS, test.peekErr, test.exposeErr, test.getExposeErr, test.getExposeNil}}
 			} else if test.du.Spec.SnapshotType == velerov2alpha1api.SnapshotTypeCSI {
 				r.snapshotExposerList = map[velerov2alpha1api.SnapshotType]exposer.SnapshotExposer{velerov2alpha1api.SnapshotTypeCSI: exposer.NewCSISnapshotExposer(r.kubeClient, r.csiSnapshotClient, velerotest.NewLogger())}
 			}
-			if !test.notCreateFSBR {
-				datapath.MicroServiceBRWatcherCreator = func(kbclient.Client, kubernetes.Interface, manager.Manager, string, string, string, string, string, string, datapath.Callbacks, logrus.FieldLogger) datapath.AsyncBR {
-					return &fakeDataUploadFSBR{
-						du:         test.du,
-						kubeClient: r.client,
-						clock:      r.Clock,
-						initErr:    test.fsBRInitErr,
-						startErr:   test.fsBRStartErr,
-					}
+
+			funcExclusiveUpdateDataUpload = exclusiveUpdateDataUpload
+			if test.needExclusiveUpdateError != nil {
+				funcExclusiveUpdateDataUpload = func(context.Context, kbclient.Client, *velerov2alpha1api.DataUpload, func(*velerov2alpha1api.DataUpload)) (bool, error) {
+					return false, test.needExclusiveUpdateError
 				}
 			}
 
-			testCreateFsBR := false
-			if test.du.Status.Phase == velerov2alpha1api.DataUploadPhaseInProgress && !test.notCreateFSBR {
+			datapath.MicroServiceBRWatcherCreator = func(kbclient.Client, kubernetes.Interface, manager.Manager, string, string, string, string, string, string, datapath.Callbacks, logrus.FieldLogger) datapath.AsyncBR {
+				return &fakeDataUploadFSBR{
+					du:         test.du,
+					kubeClient: r.client,
+					clock:      r.Clock,
+					initErr:    test.fsBRInitErr,
+					startErr:   test.fsBRStartErr,
+				}
+			}
+
+			if test.needCreateFSBR {
 				if fsBR := r.dataPathMgr.GetAsyncBR(test.du.Name); fsBR == nil {
-					testCreateFsBR = true
 					_, err := r.dataPathMgr.CreateMicroServiceBRWatcher(ctx, r.client, nil, nil, datapath.TaskTypeBackup, test.du.Name, velerov1api.DefaultNamespace, "", "", "", datapath.Callbacks{OnCancelled: r.OnDataUploadCancelled}, false, velerotest.NewLogger())
 					require.NoError(t, err)
 				}
@@ -635,41 +674,46 @@ func TestReconcile(t *testing.T) {
 				},
 			})
 
-			assert.Equal(t, test.expectedRequeue, actualResult)
-			if test.expectedErrMsg == "" {
-				require.NoError(t, err)
+			if test.expectedErr != "" {
+				assert.EqualError(t, err, test.expectedErr)
 			} else {
-				require.ErrorContains(t, err, test.expectedErrMsg)
+				assert.NoError(t, err)
 			}
 
-			du := velerov2alpha1api.DataUpload{}
-			err = r.client.Get(ctx, kbclient.ObjectKey{
-				Name:      test.du.Name,
-				Namespace: test.du.Namespace,
-			}, &du)
-			t.Logf("%s: \n %v \n", test.name, du)
-			// Assertions
-			if test.expected == nil {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, test.expected.Status.Phase, du.Status.Phase)
+			if test.expectedResult != nil {
+				assert.Equal(t, test.expectedResult.Requeue, actualResult.Requeue)
+				assert.Equal(t, test.expectedResult.RequeueAfter, actualResult.RequeueAfter)
 			}
 
-			if test.expectedProcessed {
-				assert.False(t, du.Status.CompletionTimestamp.IsZero())
+			if test.expected != nil || test.expectDeleted {
+				du := velerov2alpha1api.DataUpload{}
+				err = r.client.Get(ctx, kbclient.ObjectKey{
+					Name:      test.du.Name,
+					Namespace: test.du.Namespace,
+				}, &du)
+
+				if test.expectDeleted {
+					assert.True(t, apierrors.IsNotFound(err))
+				} else {
+					require.NoError(t, err)
+
+					assert.Equal(t, test.expected.Status.Phase, du.Status.Phase)
+					assert.Contains(t, du.Status.Message, test.expected.Status.Message)
+					assert.Equal(t, du.Finalizers, test.expected.Finalizers)
+					assert.Equal(t, du.Spec.Cancel, test.expected.Spec.Cancel)
+				}
 			}
 
-			if !test.expectedProcessed {
-				assert.True(t, du.Status.CompletionTimestamp.IsZero())
-			}
-
-			if test.checkFunc != nil {
-				assert.True(t, test.checkFunc(du))
-			}
-
-			if !testCreateFsBR && du.Status.Phase != velerov2alpha1api.DataUploadPhaseInProgress {
+			if !test.expectDataPath {
 				assert.Nil(t, r.dataPathMgr.GetAsyncBR(test.du.Name))
+			} else {
+				assert.NotNil(t, r.dataPathMgr.GetAsyncBR(test.du.Name))
+			}
+
+			if test.expectCancelRecord {
+				assert.Contains(t, r.cancelledDataUpload, test.du.Name)
+			} else {
+				assert.Empty(t, r.cancelledDataUpload)
 			}
 		})
 	}
@@ -719,7 +763,7 @@ func TestOnDataUploadProgress(t *testing.T) {
 		{
 			name:     "failed to patch dataupload",
 			du:       dataUploadBuilder().Result(),
-			needErrs: []bool{false, false, false, true},
+			needErrs: []bool{false, false, true, false},
 		},
 	}
 	for _, test := range tests {
@@ -992,7 +1036,7 @@ func TestTryCancelDataUpload(t *testing.T) {
 		err = r.client.Create(ctx, test.dd)
 		require.NoError(t, err)
 
-		r.tryCancelAcceptedDataUpload(ctx, test.dd, "")
+		r.tryCancelDataUpload(ctx, test.dd, "")
 
 		if test.expectedErr == "" {
 			assert.NoError(t, err)
@@ -1114,33 +1158,8 @@ func TestAttemptDataUploadResume(t *testing.T) {
 		expectedError         string
 	}{
 		{
-			name:                 "accepted DataUpload in other node",
-			du:                   dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseAccepted).Result(),
-			cancelledDataUploads: []string{dataUploadName},
-			acceptedDataUploads:  []string{dataUploadName},
-		},
-		{
-			name:                 "accepted DataUpload in the current node",
-			du:                   dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseAccepted).AcceptedByNode("node-1").Result(),
-			cancelledDataUploads: []string{dataUploadName},
-			acceptedDataUploads:  []string{dataUploadName},
-		},
-		{
-			name:                 "accepted DataUpload in the current node but canceled",
-			du:                   dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseAccepted).AcceptedByNode("node-1").Cancel(true).Result(),
-			cancelledDataUploads: []string{dataUploadName},
-			acceptedDataUploads:  []string{dataUploadName},
-		},
-		{
-			name:                "accepted DataUpload in the current node but update error",
-			du:                  dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseAccepted).AcceptedByNode("node-1").Result(),
-			needErrs:            []bool{false, false, true, false, false, false},
-			acceptedDataUploads: []string{dataUploadName},
-		},
-		{
-			name:                 "prepared DataUpload",
-			du:                   dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).Result(),
-			prepareddDataUploads: []string{dataUploadName},
+			name: "Other DataUpload",
+			du:   dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhasePrepared).Result(),
 		},
 		{
 			name:                  "InProgress DataUpload, not the current node",


### PR DESCRIPTION
Fix issue #8534, refactor dm controllers to tolerate cancel request in more cases, e.g., node restart, node drain