### PR TITLE
Keep manager label for VSC

### DIFF
--- a/changelogs/unreleased/8969-flx5
+++ b/changelogs/unreleased/8969-flx5
@@ -1,0 +1,1 @@
+Add support for [distributed snapshotting](https://github.com/kubernetes-csi/external-snapshotter/tree/4cedb3f45790ac593ebfa3324c490abedf739477?tab=readme-ov-file#distributed-snapshotting)

--- a/pkg/exposer/csi_snapshot.go
+++ b/pkg/exposer/csi_snapshot.go
@@ -471,8 +471,8 @@ func (e *csiSnapshotExposer) createBackupVSC(ctx context.Context, ownerObject co
 		https://github.com/kubernetes-csi/external-snapshotter/tree/4cedb3f45790ac593ebfa3324c490abedf739477?tab=readme-ov-file#distributed-snapshotting
 		https://github.com/kubernetes-csi/external-snapshotter/blob/4cedb3f45790ac593ebfa3324c490abedf739477/pkg/utils/util.go#L158
 	*/
-	if manager, ok := snapshotVSC.Labels["snapshot.storage.kubernetes.io/managed-by"]; ok {
-		vsc.ObjectMeta.Labels["snapshot.storage.kubernetes.io/managed-by"] = manager
+	if manager, ok := snapshotVSC.Labels[kube.VolumeSnapshotContentManagedByLabel]; ok {
+		vsc.ObjectMeta.Labels[kube.VolumeSnapshotContentManagedByLabel] = manager
 	}
 
 	return e.csiSnapshotClient.VolumeSnapshotContents().Create(ctx, vsc, metav1.CreateOptions{})

--- a/pkg/exposer/csi_snapshot.go
+++ b/pkg/exposer/csi_snapshot.go
@@ -446,6 +446,7 @@ func (e *csiSnapshotExposer) createBackupVSC(ctx context.Context, ownerObject co
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        backupVSCName,
 			Annotations: snapshotVSC.Annotations,
+			Labels:      map[string]string{},
 		},
 		Spec: snapshotv1api.VolumeSnapshotContentSpec{
 			VolumeSnapshotRef: corev1api.ObjectReference{
@@ -461,6 +462,17 @@ func (e *csiSnapshotExposer) createBackupVSC(ctx context.Context, ownerObject co
 			Driver:                  snapshotVSC.Spec.Driver,
 			VolumeSnapshotClassName: snapshotVSC.Spec.VolumeSnapshotClassName,
 		},
+	}
+
+	/*
+		We need to keep the label of the managing node for distributed snapshots.
+		The external snapshot manager will only manage snapshots matching it's node if that feature is enabled.
+
+		https://github.com/kubernetes-csi/external-snapshotter/tree/4cedb3f45790ac593ebfa3324c490abedf739477?tab=readme-ov-file#distributed-snapshotting
+		https://github.com/kubernetes-csi/external-snapshotter/blob/4cedb3f45790ac593ebfa3324c490abedf739477/pkg/utils/util.go#L158
+	*/
+	if manager, ok := snapshotVSC.Labels["snapshot.storage.kubernetes.io/managed-by"]; ok {
+		vsc.ObjectMeta.Labels["snapshot.storage.kubernetes.io/managed-by"] = manager
 	}
 
 	return e.csiSnapshotClient.VolumeSnapshotContents().Create(ctx, vsc, metav1.CreateOptions{})

--- a/pkg/util/kube/utils.go
+++ b/pkg/util/kube/utils.go
@@ -53,6 +53,11 @@ const (
 	KubeAnnSelectedNode           = "volume.kubernetes.io/selected-node"
 )
 
+// VolumeSnapshotContentManagedByLabel is applied by the snapshot controller
+// to the VolumeSnapshotContent object in case distributed snapshotting is enabled.
+// The value contains the name of the node that handles the snapshot for the volume local to that node.
+const VolumeSnapshotContentManagedByLabel = "snapshot.storage.kubernetes.io/managed-by"
+
 var ErrorPodVolumeIsNotPVC = errors.New("pod volume is not a PVC")
 
 // NamespaceAndName returns a string in the format <namespace>/<name>


### PR DESCRIPTION
If distributed snapshotting is enabled in the external snapshotter a manager label is added to the volume snapshot content. When exposing the snapshot velero needs to keep this label around otherwise the exposed snapshot will never become ready.

Fixes #9003 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
