### PR TITLE
Enable parameterized kubelet mount path during node-agent installation

### DIFF
--- a/pkg/cmd/cli/install/install.go
+++ b/pkg/cmd/cli/install/install.go
@@ -89,6 +89,7 @@ type Options struct {
 	RepoMaintenanceJobConfigMap     string
 	NodeAgentConfigMap              string
 	ItemBlockWorkerCount            int
+	kubeletRootDir                  string
 }
 
 // BindFlags adds command line values to the options struct.
@@ -113,6 +114,8 @@ func (o *Options) BindFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&o.NodeAgentPodMemRequest, "node-agent-pod-mem-request", o.NodeAgentPodMemRequest, `Memory request for node-agent pod. A value of "0" is treated as unbounded. Optional.`)
 	flags.StringVar(&o.NodeAgentPodCPULimit, "node-agent-pod-cpu-limit", o.NodeAgentPodCPULimit, `CPU limit for node-agent pod. A value of "0" is treated as unbounded. Optional.`)
 	flags.StringVar(&o.NodeAgentPodMemLimit, "node-agent-pod-mem-limit", o.NodeAgentPodMemLimit, `Memory limit for node-agent pod. A value of "0" is treated as unbounded. Optional.`)
+	flags.StringVar(&o.kubeletRootDir, "kubelet-root-dir", o.kubeletRootDir, `Kubelet root directory for the node agent. Optional.`)
+
 	flags.Var(&o.BackupStorageConfig, "backup-location-config", "Configuration to use for the backup storage location. Format is key1=value1,key2=value2")
 	flags.Var(&o.VolumeSnapshotConfig, "snapshot-location-config", "Configuration to use for the volume snapshot location. Format is key1=value1,key2=value2")
 	flags.BoolVar(&o.UseVolumeSnapshots, "use-volume-snapshots", o.UseVolumeSnapshots, "Whether or not to create snapshot location automatically. Set to false if you do not plan to create volume snapshots via a storage provider.")
@@ -218,6 +221,7 @@ func NewInstallOptions() *Options {
 		DefaultSnapshotMoveData:  false,
 		DisableInformerCache:     false,
 		ScheduleSkipImmediately:  false,
+		kubeletRootDir:           install.DefaultKubeletRootDir,
 	}
 }
 
@@ -292,6 +296,7 @@ func (o *Options) AsVeleroOptions() (*install.VeleroOptions, error) {
 		RepoMaintenanceJobConfigMap:     o.RepoMaintenanceJobConfigMap,
 		NodeAgentConfigMap:              o.NodeAgentConfigMap,
 		ItemBlockWorkerCount:            o.ItemBlockWorkerCount,
+		KubeletRootDir:                  o.kubeletRootDir,
 	}, nil
 }
 

--- a/pkg/install/daemonset.go
+++ b/pkg/install/daemonset.go
@@ -18,6 +18,7 @@ package install
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	appsv1api "k8s.io/api/apps/v1"
@@ -62,7 +63,8 @@ func DaemonSet(namespace string, opts ...podTemplateOption) *appsv1api.DaemonSet
 	if c.forWindows {
 		dsName = "node-agent-windows"
 	}
-
+	hostPodsVolumePath := filepath.Join(c.kubeletRootDir, "pods")
+	hostPluginsVolumePath := filepath.Join(c.kubeletRootDir, "plugins")
 	daemonSet := &appsv1api.DaemonSet{
 		ObjectMeta: objectMeta(namespace, dsName),
 		TypeMeta: metav1.TypeMeta{
@@ -93,7 +95,7 @@ func DaemonSet(namespace string, opts ...podTemplateOption) *appsv1api.DaemonSet
 							Name: "host-pods",
 							VolumeSource: corev1api.VolumeSource{
 								HostPath: &corev1api.HostPathVolumeSource{
-									Path: "/var/lib/kubelet/pods",
+									Path: hostPodsVolumePath,
 								},
 							},
 						},
@@ -101,7 +103,7 @@ func DaemonSet(namespace string, opts ...podTemplateOption) *appsv1api.DaemonSet
 							Name: "host-plugins",
 							VolumeSource: corev1api.VolumeSource{
 								HostPath: &corev1api.HostPathVolumeSource{
-									Path: "/var/lib/kubelet/plugins",
+									Path: hostPluginsVolumePath,
 								},
 							},
 						},

