### PR TITLE
Mark BackupRepository not ready when BSL changed

### DIFF
--- a/changelogs/unreleased/8975-ywk253100
+++ b/changelogs/unreleased/8975-ywk253100
@@ -1,0 +1,1 @@
+Mark BackupRepository not ready when BSL changed

--- a/pkg/util/kube/predicate.go
+++ b/pkg/util/kube/predicate.go
@@ -47,15 +47,6 @@ func (SpecChangePredicate) Update(e event.UpdateEvent) bool {
 	return !reflect.DeepEqual(oldSpec.Interface(), newSpec.Interface())
 }
 
-// NewGenericEventPredicate creates a new Predicate that checks the Generic event with the provided func
-func NewGenericEventPredicate(f func(object client.Object) bool) predicate.Predicate {
-	return predicate.Funcs{
-		GenericFunc: func(event event.GenericEvent) bool {
-			return f(event.Object)
-		},
-	}
-}
-
 // NewAllEventPredicate creates a new Predicate that checks all the events with the provided func
 func NewAllEventPredicate(f func(object client.Object) bool) predicate.Predicate {
 	return predicate.Funcs{
@@ -70,25 +61,6 @@ func NewAllEventPredicate(f func(object client.Object) bool) predicate.Predicate
 		},
 		GenericFunc: func(event event.GenericEvent) bool {
 			return f(event.Object)
-		},
-	}
-}
-
-// NewUpdateEventPredicate creates a new Predicate that checks the update events with the provided func
-// and ignore others
-func NewUpdateEventPredicate(f func(client.Object, client.Object) bool) predicate.Predicate {
-	return predicate.Funcs{
-		UpdateFunc: func(event event.UpdateEvent) bool {
-			return f(event.ObjectOld, event.ObjectNew)
-		},
-		CreateFunc: func(event event.CreateEvent) bool {
-			return false
-		},
-		DeleteFunc: func(event event.DeleteEvent) bool {
-			return false
-		},
-		GenericFunc: func(event event.GenericEvent) bool {
-			return false
 		},
 	}
 }
@@ -116,19 +88,20 @@ func (f FalsePredicate) Generic(event.GenericEvent) bool {
 	return false
 }
 
-func NewCreateEventPredicate(f func(client.Object) bool) predicate.Predicate {
+// NewGenericEventPredicate creates a new Predicate that checks the Generic event with the provided func
+func NewGenericEventPredicate(f func(object client.Object) bool) predicate.Predicate {
 	return predicate.Funcs{
-		CreateFunc: func(event event.CreateEvent) bool {
+		GenericFunc: func(event event.GenericEvent) bool {
 			return f(event.Object)
 		},
-		DeleteFunc: func(event event.DeleteEvent) bool {
-			return false
-		},
-		GenericFunc: func(event event.GenericEvent) bool {
-			return false
-		},
+	}
+}
+
+// NewUpdateEventPredicate creates a new Predicate that checks the Update event with the provided func
+func NewUpdateEventPredicate(f func(objectOld client.Object, objectNew client.Object) bool) predicate.Predicate {
+	return predicate.Funcs{
 		UpdateFunc: func(event event.UpdateEvent) bool {
-			return false
+			return f(event.ObjectOld, event.ObjectNew)
 		},
 	}
 }

--- a/pkg/util/kube/predicate_test.go
+++ b/pkg/util/kube/predicate_test.go
@@ -179,14 +179,6 @@ func TestSpecChangePredicate(t *testing.T) {
 	}
 }
 
-func TestNewGenericEventPredicate(t *testing.T) {
-	predicate := NewGenericEventPredicate(func(object client.Object) bool {
-		return false
-	})
-
-	assert.False(t, predicate.Generic(event.GenericEvent{}))
-}
-
 func TestNewAllEventPredicate(t *testing.T) {
 	predicate := NewAllEventPredicate(func(object client.Object) bool {
 		return false
@@ -196,4 +188,26 @@ func TestNewAllEventPredicate(t *testing.T) {
 	assert.False(t, predicate.Update(event.UpdateEvent{}))
 	assert.False(t, predicate.Delete(event.DeleteEvent{}))
 	assert.False(t, predicate.Generic(event.GenericEvent{}))
+}
+
+func TestNewGenericEventPredicate(t *testing.T) {
+	predicate := NewGenericEventPredicate(func(object client.Object) bool {
+		return false
+	})
+
+	assert.False(t, predicate.Generic(event.GenericEvent{}))
+	assert.True(t, predicate.Update(event.UpdateEvent{}))
+	assert.True(t, predicate.Create(event.CreateEvent{}))
+	assert.True(t, predicate.Delete(event.DeleteEvent{}))
+}
+
+func TestNewUpdateEventPredicate(t *testing.T) {
+	predicate := NewUpdateEventPredicate(func(client.Object, client.Object) bool {
+		return false
+	})
+
+	assert.False(t, predicate.Update(event.UpdateEvent{}))
+	assert.True(t, predicate.Create(event.CreateEvent{}))
+	assert.True(t, predicate.Delete(event.DeleteEvent{}))
+	assert.True(t, predicate.Generic(event.GenericEvent{}))
 }


### PR DESCRIPTION
Mark BackupRepository not ready when BSL changed

Fixes #8860

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
