### PR TITLE
fix: update mc command in minio-deployment example

### DIFF
--- a/changelogs/unreleased/8982-vishal-chdhry
+++ b/changelogs/unreleased/8982-vishal-chdhry
@@ -1,0 +1,1 @@
+fix: update mc command in minio-deployment example

--- a/examples/minio/00-minio-deployment.yaml
+++ b/examples/minio/00-minio-deployment.yaml
@@ -107,7 +107,7 @@ spec:
         command:
         - /bin/sh
         - -c
-        - "mc --config-dir=/config config host add velero http://minio:9000 minio minio123 && mc --config-dir=/config mb -p velero/velero"
+        - "mc --config-dir=/config alias set velero http://minio:9000 minio minio123 && mc --config-dir=/config mb -p velero/velero"
         volumeMounts:
         - name: config
           mountPath: "/config"


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

Minio recently removed `config` subccommand from `mc` command: https://github.com/minio/mc/issues/5206. This PR updates the commands in minio-setup example to use alias instead of config
# Does your change fix a particular issue?

No

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