--- a/pkg/install/daemonset_test.go
+++ b/pkg/install/daemonset_test.go
@@ -61,6 +61,10 @@ func TestDaemonSet(t *testing.T) {
 	ds = DaemonSet("velero", WithServiceAccountName("test-sa"))
 	assert.Equal(t, "test-sa", ds.Spec.Template.Spec.ServiceAccountName)
 
+	ds = DaemonSet("velero", WithKubeletRootDir("/data/test/kubelet"))
+	assert.Equal(t, "/data/test/kubelet/pods", ds.Spec.Template.Spec.Volumes[0].HostPath.Path)
+	assert.Equal(t, "/data/test/kubelet/plugins", ds.Spec.Template.Spec.Volumes[1].HostPath.Path)
+
 	ds = DaemonSet("velero", WithForWindows())
 	assert.Equal(t, "node-agent-windows", ds.Spec.Template.Spec.Containers[0].Name)
 	assert.Equal(t, "velero", ds.ObjectMeta.Namespace)

--- a/pkg/install/deployment.go
+++ b/pkg/install/deployment.go
@@ -59,6 +59,7 @@ type podTemplateConfig struct {
 	nodeAgentConfigMap              string
 	itemBlockWorkerCount            int
 	forWindows                      bool
+	kubeletRootDir                  string
 }
 
 func WithImage(image string) podTemplateOption {
@@ -223,6 +224,12 @@ func WithItemBlockWorkerCount(itemBlockWorkerCount int) podTemplateOption {
 func WithForWindows() podTemplateOption {
 	return func(c *podTemplateConfig) {
 		c.forWindows = true
+	}
+}
+
+func WithKubeletRootDir(kubeletRootDir string) podTemplateOption {
+	return func(c *podTemplateConfig) {
+		c.kubeletRootDir = kubeletRootDir
 	}
 }
 

--- a/pkg/install/resources.go
+++ b/pkg/install/resources.go
@@ -54,6 +54,8 @@ var (
 	DefaultNodeAgentPodMemLimit   = "0"
 
 	DefaultVeleroNamespace = "velero"
+
+	DefaultKubeletRootDir = "/var/lib/kubelet"
 )
 
 func Labels() map[string]string {
@@ -269,6 +271,7 @@ type VeleroOptions struct {
 	RepoMaintenanceJobConfigMap     string
 	NodeAgentConfigMap              string
 	ItemBlockWorkerCount            int
+	KubeletRootDir                  string
 }
 
 func AllCRDs() *unstructured.UnstructuredList {
@@ -413,6 +416,10 @@ func AllResources(o *VeleroOptions) *unstructured.UnstructuredList {
 		}
 		if len(o.NodeAgentConfigMap) > 0 {
 			dsOpts = append(dsOpts, WithNodeAgentConfigMap(o.NodeAgentConfigMap))
+		}
+
+		if len(o.KubeletRootDir) > 0 {
+			dsOpts = append(dsOpts, WithKubeletRootDir(o.KubeletRootDir))
 		}
 
 		if o.UseNodeAgent {

--- a/site/content/docs/main/velero-install.md
+++ b/site/content/docs/main/velero-install.md
@@ -21,6 +21,7 @@ velero install \
     --velero-pod-mem-request <MEMORY_REQUEST> \
     --velero-pod-cpu-limit <CPU_LIMIT> \
     --velero-pod-mem-limit <MEMORY_LIMIT> \
+    --kubelet-root-dir <PATH_TO_KUBELET_ROOT_DIR> \
     [--use-node-agent] \
     [--default-volumes-to-fs-backup] \
     [--node-agent-pod-cpu-request <CPU_REQUEST>] \


### PR DESCRIPTION
# Enables the parameterization of the kubelet mount path during node-agent installation
This PR enables the parameterization of the kubelet mount path during node-agent installation, allowing users to specify custom mount paths through configuration parameters. This addresses scenarios where different Kubernetes environments may use non-standard kubelet directories.

* This change introduces a new configuration parameter `--kubelet-root-dir` during node-agent installation.
* The default value remains unchanged to maintain backward compatibility.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.