### PR TITLE
[Readme update] Add image registry proxy option to E2E test configuration

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -80,6 +80,7 @@ These configuration parameters are expected as values to the following command l
 1. `--fail-fast`: A switch for for failing fast on meeting error.
 1. `--has-vsphere-plugin`: A switch to indicate whether the Velero vSphere plugin is installed for vSphere environment.
 1. `--worker-os`: A switch to indicate the workload should be ran on windows or linux OS.
+1. `-image-registry-proxy`: pecifies a custom image registry proxy to be used for pulling container images.
 
 These configurations or parameters are used to generate install options for Velero for each test suite.
 
@@ -133,8 +134,7 @@ Below is a mapping between `make` variables to E2E configuration flags.
 1. `FAIL_FAST`: `--fail-fast`. Optional.
 1. `HAS_VSPHERE_PLUGIN`: `--has-vsphere-plugin`. Optional.
 1. `WORKER_OS`: `--worker-os`. Optional.
-
-
+1. `IMAGE_REGISTRY_PROXY`: `-image-registry-proxy.` Optional.
 
 ### Examples
 


### PR DESCRIPTION
Signed-off-by: Priyansh Choudhary <im1706@gmail.com>

This parameter was missing from readme which lets user change the container registry used to pull images. Is necessary when their clusters have policy to block unknown Container registries.

# Does your change fix a particular issue?
No

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.

/kind changelog-not-required