### PR TITLE
[release-1.16] Allow for proper tracking of multiple hooks per container

### DIFF
--- a/changelogs/unreleased/9060-sseago
+++ b/changelogs/unreleased/9060-sseago
@@ -1,0 +1,1 @@
+Allow for proper tracking of multiple hooks per container

--- a/internal/hook/hook_tracker.go
+++ b/internal/hook/hook_tracker.go
@@ -46,6 +46,9 @@ type hookKey struct {
 	// Container indicates the container hooks use.
 	// For hooks specified in the backup/restore spec, the container might be the same under different hookName.
 	container string
+	// hookIndex contains the slice index for the specific hook, in order to track multiple hooks
+	// for the same container
+	hookIndex int
 }
 
 // hookStatus records the execution status of a specific hook.
@@ -83,7 +86,7 @@ func NewHookTracker() *HookTracker {
 // Add adds a hook to the hook tracker
 // Add must precede the Record for each individual hook.
 // In other words, a hook must be added to the tracker before its execution result is recorded.
-func (ht *HookTracker) Add(podNamespace, podName, container, source, hookName string, hookPhase HookPhase) {
+func (ht *HookTracker) Add(podNamespace, podName, container, source, hookName string, hookPhase HookPhase, hookIndex int) {
 	ht.lock.Lock()
 	defer ht.lock.Unlock()
 
@@ -94,6 +97,7 @@ func (ht *HookTracker) Add(podNamespace, podName, container, source, hookName st
 		container:    container,
 		hookPhase:    hookPhase,
 		hookName:     hookName,
+		hookIndex:    hookIndex,
 	}
 
 	if _, ok := ht.tracker[key]; !ok {
@@ -108,7 +112,7 @@ func (ht *HookTracker) Add(podNamespace, podName, container, source, hookName st
 // Record records the hook's execution status
 // Add must precede the Record for each individual hook.
 // In other words, a hook must be added to the tracker before its execution result is recorded.
-func (ht *HookTracker) Record(podNamespace, podName, container, source, hookName string, hookPhase HookPhase, hookFailed bool, hookErr error) error {
+func (ht *HookTracker) Record(podNamespace, podName, container, source, hookName string, hookPhase HookPhase, hookIndex int, hookFailed bool, hookErr error) error {
 	ht.lock.Lock()
 	defer ht.lock.Unlock()
 
@@ -119,6 +123,7 @@ func (ht *HookTracker) Record(podNamespace, podName, container, source, hookName
 		container:    container,
 		hookPhase:    hookPhase,
 		hookName:     hookName,
+		hookIndex:    hookIndex,
 	}
 
 	if _, ok := ht.tracker[key]; !ok {
@@ -179,24 +184,24 @@ func NewMultiHookTracker() *MultiHookTracker {
 }
 
 // Add adds a backup/restore hook to the tracker
-func (mht *MultiHookTracker) Add(name, podNamespace, podName, container, source, hookName string, hookPhase HookPhase) {
+func (mht *MultiHookTracker) Add(name, podNamespace, podName, container, source, hookName string, hookPhase HookPhase, hookIndex int) {
 	mht.lock.Lock()
 	defer mht.lock.Unlock()
 
 	if _, ok := mht.trackers[name]; !ok {
 		mht.trackers[name] = NewHookTracker()
 	}
-	mht.trackers[name].Add(podNamespace, podName, container, source, hookName, hookPhase)
+	mht.trackers[name].Add(podNamespace, podName, container, source, hookName, hookPhase, hookIndex)
 }
 
 // Record records a backup/restore hook execution status
-func (mht *MultiHookTracker) Record(name, podNamespace, podName, container, source, hookName string, hookPhase HookPhase, hookFailed bool, hookErr error) error {
+func (mht *MultiHookTracker) Record(name, podNamespace, podName, container, source, hookName string, hookPhase HookPhase, hookIndex int, hookFailed bool, hookErr error) error {
 	mht.lock.RLock()
 	defer mht.lock.RUnlock()
 
 	var err error
 	if _, ok := mht.trackers[name]; ok {
-		err = mht.trackers[name].Record(podNamespace, podName, container, source, hookName, hookPhase, hookFailed, hookErr)
+		err = mht.trackers[name].Record(podNamespace, podName, container, source, hookName, hookPhase, hookIndex, hookFailed, hookErr)
 	} else {
 		err = fmt.Errorf("the backup/restore not exist in hook tracker, backup/restore name: %s", name)
 	}

--- a/internal/hook/hook_tracker_test.go
+++ b/internal/hook/hook_tracker_test.go
@@ -33,7 +33,7 @@ func TestNewHookTracker(t *testing.T) {
 func TestHookTracker_Add(t *testing.T) {
 	tracker := NewHookTracker()
 
-	tracker.Add("ns1", "pod1", "container1", HookSourceAnnotation, "h1", "")
+	tracker.Add("ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", 0)
 
 	key := hookKey{
 		podNamespace: "ns1",
@@ -50,8 +50,8 @@ func TestHookTracker_Add(t *testing.T) {
 
 func TestHookTracker_Record(t *testing.T) {
 	tracker := NewHookTracker()
-	tracker.Add("ns1", "pod1", "container1", HookSourceAnnotation, "h1", "")
-	err := tracker.Record("ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", true, fmt.Errorf("err"))
+	tracker.Add("ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", 0)
+	err := tracker.Record("ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", 0, true, fmt.Errorf("err"))
 
 	key := hookKey{
 		podNamespace: "ns1",
@@ -67,10 +67,10 @@ func TestHookTracker_Record(t *testing.T) {
 	assert.True(t, info.hookExecuted)
 	assert.NoError(t, err)
 
-	err = tracker.Record("ns2", "pod2", "container1", HookSourceAnnotation, "h1", "", true, fmt.Errorf("err"))
+	err = tracker.Record("ns2", "pod2", "container1", HookSourceAnnotation, "h1", "", 0, true, fmt.Errorf("err"))
 	assert.Error(t, err)
 
-	err = tracker.Record("ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", false, nil)
+	err = tracker.Record("ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", 0, false, nil)
 	assert.NoError(t, err)
 	assert.True(t, info.hookFailed)
 }
@@ -78,29 +78,30 @@ func TestHookTracker_Record(t *testing.T) {
 func TestHookTracker_Stat(t *testing.T) {
 	tracker := NewHookTracker()
 
-	tracker.Add("ns1", "pod1", "container1", HookSourceAnnotation, "h1", "")
-	tracker.Add("ns2", "pod2", "container1", HookSourceAnnotation, "h2", "")
-	tracker.Record("ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", true, fmt.Errorf("err"))
+	tracker.Add("ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", 0)
+	tracker.Add("ns2", "pod2", "container1", HookSourceAnnotation, "h2", "", 0)
+	tracker.Add("ns2", "pod2", "container1", HookSourceAnnotation, "h2", "", 1)
+	tracker.Record("ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", 0, true, fmt.Errorf("err"))
 
 	attempted, failed := tracker.Stat()
-	assert.Equal(t, 2, attempted)
+	assert.Equal(t, 3, attempted)
 	assert.Equal(t, 1, failed)
 }
 
 func TestHookTracker_IsComplete(t *testing.T) {
 	tracker := NewHookTracker()
-	tracker.Add("ns1", "pod1", "container1", HookSourceAnnotation, "h1", PhasePre)
-	tracker.Record("ns1", "pod1", "container1", HookSourceAnnotation, "h1", PhasePre, true, fmt.Errorf("err"))
+	tracker.Add("ns1", "pod1", "container1", HookSourceAnnotation, "h1", PhasePre, 0)
+	tracker.Record("ns1", "pod1", "container1", HookSourceAnnotation, "h1", PhasePre, 0, true, fmt.Errorf("err"))
 	assert.True(t, tracker.IsComplete())
 
-	tracker.Add("ns1", "pod1", "container1", HookSourceAnnotation, "h1", "")
+	tracker.Add("ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", 0)
 	assert.False(t, tracker.IsComplete())
 }
 
 func TestHookTracker_HookErrs(t *testing.T) {
 	tracker := NewHookTracker()
-	tracker.Add("ns1", "pod1", "container1", HookSourceAnnotation, "h1", "")
-	tracker.Record("ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", true, fmt.Errorf("err"))
+	tracker.Add("ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", 0)
+	tracker.Record("ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", 0, true, fmt.Errorf("err"))
 
 	hookErrs := tracker.HookErrs()
 	assert.Len(t, hookErrs, 1)
@@ -109,7 +110,7 @@ func TestHookTracker_HookErrs(t *testing.T) {
 func TestMultiHookTracker_Add(t *testing.T) {
 	mht := NewMultiHookTracker()
 
-	mht.Add("restore1", "ns1", "pod1", "container1", HookSourceAnnotation, "h1", "")
+	mht.Add("restore1", "ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", 0)
 
 	key := hookKey{
 		podNamespace: "ns1",
@@ -118,6 +119,7 @@ func TestMultiHookTracker_Add(t *testing.T) {
 		hookPhase:    "",
 		hookSource:   HookSourceAnnotation,
 		hookName:     "h1",
+		hookIndex:    0,
 	}
 
 	_, ok := mht.trackers["restore1"].tracker[key]
@@ -126,8 +128,8 @@ func TestMultiHookTracker_Add(t *testing.T) {
 
 func TestMultiHookTracker_Record(t *testing.T) {
 	mht := NewMultiHookTracker()
-	mht.Add("restore1", "ns1", "pod1", "container1", HookSourceAnnotation, "h1", "")
-	err := mht.Record("restore1", "ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", true, fmt.Errorf("err"))
+	mht.Add("restore1", "ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", 0)
+	err := mht.Record("restore1", "ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", 0, true, fmt.Errorf("err"))
 
 	key := hookKey{
 		podNamespace: "ns1",
@@ -136,6 +138,7 @@ func TestMultiHookTracker_Record(t *testing.T) {
 		hookPhase:    "",
 		hookSource:   HookSourceAnnotation,
 		hookName:     "h1",
+		hookIndex:    0,
 	}
 
 	info := mht.trackers["restore1"].tracker[key]
@@ -143,29 +146,31 @@ func TestMultiHookTracker_Record(t *testing.T) {
 	assert.True(t, info.hookExecuted)
 	assert.NoError(t, err)
 
-	err = mht.Record("restore1", "ns2", "pod2", "container1", HookSourceAnnotation, "h1", "", true, fmt.Errorf("err"))
+	err = mht.Record("restore1", "ns2", "pod2", "container1", HookSourceAnnotation, "h1", "", 0, true, fmt.Errorf("err"))
 	assert.Error(t, err)
 
-	err = mht.Record("restore2", "ns2", "pod2", "container1", HookSourceAnnotation, "h1", "", true, fmt.Errorf("err"))
+	err = mht.Record("restore2", "ns2", "pod2", "container1", HookSourceAnnotation, "h1", "", 0, true, fmt.Errorf("err"))
 	assert.Error(t, err)
 }
 
 func TestMultiHookTracker_Stat(t *testing.T) {
 	mht := NewMultiHookTracker()
 
-	mht.Add("restore1", "ns1", "pod1", "container1", HookSourceAnnotation, "h1", "")
-	mht.Add("restore1", "ns2", "pod2", "container1", HookSourceAnnotation, "h2", "")
-	mht.Record("restore1", "ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", true, fmt.Errorf("err"))
-	mht.Record("restore1", "ns2", "pod2", "container1", HookSourceAnnotation, "h2", "", false, nil)
+	mht.Add("restore1", "ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", 0)
+	mht.Add("restore1", "ns2", "pod2", "container1", HookSourceAnnotation, "h2", "", 0)
+	mht.Add("restore1", "ns2", "pod2", "container1", HookSourceAnnotation, "h2", "", 1)
+	mht.Record("restore1", "ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", 0, true, fmt.Errorf("err"))
+	mht.Record("restore1", "ns2", "pod2", "container1", HookSourceAnnotation, "h2", "", 0, false, nil)
+	mht.Record("restore1", "ns2", "pod2", "container1", HookSourceAnnotation, "h2", "", 1, false, nil)
 
 	attempted, failed := mht.Stat("restore1")
-	assert.Equal(t, 2, attempted)
+	assert.Equal(t, 3, attempted)
 	assert.Equal(t, 1, failed)
 }
 
 func TestMultiHookTracker_Delete(t *testing.T) {
 	mht := NewMultiHookTracker()
-	mht.Add("restore1", "ns1", "pod1", "container1", HookSourceAnnotation, "h1", "")
+	mht.Add("restore1", "ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", 0)
 	mht.Delete("restore1")
 
 	_, ok := mht.trackers["restore1"]
@@ -174,11 +179,11 @@ func TestMultiHookTracker_Delete(t *testing.T) {
 
 func TestMultiHookTracker_IsComplete(t *testing.T) {
 	mht := NewMultiHookTracker()
-	mht.Add("backup1", "ns1", "pod1", "container1", HookSourceAnnotation, "h1", PhasePre)
-	mht.Record("backup1", "ns1", "pod1", "container1", HookSourceAnnotation, "h1", PhasePre, true, fmt.Errorf("err"))
+	mht.Add("backup1", "ns1", "pod1", "container1", HookSourceAnnotation, "h1", PhasePre, 0)
+	mht.Record("backup1", "ns1", "pod1", "container1", HookSourceAnnotation, "h1", PhasePre, 0, true, fmt.Errorf("err"))
 	assert.True(t, mht.IsComplete("backup1"))
 
-	mht.Add("restore1", "ns1", "pod1", "container1", HookSourceAnnotation, "h1", "")
+	mht.Add("restore1", "ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", 0)
 	assert.False(t, mht.IsComplete("restore1"))
 
 	assert.True(t, mht.IsComplete("restore2"))
@@ -186,8 +191,8 @@ func TestMultiHookTracker_IsComplete(t *testing.T) {
 
 func TestMultiHookTracker_HookErrs(t *testing.T) {
 	mht := NewMultiHookTracker()
-	mht.Add("restore1", "ns1", "pod1", "container1", HookSourceAnnotation, "h1", "")
-	mht.Record("restore1", "ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", true, fmt.Errorf("err"))
+	mht.Add("restore1", "ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", 0)
+	mht.Record("restore1", "ns1", "pod1", "container1", HookSourceAnnotation, "h1", "", 0, true, fmt.Errorf("err"))
 
 	hookErrs := mht.HookErrs("restore1")
 	assert.Len(t, hookErrs, 1)

--- a/internal/hook/item_hook_handler_test.go
+++ b/internal/hook/item_hook_handler_test.go
@@ -1151,6 +1151,7 @@ func TestGroupRestoreExecHooks(t *testing.T) {
 							WaitTimeout:  metav1.Duration{Duration: time.Minute},
 							WaitForReady: boolptr.False(),
 						},
+						hookIndex: 0,
 					},
 					{
 						HookName:   "hook1",
@@ -1163,6 +1164,7 @@ func TestGroupRestoreExecHooks(t *testing.T) {
 							WaitTimeout:  metav1.Duration{Duration: time.Minute * 2},
 							WaitForReady: boolptr.False(),
 						},
+						hookIndex: 2,
 					},
 					{
 						HookName:   "hook2",
@@ -1175,6 +1177,7 @@ func TestGroupRestoreExecHooks(t *testing.T) {
 							WaitTimeout:  metav1.Duration{Duration: time.Minute * 4},
 							WaitForReady: boolptr.True(),
 						},
+						hookIndex: 0,
 					},
 				},
 				"container2": {
@@ -1189,6 +1192,7 @@ func TestGroupRestoreExecHooks(t *testing.T) {
 							WaitTimeout:  metav1.Duration{Duration: time.Second * 3},
 							WaitForReady: boolptr.False(),
 						},
+						hookIndex: 1,
 					},
 				},
 			},

--- a/internal/hook/wait_exec_hook_handler.go
+++ b/internal/hook/wait_exec_hook_handler.go
@@ -169,7 +169,7 @@ func (e *DefaultWaitExecHookHandler) HandleHooks(
 					hookLog.Error(err)
 					errors = append(errors, err)
 
-					errTracker := multiHookTracker.Record(restoreName, newPod.Namespace, newPod.Name, hook.Hook.Container, hook.HookSource, hook.HookName, HookPhase(""), true, err)
+					errTracker := multiHookTracker.Record(restoreName, newPod.Namespace, newPod.Name, hook.Hook.Container, hook.HookSource, hook.HookName, HookPhase(""), i, true, err)
 					if errTracker != nil {
 						hookLog.WithError(errTracker).Warn("Error recording the hook in hook tracker")
 					}
@@ -195,7 +195,7 @@ func (e *DefaultWaitExecHookHandler) HandleHooks(
 					hookFailed = true
 				}
 
-				errTracker := multiHookTracker.Record(restoreName, newPod.Namespace, newPod.Name, hook.Hook.Container, hook.HookSource, hook.HookName, HookPhase(""), hookFailed, hookErr)
+				errTracker := multiHookTracker.Record(restoreName, newPod.Namespace, newPod.Name, hook.Hook.Container, hook.HookSource, hook.HookName, HookPhase(""), i, hookFailed, hookErr)
 				if errTracker != nil {
 					hookLog.WithError(errTracker).Warn("Error recording the hook in hook tracker")
 				}
@@ -239,7 +239,7 @@ func (e *DefaultWaitExecHookHandler) HandleHooks(
 	// containers to become ready.
 	// Each unexecuted hook is logged as an error and this error will be returned from this function.
 	for _, hooks := range byContainer {
-		for _, hook := range hooks {
+		for i, hook := range hooks {
 			if hook.executed {
 				continue
 			}
@@ -252,7 +252,7 @@ func (e *DefaultWaitExecHookHandler) HandleHooks(
 				},
 			)
 
-			errTracker := multiHookTracker.Record(restoreName, pod.Namespace, pod.Name, hook.Hook.Container, hook.HookSource, hook.HookName, HookPhase(""), true, err)
+			errTracker := multiHookTracker.Record(restoreName, pod.Namespace, pod.Name, hook.Hook.Container, hook.HookSource, hook.HookName, HookPhase(""), i, true, err)
 			if errTracker != nil {
 				hookLog.WithError(errTracker).Warn("Error recording the hook in hook tracker")
 			}

--- a/internal/hook/wait_exec_hook_handler_test.go
+++ b/internal/hook/wait_exec_hook_handler_test.go
@@ -1007,17 +1007,17 @@ func TestRestoreHookTrackerUpdate(t *testing.T) {
 	}
 
 	hookTracker1 := NewMultiHookTracker()
-	hookTracker1.Add("restore1", "default", "my-pod", "container1", HookSourceAnnotation, "<from-annotation>", HookPhase(""))
+	hookTracker1.Add("restore1", "default", "my-pod", "container1", HookSourceAnnotation, "<from-annotation>", HookPhase(""), 0)
 
 	hookTracker2 := NewMultiHookTracker()
-	hookTracker2.Add("restore1", "default", "my-pod", "container1", HookSourceSpec, "my-hook-1", HookPhase(""))
+	hookTracker2.Add("restore1", "default", "my-pod", "container1", HookSourceSpec, "my-hook-1", HookPhase(""), 0)
 
 	hookTracker3 := NewMultiHookTracker()
-	hookTracker3.Add("restore1", "default", "my-pod", "container1", HookSourceSpec, "my-hook-1", HookPhase(""))
-	hookTracker3.Add("restore1", "default", "my-pod", "container2", HookSourceSpec, "my-hook-2", HookPhase(""))
+	hookTracker3.Add("restore1", "default", "my-pod", "container1", HookSourceSpec, "my-hook-1", HookPhase(""), 0)
+	hookTracker3.Add("restore1", "default", "my-pod", "container2", HookSourceSpec, "my-hook-2", HookPhase(""), 0)
 
 	hookTracker4 := NewMultiHookTracker()
-	hookTracker4.Add("restore1", "default", "my-pod", "container1", HookSourceSpec, "my-hook-1", HookPhase(""))
+	hookTracker4.Add("restore1", "default", "my-pod", "container1", HookSourceSpec, "my-hook-1", HookPhase(""), 0)
 
 	tests1 := []struct {
 		name               string

--- a/pkg/controller/restore_finalizer_controller_test.go
+++ b/pkg/controller/restore_finalizer_controller_test.go
@@ -471,14 +471,14 @@ func TestWaitRestoreExecHook(t *testing.T) {
 
 	hookTracker2 := hook.NewMultiHookTracker()
 	restoreName2 := "restore2"
-	hookTracker2.Add(restoreName2, "ns", "pod", "con1", "s1", "h1", "")
-	hookTracker2.Record(restoreName2, "ns", "pod", "con1", "s1", "h1", "", false, nil)
+	hookTracker2.Add(restoreName2, "ns", "pod", "con1", "s1", "h1", "", 0)
+	hookTracker2.Record(restoreName2, "ns", "pod", "con1", "s1", "h1", "", 0, false, nil)
 
 	hookTracker3 := hook.NewMultiHookTracker()
 	restoreName3 := "restore3"
 	podNs, podName, container, source, hookName := "ns", "pod", "con1", "s1", "h1"
 	hookFailed, hookErr := true, fmt.Errorf("hook failed")
-	hookTracker3.Add(restoreName3, podNs, podName, container, source, hookName, hook.PhasePre)
+	hookTracker3.Add(restoreName3, podNs, podName, container, source, hookName, hook.PhasePre, 0)
 
 	tests := []struct {
 		name                   string
@@ -546,7 +546,7 @@ func TestWaitRestoreExecHook(t *testing.T) {
 		if tc.waitSec > 0 {
 			go func() {
 				time.Sleep(time.Second * time.Duration(tc.waitSec))
-				tc.hookTracker.Record(tc.restore.Name, tc.podNs, tc.podName, tc.Container, tc.Source, tc.hookName, hook.PhasePre, tc.hookFailed, tc.hookErr)
+				tc.hookTracker.Record(tc.restore.Name, tc.podNs, tc.podName, tc.Container, tc.Source, tc.hookName, hook.PhasePre, 0, tc.hookFailed, tc.hookErr)
 			}()
 		}
 


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Adds the slice index to the hook tracker key to properly track individual backup/restore hooks when there are multiple hooks for a single container.

# Does your change fix a particular issue?

Fixes #8910

# Please indicate you've done the following:

- [x ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x ] Updated the corresponding documentation in `site/content/docs/main`.
