### PR TITLE
Fixes #(8816) When specifying LabelSelector on restore, related items such as PVC and VolumeSnapshot are not included

### DIFF
--- a/changelogs/unreleased/9024-amastbau
+++ b/changelogs/unreleased/9024-amastbau
@@ -1,0 +1,1 @@
+Fix Issue 8816 When specifying LabelSelector on restore, related items such as PVC and VolumeSnapshot are not included

--- a/pkg/backup/actions/csi/pvc_action.go
+++ b/pkg/backup/actions/csi/pvc_action.go
@@ -42,9 +42,11 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	velerov2alpha1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v2alpha1"
-	"github.com/vmware-tanzu/velero/pkg/client"
+	veleroclient "github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/kuberesource"
 	"github.com/vmware-tanzu/velero/pkg/label"
 	plugincommon "github.com/vmware-tanzu/velero/pkg/plugin/framework/common"
@@ -267,6 +269,21 @@ func (p *pvcBackupItemAction) Execute(
 		return nil, nil, "", nil, err
 	}
 
+	// Wait until VS associated VSC snapshot handle created before
+	// continue.we later require the vsc restore size
+	vsc, err := csi.WaitUntilVSCHandleIsReady(
+		vs,
+		p.crClient,
+		p.log,
+		backup.Spec.CSISnapshotTimeout.Duration,
+	)
+	if err != nil {
+		p.log.Errorf("Failed to wait for VolumeSnapshot %s/%s to become ReadyToUse within timeout %v: %s",
+			vs.Namespace, vs.Name, backup.Spec.CSISnapshotTimeout.Duration, err.Error())
+		csi.CleanupVolumeSnapshot(vs, p.crClient, p.log)
+		return nil, nil, "", nil, errors.WithStack(err)
+	}
+
 	labels := map[string]string{
 		velerov1api.VolumeSnapshotLabel: vs.Name,
 		velerov1api.BackupNameLabel:     backup.Name,
@@ -293,23 +310,6 @@ func (p *pvcBackupItemAction) Execute(
 			"Operation ID":   operationID,
 			"Backup":         backup.Name,
 		})
-
-		// Wait until VS associated VSC snapshot handle created before
-		// returning with the Async operation for data mover.
-		vsc, err := csi.WaitUntilVSCHandleIsReady(
-			vs,
-			p.crClient,
-			p.log,
-			backup.Spec.CSISnapshotTimeout.Duration,
-		)
-		if err != nil {
-			dataUploadLog.Errorf(
-				"Fail to wait VolumeSnapshot turned to ReadyToUse: %s",
-				err.Error(),
-			)
-			csi.CleanupVolumeSnapshot(vs, p.crClient, p.log)
-			return nil, nil, "", nil, errors.WithStack(err)
-		}
 
 		dataUploadLog.Info("Starting data upload of backup")
 
