### PR TITLE
Add .config/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,8 @@ debug.test*
 
 # make lint cache
 .cache/
+
+# Go telemetry directory created when container sets HOME to working directory
+# This happens because Makefile uses 'docker run -w /github.com/vmware-tanzu/velero'
+# and Go's os.UserConfigDir() falls back to $HOME/.config when XDG_CONFIG_HOME is unset
+.config/


### PR DESCRIPTION
Thank you for contributing to Velero\!

# Please add a summary of your change

Add `.config/` directory to `.gitignore` with detailed explanation of why this directory gets created during builds.

The `.config/` directory is created by Go's telemetry system when the Makefile uses `docker run -w /github.com/vmware-tanzu/velero`. This sets the container's HOME environment variable to the working directory, causing Go's `os.UserConfigDir()` to fall back to `$HOME/.config` when `XDG_CONFIG_HOME` is unset, creating `.config/` in the project root.

# Does your change fix a particular issue?

This prevents the `.config/` directory (created during builds) from appearing as an untracked file in git status.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.