### PR TITLE
Make the backup repository controller doesn't invalidate the BSL on restart

### DIFF
--- a/changelogs/unreleased/9046-blackpiglet
+++ b/changelogs/unreleased/9046-blackpiglet
@@ -1,0 +1,1 @@
+Make the backup repository controller doesn't invalidate the BSL on restart

--- a/pkg/util/kube/predicate.go
+++ b/pkg/util/kube/predicate.go
@@ -98,10 +98,22 @@ func NewGenericEventPredicate(f func(object client.Object) bool) predicate.Predi
 }
 
 // NewUpdateEventPredicate creates a new Predicate that checks the Update event with the provided func
-func NewUpdateEventPredicate(f func(objectOld client.Object, objectNew client.Object) bool) predicate.Predicate {
+func NewUpdateEventPredicate(
+	f func(objectOld client.Object, objectNew client.Object) bool,
+) predicate.Predicate {
 	return predicate.Funcs{
 		UpdateFunc: func(event event.UpdateEvent) bool {
 			return f(event.ObjectOld, event.ObjectNew)
+		},
+	}
+}
+
+func NewCreateEventPredicate(
+	f func(object client.Object) bool,
+) predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(event event.CreateEvent) bool {
+			return f(event.Object)
 		},
 	}
 }

--- a/pkg/util/kube/predicate_test.go
+++ b/pkg/util/kube/predicate_test.go
@@ -202,12 +202,27 @@ func TestNewGenericEventPredicate(t *testing.T) {
 }
 
 func TestNewUpdateEventPredicate(t *testing.T) {
-	predicate := NewUpdateEventPredicate(func(client.Object, client.Object) bool {
-		return false
-	})
+	predicate := NewUpdateEventPredicate(
+		func(client.Object, client.Object) bool {
+			return false
+		},
+	)
 
 	assert.False(t, predicate.Update(event.UpdateEvent{}))
 	assert.True(t, predicate.Create(event.CreateEvent{}))
 	assert.True(t, predicate.Delete(event.DeleteEvent{}))
 	assert.True(t, predicate.Generic(event.GenericEvent{}))
+}
+
+func TestNewCreateEventPredicate(t *testing.T) {
+	predicate := NewCreateEventPredicate(
+		func(client.Object) bool {
+			return false
+		},
+	)
+
+	assert.False(t, predicate.Create(event.CreateEvent{}))
+	assert.True(t, predicate.Update(event.UpdateEvent{}))
+	assert.True(t, predicate.Generic(event.GenericEvent{}))
+	assert.True(t, predicate.Delete(event.DeleteEvent{}))
 }


### PR DESCRIPTION

Enlarge the timeout for maintenance job waiting for BackupRepository's readiness.

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #9032

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