@@ -355,6 +355,8 @@ func (p *pvcBackupItemAction) Execute(
 			dataUploadLog.Info("DataUpload is submitted successfully.")
 		}
 	} else {
+		setPVCRequestSizeToVSRestoreSize(&pvc, vsc, p.log)
+
 		additionalItems = []velero.ResourceIdentifier{
 			{
 				GroupResource: kuberesource.VolumeSnapshots,
@@ -571,7 +573,7 @@ func cancelDataUpload(
 	return nil
 }
 
-func NewPvcBackupItemAction(f client.Factory) plugincommon.HandlerInitializer {
+func NewPvcBackupItemAction(f veleroclient.Factory) plugincommon.HandlerInitializer {
 	return func(logger logrus.FieldLogger) (any, error) {
 		crClient, err := f.KubebuilderClient()
 		if err != nil {
@@ -1035,4 +1037,46 @@ func (p *pvcBackupItemAction) getVGSByLabels(ctx context.Context, namespace stri
 	}
 
 	return &vgsList.Items[0], nil
+}
+
+func setPVCRequestSizeToVSRestoreSize(
+	pvc *corev1api.PersistentVolumeClaim,
+	vsc *snapshotv1api.VolumeSnapshotContent,
+	logger logrus.FieldLogger,
+) {
+	if vsc.Status.RestoreSize != nil {
+		logger.Debugf("Patching PVC request size to fit the volumesnapshot restore size %d", vsc.Status.RestoreSize)
+		restoreSize := *resource.NewQuantity(*vsc.Status.RestoreSize, resource.BinarySI)
+
+		// It is possible that the volume provider allocated a larger
+		// capacity volume than what was requested in the backed up PVC.
+		// In this scenario the volumesnapshot of the PVC will end being
+		// larger than its requested storage size.  Such a PVC, on restore
+		// as-is, will be stuck attempting to use a VolumeSnapshot as a
+		// data source for a PVC that is not large enough.
+		// To counter that, here we set the storage request on the PVC
+		// to the larger of the PVC's storage request and the size of the
+		// VolumeSnapshot
+		setPVCStorageResourceRequest(pvc, restoreSize, logger)
+	}
+}
+
+func setPVCStorageResourceRequest(
+	pvc *corev1api.PersistentVolumeClaim,
+	restoreSize resource.Quantity,
+	log logrus.FieldLogger,
+) {
+	{
+		if pvc.Spec.Resources.Requests == nil {
+			pvc.Spec.Resources.Requests = corev1api.ResourceList{}
+		}
+
+		storageReq, exists := pvc.Spec.Resources.Requests[corev1api.ResourceStorage]
+		if !exists || storageReq.Cmp(restoreSize) < 0 {
+			pvc.Spec.Resources.Requests[corev1api.ResourceStorage] = restoreSize
+			rs := pvc.Spec.Resources.Requests[corev1api.ResourceStorage]
+			log.Infof("Resetting storage requests for PVC %s/%s to %s",
+				pvc.Namespace, pvc.Name, rs.String())
+		}
+	}
 }

--- a/pkg/restore/actions/csi/pvc_action.go
+++ b/pkg/restore/actions/csi/pvc_action.go
@@ -22,10 +22,10 @@ import (
 	"fmt"
 
 	snapshotv1api "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	corev1api "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -36,6 +36,7 @@ import (
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	velerov2alpha1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v2alpha1"
 	"github.com/vmware-tanzu/velero/pkg/client"
+	kuberesource "github.com/vmware-tanzu/velero/pkg/kuberesource"
 	"github.com/vmware-tanzu/velero/pkg/label"
 	plugincommon "github.com/vmware-tanzu/velero/pkg/plugin/framework/common"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
@@ -63,39 +64,6 @@ func (p *pvcRestoreItemAction) AppliesTo() (velero.ResourceSelector, error) {
 		IncludedResources: []string{"persistentvolumeclaims"},
 		//TODO: add label selector volumeSnapshotLabel
 	}, nil
-}
-
-func resetPVCSpec(pvc *corev1api.PersistentVolumeClaim, vsName string) {
-	// Restore operation for the PVC will use the VolumeSnapshot as the data source.
-	// So clear out the volume name, which is a ref to the PV
-	pvc.Spec.VolumeName = ""
-	dataSource := &corev1api.TypedLocalObjectReference{
-		APIGroup: &snapshotv1api.SchemeGroupVersion.Group,
-		Kind:     "VolumeSnapshot",
-		Name:     vsName,
-	}
-	pvc.Spec.DataSource = dataSource
-	pvc.Spec.DataSourceRef = nil
-}
-
-func setPVCStorageResourceRequest(
-	pvc *corev1api.PersistentVolumeClaim,
-	restoreSize resource.Quantity,
-	log logrus.FieldLogger,
-) {
-	{
-		if pvc.Spec.Resources.Requests == nil {
-			pvc.Spec.Resources.Requests = corev1api.ResourceList{}
-		}
-
-		storageReq, exists := pvc.Spec.Resources.Requests[corev1api.ResourceStorage]
-		if !exists || storageReq.Cmp(restoreSize) < 0 {
-			pvc.Spec.Resources.Requests[corev1api.ResourceStorage] = restoreSize
-			rs := pvc.Spec.Resources.Requests[corev1api.ResourceStorage]
-			log.Infof("Resetting storage requests for PVC %s/%s to %s",
-				pvc.Namespace, pvc.Name, rs.String())
-		}
-	}
 }
 
 // Execute modifies the PVC's spec to use the VolumeSnapshot object as the
@@ -139,6 +107,7 @@ func (p *pvcRestoreItemAction) Execute(
 
 	operationID := ""
 
+	additionalItems := []velero.ResourceIdentifier{}
 	if boolptr.IsSetToFalse(input.Restore.Spec.RestorePVs) {
 		logger.Info("Restore did not request for PVs to be restored from snapshot")
 		pvc.Spec.VolumeName = ""
@@ -186,24 +155,27 @@ func (p *pvcRestoreItemAction) Execute(
 			logger.Infof("DataDownload %s/%s is created successfully.",
 				dataDownload.Namespace, dataDownload.Name)
 		} else {
-			targetVSName := ""
-			if vsName, nameOK := pvcFromBackup.Annotations[velerov1api.VolumeSnapshotLabel]; nameOK {
-				targetVSName = util.GenerateSha256FromRestoreUIDAndVsName(string(input.Restore.UID), vsName)
-			} else {
-				logger.Info("Skipping PVCRestoreItemAction for PVC,",
-					"PVC does not have a CSI VolumeSnapshot.")
-				// Make no change in the input PVC.
+			//CSI restore
+			vsName, nameOK := pvcFromBackup.Annotations[velerov1api.VolumeSnapshotLabel]
+			if !nameOK {
+				logger.Info("Skipping PVCRestoreItemAction for PVC, PVC does not have a CSI VolumeSnapshot.")
 				return &velero.RestoreItemActionExecuteOutput{
 					UpdatedItem: input.Item,
 				}, nil
 			}
 
-			if err := restoreFromVolumeSnapshot(
-				&pvc, newNamespace, p.crClient, targetVSName, logger,
-			); err != nil {
-				logger.Errorf("Failed to restore PVC from VolumeSnapshot.")
-				return nil, errors.WithStack(err)
-			}
+			//To avoid confilcs, vs and vsc get a new uniq name based in restore UID
+			// and vs name old name
+			newVSName := util.GenerateSha256FromRestoreUIDAndVsName(string(input.Restore.UID), vsName)
+
+			p.log.Debugf("Setting PVC source to VolumeSnapshot new name: %s", newVSName)
+			resetPVCSourceToVolumeSnapshot(&pvc, newVSName)
+
+			additionalItems = append(additionalItems, velero.ResourceIdentifier{
+				GroupResource: kuberesource.VolumeSnapshots,
+				Name:          vsName,
+				Namespace:     pvc.Namespace,
+			})
 		}
 	}
 
@@ -214,9 +186,23 @@ func (p *pvcRestoreItemAction) Execute(
 	logger.Info("Returning from PVCRestoreItemAction for PVC")
 
 	return &velero.RestoreItemActionExecuteOutput{
-		UpdatedItem: &unstructured.Unstructured{Object: pvcMap},
-		OperationID: operationID,
+		UpdatedItem:     &unstructured.Unstructured{Object: pvcMap},
+		OperationID:     operationID,
+		AdditionalItems: additionalItems,
 	}, nil
+}
+
+func resetPVCSourceToVolumeSnapshot(pvc *corev1api.PersistentVolumeClaim, vsName string) {
+	// Restore operation for the PVC will use the VolumeSnapshot as the data source.
+	// So clear out the volume name, which is a ref to the PV
+	pvc.Spec.VolumeName = ""
+	dataSource := &corev1api.TypedLocalObjectReference{
+		APIGroup: &snapshotv1api.SchemeGroupVersion.Group,
+		Kind:     "VolumeSnapshot",
+		Name:     vsName,
+	}
+	pvc.Spec.DataSource = dataSource
+	pvc.Spec.DataSourceRef = nil
 }
 
 func (p *pvcRestoreItemAction) Name() string {
@@ -454,50 +440,6 @@ func newDataDownload(
 		dataDownload.Spec.DataMoverConfig = uploaderUtil.StoreRestoreConfig(restore.Spec.UploaderConfig)
 	}
 	return dataDownload
-}
-
-func restoreFromVolumeSnapshot(
-	pvc *corev1api.PersistentVolumeClaim,
-	newNamespace string,
-	crClient crclient.Client,
-	volumeSnapshotName string,
-	logger logrus.FieldLogger,
-) error {
-	vs := new(snapshotv1api.VolumeSnapshot)
-	if err := crClient.Get(context.TODO(),
-		crclient.ObjectKey{
-			Namespace: newNamespace,
-			Name:      volumeSnapshotName,
-		},
-		vs,
-	); err != nil {
-		return errors.Wrapf(err, "Failed to get Volumesnapshot %s/%s to restore PVC %s/%s",
-			newNamespace, volumeSnapshotName, newNamespace, pvc.Name)
-	}
-
-	if _, exists := vs.Annotations[velerov1api.VolumeSnapshotRestoreSize]; exists {
-		restoreSize, err := resource.ParseQuantity(
-			vs.Annotations[velerov1api.VolumeSnapshotRestoreSize])
-		if err != nil {
-			return errors.Wrapf(err,
-				"Failed to parse %s from annotation on Volumesnapshot %s/%s into restore size",
-				vs.Annotations[velerov1api.VolumeSnapshotRestoreSize], vs.Namespace, vs.Name)
-		}
-		// It is possible that the volume provider allocated a larger
-		// capacity volume than what was requested in the backed up PVC.
-		// In this scenario the volumesnapshot of the PVC will end being
-		// larger than its requested storage size.  Such a PVC, on restore
-		// as-is, will be stuck attempting to use a VolumeSnapshot as a
-		// data source for a PVC that is not large enough.
-		// To counter that, here we set the storage request on the PVC
-		// to the larger of the PVC's storage request and the size of the
-		// VolumeSnapshot
-		setPVCStorageResourceRequest(pvc, restoreSize, logger)
-	}
-
-	resetPVCSpec(pvc, volumeSnapshotName)
-
-	return nil
 }
 
 func restoreFromDataUploadResult(

--- a/pkg/restore/actions/csi/pvc_action_test.go
+++ b/pkg/restore/actions/csi/pvc_action_test.go
@@ -154,7 +154,7 @@ func TestResetPVCSpec(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			before := tc.pvc.DeepCopy()
-			resetPVCSpec(&tc.pvc, tc.vsName)
+			resetPVCSourceToVolumeSnapshot(&tc.pvc, tc.vsName)
 
 			assert.Equalf(t, tc.pvc.Name, before.Name, "unexpected change to Object.Name, Want: %s; Got %s", before.Name, tc.pvc.Name)
 			assert.Equalf(t, tc.pvc.Namespace, before.Namespace, "unexpected change to Object.Namespace, Want: %s; Got %s", before.Namespace, tc.pvc.Namespace)
@@ -166,101 +166,6 @@ func TestResetPVCSpec(t *testing.T) {
 			assert.NotNil(t, tc.pvc.Spec.DataSource, "expected change to Spec.DataSource missing")
 			assert.Equalf(t, "VolumeSnapshot", tc.pvc.Spec.DataSource.Kind, "expected change to Spec.DataSource.Kind missing, Want: VolumeSnapshot, Got: %s", tc.pvc.Spec.DataSource.Kind)
 			assert.Equalf(t, tc.pvc.Spec.DataSource.Name, tc.vsName, "expected change to Spec.DataSource.Name missing, Want: %s, Got: %s", tc.vsName, tc.pvc.Spec.DataSource.Name)
-		})
-	}
-}
-
-func TestResetPVCResourceRequest(t *testing.T) {
-	var storageReq50Mi, storageReq1Gi, cpuQty resource.Quantity
-
-	storageReq50Mi, err := resource.ParseQuantity("50Mi")
-	require.NoError(t, err)
-	storageReq1Gi, err = resource.ParseQuantity("1Gi")
-	require.NoError(t, err)
-	cpuQty, err = resource.ParseQuantity("100m")
-	require.NoError(t, err)
-
-	testCases := []struct {
-		name                      string
-		pvc                       corev1api.PersistentVolumeClaim
-		restoreSize               resource.Quantity
-		expectedStorageRequestQty string
-	}{
-		{
-			name: "should set storage resource request from volumesnapshot, pvc has nil resource requests",
-			pvc: corev1api.PersistentVolumeClaim{
-				Spec: corev1api.PersistentVolumeClaimSpec{
-					Resources: corev1api.VolumeResourceRequirements{
-						Requests: nil,
-					},
-				},
-			},
-			restoreSize:               storageReq50Mi,
-			expectedStorageRequestQty: "50Mi",
-		},
-		{
-			name: "should set storage resource request from volumesnapshot, pvc has empty resource requests",
-			pvc: corev1api.PersistentVolumeClaim{
-				Spec: corev1api.PersistentVolumeClaimSpec{
-					Resources: corev1api.VolumeResourceRequirements{
-						Requests: corev1api.ResourceList{},
-					},
-				},
-			},
-			restoreSize:               storageReq50Mi,
-			expectedStorageRequestQty: "50Mi",
-		},
-		{
-			name: "should merge resource requests from volumesnapshot into pvc with no storage resource requests",
-			pvc: corev1api.PersistentVolumeClaim{
-				Spec: corev1api.PersistentVolumeClaimSpec{
-					Resources: corev1api.VolumeResourceRequirements{
-						Requests: corev1api.ResourceList{
-							corev1api.ResourceCPU: cpuQty,
-						},
-					},
-				},
-			},
-			restoreSize:               storageReq50Mi,
-			expectedStorageRequestQty: "50Mi",
-		},
-		{
-			name: "should set storage resource request from volumesnapshot, pvc requests less storage",
-			pvc: corev1api.PersistentVolumeClaim{
-				Spec: corev1api.PersistentVolumeClaimSpec{
-					Resources: corev1api.VolumeResourceRequirements{
-						Requests: corev1api.ResourceList{
-							corev1api.ResourceStorage: storageReq50Mi,
-						},
-					},
-				},
-			},
-			restoreSize:               storageReq1Gi,
-			expectedStorageRequestQty: "1Gi",
-		},
-		{
-			name: "should not set storage resource request from volumesnapshot, pvc requests more storage",
-			pvc: corev1api.PersistentVolumeClaim{
-				Spec: corev1api.PersistentVolumeClaimSpec{
-					Resources: corev1api.VolumeResourceRequirements{
-						Requests: corev1api.ResourceList{
-							corev1api.ResourceStorage: storageReq1Gi,
-						},
-					},
-				},
-			},
-			restoreSize:               storageReq50Mi,
-			expectedStorageRequestQty: "1Gi",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			log := logrus.New().WithField("unit-test", tc.name)
-			setPVCStorageResourceRequest(&tc.pvc, tc.restoreSize, log)
-			expected, err := resource.ParseQuantity(tc.expectedStorageRequestQty)
-			require.NoError(t, err)
-			assert.Equal(t, expected, tc.pvc.Spec.Resources.Requests[corev1api.ResourceStorage])
 		})
 	}
 }
@@ -484,13 +389,6 @@ func TestExecute(t *testing.T) {
 			restore:     builder.ForRestore("velero", "testRestore").Backup("testBackup").Result(),
 			pvc:         builder.ForPersistentVolumeClaim("velero", "testPVC").Result(),
 			expectedErr: "fail to get backup for restore: backups.velero.io \"testBackup\" not found",
-		},
-		{
-			name:        "VolumeSnapshot cannot be found",
-			backup:      builder.ForBackup("velero", "testBackup").Result(),
-			restore:     builder.ForRestore("velero", "testRestore").ObjectMeta(builder.WithUID("restoreUID")).Backup("testBackup").Result(),
-			pvc:         builder.ForPersistentVolumeClaim("velero", "testPVC").ObjectMeta(builder.WithAnnotations(velerov1api.VolumeSnapshotLabel, "vsName")).Result(),
-			expectedErr: fmt.Sprintf("Failed to get Volumesnapshot velero/%s to restore PVC velero/testPVC: volumesnapshots.snapshot.storage.k8s.io \"%s\" not found", vsName, vsName),
 		},
 		{
 			name:    "Restore from VolumeSnapshot",

--- a/pkg/restore/actions/csi/volumesnapshot_action.go
+++ b/pkg/restore/actions/csi/volumesnapshot_action.go
@@ -121,7 +121,7 @@ func (p *volumeSnapshotRestoreItemAction) Execute(
 	}
 
 	p.log.Infof(`Returning from VolumeSnapshotRestoreItemAction with 
-		no additionalItems`)
+		VolumeSnapshotContent in additionalItems`)
 
 	return &velero.RestoreItemActionExecuteOutput{
 		UpdatedItem:     &unstructured.Unstructured{Object: vsMap},


### PR DESCRIPTION
This pull request introduces several improvements to the CSI plugin's backup and restore actions to resolve issue #8816.

Key changes include:

- Moves the logic for patching the PVC's request size to the backup action. This is done to resolve a dependency on the VolumeSnapshot's existence during restore, as the snapshot may not have been restored yet when the PVC action runs.
- Includes the associated VolumeSnapshot as an additional item during the CSI PVC backup action to ensure it is always included, even when not applying a label selector.
- Corrects a log message in the VolumeSnapshot CSI action to properly indicate that the associated VolumeSnapshotContent is also included in the backup.

Fixes #8816

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
