### PR TITLE
chore: enable unused-parameter and unused-receiver rules from revive

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -238,7 +238,7 @@ linters:
         - name: unnecessary-stmt
         - name: unreachable-code
         - name: unused-parameter
-          disabled: true
+        - name: unused-receiver
         - name: use-any
         - name: var-declaration
         - name: var-naming
@@ -383,6 +383,10 @@ linters:
         linters:
           - dupword
         text: "bucket"
+      - path: examples_test.go
+        text: unused-parameter
+        linters:
+          - revive
 
     generated: lax
     presets:

--- a/internal/delete/actions/csi/volumesnapshotcontent_action.go
+++ b/internal/delete/actions/csi/volumesnapshotcontent_action.go
@@ -47,7 +47,7 @@ type volumeSnapshotContentDeleteItemAction struct {
 // AppliesTo returns information indicating
 // VolumeSnapshotContentRestoreItemAction action should be invoked
 // while restoring VolumeSnapshotContent.snapshot.storage.k8s.io resources
-func (p *volumeSnapshotContentDeleteItemAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*volumeSnapshotContentDeleteItemAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"volumesnapshotcontents.snapshot.storage.k8s.io"},
 	}, nil

--- a/internal/delete/actions/csi/volumesnapshotcontent_action_test.go
+++ b/internal/delete/actions/csi/volumesnapshotcontent_action_test.go
@@ -74,9 +74,9 @@ func TestVSCExecute(t *testing.T) {
 			backup:    builder.ForBackup("velero", "backup").ObjectMeta(builder.WithAnnotationsMap(map[string]string{velerov1api.ResourceTimeoutAnnotation: "5s"})).Result(),
 			expectErr: false,
 			function: func(
-				ctx context.Context,
-				vsc *snapshotv1api.VolumeSnapshotContent,
-				client crclient.Client,
+				context.Context,
+				*snapshotv1api.VolumeSnapshotContent,
+				crclient.Client,
 			) (bool, error) {
 				return true, nil
 			},
@@ -87,9 +87,9 @@ func TestVSCExecute(t *testing.T) {
 			backup:    builder.ForBackup("velero", "backup").ObjectMeta(builder.WithAnnotationsMap(map[string]string{velerov1api.ResourceTimeoutAnnotation: "5s"})).Result(),
 			expectErr: true,
 			function: func(
-				ctx context.Context,
-				vsc *snapshotv1api.VolumeSnapshotContent,
-				client crclient.Client,
+				context.Context,
+				*snapshotv1api.VolumeSnapshotContent,
+				crclient.Client,
 			) (bool, error) {
 				return false, errors.Errorf("test error case")
 			},

--- a/internal/hook/item_hook_handler.go
+++ b/internal/hook/item_hook_handler.go
@@ -103,7 +103,7 @@ type InitContainerRestoreHookHandler struct{}
 // If the item is a pod, then hooks are chosen to be run as follows:
 // If the pod has the appropriate annotations specifying the hook action, then hooks from the annotation are run
 // Otherwise, the supplied ResourceRestoreHooks are applied.
-func (i *InitContainerRestoreHookHandler) HandleRestoreHooks(
+func (*InitContainerRestoreHookHandler) HandleRestoreHooks(
 	log logrus.FieldLogger,
 	groupResource schema.GroupResource,
 	obj runtime.Unstructured,
@@ -307,13 +307,13 @@ func (h *DefaultItemHookHandler) HandleHooks(
 // NoOpItemHookHandler is the an itemHookHandler for the Finalize controller where hooks don't run
 type NoOpItemHookHandler struct{}
 
-func (h *NoOpItemHookHandler) HandleHooks(
-	log logrus.FieldLogger,
-	groupResource schema.GroupResource,
-	obj runtime.Unstructured,
-	resourceHooks []ResourceHook,
-	phase HookPhase,
-	hookTracker *HookTracker,
+func (*NoOpItemHookHandler) HandleHooks(
+	logrus.FieldLogger,
+	schema.GroupResource,
+	runtime.Unstructured,
+	[]ResourceHook,
+	HookPhase,
+	*HookTracker,
 ) error {
 	return nil
 }

--- a/internal/hook/wait_exec_hook_handler.go
+++ b/internal/hook/wait_exec_hook_handler.go
@@ -223,7 +223,7 @@ func (e *DefaultWaitExecHookHandler) HandleHooks(
 			UpdateFunc: func(_, newObj any) {
 				handler(newObj)
 			},
-			DeleteFunc: func(obj any) {
+			DeleteFunc: func(any) {
 				err := fmt.Errorf("pod %s deleted before all hooks were executed", kube.NamespaceAndName(pod))
 				log.Error(err)
 				cancel()

--- a/internal/hook/wait_exec_hook_handler_test.go
+++ b/internal/hook/wait_exec_hook_handler_test.go
@@ -42,7 +42,7 @@ type fakeListWatchFactory struct {
 	lw cache.ListerWatcher
 }
 
-func (f *fakeListWatchFactory) NewListWatch(ns string, selector fields.Selector) cache.ListerWatcher {
+func (f *fakeListWatchFactory) NewListWatch(string, fields.Selector) cache.ListerWatcher {
 	return f.lw
 }
 

--- a/internal/resourcepolicies/resource_policies.go
+++ b/internal/resourcepolicies/resource_policies.go
@@ -69,7 +69,7 @@ func (p *IncludeExcludePolicy) Validate() error {
 	return p.validateIncludeExclude(p.IncludedNamespaceScopedResources, p.ExcludedNamespaceScopedResources)
 }
 
-func (p *IncludeExcludePolicy) validateIncludeExclude(includesList, excludesList []string) error {
+func (*IncludeExcludePolicy) validateIncludeExclude(includesList, excludesList []string) error {
 	includes := sets.NewString(includesList...)
 	excludes := sets.NewString(excludesList...)
 

--- a/internal/resourcepolicies/volume_resources.go
+++ b/internal/resourcepolicies/volume_resources.go
@@ -106,7 +106,7 @@ func (c *pvcLabelsCondition) match(v *structuredVolume) bool {
 	return selector.Matches(labels.Set(v.pvcLabels))
 }
 
-func (c *pvcLabelsCondition) validate() error {
+func (*pvcLabelsCondition) validate() error {
 	return nil
 }
 

--- a/internal/resourcepolicies/volume_resources_validator.go
+++ b/internal/resourcepolicies/volume_resources_validator.go
@@ -60,12 +60,12 @@ func (c *capacityCondition) validate() error {
 	return errors.Errorf("illegal values for capacity %v", c.capacity)
 }
 
-func (s *storageClassCondition) validate() error {
+func (*storageClassCondition) validate() error {
 	// validate by yamlv3
 	return nil
 }
 
-func (c *nfsCondition) validate() error {
+func (*nfsCondition) validate() error {
 	// validate by yamlv3
 	return nil
 }

--- a/internal/resourcepolicies/volume_types_conditions.go
+++ b/internal/resourcepolicies/volume_types_conditions.go
@@ -72,7 +72,7 @@ func (v *volumeTypeCondition) match(s *structuredVolume) bool {
 	return false
 }
 
-func (v *volumeTypeCondition) validate() error {
+func (*volumeTypeCondition) validate() error {
 	// validate by yamlv3
 	return nil
 }

--- a/internal/storage/storagelocation.go
+++ b/internal/storage/storagelocation.go
@@ -93,7 +93,7 @@ func ListBackupStorageLocations(ctx context.Context, kbClient client.Client, nam
 	return locations, nil
 }
 
-func GetDefaultBackupStorageLocations(ctx context.Context, kbClient client.Client, namespace string) (*velerov1api.BackupStorageLocationList, error) {
+func GetDefaultBackupStorageLocations(_ context.Context, kbClient client.Client, namespace string) (*velerov1api.BackupStorageLocationList, error) {
 	locations := new(velerov1api.BackupStorageLocationList)
 	defaultLocations := new(velerov1api.BackupStorageLocationList)
 	if err := kbClient.List(context.Background(), locations, &client.ListOptions{Namespace: namespace}); err != nil {

--- a/internal/volumehelper/volume_policy_helper.go
+++ b/internal/volumehelper/volume_policy_helper.go
@@ -257,7 +257,7 @@ func (v *volumeHelperImpl) shouldIncludeVolumeInBackup(vol corev1api.Volume) boo
 	return includeVolumeInBackup
 }
 
-func (v *volumeHelperImpl) getVolumeFromResource(resource any) (*corev1api.PersistentVolume, *corev1api.Volume, error) {
+func (*volumeHelperImpl) getVolumeFromResource(resource any) (*corev1api.PersistentVolume, *corev1api.Volume, error) {
 	if pv, ok := resource.(*corev1api.PersistentVolume); ok {
 		return pv, nil, nil
 	} else if podVol, ok := resource.(*corev1api.Volume); ok {

--- a/pkg/backup/actions/backup_pv_action.go
+++ b/pkg/backup/actions/backup_pv_action.go
@@ -40,7 +40,7 @@ func NewPVCAction(logger logrus.FieldLogger) *PVCAction {
 	return &PVCAction{log: logger}
 }
 
-func (a *PVCAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*PVCAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"persistentvolumeclaims"},
 	}, nil
@@ -48,7 +48,7 @@ func (a *PVCAction) AppliesTo() (velero.ResourceSelector, error) {
 
 // Execute finds the PersistentVolume bound by the provided
 // PersistentVolumeClaim, if any, and backs it up
-func (a *PVCAction) Execute(item runtime.Unstructured, backup *v1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, error) {
+func (a *PVCAction) Execute(item runtime.Unstructured, _ *v1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, error) {
 	a.log.Info("Executing PVCAction")
 
 	pvc := new(corev1api.PersistentVolumeClaim)

--- a/pkg/backup/actions/csi/pvc_action.go
+++ b/pkg/backup/actions/csi/pvc_action.go
@@ -76,7 +76,7 @@ type pvcBackupItemAction struct {
 
 // AppliesTo returns information indicating that the PVCBackupItemAction
 // should be invoked to backup PVCs.
-func (p *pvcBackupItemAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*pvcBackupItemAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"persistentvolumeclaims"},
 	}, nil
@@ -383,7 +383,7 @@ func (p *pvcBackupItemAction) Execute(
 		additionalItems, operationID, itemToUpdate, nil
 }
 
-func (p *pvcBackupItemAction) Name() string {
+func (*pvcBackupItemAction) Name() string {
 	return "PVCBackupItemAction"
 }
 

--- a/pkg/backup/actions/csi/pvc_action_test.go
+++ b/pkg/backup/actions/csi/pvc_action_test.go
@@ -1526,7 +1526,7 @@ type failingClient struct {
 	crclient.Client
 }
 
-func (f *failingClient) List(ctx context.Context, list crclient.ObjectList, opts ...crclient.ListOption) error {
+func (*failingClient) List(context.Context, crclient.ObjectList, ...crclient.ListOption) error {
 	return fmt.Errorf("simulated list error")
 }
 

--- a/pkg/backup/actions/csi/volumesnapshot_action.go
+++ b/pkg/backup/actions/csi/volumesnapshot_action.go
@@ -52,7 +52,7 @@ type volumeSnapshotBackupItemAction struct {
 // AppliesTo returns information indicating that the
 // VolumeSnapshotBackupItemAction should be invoked to
 // backup VolumeSnapshots.
-func (p *volumeSnapshotBackupItemAction) AppliesTo() (
+func (*volumeSnapshotBackupItemAction) AppliesTo() (
 	velero.ResourceSelector,
 	error,
 ) {
@@ -236,13 +236,13 @@ func (p *volumeSnapshotBackupItemAction) Execute(
 }
 
 // Name returns the plugin's name.
-func (p *volumeSnapshotBackupItemAction) Name() string {
+func (*volumeSnapshotBackupItemAction) Name() string {
 	return "VolumeSnapshotBackupItemAction"
 }
 
 func (p *volumeSnapshotBackupItemAction) Progress(
 	operationID string,
-	backup *velerov1api.Backup,
+	_ *velerov1api.Backup,
 ) (velero.OperationProgress, error) {
 	progress := velero.OperationProgress{}
 	if operationID == "" {
@@ -331,9 +331,9 @@ func (p *volumeSnapshotBackupItemAction) Progress(
 }
 
 // Cancel is not implemented for VolumeSnapshotBackupItemAction
-func (p *volumeSnapshotBackupItemAction) Cancel(
-	operationID string,
-	backup *velerov1api.Backup,
+func (*volumeSnapshotBackupItemAction) Cancel(
+	string,
+	*velerov1api.Backup,
 ) error {
 	// CSI Specification doesn't support canceling a snapshot creation.
 	return nil

--- a/pkg/backup/actions/csi/volumesnapshotclass_action.go
+++ b/pkg/backup/actions/csi/volumesnapshotclass_action.go
@@ -40,7 +40,7 @@ type volumeSnapshotClassBackupItemAction struct {
 // AppliesTo returns information indicating that the
 // VolumeSnapshotClassBackupItemAction action should be invoked
 // to backup VolumeSnapshotClass.
-func (p *volumeSnapshotClassBackupItemAction) AppliesTo() (
+func (*volumeSnapshotClassBackupItemAction) AppliesTo() (
 	velero.ResourceSelector,
 	error,
 ) {
@@ -53,7 +53,7 @@ func (p *volumeSnapshotClassBackupItemAction) AppliesTo() (
 // items any snapshot lister secret that may be referenced in its annotations.
 func (p *volumeSnapshotClassBackupItemAction) Execute(
 	item runtime.Unstructured,
-	backup *velerov1api.Backup,
+	_ *velerov1api.Backup,
 ) (
 	runtime.Unstructured,
 	[]velero.ResourceIdentifier,
@@ -97,22 +97,22 @@ func (p *volumeSnapshotClassBackupItemAction) Execute(
 }
 
 // Name returns the plugin's name.
-func (p *volumeSnapshotClassBackupItemAction) Name() string {
+func (*volumeSnapshotClassBackupItemAction) Name() string {
 	return "VolumeSnapshotClassBackupItemAction"
 }
 
 // Progress is not implemented for VolumeSnapshotClassBackupItemAction
-func (p *volumeSnapshotClassBackupItemAction) Progress(
-	operationID string,
-	backup *velerov1api.Backup,
+func (*volumeSnapshotClassBackupItemAction) Progress(
+	string,
+	*velerov1api.Backup,
 ) (velero.OperationProgress, error) {
 	return velero.OperationProgress{}, nil
 }
 
 // Cancel is not implemented for VolumeSnapshotClassBackupItemAction
-func (p *volumeSnapshotClassBackupItemAction) Cancel(
-	operationID string,
-	backup *velerov1api.Backup,
+func (*volumeSnapshotClassBackupItemAction) Cancel(
+	string,
+	*velerov1api.Backup,
 ) error {
 	return nil
 }

--- a/pkg/backup/actions/csi/volumesnapshotcontent_action.go
+++ b/pkg/backup/actions/csi/volumesnapshotcontent_action.go
@@ -41,7 +41,7 @@ type volumeSnapshotContentBackupItemAction struct {
 // AppliesTo returns information indicating that the
 // VolumeSnapshotContentBackupItemAction action should be invoked to
 // backup VolumeSnapshotContents.
-func (p *volumeSnapshotContentBackupItemAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*volumeSnapshotContentBackupItemAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"volumesnapshotcontents.snapshot.storage.k8s.io"},
 	}, nil
@@ -111,22 +111,22 @@ func (p *volumeSnapshotContentBackupItemAction) Execute(
 }
 
 // Name returns the plugin's name.
-func (p *volumeSnapshotContentBackupItemAction) Name() string {
+func (*volumeSnapshotContentBackupItemAction) Name() string {
 	return "VolumeSnapshotContentBackupItemAction"
 }
 
 // Progress is not implemented for VolumeSnapshotContentBackupItemAction.
-func (p *volumeSnapshotContentBackupItemAction) Progress(
-	operationID string,
-	backup *velerov1api.Backup,
+func (*volumeSnapshotContentBackupItemAction) Progress(
+	string,
+	*velerov1api.Backup,
 ) (velero.OperationProgress, error) {
 	return velero.OperationProgress{}, nil
 }
 
 // Cancel is not implemented for VolumeSnapshotContentBackupItemAction.
-func (p *volumeSnapshotContentBackupItemAction) Cancel(
-	operationID string,
-	backup *velerov1api.Backup,
+func (*volumeSnapshotContentBackupItemAction) Cancel(
+	string,
+	*velerov1api.Backup,
 ) error {
 	// CSI Specification doesn't support canceling a snapshot creation.
 	return nil

--- a/pkg/backup/actions/pod_action.go
+++ b/pkg/backup/actions/pod_action.go
@@ -38,7 +38,7 @@ func NewPodAction(logger logrus.FieldLogger) *PodAction {
 }
 
 // AppliesTo returns a ResourceSelector that applies only to pods.
-func (a *PodAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*PodAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"pods"},
 	}, nil
@@ -47,7 +47,7 @@ func (a *PodAction) AppliesTo() (velero.ResourceSelector, error) {
 // Execute scans the pod's spec.volumes for persistentVolumeClaim volumes and returns a
 // ResourceIdentifier list containing references to all of the persistentVolumeClaim volumes used by
 // the pod. This ensures that when a pod is backed up, all referenced PVCs are backed up too.
-func (a *PodAction) Execute(item runtime.Unstructured, backup *v1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, error) {
+func (a *PodAction) Execute(item runtime.Unstructured, _ *v1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, error) {
 	a.log.Info("Executing podAction")
 	defer a.log.Info("Done executing podAction")
 

--- a/pkg/backup/actions/remap_crd_version_action.go
+++ b/pkg/backup/actions/remap_crd_version_action.go
@@ -50,14 +50,14 @@ func NewRemapCRDVersionAction(logger logrus.FieldLogger, betaCRDClient apiextv1b
 }
 
 // AppliesTo selects the resources the plugin should run against. In this case, CustomResourceDefinitions.
-func (a *RemapCRDVersionAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*RemapCRDVersionAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"customresourcedefinition.apiextensions.k8s.io"},
 	}, nil
 }
 
 // Execute executes logic necessary to check a CustomResourceDefinition and inspect it for characteristics that necessitate saving it as v1beta1 instead of v1.
-func (a *RemapCRDVersionAction) Execute(item runtime.Unstructured, backup *v1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, error) {
+func (a *RemapCRDVersionAction) Execute(item runtime.Unstructured, _ *v1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, error) {
 	a.logger.Info("Executing RemapCRDVersionAction")
 
 	// This plugin is only relevant for CRDs retrieved from the v1 endpoint that were installed via the v1beta1

--- a/pkg/backup/actions/service_account_action.go
+++ b/pkg/backup/actions/service_account_action.go
@@ -48,7 +48,7 @@ func NewServiceAccountAction(logger logrus.FieldLogger, clusterRoleBindingLister
 }
 
 // AppliesTo returns a ResourceSelector that applies only to service accounts.
-func (a *ServiceAccountAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*ServiceAccountAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"serviceaccounts"},
 	}, nil
@@ -57,7 +57,7 @@ func (a *ServiceAccountAction) AppliesTo() (velero.ResourceSelector, error) {
 // Execute checks for any ClusterRoleBindings that have this service account as a subject, and
 // adds the ClusterRoleBinding and associated ClusterRole to the list of additional items to
 // be backed up.
-func (a *ServiceAccountAction) Execute(item runtime.Unstructured, backup *v1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, error) {
+func (a *ServiceAccountAction) Execute(item runtime.Unstructured, _ *v1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, error) {
 	a.log.Info("Running ServiceAccountAction")
 	defer a.log.Info("Done running ServiceAccountAction")
 

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -763,7 +763,7 @@ func (kb *kubernetesBackupper) backupItemBlock(itemBlock *BackupItemBlock) []sch
 	return grList
 }
 
-func (kb *kubernetesBackupper) getItemKey(item itemblock.ItemBlockItem) (itemKey, error) {
+func (*kubernetesBackupper) getItemKey(item itemblock.ItemBlockItem) (itemKey, error) {
 	metadata, err := meta.Accessor(item.Item)
 	if err != nil {
 		return itemKey{}, err
@@ -776,7 +776,7 @@ func (kb *kubernetesBackupper) getItemKey(item itemblock.ItemBlockItem) (itemKey
 	return key, nil
 }
 
-func (kb *kubernetesBackupper) handleItemBlockPreHooks(itemBlock *BackupItemBlock, hookPods []itemblock.ItemBlockItem) ([]itemblock.ItemBlockItem, []itemblock.ItemBlockItem, []error) {
+func (*kubernetesBackupper) handleItemBlockPreHooks(itemBlock *BackupItemBlock, hookPods []itemblock.ItemBlockItem) ([]itemblock.ItemBlockItem, []itemblock.ItemBlockItem, []error) {
 	var successPods []itemblock.ItemBlockItem
 	var failedPods []itemblock.ItemBlockItem
 	var errs []error
@@ -811,7 +811,7 @@ func (kb *kubernetesBackupper) handleItemBlockPostHooks(itemBlock *BackupItemBlo
 }
 
 // wait all PVBs of the item block pods to be processed
-func (kb *kubernetesBackupper) waitUntilPVBsProcessed(ctx context.Context, log logrus.FieldLogger, itemBlock *BackupItemBlock, pods []itemblock.ItemBlockItem) error {
+func (*kubernetesBackupper) waitUntilPVBsProcessed(ctx context.Context, log logrus.FieldLogger, itemBlock *BackupItemBlock, pods []itemblock.ItemBlockItem) error {
 	pvbMap := map[*velerov1api.PodVolumeBackup]bool{}
 	for _, pod := range pods {
 		namespace, name := pod.Item.GetNamespace(), pod.Item.GetName()
@@ -853,7 +853,7 @@ func (kb *kubernetesBackupper) waitUntilPVBsProcessed(ctx context.Context, log l
 	return wait.PollUntilContextCancel(ctx, 5*time.Second, true, checkFunc)
 }
 
-func (kb *kubernetesBackupper) backupItem(log logrus.FieldLogger, gr schema.GroupResource, itemBackupper *itemBackupper, unstructured *unstructured.Unstructured, preferredGVR schema.GroupVersionResource, itemBlock *BackupItemBlock) bool {
+func (*kubernetesBackupper) backupItem(log logrus.FieldLogger, gr schema.GroupResource, itemBackupper *itemBackupper, unstructured *unstructured.Unstructured, preferredGVR schema.GroupVersionResource, itemBlock *BackupItemBlock) bool {
 	backedUpItem, _, err := itemBackupper.backupItem(log, unstructured, gr, preferredGVR, false, false, itemBlock)
 	if aggregate, ok := err.(kubeerrs.Aggregate); ok {
 		log.WithField("name", unstructured.GetName()).Infof("%d errors encountered backup up item", len(aggregate.Errors()))
@@ -872,7 +872,7 @@ func (kb *kubernetesBackupper) backupItem(log logrus.FieldLogger, gr schema.Grou
 	return backedUpItem
 }
 
-func (kb *kubernetesBackupper) finalizeItem(
+func (*kubernetesBackupper) finalizeItem(
 	log logrus.FieldLogger,
 	gr schema.GroupResource,
 	itemBackupper *itemBackupper,
@@ -936,7 +936,7 @@ func (kb *kubernetesBackupper) backupCRD(log logrus.FieldLogger, gr schema.Group
 	kb.backupItem(log, gvr.GroupResource(), itemBackupper, unstructured, gvr, nil)
 }
 
-func (kb *kubernetesBackupper) writeBackupVersion(tw tarWriter) error {
+func (*kubernetesBackupper) writeBackupVersion(tw tarWriter) error {
 	versionFile := filepath.Join(velerov1api.MetadataDir, "version")
 	versionString := fmt.Sprintf("%s\n", BackupFormatVersion)
 

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -815,7 +815,7 @@ func TestBackupOldResourceFiltering(t *testing.T) {
 			actions: []biav2.BackupItemAction{
 				&pluggableAction{
 					selector: velero.ResourceSelector{IncludedResources: []string{"persistentvolumeclaims"}},
-					executeFunc: func(item runtime.Unstructured, backup *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
+					executeFunc: func(item runtime.Unstructured, _ *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
 						additionalItems := []velero.ResourceIdentifier{
 							{GroupResource: kuberesource.PersistentVolumes, Name: "test1"},
 						}
@@ -1311,11 +1311,11 @@ func (a *recordResourcesAction) AppliesTo() (velero.ResourceSelector, error) {
 	return a.selector, nil
 }
 
-func (a *recordResourcesAction) Progress(operationID string, backup *velerov1.Backup) (velero.OperationProgress, error) {
+func (*recordResourcesAction) Progress(string, *velerov1.Backup) (velero.OperationProgress, error) {
 	return velero.OperationProgress{}, nil
 }
 
-func (a *recordResourcesAction) Cancel(operationID string, backup *velerov1.Backup) error {
+func (*recordResourcesAction) Cancel(string, *velerov1.Backup) error {
 	return nil
 }
 
@@ -1782,27 +1782,27 @@ func TestBackupWithInvalidActions(t *testing.T) {
 // an error when AppliesTo() is called.
 type appliesToErrorAction struct{}
 
-func (a *appliesToErrorAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*appliesToErrorAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{}, errors.New("error calling AppliesTo")
 }
 
-func (a *appliesToErrorAction) Execute(item runtime.Unstructured, backup *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
+func (*appliesToErrorAction) Execute(runtime.Unstructured, *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
 	panic("not implemented")
 }
 
-func (a *appliesToErrorAction) GetRelatedItems(item runtime.Unstructured, backup *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
+func (*appliesToErrorAction) GetRelatedItems(runtime.Unstructured, *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
 	panic("not implemented")
 }
 
-func (a *appliesToErrorAction) Progress(operationID string, backup *velerov1.Backup) (velero.OperationProgress, error) {
+func (*appliesToErrorAction) Progress(string, *velerov1.Backup) (velero.OperationProgress, error) {
 	panic("not implemented")
 }
 
-func (a *appliesToErrorAction) Cancel(operationID string, backup *velerov1.Backup) error {
+func (*appliesToErrorAction) Cancel(string, *velerov1.Backup) error {
 	panic("not implemented")
 }
 
-func (a *appliesToErrorAction) Name() string {
+func (*appliesToErrorAction) Name() string {
 	return ""
 }
 
@@ -1815,7 +1815,7 @@ func TestBackupActionModifications(t *testing.T) {
 	// method modifies the item being passed in by calling the 'modify' function on it.
 	modifyingActionGetter := func(modify func(*unstructured.Unstructured)) *pluggableAction {
 		return &pluggableAction{
-			executeFunc: func(item runtime.Unstructured, backup *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
+			executeFunc: func(item runtime.Unstructured, _ *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
 				obj, ok := item.(*unstructured.Unstructured)
 				if !ok {
 					return nil, nil, "", nil, errors.Errorf("unexpected type %T", item)
@@ -1961,7 +1961,7 @@ func TestBackupActionAdditionalItems(t *testing.T) {
 			actions: []biav2.BackupItemAction{
 				&pluggableAction{
 					selector: velero.ResourceSelector{IncludedNamespaces: []string{"ns-1"}},
-					executeFunc: func(item runtime.Unstructured, backup *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
+					executeFunc: func(item runtime.Unstructured, _ *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
 						additionalItems := []velero.ResourceIdentifier{
 							{GroupResource: kuberesource.Pods, Namespace: "ns-2", Name: "pod-2"},
 							{GroupResource: kuberesource.Pods, Namespace: "ns-3", Name: "pod-3"},
@@ -1992,7 +1992,7 @@ func TestBackupActionAdditionalItems(t *testing.T) {
 			},
 			actions: []biav2.BackupItemAction{
 				&pluggableAction{
-					executeFunc: func(item runtime.Unstructured, backup *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
+					executeFunc: func(item runtime.Unstructured, _ *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
 						additionalItems := []velero.ResourceIdentifier{
 							{GroupResource: kuberesource.Pods, Namespace: "ns-2", Name: "pod-2"},
 							{GroupResource: kuberesource.Pods, Namespace: "ns-3", Name: "pod-3"},
@@ -2022,7 +2022,7 @@ func TestBackupActionAdditionalItems(t *testing.T) {
 			},
 			actions: []biav2.BackupItemAction{
 				&pluggableAction{
-					executeFunc: func(item runtime.Unstructured, backup *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
+					executeFunc: func(item runtime.Unstructured, _ *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
 						additionalItems := []velero.ResourceIdentifier{
 							{GroupResource: kuberesource.PersistentVolumes, Name: "pv-1"},
 							{GroupResource: kuberesource.PersistentVolumes, Name: "pv-2"},
@@ -2055,7 +2055,7 @@ func TestBackupActionAdditionalItems(t *testing.T) {
 			},
 			actions: []biav2.BackupItemAction{
 				&pluggableAction{
-					executeFunc: func(item runtime.Unstructured, backup *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
+					executeFunc: func(item runtime.Unstructured, _ *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
 						additionalItems := []velero.ResourceIdentifier{
 							{GroupResource: kuberesource.PersistentVolumes, Name: "pv-1"},
 							{GroupResource: kuberesource.PersistentVolumes, Name: "pv-2"},
@@ -2085,7 +2085,7 @@ func TestBackupActionAdditionalItems(t *testing.T) {
 			},
 			actions: []biav2.BackupItemAction{
 				&pluggableAction{
-					executeFunc: func(item runtime.Unstructured, backup *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
+					executeFunc: func(item runtime.Unstructured, _ *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
 						additionalItems := []velero.ResourceIdentifier{
 							{GroupResource: kuberesource.PersistentVolumes, Name: "pv-1"},
 							{GroupResource: kuberesource.PersistentVolumes, Name: "pv-2"},
@@ -2116,7 +2116,7 @@ func TestBackupActionAdditionalItems(t *testing.T) {
 			},
 			actions: []biav2.BackupItemAction{
 				&pluggableAction{
-					executeFunc: func(item runtime.Unstructured, backup *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
+					executeFunc: func(item runtime.Unstructured, _ *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
 						additionalItems := []velero.ResourceIdentifier{
 							{GroupResource: kuberesource.PersistentVolumes, Name: "pv-1"},
 							{GroupResource: kuberesource.PersistentVolumes, Name: "pv-2"},
@@ -2147,7 +2147,7 @@ func TestBackupActionAdditionalItems(t *testing.T) {
 			actions: []biav2.BackupItemAction{
 				&pluggableAction{
 					selector: velero.ResourceSelector{IncludedNamespaces: []string{"ns-1"}},
-					executeFunc: func(item runtime.Unstructured, backup *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
+					executeFunc: func(item runtime.Unstructured, _ *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
 						additionalItems := []velero.ResourceIdentifier{
 							{GroupResource: kuberesource.Pods, Namespace: "ns-4", Name: "pod-4"},
 							{GroupResource: kuberesource.Pods, Namespace: "ns-5", Name: "pod-5"},
@@ -2563,7 +2563,7 @@ func TestItemBlockActionRelatedItems(t *testing.T) {
 			actions: []ibav1.ItemBlockAction{
 				&pluggableIBA{
 					selector: velero.ResourceSelector{IncludedNamespaces: []string{"ns-1"}},
-					getRelatedItemsFunc: func(item runtime.Unstructured, backup *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
+					getRelatedItemsFunc: func(runtime.Unstructured, *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
 						relatedItems := []velero.ResourceIdentifier{
 							{GroupResource: kuberesource.Pods, Namespace: "ns-2", Name: "pod-2"},
 							{GroupResource: kuberesource.Pods, Namespace: "ns-3", Name: "pod-3"},
@@ -2594,7 +2594,7 @@ func TestItemBlockActionRelatedItems(t *testing.T) {
 			},
 			actions: []ibav1.ItemBlockAction{
 				&pluggableIBA{
-					getRelatedItemsFunc: func(item runtime.Unstructured, backup *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
+					getRelatedItemsFunc: func(runtime.Unstructured, *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
 						relatedItems := []velero.ResourceIdentifier{
 							{GroupResource: kuberesource.Pods, Namespace: "ns-2", Name: "pod-2"},
 							{GroupResource: kuberesource.Pods, Namespace: "ns-3", Name: "pod-3"},
@@ -2624,7 +2624,7 @@ func TestItemBlockActionRelatedItems(t *testing.T) {
 			},
 			actions: []ibav1.ItemBlockAction{
 				&pluggableIBA{
-					getRelatedItemsFunc: func(item runtime.Unstructured, backup *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
+					getRelatedItemsFunc: func(runtime.Unstructured, *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
 						relatedItems := []velero.ResourceIdentifier{
 							{GroupResource: kuberesource.PersistentVolumes, Name: "pv-1"},
 							{GroupResource: kuberesource.PersistentVolumes, Name: "pv-2"},
@@ -2657,7 +2657,7 @@ func TestItemBlockActionRelatedItems(t *testing.T) {
 			},
 			actions: []ibav1.ItemBlockAction{
 				&pluggableIBA{
-					getRelatedItemsFunc: func(item runtime.Unstructured, backup *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
+					getRelatedItemsFunc: func(runtime.Unstructured, *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
 						relatedItems := []velero.ResourceIdentifier{
 							{GroupResource: kuberesource.PersistentVolumes, Name: "pv-1"},
 							{GroupResource: kuberesource.PersistentVolumes, Name: "pv-2"},
@@ -2687,7 +2687,7 @@ func TestItemBlockActionRelatedItems(t *testing.T) {
 			},
 			actions: []ibav1.ItemBlockAction{
 				&pluggableIBA{
-					getRelatedItemsFunc: func(item runtime.Unstructured, backup *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
+					getRelatedItemsFunc: func(runtime.Unstructured, *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
 						relatedItems := []velero.ResourceIdentifier{
 							{GroupResource: kuberesource.PersistentVolumes, Name: "pv-1"},
 							{GroupResource: kuberesource.PersistentVolumes, Name: "pv-2"},
@@ -2718,7 +2718,7 @@ func TestItemBlockActionRelatedItems(t *testing.T) {
 			},
 			actions: []ibav1.ItemBlockAction{
 				&pluggableIBA{
-					getRelatedItemsFunc: func(item runtime.Unstructured, backup *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
+					getRelatedItemsFunc: func(runtime.Unstructured, *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
 						relatedItems := []velero.ResourceIdentifier{
 							{GroupResource: kuberesource.PersistentVolumes, Name: "pv-1"},
 							{GroupResource: kuberesource.PersistentVolumes, Name: "pv-2"},
@@ -2749,7 +2749,7 @@ func TestItemBlockActionRelatedItems(t *testing.T) {
 			actions: []ibav1.ItemBlockAction{
 				&pluggableIBA{
 					selector: velero.ResourceSelector{IncludedNamespaces: []string{"ns-1"}},
-					getRelatedItemsFunc: func(item runtime.Unstructured, backup *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
+					getRelatedItemsFunc: func(runtime.Unstructured, *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
 						relatedItems := []velero.ResourceIdentifier{
 							{GroupResource: kuberesource.Pods, Namespace: "ns-4", Name: "pod-4"},
 							{GroupResource: kuberesource.Pods, Namespace: "ns-5", Name: "pod-5"},
@@ -2864,7 +2864,7 @@ func (vs *fakeVolumeSnapshotter) WithVolume(pvName, id, az, volumeType string, i
 }
 
 // Init is a no-op.
-func (*fakeVolumeSnapshotter) Init(config map[string]string) error {
+func (*fakeVolumeSnapshotter) Init(map[string]string) error {
 	return nil
 }
 
@@ -2884,7 +2884,7 @@ func (vs *fakeVolumeSnapshotter) GetVolumeID(pv runtime.Unstructured) (string, e
 // CreateSnapshot looks up the volume in the Volume map. If it's not found, an error is
 // returned; if snapshotErr is true on the result, an error is returned; otherwise,
 // a snapshotID of "<volumeID>-snapshot" is returned.
-func (vs *fakeVolumeSnapshotter) CreateSnapshot(volumeID, volumeAZ string, tags map[string]string) (snapshotID string, err error) {
+func (vs *fakeVolumeSnapshotter) CreateSnapshot(volumeID, volumeAZ string, _ map[string]string) (snapshotID string, err error) {
 	vi, ok := vs.Volumes[volumeIdentifier{volumeID: volumeID, volumeAZ: volumeAZ}]
 	if !ok {
 		return "", errors.New("volume not found")
@@ -2909,17 +2909,17 @@ func (vs *fakeVolumeSnapshotter) GetVolumeInfo(volumeID, volumeAZ string) (strin
 }
 
 // CreateVolumeFromSnapshot panics because it's not expected to be used for backups.
-func (*fakeVolumeSnapshotter) CreateVolumeFromSnapshot(snapshotID, volumeType, volumeAZ string, iops *int64) (volumeID string, err error) {
+func (*fakeVolumeSnapshotter) CreateVolumeFromSnapshot(string, string, string, *int64) (volumeID string, err error) {
 	panic("CreateVolumeFromSnapshot should not be used for backups")
 }
 
 // SetVolumeID panics because it's not expected to be used for backups.
-func (*fakeVolumeSnapshotter) SetVolumeID(pv runtime.Unstructured, volumeID string) (runtime.Unstructured, error) {
+func (*fakeVolumeSnapshotter) SetVolumeID(runtime.Unstructured, string) (runtime.Unstructured, error) {
 	panic("SetVolumeID should not be used for backups")
 }
 
 // DeleteSnapshot panics because it's not expected to be used for backups.
-func (*fakeVolumeSnapshotter) DeleteSnapshot(snapshotID string) error {
+func (*fakeVolumeSnapshotter) DeleteSnapshot(string) error {
 	panic("DeleteSnapshot should not be used for backups")
 }
 
@@ -3281,7 +3281,7 @@ func TestBackupWithAsyncOperations(t *testing.T) {
 	// completedOperationAction is a *pluggableAction, whose Execute(...)
 	// method returns an operationID which will always be done when calling Progress.
 	completedOperationAction := &pluggableAction{
-		executeFunc: func(item runtime.Unstructured, backup *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
+		executeFunc: func(item runtime.Unstructured, _ *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
 			obj, ok := item.(*unstructured.Unstructured)
 			if !ok {
 				return nil, nil, "", nil, errors.Errorf("unexpected type %T", item)
@@ -3289,7 +3289,7 @@ func TestBackupWithAsyncOperations(t *testing.T) {
 
 			return obj, nil, obj.GetName() + "-1", nil, nil
 		},
-		progressFunc: func(operationID string, backup *velerov1.Backup) (velero.OperationProgress, error) {
+		progressFunc: func(string, *velerov1.Backup) (velero.OperationProgress, error) {
 			return velero.OperationProgress{
 				Completed:   true,
 				Description: "Done!",
@@ -3300,7 +3300,7 @@ func TestBackupWithAsyncOperations(t *testing.T) {
 	// incompleteOperationAction is a *pluggableAction, whose Execute(...)
 	// method returns an operationID which will never be done when calling Progress.
 	incompleteOperationAction := &pluggableAction{
-		executeFunc: func(item runtime.Unstructured, backup *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
+		executeFunc: func(item runtime.Unstructured, _ *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
 			obj, ok := item.(*unstructured.Unstructured)
 			if !ok {
 				return nil, nil, "", nil, errors.Errorf("unexpected type %T", item)
@@ -3308,7 +3308,7 @@ func TestBackupWithAsyncOperations(t *testing.T) {
 
 			return obj, nil, obj.GetName() + "-1", nil, nil
 		},
-		progressFunc: func(operationID string, backup *velerov1.Backup) (velero.OperationProgress, error) {
+		progressFunc: func(string, *velerov1.Backup) (velero.OperationProgress, error) {
 			return velero.OperationProgress{
 				Completed:   false,
 				Description: "Working...",
@@ -3319,7 +3319,7 @@ func TestBackupWithAsyncOperations(t *testing.T) {
 	// noOperationAction is a *pluggableAction, whose Execute(...)
 	// method does not return an operationID.
 	noOperationAction := &pluggableAction{
-		executeFunc: func(item runtime.Unstructured, backup *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
+		executeFunc: func(item runtime.Unstructured, _ *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
 			obj, ok := item.(*unstructured.Unstructured)
 			if !ok {
 				return nil, nil, "", nil, errors.Errorf("unexpected type %T", item)
@@ -3823,7 +3823,7 @@ func TestBackupWithHooks(t *testing.T) {
 			actions: []ibav1.ItemBlockAction{
 				&pluggableIBA{
 					selector: velero.ResourceSelector{IncludedNamespaces: []string{"ns-1"}},
-					getRelatedItemsFunc: func(item runtime.Unstructured, backup *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
+					getRelatedItemsFunc: func(runtime.Unstructured, *velerov1.Backup) ([]velero.ResourceIdentifier, error) {
 						relatedItems := []velero.ResourceIdentifier{
 							{GroupResource: kuberesource.Pods, Namespace: "ns-1", Name: "pod-1"},
 							{GroupResource: kuberesource.Pods, Namespace: "ns-1", Name: "pod-2"},
@@ -4004,7 +4004,7 @@ func TestBackupWithHooks(t *testing.T) {
 
 type fakePodVolumeBackupperFactory struct{}
 
-func (f *fakePodVolumeBackupperFactory) NewBackupper(context.Context, logrus.FieldLogger, *velerov1.Backup, string) (podvolume.Backupper, error) {
+func (*fakePodVolumeBackupperFactory) NewBackupper(context.Context, logrus.FieldLogger, *velerov1.Backup, string) (podvolume.Backupper, error) {
 	return &fakePodVolumeBackupper{}, nil
 }
 
@@ -4014,7 +4014,7 @@ type fakePodVolumeBackupper struct {
 
 // BackupPodVolumes returns one pod volume backup per entry in volumes, with namespace "velero"
 // and name "pvb-<pod-namespace>-<pod-name>-<volume-name>".
-func (b *fakePodVolumeBackupper) BackupPodVolumes(backup *velerov1.Backup, pod *corev1api.Pod, volumes []string, _ *resourcepolicies.Policies, _ logrus.FieldLogger) ([]*velerov1.PodVolumeBackup, *podvolume.PVCBackupSummary, []error) {
+func (b *fakePodVolumeBackupper) BackupPodVolumes(_ *velerov1.Backup, pod *corev1api.Pod, volumes []string, _ *resourcepolicies.Policies, _ logrus.FieldLogger) ([]*velerov1.PodVolumeBackup, *podvolume.PVCBackupSummary, []error) {
 	var res []*velerov1.PodVolumeBackup
 	pvcSummary := podvolume.NewPVCBackupSummary()
 
@@ -4033,7 +4033,7 @@ func (b *fakePodVolumeBackupper) BackupPodVolumes(backup *velerov1.Backup, pod *
 	return res, pvcSummary, nil
 }
 
-func (b *fakePodVolumeBackupper) WaitAllPodVolumesProcessed(log logrus.FieldLogger) []*velerov1.PodVolumeBackup {
+func (b *fakePodVolumeBackupper) WaitAllPodVolumesProcessed(_ logrus.FieldLogger) []*velerov1.PodVolumeBackup {
 	return b.pvbs
 }
 
@@ -4246,11 +4246,11 @@ func (a *pluggableAction) Progress(operationID string, backup *velerov1.Backup) 
 	return a.progressFunc(operationID, backup)
 }
 
-func (a *pluggableAction) Cancel(operationID string, backup *velerov1.Backup) error {
+func (*pluggableAction) Cancel(string, *velerov1.Backup) error {
 	return nil
 }
 
-func (a *pluggableAction) Name() string {
+func (*pluggableAction) Name() string {
 	return ""
 }
 
@@ -4272,7 +4272,7 @@ func (a *pluggableIBA) AppliesTo() (velero.ResourceSelector, error) {
 	return a.selector, nil
 }
 
-func (a *pluggableIBA) Name() string {
+func (*pluggableIBA) Name() string {
 	return ""
 }
 
@@ -4692,7 +4692,7 @@ func TestBackupNewResourceFiltering(t *testing.T) {
 			actions: []biav2.BackupItemAction{
 				&pluggableAction{
 					selector: velero.ResourceSelector{IncludedResources: []string{"persistentvolumeclaims"}},
-					executeFunc: func(item runtime.Unstructured, backup *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
+					executeFunc: func(item runtime.Unstructured, _ *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
 						additionalItems := []velero.ResourceIdentifier{
 							{GroupResource: kuberesource.PersistentVolumes, Name: "test1"},
 						}
@@ -4732,7 +4732,7 @@ func TestBackupNewResourceFiltering(t *testing.T) {
 			actions: []biav2.BackupItemAction{
 				&pluggableAction{
 					selector: velero.ResourceSelector{IncludedResources: []string{"persistentvolumeclaims"}},
-					executeFunc: func(item runtime.Unstructured, backup *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
+					executeFunc: func(item runtime.Unstructured, _ *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
 						additionalItems := []velero.ResourceIdentifier{
 							{GroupResource: kuberesource.PersistentVolumes, Name: "test1"},
 						}
@@ -4780,7 +4780,7 @@ func TestBackupNewResourceFiltering(t *testing.T) {
 			actions: []biav2.BackupItemAction{
 				&pluggableAction{
 					selector: velero.ResourceSelector{IncludedResources: []string{"persistentvolumeclaims"}},
-					executeFunc: func(item runtime.Unstructured, backup *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
+					executeFunc: func(item runtime.Unstructured, _ *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
 						additionalItems := []velero.ResourceIdentifier{
 							{GroupResource: kuberesource.PersistentVolumes, Name: "test1"},
 						}
@@ -4824,7 +4824,7 @@ func TestBackupNewResourceFiltering(t *testing.T) {
 			actions: []biav2.BackupItemAction{
 				&pluggableAction{
 					selector: velero.ResourceSelector{IncludedResources: []string{"persistentvolumeclaims"}},
-					executeFunc: func(item runtime.Unstructured, backup *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
+					executeFunc: func(item runtime.Unstructured, _ *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
 						additionalItems := []velero.ResourceIdentifier{
 							{GroupResource: kuberesource.PersistentVolumes, Name: "test1"},
 						}
@@ -4870,7 +4870,7 @@ func TestBackupNewResourceFiltering(t *testing.T) {
 			actions: []biav2.BackupItemAction{
 				&pluggableAction{
 					selector: velero.ResourceSelector{IncludedResources: []string{"persistentvolumeclaims"}},
-					executeFunc: func(item runtime.Unstructured, backup *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
+					executeFunc: func(item runtime.Unstructured, _ *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
 						additionalItems := []velero.ResourceIdentifier{
 							{GroupResource: kuberesource.PersistentVolumes, Name: "test1"},
 						}
@@ -4916,7 +4916,7 @@ func TestBackupNewResourceFiltering(t *testing.T) {
 			actions: []biav2.BackupItemAction{
 				&pluggableAction{
 					selector: velero.ResourceSelector{IncludedResources: []string{"persistentvolumeclaims"}},
-					executeFunc: func(item runtime.Unstructured, backup *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
+					executeFunc: func(item runtime.Unstructured, _ *velerov1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
 						additionalItems := []velero.ResourceIdentifier{
 							{GroupResource: kuberesource.PersistentVolumes, Name: "test1"},
 						}

--- a/pkg/cmd/cli/backup/describe.go
+++ b/pkg/cmd/cli/backup/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 	c := &cobra.Command{
 		Use:   use + " [NAME1] [NAME2] [NAME...]",
 		Short: "Describe backups",
-		Run: func(c *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			kbClient, err := f.KubebuilderClient()
 			cmd.CheckError(err)
 

--- a/pkg/cmd/cli/backup/download.go
+++ b/pkg/cmd/cli/backup/download.go
@@ -84,7 +84,7 @@ func (o *DownloadOptions) BindFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&o.caCertFile, "cacert", o.caCertFile, "Path to a certificate bundle to use when verifying TLS connections. If not specified, the CA certificate from the BackupStorageLocation will be used if available.")
 }
 
-func (o *DownloadOptions) Validate(c *cobra.Command, args []string, f client.Factory) error {
+func (o *DownloadOptions) Validate(_ *cobra.Command, _ []string, f client.Factory) error {
 	kbClient, err := f.KubebuilderClient()
 	cmd.CheckError(err)
 
@@ -115,7 +115,7 @@ func (o *DownloadOptions) Complete(args []string) error {
 	return nil
 }
 
-func (o *DownloadOptions) Run(c *cobra.Command, f client.Factory) error {
+func (o *DownloadOptions) Run(_ *cobra.Command, f client.Factory) error {
 	kbClient, err := f.KubebuilderClient()
 	cmd.CheckError(err)
 

--- a/pkg/cmd/cli/backup/logs.go
+++ b/pkg/cmd/cli/backup/logs.go
@@ -61,7 +61,7 @@ func (l *LogsOptions) BindFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&l.CaCertFile, "cacert", l.CaCertFile, "Path to a certificate bundle to use when verifying TLS connections.")
 }
 
-func (l *LogsOptions) Run(c *cobra.Command, f client.Factory) error {
+func (l *LogsOptions) Run(_ *cobra.Command, f client.Factory) error {
 	backup := new(velerov1api.Backup)
 	err := l.Client.Get(context.Background(), kbclient.ObjectKey{Namespace: f.Namespace(), Name: l.BackupName}, backup)
 	if apierrors.IsNotFound(err) {

--- a/pkg/cmd/cli/backup/logs_test.go
+++ b/pkg/cmd/cli/backup/logs_test.go
@@ -223,7 +223,7 @@ func TestNewLogsCommand(t *testing.T) {
 		assert.Equal(t, expectedCACert, cacertValue, "BSL cacert should be retrieved correctly")
 
 		// Create a mock HTTP server to serve the log content
-		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			// For logs, we need to gzip the content
 			gzipWriter := gzip.NewWriter(w)
 			defer gzipWriter.Close()

--- a/pkg/cmd/cli/backuplocation/create.go
+++ b/pkg/cmd/cli/backuplocation/create.go
@@ -106,7 +106,7 @@ func (o *CreateOptions) BindFlags(flags *pflag.FlagSet) {
 	)
 }
 
-func (o *CreateOptions) Validate(c *cobra.Command, args []string, f client.Factory) error {
+func (o *CreateOptions) Validate(c *cobra.Command, _ []string, _ client.Factory) error {
 	if err := output.ValidateFlags(c); err != nil {
 		return err
 	}
@@ -130,7 +130,7 @@ func (o *CreateOptions) Validate(c *cobra.Command, args []string, f client.Facto
 	return nil
 }
 
-func (o *CreateOptions) Complete(args []string, f client.Factory) error {
+func (o *CreateOptions) Complete(args []string, _ client.Factory) error {
 	o.Name = args[0]
 	return nil
 }

--- a/pkg/cmd/cli/backuplocation/set.go
+++ b/pkg/cmd/cli/backuplocation/set.go
@@ -76,7 +76,7 @@ func (o *SetOptions) BindFlags(flags *pflag.FlagSet) {
 	f.NoOptDefVal = cmd.TRUE
 }
 
-func (o *SetOptions) Validate(c *cobra.Command, args []string, f client.Factory) error {
+func (o *SetOptions) Validate(*cobra.Command, []string, client.Factory) error {
 	if len(o.Credential.Data()) > 1 {
 		return errors.New("--credential can only contain 1 key/value pair")
 	}
@@ -84,12 +84,12 @@ func (o *SetOptions) Validate(c *cobra.Command, args []string, f client.Factory)
 	return nil
 }
 
-func (o *SetOptions) Complete(args []string, f client.Factory) error {
+func (o *SetOptions) Complete(args []string, _ client.Factory) error {
 	o.Name = args[0]
 	return nil
 }
 
-func (o *SetOptions) Run(c *cobra.Command, f client.Factory) error {
+func (o *SetOptions) Run(_ *cobra.Command, f client.Factory) error {
 	kbClient, err := f.KubebuilderClient()
 	if err != nil {
 		return err

--- a/pkg/cmd/cli/bug/bug.go
+++ b/pkg/cmd/cli/bug/bug.go
@@ -107,7 +107,7 @@ func NewCommand() *cobra.Command {
 		Use:   "bug",
 		Short: "Report a Velero bug",
 		Long:  "Open a browser window to report a Velero bug",
-		Run: func(c *cobra.Command, args []string) {
+		Run: func(*cobra.Command, []string) {
 			kubectlVersion, err := getKubectlVersion()
 			if err != nil {
 				// we don't want to prevent the user from submitting a bug

--- a/pkg/cmd/cli/client/config/get.go
+++ b/pkg/cmd/cli/client/config/get.go
@@ -30,7 +30,7 @@ func NewGetCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "get [KEY 1] [KEY 2] [...]",
 		Short: "Get client configuration file values",
-		Run: func(c *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			config, err := client.LoadConfig()
 			cmd.CheckError(err)
 

--- a/pkg/cmd/cli/client/config/set.go
+++ b/pkg/cmd/cli/client/config/set.go
@@ -32,7 +32,7 @@ func NewSetCommand() *cobra.Command {
 		Use:   "set KEY=VALUE [KEY=VALUE]...",
 		Short: "Set client configuration file values",
 		Args:  cobra.MinimumNArgs(1),
-		Run: func(c *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			config, err := client.LoadConfig()
 			cmd.CheckError(err)
 

--- a/pkg/cmd/cli/datamover/backup.go
+++ b/pkg/cmd/cli/datamover/backup.go
@@ -69,7 +69,7 @@ func NewBackupCommand(f client.Factory) *cobra.Command {
 		Short:  "Run the velero data-mover backup",
 		Long:   "Run the velero data-mover backup",
 		Hidden: true,
-		Run: func(c *cobra.Command, args []string) {
+		Run: func(c *cobra.Command, _ []string) {
 			logLevel := logLevelFlag.Parse()
 			logrus.Infof("Setting log-level to %s", strings.ToUpper(logLevel.String()))
 

--- a/pkg/cmd/cli/datamover/backup_test.go
+++ b/pkg/cmd/cli/datamover/backup_test.go
@@ -60,11 +60,11 @@ func (fr *fakeRunHelper) RunCancelableDataPath(_ context.Context) (string, error
 	}
 }
 
-func (fr *fakeRunHelper) Shutdown() {
+func (*fakeRunHelper) Shutdown() {
 
 }
 
-func (fr *fakeRunHelper) ExitWithMessage(logger logrus.FieldLogger, succeed bool, message string, a ...any) {
+func (fr *fakeRunHelper) ExitWithMessage(_ logrus.FieldLogger, succeed bool, message string, a ...any) {
 	fr.succeed = succeed
 	fr.exitMessage = fmt.Sprintf(message, a...)
 }

--- a/pkg/cmd/cli/datamover/restore.go
+++ b/pkg/cmd/cli/datamover/restore.go
@@ -67,7 +67,7 @@ func NewRestoreCommand(f client.Factory) *cobra.Command {
 		Short:  "Run the velero data-mover restore",
 		Long:   "Run the velero data-mover restore",
 		Hidden: true,
-		Run: func(c *cobra.Command, args []string) {
+		Run: func(c *cobra.Command, _ []string) {
 			logLevel := logLevelFlag.Parse()
 			logrus.Infof("Setting log-level to %s", strings.ToUpper(logLevel.String()))
 

--- a/pkg/cmd/cli/debug/debug.go
+++ b/pkg/cmd/cli/debug/debug.go
@@ -153,7 +153,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 		Short: "Generate debug bundle",
 		Long: `Generate a tarball containing the logs of velero deployment, plugin logs, node-agent DaemonSet, 
 specs of resources created by velero server, and optionally the logs of backup and restore.`,
-		Run: func(c *cobra.Command, args []string) {
+		Run: func(c *cobra.Command, _ []string) {
 			flags := c.Flags()
 			err := o.complete(f, flags)
 			cmd.CheckError(err)

--- a/pkg/cmd/cli/delete_options.go
+++ b/pkg/cmd/cli/delete_options.go
@@ -54,7 +54,7 @@ func (o *DeleteOptions) Complete(f client.Factory, args []string) error {
 }
 
 // Validate validates the fields of the DeleteOptions struct.
-func (o *DeleteOptions) Validate(c *cobra.Command, f client.Factory, args []string) error {
+func (o *DeleteOptions) Validate(*cobra.Command, client.Factory, []string) error {
 	if o.Client == nil {
 		return errors.New("velero client is not set; unable to proceed")
 	}

--- a/pkg/cmd/cli/install/install.go
+++ b/pkg/cmd/cli/install/install.go
@@ -446,13 +446,13 @@ func (o *Options) Run(c *cobra.Command, f client.Factory) error {
 }
 
 // Complete completes options for a command.
-func (o *Options) Complete(args []string, f client.Factory) error {
+func (o *Options) Complete(_ []string, f client.Factory) error {
 	o.Namespace = f.Namespace()
 	return nil
 }
 
 // Validate validates options provided to a command.
-func (o *Options) Validate(c *cobra.Command, args []string, f client.Factory) error {
+func (o *Options) Validate(c *cobra.Command, _ []string, _ client.Factory) error {
 	if err := output.ValidateFlags(c); err != nil {
 		return err
 	}

--- a/pkg/cmd/cli/nodeagent/server.go
+++ b/pkg/cmd/cli/nodeagent/server.go
@@ -101,7 +101,7 @@ func NewServerCommand(f client.Factory) *cobra.Command {
 		Short:  "Run the velero node-agent server",
 		Long:   "Run the velero node-agent server",
 		Hidden: true,
-		Run: func(c *cobra.Command, args []string) {
+		Run: func(c *cobra.Command, _ []string) {
 			logLevel := logLevelFlag.Parse()
 			logrus.Infof("Setting log-level to %s", strings.ToUpper(logLevel.String()))
 

--- a/pkg/cmd/cli/plugin/add.go
+++ b/pkg/cmd/cli/plugin/add.go
@@ -51,7 +51,7 @@ func NewAddCommand(f client.Factory) *cobra.Command {
 		Use:   "add IMAGE",
 		Short: "Add a plugin",
 		Args:  cobra.ExactArgs(1),
-		Run: func(c *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			if !o.Confirm && !confirm.GetConfirmation("velero plugin add may cause the Velero server pod restart, so it is a dangerous operation",
 				"once Velero server restarts, all the ongoing jobs will fail.") {
 				// Don't do anything unless we get confirmation

--- a/pkg/cmd/cli/plugin/get.go
+++ b/pkg/cmd/cli/plugin/get.go
@@ -36,7 +36,7 @@ func NewGetCommand(f client.Factory, use string) *cobra.Command {
 	c := &cobra.Command{
 		Use:   use,
 		Short: "Get information for all plugins on the velero server",
-		Run: func(c *cobra.Command, args []string) {
+		Run: func(c *cobra.Command, _ []string) {
 			err := output.ValidateFlags(c)
 			cmd.CheckError(err)
 

--- a/pkg/cmd/cli/plugin/remove.go
+++ b/pkg/cmd/cli/plugin/remove.go
@@ -35,7 +35,7 @@ func NewRemoveCommand(f client.Factory) *cobra.Command {
 		Use:   "remove [NAME | IMAGE]",
 		Short: "Remove a plugin",
 		Args:  cobra.ExactArgs(1),
-		Run: func(c *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			kubeClient, err := f.KubeClient()
 			if err != nil {
 				cmd.CheckError(err)

--- a/pkg/cmd/cli/podvolume/backup.go
+++ b/pkg/cmd/cli/podvolume/backup.go
@@ -67,7 +67,7 @@ func NewBackupCommand(f client.Factory) *cobra.Command {
 		Short:  "Run the velero pod volume backup",
 		Long:   "Run the velero pod volume backup",
 		Hidden: true,
-		Run: func(c *cobra.Command, args []string) {
+		Run: func(c *cobra.Command, _ []string) {
 			logLevel := logLevelFlag.Parse()
 			logrus.Infof("Setting log-level to %s", strings.ToUpper(logLevel.String()))
 

--- a/pkg/cmd/cli/podvolume/backup_test.go
+++ b/pkg/cmd/cli/podvolume/backup_test.go
@@ -60,11 +60,11 @@ func (fr *fakeRunHelper) RunCancelableDataPath(_ context.Context) (string, error
 	}
 }
 
-func (fr *fakeRunHelper) Shutdown() {
+func (*fakeRunHelper) Shutdown() {
 
 }
 
-func (fr *fakeRunHelper) ExitWithMessage(logger logrus.FieldLogger, succeed bool, message string, a ...any) {
+func (fr *fakeRunHelper) ExitWithMessage(_ logrus.FieldLogger, succeed bool, message string, a ...any) {
 	fr.succeed = succeed
 	fr.exitMessage = fmt.Sprintf(message, a...)
 }

--- a/pkg/cmd/cli/podvolume/restore.go
+++ b/pkg/cmd/cli/podvolume/restore.go
@@ -65,7 +65,7 @@ func NewRestoreCommand(f client.Factory) *cobra.Command {
 		Short:  "Run the velero pod volume restore",
 		Long:   "Run the velero pod volume restore",
 		Hidden: true,
-		Run: func(c *cobra.Command, args []string) {
+		Run: func(c *cobra.Command, _ []string) {
 			logLevel := logLevelFlag.Parse()
 			logrus.Infof("Setting log-level to %s", strings.ToUpper(logLevel.String()))
 
@@ -92,7 +92,7 @@ func NewRestoreCommand(f client.Factory) *cobra.Command {
 	_ = command.MarkFlagRequired("pod-volume-restore")
 	_ = command.MarkFlagRequired("resource-timeout")
 
-	command.PreRunE = func(cmd *cobra.Command, args []string) error {
+	command.PreRunE = func(*cobra.Command, []string) error {
 		if config.resourceTimeout <= 0 {
 			return errors.New("resource-timeout must be greater than 0")
 		}

--- a/pkg/cmd/cli/repomantenance/maintenance.go
+++ b/pkg/cmd/cli/repomantenance/maintenance.go
@@ -56,7 +56,7 @@ func NewCommand(f velerocli.Factory) *cobra.Command {
 		Use:    "repo-maintenance",
 		Hidden: true,
 		Short:  "VELERO INTERNAL COMMAND ONLY - not intended to be run directly by users",
-		Run: func(c *cobra.Command, args []string) {
+		Run: func(*cobra.Command, []string) {
 			o.Run(f)
 		},
 	}
@@ -83,7 +83,7 @@ func (o *Options) Run(f velerocli.Factory) {
 	}
 }
 
-func (o *Options) initClient(f velerocli.Factory) (client.Client, error) {
+func (*Options) initClient(f velerocli.Factory) (client.Client, error) {
 	scheme := runtime.NewScheme()
 	err := velerov1api.AddToScheme(scheme)
 	if err != nil {

--- a/pkg/cmd/cli/restore/create.go
+++ b/pkg/cmd/cli/restore/create.go
@@ -181,7 +181,7 @@ func (o *CreateOptions) Complete(args []string, f client.Factory) error {
 	return nil
 }
 
-func (o *CreateOptions) Validate(c *cobra.Command, args []string, f client.Factory) error {
+func (o *CreateOptions) Validate(c *cobra.Command, _ []string, f client.Factory) error {
 	if o.BackupName != "" && o.ScheduleName != "" {
 		return errors.New("either a backup or schedule must be specified, but not both")
 	}

--- a/pkg/cmd/cli/restore/describe.go
+++ b/pkg/cmd/cli/restore/describe.go
@@ -49,7 +49,7 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 	c := &cobra.Command{
 		Use:   use + " [NAME1] [NAME2] [NAME...]",
 		Short: "Describe restores",
-		Run: func(c *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			kbClient, err := f.KubebuilderClient()
 			cmd.CheckError(err)
 

--- a/pkg/cmd/cli/restore/logs.go
+++ b/pkg/cmd/cli/restore/logs.go
@@ -47,7 +47,7 @@ func NewLogsCommand(f client.Factory) *cobra.Command {
 		Use:   "logs RESTORE",
 		Short: "Get restore logs",
 		Args:  cobra.ExactArgs(1),
-		Run: func(c *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			restoreName := args[0]
 
 			kbClient, err := f.KubebuilderClient()

--- a/pkg/cmd/cli/schedule/describe.go
+++ b/pkg/cmd/cli/schedule/describe.go
@@ -37,7 +37,7 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 	c := &cobra.Command{
 		Use:   use + " [NAME1] [NAME2] [NAME...]",
 		Short: "Describe schedules",
-		Run: func(c *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			crClient, err := f.KubebuilderClient()
 			cmd.CheckError(err)
 

--- a/pkg/cmd/cli/schedule/pause.go
+++ b/pkg/cmd/cli/schedule/pause.go
@@ -53,7 +53,7 @@ func NewPauseCommand(f client.Factory, use string) *cobra.Command {
 
   # Pause all schedules.
   velero schedule pause --all`,
-		Run: func(c *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			cmd.CheckError(o.Complete(args))
 			cmd.CheckError(o.Validate())
 			cmd.CheckError(runPause(f, o, true, pauseOpts.SkipOptions.SkipImmediately.Value))

--- a/pkg/cmd/cli/schedule/unpause.go
+++ b/pkg/cmd/cli/schedule/unpause.go
@@ -42,7 +42,7 @@ func NewUnpauseCommand(f client.Factory, use string) *cobra.Command {
 
   # Unpause all schedules.
   velero schedule unpause --all`,
-		Run: func(c *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			cmd.CheckError(o.Complete(args))
 			cmd.CheckError(o.Validate())
 			cmd.CheckError(runPause(f, o, false, pauseOpts.SkipOptions.SkipImmediately.Value))

--- a/pkg/cmd/cli/snapshotlocation/create.go
+++ b/pkg/cmd/cli/snapshotlocation/create.go
@@ -77,7 +77,7 @@ func (o *CreateOptions) BindFlags(flags *pflag.FlagSet) {
 	flags.Var(&o.Credential, "credential", "The credential to be used by this location as a key-value pair, where the key is the Kubernetes Secret name, and the value is the data key name within the Secret. Optional, one value only.")
 }
 
-func (o *CreateOptions) Validate(c *cobra.Command, args []string, f client.Factory) error {
+func (o *CreateOptions) Validate(c *cobra.Command, _ []string, _ client.Factory) error {
 	if err := output.ValidateFlags(c); err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func (o *CreateOptions) Validate(c *cobra.Command, args []string, f client.Facto
 	return nil
 }
 
-func (o *CreateOptions) Complete(args []string, f client.Factory) error {
+func (o *CreateOptions) Complete(args []string, _ client.Factory) error {
 	o.Name = args[0]
 	return nil
 }

--- a/pkg/cmd/cli/snapshotlocation/set.go
+++ b/pkg/cmd/cli/snapshotlocation/set.go
@@ -67,7 +67,7 @@ func (o *SetOptions) BindFlags(flags *pflag.FlagSet) {
 	flags.Var(&o.Credential, "credential", "Sets the credential to be used by this location as a key-value pair, where the key is the Kubernetes Secret name, and the value is the data key name within the Secret. Optional, one value only.")
 }
 
-func (o *SetOptions) Validate(c *cobra.Command, args []string, f client.Factory) error {
+func (o *SetOptions) Validate(c *cobra.Command, _ []string, _ client.Factory) error {
 	if err := output.ValidateFlags(c); err != nil {
 		return err
 	}
@@ -79,12 +79,12 @@ func (o *SetOptions) Validate(c *cobra.Command, args []string, f client.Factory)
 	return nil
 }
 
-func (o *SetOptions) Complete(args []string, f client.Factory) error {
+func (o *SetOptions) Complete(args []string, _ client.Factory) error {
 	o.Name = args[0]
 	return nil
 }
 
-func (o *SetOptions) Run(c *cobra.Command, f client.Factory) error {
+func (o *SetOptions) Run(_ *cobra.Command, f client.Factory) error {
 	kbClient, err := f.KubebuilderClient()
 	if err != nil {
 		return err

--- a/pkg/cmd/cli/uninstall/uninstall.go
+++ b/pkg/cmd/cli/uninstall/uninstall.go
@@ -80,7 +80,7 @@ The '--namespace' flag can be used to specify the namespace where velero is inst
 Use '--force' to skip the prompt confirming if you want to uninstall Velero.
 		`,
 		Example: ` # velero uninstall --namespace staging`,
-		Run: func(c *cobra.Command, args []string) {
+		Run: func(*cobra.Command, []string) {
 			if o.wait {
 				fmt.Println("Warning: the \"--wait\" option is deprecated and will be removed in a future release. The uninstall command always waits for the uninstall to complete.")
 			}

--- a/pkg/cmd/cli/version/version.go
+++ b/pkg/cmd/cli/version/version.go
@@ -40,7 +40,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "version",
 		Short: "Print the velero version and associated image",
-		Run: func(c *cobra.Command, args []string) {
+		Run: func(*cobra.Command, []string) {
 			var kbClient kbclient.Client
 			if !clientOnly {
 				var err error

--- a/pkg/cmd/server/plugin/plugin.go
+++ b/pkg/cmd/server/plugin/plugin.go
@@ -45,7 +45,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 		Use:    "run-plugins",
 		Hidden: true,
 		Short:  "INTERNAL COMMAND ONLY - not intended to be run directly by users",
-		Run: func(c *cobra.Command, args []string) {
+		Run: func(*cobra.Command, []string) {
 			config := pluginServer.GetConfig()
 			f.SetClientQPS(config.ClientQPS)
 			f.SetClientBurst(config.ClientBurst)

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -97,7 +97,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 		Short:  "Run the velero server",
 		Long:   "Run the velero server",
 		Hidden: true,
-		Run: func(c *cobra.Command, args []string) {
+		Run: func(c *cobra.Command, _ []string) {
 			// go-plugin uses log.Println to log when it's waiting for all plugin processes to complete so we need to
 			// set its output to stdout.
 			log.SetOutput(os.Stdout)

--- a/pkg/cmd/util/downloadrequest/downloadrequest_test.go
+++ b/pkg/cmd/util/downloadrequest/downloadrequest_test.go
@@ -175,7 +175,7 @@ func TestStream(t *testing.T) {
 			name:    "timeout waiting for download URL",
 			target:  velerov1api.DownloadTargetKindBackupLog,
 			timeout: 50 * time.Millisecond,
-			setupClient: func(t *testing.T, client kbclient.WithWatch) {
+			setupClient: func(t *testing.T, _ kbclient.WithWatch) {
 				t.Helper()
 			},
 			expectedError:      true,
@@ -382,7 +382,7 @@ func TestStreamWithBSLCACert(t *testing.T) {
 			target:    velerov1api.DownloadTargetKindBackupLog,
 			bslCACert: "test-ca-cert-content",
 			timeout:   50 * time.Millisecond,
-			setupClient: func(t *testing.T, client kbclient.WithWatch) {
+			setupClient: func(t *testing.T, _ kbclient.WithWatch) {
 				t.Helper()
 			},
 			expectedError:      true,
@@ -466,7 +466,7 @@ func TestDownload(t *testing.T) {
 	}{
 		{
 			name: "successful download with gzip for logs",
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				w.Write(compressedContent.Bytes())
 			},
@@ -476,7 +476,7 @@ func TestDownload(t *testing.T) {
 		},
 		{
 			name: "successful download without gzip for backup contents",
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(testContent))
 			},
@@ -486,7 +486,7 @@ func TestDownload(t *testing.T) {
 		},
 		{
 			name: "404 not found error",
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusNotFound)
 			},
 			target:        velerov1api.DownloadTargetKindBackupLog,
@@ -495,7 +495,7 @@ func TestDownload(t *testing.T) {
 		},
 		{
 			name: "500 internal server error",
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
 				w.Write([]byte("internal server error"))
 			},
@@ -709,7 +709,7 @@ func TestMixedEnvironmentHTTPAndHTTPS(t *testing.T) {
 	testContentHTTPS := "https content"
 
 	// Create HTTP server
-	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(testContentHTTP))
 	}))
@@ -717,7 +717,7 @@ func TestMixedEnvironmentHTTPAndHTTPS(t *testing.T) {
 
 	// Create HTTPS server with self-signed cert
 	tlsCert, serverCACertPEM := createSelfSignedCertificate(t)
-	httpsServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	httpsServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(testContentHTTPS))
 	}))
@@ -955,7 +955,7 @@ func TestConcurrentDownloadsWithBSLCACert(t *testing.T) {
 	tlsCert, serverCACertPEM := createSelfSignedCertificate(t)
 
 	// Create TLS test server
-	tlsServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tlsServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// Simulate some processing time
 		time.Sleep(10 * time.Millisecond)
 		w.WriteHeader(http.StatusOK)
@@ -973,7 +973,7 @@ func TestConcurrentDownloadsWithBSLCACert(t *testing.T) {
 	results := make(chan string, numConcurrent)
 
 	for i := range numConcurrent {
-		go func(idx int) {
+		go func(int) {
 			var buf bytes.Buffer
 			err := download(
 				t.Context(),
@@ -1012,7 +1012,7 @@ func TestDownloadWithBSLCACert(t *testing.T) {
 	tlsCert, serverCACertPEM := createSelfSignedCertificate(t)
 
 	// Create TLS test server with self-signed cert
-	tlsServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tlsServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(testContent))
 	}))
@@ -1023,7 +1023,7 @@ func TestDownloadWithBSLCACert(t *testing.T) {
 	defer tlsServer.Close()
 
 	// Create HTTP test server for non-TLS tests
-	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(testContent))
 	}))
@@ -1124,7 +1124,7 @@ func TestCACertFallback(t *testing.T) {
 	tlsCert, serverCACertPEM := createSelfSignedCertificate(t)
 
 	// Create TLS test server
-	tlsServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tlsServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(testContent))
 	}))

--- a/pkg/cmd/util/flag/array.go
+++ b/pkg/cmd/util/flag/array.go
@@ -46,6 +46,6 @@ func (sa *StringArray) Set(s string) error {
 
 // Type returns a string representation of the
 // StringArray type.
-func (sa *StringArray) Type() string {
+func (*StringArray) Type() string {
 	return "stringArray"
 }

--- a/pkg/cmd/util/flag/enum.go
+++ b/pkg/cmd/util/flag/enum.go
@@ -60,7 +60,7 @@ func (e *Enum) Set(s string) error {
 
 // Type returns a string representation of the
 // Enum type.
-func (e *Enum) Type() string {
+func (*Enum) Type() string {
 	// we don't want the help text to display anything regarding
 	// the type because the usage text for the flag should capture
 	// the possible options.

--- a/pkg/cmd/util/flag/labelselector.go
+++ b/pkg/cmd/util/flag/labelselector.go
@@ -46,6 +46,6 @@ func (ls *LabelSelector) Set(s string) error {
 
 // Type returns a string representation of the
 // LabelSelector type.
-func (ls *LabelSelector) Type() string {
+func (*LabelSelector) Type() string {
 	return "labelSelector"
 }

--- a/pkg/cmd/util/flag/map.go
+++ b/pkg/cmd/util/flag/map.go
@@ -94,7 +94,7 @@ func (m *Map) Set(s string) error {
 
 // Type returns a string representation of the
 // Map type.
-func (m *Map) Type() string {
+func (*Map) Type() string {
 	return "mapStringString"
 }
 

--- a/pkg/cmd/util/flag/optional_bool.go
+++ b/pkg/cmd/util/flag/optional_bool.go
@@ -55,6 +55,6 @@ func (f *OptionalBool) Set(val string) error {
 	return nil
 }
 
-func (f *OptionalBool) Type() string {
+func (*OptionalBool) Type() string {
 	return "optionalBool"
 }

--- a/pkg/cmd/util/flag/orlabelselector.go
+++ b/pkg/cmd/util/flag/orlabelselector.go
@@ -56,6 +56,6 @@ func (ls *OrLabelSelector) Set(s string) error {
 
 // Type returns a string representation of the
 // OrLabelSelector type.
-func (ls *OrLabelSelector) Type() string {
+func (*OrLabelSelector) Type() string {
 	return "orLabelSelector"
 }

--- a/pkg/cmd/util/output/backup_describer_test.go
+++ b/pkg/cmd/util/output/backup_describer_test.go
@@ -460,7 +460,7 @@ func TestDescribeNativeSnapshots(t *testing.T) {
 			d.out.Init(d.buf, 0, 8, 2, ' ', 0)
 			describeNativeSnapshots(d, tc.inputDetails, tc.volumeInfo)
 			d.out.Flush()
-			assert.Equal(t, tc.expect, d.buf.String())
+			assert.Equal(tt, tc.expect, d.buf.String())
 		})
 	}
 }
@@ -628,7 +628,7 @@ func TestCSISnapshots(t *testing.T) {
 			d.out.Init(d.buf, 0, 8, 2, ' ', 0)
 			describeCSISnapshots(d, tc.inputDetails, tc.volumeInfo, tc.legacyInfoSource)
 			d.out.Flush()
-			assert.Equal(t, tc.expect, d.buf.String())
+			assert.Equal(tt, tc.expect, d.buf.String())
 		})
 	}
 }

--- a/pkg/cmd/velero/velero.go
+++ b/pkg/cmd/velero/velero.go
@@ -81,7 +81,7 @@ operations can also be performed as 'velero backup get' and 'velero schedule cre
 		// PersistentPreRun will run before all subcommands EXCEPT in the following conditions:
 		//  - a subcommand defines its own PersistentPreRun function
 		//  - the command is run without arguments or with --help and only prints the usage info
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		PersistentPreRun: func(*cobra.Command, []string) {
 			features.Enable(config.Features()...)
 			features.Enable(cmdFeatures...)
 

--- a/pkg/controller/backup_controller_test.go
+++ b/pkg/controller/backup_controller_test.go
@@ -74,7 +74,7 @@ func (b *fakeBackupper) Backup(logger logrus.FieldLogger, backup *pkgbackup.Requ
 
 func (b *fakeBackupper) BackupWithResolvers(logger logrus.FieldLogger, backup *pkgbackup.Request, backupFile io.Writer,
 	backupItemActionResolver framework.BackupItemActionResolverV2,
-	itemBlockActionResolver framework.ItemBlockActionResolver,
+	_ framework.ItemBlockActionResolver,
 	volumeSnapshotterGetter pkgbackup.VolumeSnapshotterGetter,
 ) error {
 	args := b.Called(logger, backup, backupFile, backupItemActionResolver, volumeSnapshotterGetter)
@@ -88,7 +88,7 @@ func (b *fakeBackupper) FinalizeBackup(
 	outBackupFile io.Writer,
 	backupItemActionResolver framework.BackupItemActionResolverV2,
 	asyncBIAOperations []*itemoperation.BackupOperation,
-	backupStore persistence.BackupStore,
+	_ persistence.BackupStore,
 ) error {
 	args := b.Called(logger, backup, inBackupFile, outBackupFile, backupItemActionResolver, asyncBIAOperations)
 	return args.Error(0)

--- a/pkg/controller/backup_deletion_controller_test.go
+++ b/pkg/controller/backup_deletion_controller_test.go
@@ -907,11 +907,11 @@ func TestGetSnapshotsInBackup(t *testing.T) {
 	}
 }
 
-func batchDeleteSucceed(ctx context.Context, repoEnsurer *repository.Ensurer, repoMgr repomanager.Manager, directSnapshots map[string][]repotypes.SnapshotIdentifier, backup *velerov1api.Backup, logger logrus.FieldLogger) []error {
+func batchDeleteSucceed(context.Context, *repository.Ensurer, repomanager.Manager, map[string][]repotypes.SnapshotIdentifier, *velerov1api.Backup, logrus.FieldLogger) []error {
 	return nil
 }
 
-func batchDeleteFail(ctx context.Context, repoEnsurer *repository.Ensurer, repoMgr repomanager.Manager, directSnapshots map[string][]repotypes.SnapshotIdentifier, backup *velerov1api.Backup, logger logrus.FieldLogger) []error {
+func batchDeleteFail(context.Context, *repository.Ensurer, repomanager.Manager, map[string][]repotypes.SnapshotIdentifier, *velerov1api.Backup, logrus.FieldLogger) []error {
 	return []error{
 		errors.New("fake-delete-1"),
 		errors.New("fake-delete-2"),

--- a/pkg/controller/backup_finalizer_controller.go
+++ b/pkg/controller/backup_finalizer_controller.go
@@ -68,7 +68,7 @@ func NewBackupFinalizerReconciler(
 	backupStoreGetter persistence.ObjectBackupStoreGetter,
 	log logrus.FieldLogger,
 	metrics *metrics.ServerMetrics,
-	resourceTimeout time.Duration,
+	_ time.Duration,
 ) *backupFinalizerReconciler {
 	return &backupFinalizerReconciler{
 		client:            client,

--- a/pkg/controller/backup_repository_controller.go
+++ b/pkg/controller/backup_repository_controller.go
@@ -132,7 +132,7 @@ func (r *BackupRepoReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *BackupRepoReconciler) invalidateBackupReposForBSL(ctx context.Context, bslObj client.Object) []reconcile.Request {
+func (r *BackupRepoReconciler) invalidateBackupReposForBSL(_ context.Context, bslObj client.Object) []reconcile.Request {
 	bsl := bslObj.(*velerov1api.BackupStorageLocation)
 
 	list := &velerov1api.BackupRepositoryList{}
@@ -296,7 +296,7 @@ func (r *BackupRepoReconciler) getBSL(ctx context.Context, req *velerov1api.Back
 	return loc, nil
 }
 
-func (r *BackupRepoReconciler) getIdentifierByBSL(bsl *velerov1api.BackupStorageLocation, req *velerov1api.BackupRepository) (string, error) {
+func (*BackupRepoReconciler) getIdentifierByBSL(bsl *velerov1api.BackupStorageLocation, req *velerov1api.BackupRepository) (string, error) {
 	repoIdentifier, err := repoconfig.GetRepoIdentifier(bsl, req.Spec.VolumeNamespace)
 	if err != nil {
 		return "", errors.Wrapf(err, "error to get identifier for repo %s", req.Name)

--- a/pkg/controller/backup_repository_controller_test.go
+++ b/pkg/controller/backup_repository_controller_test.go
@@ -205,14 +205,14 @@ type fakeClock struct {
 	now time.Time
 }
 
-func (f *fakeClock) After(time.Duration) <-chan time.Time {
+func (*fakeClock) After(time.Duration) <-chan time.Time {
 	return nil
 }
 
-func (f *fakeClock) NewTicker(time.Duration) clock.Ticker {
+func (*fakeClock) NewTicker(time.Duration) clock.Ticker {
 	return nil
 }
-func (f *fakeClock) NewTimer(time.Duration) clock.Timer {
+func (*fakeClock) NewTimer(time.Duration) clock.Timer {
 	return nil
 }
 
@@ -220,17 +220,17 @@ func (f *fakeClock) Now() time.Time {
 	return f.now
 }
 
-func (f *fakeClock) Since(time.Time) time.Duration {
+func (*fakeClock) Since(time.Time) time.Duration {
 	return 0
 }
 
-func (f *fakeClock) Sleep(time.Duration) {}
+func (*fakeClock) Sleep(time.Duration) {}
 
-func (f *fakeClock) Tick(time.Duration) <-chan time.Time {
+func (*fakeClock) Tick(time.Duration) <-chan time.Time {
 	return nil
 }
 
-func (f *fakeClock) AfterFunc(time.Duration, func()) clock.Timer {
+func (*fakeClock) AfterFunc(time.Duration, func()) clock.Timer {
 	return nil
 }
 

--- a/pkg/controller/backup_storage_location_controller.go
+++ b/pkg/controller/backup_storage_location_controller.go
@@ -82,7 +82,7 @@ func NewBackupStorageLocationReconciler(
 // +kubebuilder:rbac:groups=velero.io,resources=backupstoragelocations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=velero.io,resources=backupstoragelocations/status,verbs=get;update;patch
 
-func (r *backupStorageLocationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *backupStorageLocationReconciler) Reconcile(_ context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var unavailableErrors []string
 	var location velerov1api.BackupStorageLocation
 

--- a/pkg/controller/data_download_controller.go
+++ b/pkg/controller/data_download_controller.go
@@ -414,7 +414,7 @@ func (r *DataDownloadReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	return ctrl.Result{}, nil
 }
 
-func (r *DataDownloadReconciler) initCancelableDataPath(ctx context.Context, asyncBR datapath.AsyncBR, res *exposer.ExposeResult, log logrus.FieldLogger) error {
+func (*DataDownloadReconciler) initCancelableDataPath(ctx context.Context, asyncBR datapath.AsyncBR, res *exposer.ExposeResult, log logrus.FieldLogger) error {
 	log.Info("Init cancelable dataDownload")
 
 	if err := asyncBR.Init(ctx, nil); err != nil {
@@ -426,7 +426,7 @@ func (r *DataDownloadReconciler) initCancelableDataPath(ctx context.Context, asy
 	return nil
 }
 
-func (r *DataDownloadReconciler) startCancelableDataPath(asyncBR datapath.AsyncBR, dd *velerov2alpha1api.DataDownload, res *exposer.ExposeResult, log logrus.FieldLogger) error {
+func (*DataDownloadReconciler) startCancelableDataPath(asyncBR datapath.AsyncBR, dd *velerov2alpha1api.DataDownload, res *exposer.ExposeResult, log logrus.FieldLogger) error {
 	log.Info("Start cancelable dataDownload")
 
 	if err := asyncBR.StartRestore(dd.Spec.SnapshotID, datapath.AccessPoint{
@@ -439,7 +439,7 @@ func (r *DataDownloadReconciler) startCancelableDataPath(asyncBR datapath.AsyncB
 	return nil
 }
 
-func (r *DataDownloadReconciler) OnDataDownloadCompleted(ctx context.Context, namespace string, ddName string, result datapath.Result) {
+func (r *DataDownloadReconciler) OnDataDownloadCompleted(ctx context.Context, namespace string, ddName string, _ datapath.Result) {
 	defer r.dataPathMgr.RemoveAsyncBR(ddName)
 
 	log := r.logger.WithField("datadownload", ddName)
@@ -623,17 +623,17 @@ func (r *DataDownloadReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				CreateFunc: func(event.CreateEvent) bool {
 					return false
 				},
-				DeleteFunc: func(de event.DeleteEvent) bool {
+				DeleteFunc: func(event.DeleteEvent) bool {
 					return false
 				},
-				GenericFunc: func(ge event.GenericEvent) bool {
+				GenericFunc: func(event.GenericEvent) bool {
 					return false
 				},
 			})).
 		Complete(r)
 }
 
-func (r *DataDownloadReconciler) findSnapshotRestoreForPod(ctx context.Context, podObj client.Object) []reconcile.Request {
+func (r *DataDownloadReconciler) findSnapshotRestoreForPod(_ context.Context, podObj client.Object) []reconcile.Request {
 	pod := podObj.(*corev1api.Pod)
 	dd, err := findDataDownloadByPod(r.client, *pod)
 

--- a/pkg/controller/data_download_controller_test.go
+++ b/pkg/controller/data_download_controller_test.go
@@ -813,7 +813,7 @@ func TestFindDataDownloadForPod(t *testing.T) {
 			name: "no selected label found for pod",
 			du:   dataDownloadBuilder().Phase(velerov2alpha1api.DataDownloadPhaseAccepted).Result(),
 			pod:  builder.ForPod(velerov1api.DefaultNamespace, dataDownloadName).Result(),
-			checkFunc: func(du *velerov2alpha1api.DataDownload, requests []reconcile.Request) {
+			checkFunc: func(_ *velerov2alpha1api.DataDownload, requests []reconcile.Request) {
 				// Assert that the function returns a single request
 				assert.Empty(t, requests)
 			},
@@ -821,7 +821,7 @@ func TestFindDataDownloadForPod(t *testing.T) {
 			name: "no matched pod",
 			du:   dataDownloadBuilder().Phase(velerov2alpha1api.DataDownloadPhaseAccepted).Result(),
 			pod:  builder.ForPod(velerov1api.DefaultNamespace, dataDownloadName).Labels(map[string]string{velerov1api.DataDownloadLabel: "non-existing-datadownload"}).Result(),
-			checkFunc: func(du *velerov2alpha1api.DataDownload, requests []reconcile.Request) {
+			checkFunc: func(_ *velerov2alpha1api.DataDownload, requests []reconcile.Request) {
 				assert.Empty(t, requests)
 			},
 		},
@@ -829,7 +829,7 @@ func TestFindDataDownloadForPod(t *testing.T) {
 			name: "dataDownload not accept",
 			du:   dataDownloadBuilder().Phase(velerov2alpha1api.DataDownloadPhaseInProgress).Result(),
 			pod:  builder.ForPod(velerov1api.DefaultNamespace, dataDownloadName).Labels(map[string]string{velerov1api.DataDownloadLabel: dataDownloadName}).Result(),
-			checkFunc: func(du *velerov2alpha1api.DataDownload, requests []reconcile.Request) {
+			checkFunc: func(_ *velerov2alpha1api.DataDownload, requests []reconcile.Request) {
 				assert.Empty(t, requests)
 			},
 		},
@@ -1057,7 +1057,7 @@ func (dt *ddResumeTestHelper) resumeCancellableDataPath(_ *DataUploadReconciler,
 	return dt.resumeErr
 }
 
-func (dt *ddResumeTestHelper) Expose(context.Context, corev1api.ObjectReference, exposer.GenericRestoreExposeParam) error {
+func (*ddResumeTestHelper) Expose(context.Context, corev1api.ObjectReference, exposer.GenericRestoreExposeParam) error {
 	return nil
 }
 
@@ -1065,19 +1065,19 @@ func (dt *ddResumeTestHelper) GetExposed(context.Context, corev1api.ObjectRefere
 	return dt.exposeResult, dt.getExposeErr
 }
 
-func (dt *ddResumeTestHelper) PeekExposed(context.Context, corev1api.ObjectReference) error {
+func (*ddResumeTestHelper) PeekExposed(context.Context, corev1api.ObjectReference) error {
 	return nil
 }
 
-func (dt *ddResumeTestHelper) DiagnoseExpose(context.Context, corev1api.ObjectReference) string {
+func (*ddResumeTestHelper) DiagnoseExpose(context.Context, corev1api.ObjectReference) string {
 	return ""
 }
 
-func (dt *ddResumeTestHelper) RebindVolume(context.Context, corev1api.ObjectReference, string, string, time.Duration) error {
+func (*ddResumeTestHelper) RebindVolume(context.Context, corev1api.ObjectReference, string, string, time.Duration) error {
 	return nil
 }
 
-func (dt *ddResumeTestHelper) CleanUp(context.Context, corev1api.ObjectReference) {}
+func (*ddResumeTestHelper) CleanUp(context.Context, corev1api.ObjectReference) {}
 
 func (dt *ddResumeTestHelper) newMicroServiceBRWatcher(kbclient.Client, kubernetes.Interface, manager.Manager, string, string, string, string, string, string,
 	datapath.Callbacks, logrus.FieldLogger) datapath.AsyncBR {

--- a/pkg/controller/data_upload_controller.go
+++ b/pkg/controller/data_upload_controller.go
@@ -432,7 +432,7 @@ func (r *DataUploadReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	return ctrl.Result{}, nil
 }
 
-func (r *DataUploadReconciler) initCancelableDataPath(ctx context.Context, asyncBR datapath.AsyncBR, res *exposer.ExposeResult, log logrus.FieldLogger) error {
+func (*DataUploadReconciler) initCancelableDataPath(ctx context.Context, asyncBR datapath.AsyncBR, res *exposer.ExposeResult, log logrus.FieldLogger) error {
 	log.Info("Init cancelable dataUpload")
 
 	if err := asyncBR.Init(ctx, nil); err != nil {
@@ -444,7 +444,7 @@ func (r *DataUploadReconciler) initCancelableDataPath(ctx context.Context, async
 	return nil
 }
 
-func (r *DataUploadReconciler) startCancelableDataPath(asyncBR datapath.AsyncBR, du *velerov2alpha1api.DataUpload, res *exposer.ExposeResult, log logrus.FieldLogger) error {
+func (*DataUploadReconciler) startCancelableDataPath(asyncBR datapath.AsyncBR, du *velerov2alpha1api.DataUpload, res *exposer.ExposeResult, log logrus.FieldLogger) error {
 	log.Info("Start cancelable dataUpload")
 
 	if err := asyncBR.StartBackup(datapath.AccessPoint{
@@ -666,17 +666,17 @@ func (r *DataUploadReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				CreateFunc: func(event.CreateEvent) bool {
 					return false
 				},
-				DeleteFunc: func(de event.DeleteEvent) bool {
+				DeleteFunc: func(event.DeleteEvent) bool {
 					return false
 				},
-				GenericFunc: func(ge event.GenericEvent) bool {
+				GenericFunc: func(event.GenericEvent) bool {
 					return false
 				},
 			})).
 		Complete(r)
 }
 
-func (r *DataUploadReconciler) findDataUploadForPod(ctx context.Context, podObj client.Object) []reconcile.Request {
+func (r *DataUploadReconciler) findDataUploadForPod(_ context.Context, podObj client.Object) []reconcile.Request {
 	pod := podObj.(*corev1api.Pod)
 	du, err := findDataUploadByPod(r.client, *pod)
 	log := r.logger.WithFields(logrus.Fields{

--- a/pkg/controller/data_upload_controller_test.go
+++ b/pkg/controller/data_upload_controller_test.go
@@ -75,7 +75,7 @@ type FakeClient struct {
 	listError      error
 }
 
-func (c *FakeClient) Get(ctx context.Context, key kbclient.ObjectKey, obj kbclient.Object, opts ...kbclient.GetOption) error {
+func (c *FakeClient) Get(ctx context.Context, key kbclient.ObjectKey, obj kbclient.Object, _ ...kbclient.GetOption) error {
 	if c.getError != nil {
 		return c.getError
 	}
@@ -275,7 +275,7 @@ type fakeSnapshotExposer struct {
 	getNil          bool
 }
 
-func (f *fakeSnapshotExposer) Expose(ctx context.Context, ownerObject corev1api.ObjectReference, param any) error {
+func (f *fakeSnapshotExposer) Expose(context.Context, corev1api.ObjectReference, any) error {
 	if f.exposeErr != nil {
 		return f.exposeErr
 	}
@@ -283,7 +283,7 @@ func (f *fakeSnapshotExposer) Expose(ctx context.Context, ownerObject corev1api.
 	return nil
 }
 
-func (f *fakeSnapshotExposer) GetExposed(ctx context.Context, du corev1api.ObjectReference, tm time.Duration, para any) (*exposer.ExposeResult, error) {
+func (f *fakeSnapshotExposer) GetExposed(context.Context, corev1api.ObjectReference, time.Duration, any) (*exposer.ExposeResult, error) {
 	if f.getErr != nil {
 		return nil, f.getErr
 	}
@@ -302,15 +302,15 @@ func (f *fakeSnapshotExposer) GetExposed(ctx context.Context, du corev1api.Objec
 	return &exposer.ExposeResult{ByPod: exposer.ExposeByPod{HostingPod: pod, VolumeName: dataUploadName, NodeOS: pNodeOS}}, nil
 }
 
-func (f *fakeSnapshotExposer) PeekExposed(ctx context.Context, ownerObject corev1api.ObjectReference) error {
+func (f *fakeSnapshotExposer) PeekExposed(context.Context, corev1api.ObjectReference) error {
 	return f.peekErr
 }
 
-func (f *fakeSnapshotExposer) DiagnoseExpose(context.Context, corev1api.ObjectReference) string {
+func (*fakeSnapshotExposer) DiagnoseExpose(context.Context, corev1api.ObjectReference) string {
 	return ""
 }
 
-func (f *fakeSnapshotExposer) CleanUp(context.Context, corev1api.ObjectReference, string, string) {
+func (*fakeSnapshotExposer) CleanUp(context.Context, corev1api.ObjectReference, string, string) {
 }
 
 type fakeFSBR struct {
@@ -320,22 +320,22 @@ type fakeFSBR struct {
 	startErr   error
 }
 
-func (f *fakeFSBR) Init(ctx context.Context, param any) error {
+func (f *fakeFSBR) Init(context.Context, any) error {
 	return f.initErr
 }
 
-func (f *fakeFSBR) StartBackup(source datapath.AccessPoint, uploaderConfigs map[string]string, param any) error {
+func (f *fakeFSBR) StartBackup(datapath.AccessPoint, map[string]string, any) error {
 	return f.startErr
 }
 
-func (f *fakeFSBR) StartRestore(snapshotID string, target datapath.AccessPoint, uploaderConfigs map[string]string) error {
+func (*fakeFSBR) StartRestore(string, datapath.AccessPoint, map[string]string) error {
 	return nil
 }
 
-func (b *fakeFSBR) Cancel() {
+func (*fakeFSBR) Cancel() {
 }
 
-func (b *fakeFSBR) Close(ctx context.Context) {
+func (*fakeFSBR) Close(context.Context) {
 }
 
 func TestReconcile(t *testing.T) {
@@ -882,7 +882,7 @@ func TestFindDataUploadForPod(t *testing.T) {
 			name: "no selected label found for pod",
 			du:   dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseAccepted).Result(),
 			pod:  builder.ForPod(velerov1api.DefaultNamespace, dataUploadName).Result(),
-			checkFunc: func(du *velerov2alpha1api.DataUpload, requests []reconcile.Request) {
+			checkFunc: func(_ *velerov2alpha1api.DataUpload, requests []reconcile.Request) {
 				// Assert that the function returns a single request
 				assert.Empty(t, requests)
 			},
@@ -890,7 +890,7 @@ func TestFindDataUploadForPod(t *testing.T) {
 			name: "no matched pod",
 			du:   dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseAccepted).Result(),
 			pod:  builder.ForPod(velerov1api.DefaultNamespace, dataUploadName).Labels(map[string]string{velerov1api.DataUploadLabel: "non-existing-dataupload"}).Result(),
-			checkFunc: func(du *velerov2alpha1api.DataUpload, requests []reconcile.Request) {
+			checkFunc: func(_ *velerov2alpha1api.DataUpload, requests []reconcile.Request) {
 				assert.Empty(t, requests)
 			},
 		},
@@ -898,7 +898,7 @@ func TestFindDataUploadForPod(t *testing.T) {
 			name: "dataUpload not accepte",
 			du:   dataUploadBuilder().Phase(velerov2alpha1api.DataUploadPhaseInProgress).Result(),
 			pod:  builder.ForPod(velerov1api.DefaultNamespace, dataUploadName).Labels(map[string]string{velerov1api.DataUploadLabel: dataUploadName}).Result(),
-			checkFunc: func(du *velerov2alpha1api.DataUpload, requests []reconcile.Request) {
+			checkFunc: func(_ *velerov2alpha1api.DataUpload, requests []reconcile.Request) {
 				assert.Empty(t, requests)
 			},
 		},
@@ -1139,7 +1139,7 @@ func (dt *duResumeTestHelper) resumeCancellableDataPath(_ *DataUploadReconciler,
 	return dt.resumeErr
 }
 
-func (dt *duResumeTestHelper) Expose(context.Context, corev1api.ObjectReference, any) error {
+func (*duResumeTestHelper) Expose(context.Context, corev1api.ObjectReference, any) error {
 	return nil
 }
 
@@ -1147,15 +1147,15 @@ func (dt *duResumeTestHelper) GetExposed(context.Context, corev1api.ObjectRefere
 	return dt.exposeResult, dt.getExposeErr
 }
 
-func (dt *duResumeTestHelper) PeekExposed(context.Context, corev1api.ObjectReference) error {
+func (*duResumeTestHelper) PeekExposed(context.Context, corev1api.ObjectReference) error {
 	return nil
 }
 
-func (dt *duResumeTestHelper) DiagnoseExpose(context.Context, corev1api.ObjectReference) string {
+func (*duResumeTestHelper) DiagnoseExpose(context.Context, corev1api.ObjectReference) string {
 	return ""
 }
 
-func (dt *duResumeTestHelper) CleanUp(context.Context, corev1api.ObjectReference, string, string) {}
+func (*duResumeTestHelper) CleanUp(context.Context, corev1api.ObjectReference, string, string) {}
 
 func (dt *duResumeTestHelper) newMicroServiceBRWatcher(kbclient.Client, kubernetes.Interface, manager.Manager, string, string, string, string, string, string,
 	datapath.Callbacks, logrus.FieldLogger) datapath.AsyncBR {

--- a/pkg/controller/gc_controller.go
+++ b/pkg/controller/gc_controller.go
@@ -82,13 +82,13 @@ func (c *gcReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	s := kube.NewPeriodicalEnqueueSource(c.logger.WithField("controller", constant.ControllerGarbageCollection), mgr.GetClient(), &velerov1api.BackupList{}, c.frequency, kube.PeriodicalEnqueueSourceOption{})
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&velerov1api.Backup{}, builder.WithPredicates(predicate.Funcs{
-			UpdateFunc: func(ue event.UpdateEvent) bool {
+			UpdateFunc: func(event.UpdateEvent) bool {
 				return false
 			},
-			DeleteFunc: func(de event.DeleteEvent) bool {
+			DeleteFunc: func(event.DeleteEvent) bool {
 				return false
 			},
-			GenericFunc: func(ge event.GenericEvent) bool {
+			GenericFunc: func(event.GenericEvent) bool {
 				return false
 			},
 		})).

--- a/pkg/controller/pod_volume_backup_controller.go
+++ b/pkg/controller/pod_volume_backup_controller.go
@@ -470,7 +470,7 @@ func (r *PodVolumeBackupReconciler) onPrepareTimeout(ctx context.Context, pvb *v
 	log.Info("PVB has been cleaned up")
 }
 
-func (r *PodVolumeBackupReconciler) initCancelableDataPath(ctx context.Context, asyncBR datapath.AsyncBR, res *exposer.ExposeResult, log logrus.FieldLogger) error {
+func (*PodVolumeBackupReconciler) initCancelableDataPath(ctx context.Context, asyncBR datapath.AsyncBR, res *exposer.ExposeResult, log logrus.FieldLogger) error {
 	log.Info("Init cancelable PVB")
 
 	if err := asyncBR.Init(ctx, nil); err != nil {
@@ -482,7 +482,7 @@ func (r *PodVolumeBackupReconciler) initCancelableDataPath(ctx context.Context, 
 	return nil
 }
 
-func (r *PodVolumeBackupReconciler) startCancelableDataPath(asyncBR datapath.AsyncBR, pvb *velerov1api.PodVolumeBackup, res *exposer.ExposeResult, log logrus.FieldLogger) error {
+func (*PodVolumeBackupReconciler) startCancelableDataPath(asyncBR datapath.AsyncBR, pvb *velerov1api.PodVolumeBackup, res *exposer.ExposeResult, log logrus.FieldLogger) error {
 	log.Info("Start cancelable PVB")
 
 	if err := asyncBR.StartBackup(datapath.AccessPoint{
@@ -657,17 +657,17 @@ func (r *PodVolumeBackupReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				CreateFunc: func(event.CreateEvent) bool {
 					return false
 				},
-				DeleteFunc: func(de event.DeleteEvent) bool {
+				DeleteFunc: func(event.DeleteEvent) bool {
 					return false
 				},
-				GenericFunc: func(ge event.GenericEvent) bool {
+				GenericFunc: func(event.GenericEvent) bool {
 					return false
 				},
 			})).
 		Complete(r)
 }
 
-func (r *PodVolumeBackupReconciler) findPVBForPod(ctx context.Context, podObj client.Object) []reconcile.Request {
+func (r *PodVolumeBackupReconciler) findPVBForPod(_ context.Context, podObj client.Object) []reconcile.Request {
 	pod := podObj.(*corev1api.Pod)
 	pvb, err := findPVBByPod(r.client, *pod)
 
@@ -742,7 +742,7 @@ func (r *PodVolumeBackupReconciler) errorOut(ctx context.Context, pvb *velerov1a
 	return ctrl.Result{}, err
 }
 
-func UpdatePVBStatusToFailed(ctx context.Context, c client.Client, pvb *velerov1api.PodVolumeBackup, errOut error, msg string, time time.Time, log logrus.FieldLogger) error {
+func UpdatePVBStatusToFailed(_ context.Context, c client.Client, pvb *velerov1api.PodVolumeBackup, errOut error, msg string, time time.Time, log logrus.FieldLogger) error {
 	log.Info("update PVB status to Failed")
 
 	if patchErr := UpdatePVBWithRetry(context.Background(), c, types.NamespacedName{Namespace: pvb.Namespace, Name: pvb.Name}, log,

--- a/pkg/controller/pod_volume_backup_controller_test.go
+++ b/pkg/controller/pod_volume_backup_controller_test.go
@@ -168,7 +168,7 @@ type fakePvbExposer struct {
 	getNil     bool
 }
 
-func (f *fakePvbExposer) Expose(ctx context.Context, ownerObject corev1api.ObjectReference, param exposer.PodVolumeExposeParam) error {
+func (f *fakePvbExposer) Expose(context.Context, corev1api.ObjectReference, exposer.PodVolumeExposeParam) error {
 	if f.exposeErr != nil {
 		return f.exposeErr
 	}
@@ -193,15 +193,15 @@ func (f *fakePvbExposer) GetExposed(context.Context, corev1api.ObjectReference, 
 	return &exposer.ExposeResult{ByPod: exposer.ExposeByPod{HostingPod: pod, VolumeName: pvbName, NodeOS: pNodeOS}}, nil
 }
 
-func (f *fakePvbExposer) PeekExposed(ctx context.Context, ownerObject corev1api.ObjectReference) error {
+func (f *fakePvbExposer) PeekExposed(context.Context, corev1api.ObjectReference) error {
 	return f.peekErr
 }
 
-func (f *fakePvbExposer) DiagnoseExpose(context.Context, corev1api.ObjectReference) string {
+func (*fakePvbExposer) DiagnoseExpose(context.Context, corev1api.ObjectReference) string {
 	return ""
 }
 
-func (f *fakePvbExposer) CleanUp(context.Context, corev1api.ObjectReference) {
+func (*fakePvbExposer) CleanUp(context.Context, corev1api.ObjectReference) {
 }
 
 func TestPVBReconcile(t *testing.T) {
@@ -720,7 +720,7 @@ func TestFindPvbForPod(t *testing.T) {
 			name: "no selected label found for pod",
 			pvb:  pvbBuilder().Phase(velerov1api.PodVolumeBackupPhaseAccepted).Result(),
 			pod:  builder.ForPod(velerov1api.DefaultNamespace, pvbName).Result(),
-			checkFunc: func(pvb *velerov1api.PodVolumeBackup, requests []reconcile.Request) {
+			checkFunc: func(_ *velerov1api.PodVolumeBackup, requests []reconcile.Request) {
 				// Assert that the function returns a single request
 				assert.Empty(t, requests)
 			},
@@ -728,7 +728,7 @@ func TestFindPvbForPod(t *testing.T) {
 			name: "no matched pod",
 			pvb:  pvbBuilder().Phase(velerov1api.PodVolumeBackupPhaseAccepted).Result(),
 			pod:  builder.ForPod(velerov1api.DefaultNamespace, pvbName).Labels(map[string]string{velerov1api.PVBLabel: "non-existing-pvb"}).Result(),
-			checkFunc: func(pvb *velerov1api.PodVolumeBackup, requests []reconcile.Request) {
+			checkFunc: func(_ *velerov1api.PodVolumeBackup, requests []reconcile.Request) {
 				assert.Empty(t, requests)
 			},
 		},
@@ -736,7 +736,7 @@ func TestFindPvbForPod(t *testing.T) {
 			name: "pvb not accepte",
 			pvb:  pvbBuilder().Phase(velerov1api.PodVolumeBackupPhaseInProgress).Result(),
 			pod:  builder.ForPod(velerov1api.DefaultNamespace, pvbName).Labels(map[string]string{velerov1api.PVBLabel: pvbName}).Result(),
-			checkFunc: func(pvb *velerov1api.PodVolumeBackup, requests []reconcile.Request) {
+			checkFunc: func(_ *velerov1api.PodVolumeBackup, requests []reconcile.Request) {
 				assert.Empty(t, requests)
 			},
 		},
@@ -955,7 +955,7 @@ func (dt *pvbResumeTestHelper) resumeCancellableDataPath(_ *DataUploadReconciler
 	return dt.resumeErr
 }
 
-func (dt *pvbResumeTestHelper) Expose(context.Context, corev1api.ObjectReference, exposer.PodVolumeExposeParam) error {
+func (*pvbResumeTestHelper) Expose(context.Context, corev1api.ObjectReference, exposer.PodVolumeExposeParam) error {
 	return nil
 }
 
@@ -963,15 +963,15 @@ func (dt *pvbResumeTestHelper) GetExposed(context.Context, corev1api.ObjectRefer
 	return dt.exposeResult, dt.getExposeErr
 }
 
-func (dt *pvbResumeTestHelper) PeekExposed(context.Context, corev1api.ObjectReference) error {
+func (*pvbResumeTestHelper) PeekExposed(context.Context, corev1api.ObjectReference) error {
 	return nil
 }
 
-func (dt *pvbResumeTestHelper) DiagnoseExpose(context.Context, corev1api.ObjectReference) string {
+func (*pvbResumeTestHelper) DiagnoseExpose(context.Context, corev1api.ObjectReference) string {
 	return ""
 }
 
-func (dt *pvbResumeTestHelper) CleanUp(context.Context, corev1api.ObjectReference) {}
+func (*pvbResumeTestHelper) CleanUp(context.Context, corev1api.ObjectReference) {}
 
 func (dt *pvbResumeTestHelper) newMicroServiceBRWatcher(kbclient.Client, kubernetes.Interface, manager.Manager, string, string, string, string, string, string,
 	datapath.Callbacks, logrus.FieldLogger) datapath.AsyncBR {

--- a/pkg/controller/pod_volume_restore_controller.go
+++ b/pkg/controller/pod_volume_restore_controller.go
@@ -475,7 +475,7 @@ func (r *PodVolumeRestoreReconciler) onPrepareTimeout(ctx context.Context, pvr *
 	log.Info("PVR has been cleaned up")
 }
 
-func (r *PodVolumeRestoreReconciler) initCancelableDataPath(ctx context.Context, asyncBR datapath.AsyncBR, res *exposer.ExposeResult, log logrus.FieldLogger) error {
+func (*PodVolumeRestoreReconciler) initCancelableDataPath(ctx context.Context, asyncBR datapath.AsyncBR, res *exposer.ExposeResult, log logrus.FieldLogger) error {
 	log.Info("Init cancelable PVR")
 
 	if err := asyncBR.Init(ctx, nil); err != nil {
@@ -487,7 +487,7 @@ func (r *PodVolumeRestoreReconciler) initCancelableDataPath(ctx context.Context,
 	return nil
 }
 
-func (r *PodVolumeRestoreReconciler) startCancelableDataPath(asyncBR datapath.AsyncBR, pvr *velerov1api.PodVolumeRestore, res *exposer.ExposeResult, log logrus.FieldLogger) error {
+func (*PodVolumeRestoreReconciler) startCancelableDataPath(asyncBR datapath.AsyncBR, pvr *velerov1api.PodVolumeRestore, res *exposer.ExposeResult, log logrus.FieldLogger) error {
 	log.Info("Start cancelable PVR")
 
 	if err := asyncBR.StartRestore(pvr.Spec.SnapshotID, datapath.AccessPoint{
@@ -506,7 +506,7 @@ func (r *PodVolumeRestoreReconciler) errorOut(ctx context.Context, pvr *velerov1
 	return ctrl.Result{}, UpdatePVRStatusToFailed(ctx, r.client, pvr, err, msg, r.clock.Now(), log)
 }
 
-func UpdatePVRStatusToFailed(ctx context.Context, c client.Client, pvr *velerov1api.PodVolumeRestore, err error, msg string, time time.Time, log logrus.FieldLogger) error {
+func UpdatePVRStatusToFailed(_ context.Context, c client.Client, pvr *velerov1api.PodVolumeRestore, err error, msg string, time time.Time, log logrus.FieldLogger) error {
 	log.Info("update PVR status to Failed")
 
 	if patchErr := UpdatePVRWithRetry(context.Background(), c, types.NamespacedName{Namespace: pvr.Namespace, Name: pvr.Name}, log,
@@ -617,17 +617,17 @@ func (r *PodVolumeRestoreReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				CreateFunc: func(event.CreateEvent) bool {
 					return false
 				},
-				DeleteFunc: func(de event.DeleteEvent) bool {
+				DeleteFunc: func(_ event.DeleteEvent) bool {
 					return false
 				},
-				GenericFunc: func(ge event.GenericEvent) bool {
+				GenericFunc: func(_ event.GenericEvent) bool {
 					return false
 				},
 			})).
 		Complete(r)
 }
 
-func (r *PodVolumeRestoreReconciler) findPVRForTargetPod(ctx context.Context, pod client.Object) []reconcile.Request {
+func (r *PodVolumeRestoreReconciler) findPVRForTargetPod(_ context.Context, pod client.Object) []reconcile.Request {
 	list := &velerov1api.PodVolumeRestoreList{}
 	options := &client.ListOptions{
 		LabelSelector: labels.Set(map[string]string{
@@ -656,7 +656,7 @@ func (r *PodVolumeRestoreReconciler) findPVRForTargetPod(ctx context.Context, po
 	return requests
 }
 
-func (r *PodVolumeRestoreReconciler) findPVRForRestorePod(ctx context.Context, podObj client.Object) []reconcile.Request {
+func (r *PodVolumeRestoreReconciler) findPVRForRestorePod(_ context.Context, podObj client.Object) []reconcile.Request {
 	pod := podObj.(*corev1api.Pod)
 	pvr, err := findPVRByRestorePod(r.client, *pod)
 

--- a/pkg/controller/pod_volume_restore_controller_legacy.go
+++ b/pkg/controller/pod_volume_restore_controller_legacy.go
@@ -214,7 +214,7 @@ func (c *PodVolumeRestoreReconcilerLegacy) SetupWithManager(mgr ctrl.Manager) er
 		Complete(c)
 }
 
-func (c *PodVolumeRestoreReconcilerLegacy) findVolumeRestoresForPod(ctx context.Context, pod client.Object) []reconcile.Request {
+func (c *PodVolumeRestoreReconcilerLegacy) findVolumeRestoresForPod(_ context.Context, pod client.Object) []reconcile.Request {
 	list := &velerov1api.PodVolumeRestoreList{}
 	options := &client.ListOptions{
 		LabelSelector: labels.Set(map[string]string{

--- a/pkg/controller/pod_volume_restore_controller_test.go
+++ b/pkg/controller/pod_volume_restore_controller_test.go
@@ -1268,7 +1268,7 @@ func TestFindPVBForRestorePod(t *testing.T) {
 			name: "no selected label found for pod",
 			pvr:  pvrBuilder().Phase(velerov1api.PodVolumeRestorePhaseAccepted).Result(),
 			pod:  builder.ForPod(velerov1api.DefaultNamespace, pvrName).Result(),
-			checkFunc: func(pvr *velerov1api.PodVolumeRestore, requests []reconcile.Request) {
+			checkFunc: func(_ *velerov1api.PodVolumeRestore, requests []reconcile.Request) {
 				// Assert that the function returns a single request
 				assert.Empty(t, requests)
 			},
@@ -1276,7 +1276,7 @@ func TestFindPVBForRestorePod(t *testing.T) {
 			name: "no matched pod",
 			pvr:  pvrBuilder().Phase(velerov1api.PodVolumeRestorePhaseAccepted).Result(),
 			pod:  builder.ForPod(velerov1api.DefaultNamespace, pvrName).Labels(map[string]string{velerov1api.PVRLabel: "non-existing-pvr"}).Result(),
-			checkFunc: func(pvr *velerov1api.PodVolumeRestore, requests []reconcile.Request) {
+			checkFunc: func(_ *velerov1api.PodVolumeRestore, requests []reconcile.Request) {
 				assert.Empty(t, requests)
 			},
 		},
@@ -1284,7 +1284,7 @@ func TestFindPVBForRestorePod(t *testing.T) {
 			name: "pvr not accept",
 			pvr:  pvrBuilder().Phase(velerov1api.PodVolumeRestorePhaseInProgress).Result(),
 			pod:  builder.ForPod(velerov1api.DefaultNamespace, pvrName).Labels(map[string]string{velerov1api.PVRLabel: pvrName}).Result(),
-			checkFunc: func(pvr *velerov1api.PodVolumeRestore, requests []reconcile.Request) {
+			checkFunc: func(_ *velerov1api.PodVolumeRestore, requests []reconcile.Request) {
 				assert.Empty(t, requests)
 			},
 		},

--- a/pkg/controller/restore_controller_test.go
+++ b/pkg/controller/restore_controller_test.go
@@ -1028,7 +1028,7 @@ type fakeRestorer struct {
 func (r *fakeRestorer) Restore(
 	info *pkgrestore.Request,
 	actions []riav2.RestoreItemAction,
-	volumeSnapshotterGetter pkgrestore.VolumeSnapshotterGetter,
+	_ pkgrestore.VolumeSnapshotterGetter,
 ) (results.Result, results.Result) {
 	res := r.Called(info.Log, info.Restore, info.Backup, info.BackupReader, actions)
 

--- a/pkg/controller/restore_finalizer_controller.go
+++ b/pkg/controller/restore_finalizer_controller.go
@@ -215,7 +215,7 @@ func (r *restoreFinalizerReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	return ctrl.Result{}, nil
 }
 
-func (r *restoreFinalizerReconciler) updateResults(backupStore persistence.BackupStore, restore *velerov1api.Restore, newWarnings *results.Result, newErrs *results.Result) error {
+func (*restoreFinalizerReconciler) updateResults(backupStore persistence.BackupStore, restore *velerov1api.Restore, newWarnings *results.Result, newErrs *results.Result) error {
 	originResults, err := backupStore.GetRestoreResults(restore.Name)
 	if err != nil {
 		return errors.Wrap(err, "error getting restore results")

--- a/pkg/controller/server_status_request_controller.go
+++ b/pkg/controller/server_status_request_controller.go
@@ -76,7 +76,7 @@ func NewServerStatusRequestReconciler(
 // +kubebuilder:rbac:groups=velero.io,resources=serverstatusrequests,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=velero.io,resources=serverstatusrequests/status,verbs=get;update;patch
 
-func (r *serverStatusRequestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *serverStatusRequestReconciler) Reconcile(_ context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.log.WithFields(logrus.Fields{
 		"controller":          constant.ControllerServerStatusRequest,
 		"serverStatusRequest": req.NamespacedName,

--- a/pkg/controller/suite_test.go
+++ b/pkg/controller/suite_test.go
@@ -129,7 +129,7 @@ func (t *testEnvironment) startManager() error {
 	return t.Manager.Start(t.doneMgr)
 }
 
-func (t *testEnvironment) stop() error {
+func (*testEnvironment) stop() error {
 	cancel()
 	return env.Stop()
 }
@@ -137,7 +137,7 @@ func (t *testEnvironment) stop() error {
 type fakeErrorBackupStoreGetter struct {
 }
 
-func (f *fakeErrorBackupStoreGetter) Get(*velerov1api.BackupStorageLocation, persistence.ObjectStoreGetter, logrus.FieldLogger) (persistence.BackupStore, error) {
+func (*fakeErrorBackupStoreGetter) Get(*velerov1api.BackupStorageLocation, persistence.ObjectStoreGetter, logrus.FieldLogger) (persistence.BackupStore, error) {
 	return nil, fmt.Errorf("some error")
 }
 

--- a/pkg/datamover/backup_micro_service.go
+++ b/pkg/datamover/backup_micro_service.go
@@ -240,7 +240,7 @@ func (r *BackupMicroService) Shutdown() {
 
 var funcMarshal = json.Marshal
 
-func (r *BackupMicroService) OnDataUploadCompleted(ctx context.Context, namespace string, duName string, result datapath.Result) {
+func (r *BackupMicroService) OnDataUploadCompleted(_ context.Context, _ string, duName string, result datapath.Result) {
 	log := r.logger.WithField("dataupload", duName)
 
 	backupBytes, err := funcMarshal(result.Backup)
@@ -259,7 +259,7 @@ func (r *BackupMicroService) OnDataUploadCompleted(ctx context.Context, namespac
 	log.Info("Async fs backup completed")
 }
 
-func (r *BackupMicroService) OnDataUploadFailed(ctx context.Context, namespace string, duName string, err error) {
+func (r *BackupMicroService) OnDataUploadFailed(_ context.Context, _ string, duName string, err error) {
 	log := r.logger.WithField("dataupload", duName)
 	log.WithError(err).Error("Async fs backup data path failed")
 
@@ -269,7 +269,7 @@ func (r *BackupMicroService) OnDataUploadFailed(ctx context.Context, namespace s
 	}
 }
 
-func (r *BackupMicroService) OnDataUploadCancelled(ctx context.Context, namespace string, duName string) {
+func (r *BackupMicroService) OnDataUploadCancelled(_ context.Context, _ string, duName string) {
 	log := r.logger.WithField("dataupload", duName)
 	log.Warn("Async fs backup data path canceled")
 
@@ -279,7 +279,7 @@ func (r *BackupMicroService) OnDataUploadCancelled(ctx context.Context, namespac
 	}
 }
 
-func (r *BackupMicroService) OnDataUploadProgress(ctx context.Context, namespace string, duName string, progress *uploader.Progress) {
+func (r *BackupMicroService) OnDataUploadProgress(_ context.Context, _ string, duName string, progress *uploader.Progress) {
 	log := r.logger.WithFields(logrus.Fields{
 		"dataupload": duName,
 	})

--- a/pkg/datamover/backup_micro_service_test.go
+++ b/pkg/datamover/backup_micro_service_test.go
@@ -72,9 +72,9 @@ func (bt *backupMsTestHelper) EndingEvent(_ runtime.Object, _ bool, reason strin
 	bt.eventReason = reason
 	bt.eventMsg = fmt.Sprintf(message, a...)
 }
-func (bt *backupMsTestHelper) Shutdown() {}
+func (*backupMsTestHelper) Shutdown() {}
 
-func (bt *backupMsTestHelper) Marshal(v any) ([]byte, error) {
+func (bt *backupMsTestHelper) Marshal(any) ([]byte, error) {
 	if bt.marshalErr != nil {
 		return nil, bt.marshalErr
 	}

--- a/pkg/datamover/dataupload_delete_action.go
+++ b/pkg/datamover/dataupload_delete_action.go
@@ -23,7 +23,7 @@ type DataUploadDeleteAction struct {
 	client client.Client
 }
 
-func (d *DataUploadDeleteAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*DataUploadDeleteAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"datauploads.velero.io"},
 	}, nil

--- a/pkg/datamover/restore_micro_service.go
+++ b/pkg/datamover/restore_micro_service.go
@@ -215,7 +215,7 @@ func (r *RestoreMicroService) Shutdown() {
 	}
 }
 
-func (r *RestoreMicroService) OnDataDownloadCompleted(ctx context.Context, namespace string, ddName string, result datapath.Result) {
+func (r *RestoreMicroService) OnDataDownloadCompleted(_ context.Context, _ string, ddName string, result datapath.Result) {
 	log := r.logger.WithField("datadownload", ddName)
 
 	restoreBytes, err := funcMarshal(result.Restore)
@@ -234,7 +234,7 @@ func (r *RestoreMicroService) OnDataDownloadCompleted(ctx context.Context, names
 	log.Info("Async fs restore data path completed")
 }
 
-func (r *RestoreMicroService) OnDataDownloadFailed(ctx context.Context, namespace string, ddName string, err error) {
+func (r *RestoreMicroService) OnDataDownloadFailed(_ context.Context, _ string, ddName string, err error) {
 	log := r.logger.WithField("datadownload", ddName)
 	log.WithError(err).Error("Async fs restore data path failed")
 
@@ -244,7 +244,7 @@ func (r *RestoreMicroService) OnDataDownloadFailed(ctx context.Context, namespac
 	}
 }
 
-func (r *RestoreMicroService) OnDataDownloadCancelled(ctx context.Context, namespace string, ddName string) {
+func (r *RestoreMicroService) OnDataDownloadCancelled(_ context.Context, _ string, ddName string) {
 	log := r.logger.WithField("datadownload", ddName)
 	log.Warn("Async fs restore data path canceled")
 
@@ -254,7 +254,7 @@ func (r *RestoreMicroService) OnDataDownloadCancelled(ctx context.Context, names
 	}
 }
 
-func (r *RestoreMicroService) OnDataDownloadProgress(ctx context.Context, namespace string, ddName string, progress *uploader.Progress) {
+func (r *RestoreMicroService) OnDataDownloadProgress(_ context.Context, _ string, ddName string, progress *uploader.Progress) {
 	log := r.logger.WithFields(logrus.Fields{
 		"datadownload": ddName,
 	})

--- a/pkg/datapath/file_system_test.go
+++ b/pkg/datapath/file_system_test.go
@@ -48,7 +48,7 @@ func TestAsyncBackup(t *testing.T) {
 			callbacks: Callbacks{
 				OnCompleted: nil,
 				OnCancelled: nil,
-				OnFailed: func(ctx context.Context, namespace string, job string, err error) {
+				OnFailed: func(context.Context, string, string, error) {
 					asyncErr = failErr
 					asyncResult = Result{}
 					finish <- struct{}{}
@@ -61,7 +61,7 @@ func TestAsyncBackup(t *testing.T) {
 			callbacks: Callbacks{
 				OnCompleted: nil,
 				OnFailed:    nil,
-				OnCancelled: func(ctx context.Context, namespace string, job string) {
+				OnCancelled: func(context.Context, string, string) {
 					asyncErr = provider.ErrorCanceled
 					asyncResult = Result{}
 					finish <- struct{}{}
@@ -74,7 +74,7 @@ func TestAsyncBackup(t *testing.T) {
 			callbacks: Callbacks{
 				OnFailed:    nil,
 				OnCancelled: nil,
-				OnCompleted: func(ctx context.Context, namespace string, job string, result Result) {
+				OnCompleted: func(_ context.Context, _ string, _ string, result Result) {
 					asyncResult = result
 					asyncErr = nil
 					finish <- struct{}{}
@@ -134,7 +134,7 @@ func TestAsyncRestore(t *testing.T) {
 			callbacks: Callbacks{
 				OnCompleted: nil,
 				OnCancelled: nil,
-				OnFailed: func(ctx context.Context, namespace string, job string, err error) {
+				OnFailed: func(context.Context, string, string, error) {
 					asyncErr = failErr
 					asyncResult = Result{}
 					finish <- struct{}{}
@@ -147,7 +147,7 @@ func TestAsyncRestore(t *testing.T) {
 			callbacks: Callbacks{
 				OnCompleted: nil,
 				OnFailed:    nil,
-				OnCancelled: func(ctx context.Context, namespace string, job string) {
+				OnCancelled: func(context.Context, string, string) {
 					asyncErr = provider.ErrorCanceled
 					asyncResult = Result{}
 					finish <- struct{}{}
@@ -160,7 +160,7 @@ func TestAsyncRestore(t *testing.T) {
 			callbacks: Callbacks{
 				OnFailed:    nil,
 				OnCancelled: nil,
-				OnCompleted: func(ctx context.Context, namespace string, job string, result Result) {
+				OnCompleted: func(_ context.Context, _ string, _ string, result Result) {
 					asyncResult = result
 					asyncErr = nil
 					finish <- struct{}{}

--- a/pkg/datapath/manager.go
+++ b/pkg/datapath/manager.go
@@ -46,7 +46,7 @@ func NewManager(cocurrentNum int) *Manager {
 }
 
 // CreateFileSystemBR creates a new file system backup/restore data path instance
-func (m *Manager) CreateFileSystemBR(jobName string, requestorType string, ctx context.Context, client client.Client, namespace string, callbacks Callbacks, log logrus.FieldLogger) (AsyncBR, error) {
+func (m *Manager) CreateFileSystemBR(jobName string, requestorType string, _ context.Context, client client.Client, namespace string, callbacks Callbacks, log logrus.FieldLogger) (AsyncBR, error) {
 	m.trackerLock.Lock()
 	defer m.trackerLock.Unlock()
 
@@ -60,7 +60,7 @@ func (m *Manager) CreateFileSystemBR(jobName string, requestorType string, ctx c
 }
 
 // CreateMicroServiceBRWatcher creates a new micro service watcher instance
-func (m *Manager) CreateMicroServiceBRWatcher(ctx context.Context, client client.Client, kubeClient kubernetes.Interface, mgr manager.Manager, taskType string,
+func (m *Manager) CreateMicroServiceBRWatcher(_ context.Context, client client.Client, kubeClient kubernetes.Interface, mgr manager.Manager, taskType string,
 	taskName string, namespace string, podName string, containerName string, associatedObject string, callbacks Callbacks, resume bool, log logrus.FieldLogger) (AsyncBR, error) {
 	m.trackerLock.Lock()
 	defer m.trackerLock.Unlock()

--- a/pkg/datapath/micro_service_watcher.go
+++ b/pkg/datapath/micro_service_watcher.go
@@ -104,7 +104,7 @@ func newMicroServiceBRWatcher(client client.Client, kubeClient kubernetes.Interf
 	return ms
 }
 
-func (ms *microServiceBRWatcher) Init(ctx context.Context, param any) error {
+func (ms *microServiceBRWatcher) Init(ctx context.Context, _ any) error {
 	eventInformer, err := ms.mgr.GetCache().GetInformer(ctx, &corev1api.Event{})
 	if err != nil {
 		return errors.Wrap(err, "error getting event informer")
@@ -178,7 +178,7 @@ func (ms *microServiceBRWatcher) Init(ctx context.Context, param any) error {
 	return nil
 }
 
-func (ms *microServiceBRWatcher) Close(ctx context.Context) {
+func (ms *microServiceBRWatcher) Close(context.Context) {
 	if ms.cancel != nil {
 		ms.cancel()
 	}
@@ -213,7 +213,7 @@ func (ms *microServiceBRWatcher) close() {
 	}
 }
 
-func (ms *microServiceBRWatcher) StartBackup(source AccessPoint, uploaderConfig map[string]string, param any) error {
+func (ms *microServiceBRWatcher) StartBackup(source AccessPoint, _ map[string]string, _ any) error {
 	ms.log.Infof("Start watching backup ms for source %v", source.ByPath)
 
 	ms.startWatch()
@@ -221,7 +221,7 @@ func (ms *microServiceBRWatcher) StartBackup(source AccessPoint, uploaderConfig 
 	return nil
 }
 
-func (ms *microServiceBRWatcher) StartRestore(snapshotID string, target AccessPoint, uploaderConfigs map[string]string) error {
+func (ms *microServiceBRWatcher) StartRestore(snapshotID string, target AccessPoint, _ map[string]string) error {
 	ms.log.Infof("Start watching restore ms to target %s, from snapshot %s", target.ByPath, snapshotID)
 
 	ms.startWatch()

--- a/pkg/datapath/micro_service_watcher_test.go
+++ b/pkg/datapath/micro_service_watcher_test.go
@@ -124,31 +124,31 @@ type startWatchFake struct {
 	progress           int
 }
 
-func (sw *startWatchFake) getPodContainerTerminateMessage(pod *corev1api.Pod, container string) string {
+func (sw *startWatchFake) getPodContainerTerminateMessage(*corev1api.Pod, string) string {
 	return sw.terminationMessage
 }
 
-func (sw *startWatchFake) redirectDataMoverLogs(ctx context.Context, kubeClient kubernetes.Interface, namespace string, thisPod string, thisContainer string, logger logrus.FieldLogger) error {
+func (sw *startWatchFake) redirectDataMoverLogs(context.Context, kubernetes.Interface, string, string, string, logrus.FieldLogger) error {
 	return sw.redirectErr
 }
 
-func (sw *startWatchFake) getResultFromMessage(_ string, _ string, _ logrus.FieldLogger) Result {
+func (*startWatchFake) getResultFromMessage(string, string, logrus.FieldLogger) Result {
 	return Result{}
 }
 
-func (sw *startWatchFake) OnCompleted(ctx context.Context, namespace string, task string, result Result) {
+func (sw *startWatchFake) OnCompleted(context.Context, string, string, Result) {
 	sw.complete = true
 }
 
-func (sw *startWatchFake) OnFailed(ctx context.Context, namespace string, task string, err error) {
+func (sw *startWatchFake) OnFailed(context.Context, string, string, error) {
 	sw.failed = true
 }
 
-func (sw *startWatchFake) OnCancelled(ctx context.Context, namespace string, task string) {
+func (sw *startWatchFake) OnCancelled(context.Context, string, string) {
 	sw.canceled = true
 }
 
-func (sw *startWatchFake) OnProgress(ctx context.Context, namespace string, task string, progress *uploader.Progress) {
+func (sw *startWatchFake) OnProgress(context.Context, string, string, *uploader.Progress) {
 	sw.progress++
 }
 

--- a/pkg/exposer/csi_snapshot_test.go
+++ b/pkg/exposer/csi_snapshot_test.go
@@ -211,7 +211,7 @@ func TestExpose(t *testing.T) {
 				{
 					verb:     "delete",
 					resource: "volumesnapshots",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-delete-error")
 					},
 				},
@@ -235,7 +235,7 @@ func TestExpose(t *testing.T) {
 				{
 					verb:     "delete",
 					resource: "volumesnapshotcontents",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-delete-error")
 					},
 				},
@@ -259,7 +259,7 @@ func TestExpose(t *testing.T) {
 				{
 					verb:     "create",
 					resource: "volumesnapshots",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-create-error")
 					},
 				},
@@ -283,7 +283,7 @@ func TestExpose(t *testing.T) {
 				{
 					verb:     "create",
 					resource: "volumesnapshotcontents",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-create-error")
 					},
 				},
@@ -322,7 +322,7 @@ func TestExpose(t *testing.T) {
 				{
 					verb:     "create",
 					resource: "persistentvolumeclaims",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-create-error")
 					},
 				},
@@ -350,7 +350,7 @@ func TestExpose(t *testing.T) {
 				{
 					verb:     "create",
 					resource: "pods",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-create-error")
 					},
 				},

--- a/pkg/exposer/generic_restore_test.go
+++ b/pkg/exposer/generic_restore_test.go
@@ -139,7 +139,7 @@ func TestRestoreExpose(t *testing.T) {
 				{
 					verb:     "create",
 					resource: "pods",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-create-error")
 					},
 				},
@@ -160,7 +160,7 @@ func TestRestoreExpose(t *testing.T) {
 				{
 					verb:     "create",
 					resource: "persistentvolumeclaims",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-create-error")
 					},
 				},
@@ -298,7 +298,7 @@ func TestRebindVolume(t *testing.T) {
 				{
 					verb:     "patch",
 					resource: "persistentvolumes",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-patch-error")
 					},
 				},
@@ -320,7 +320,7 @@ func TestRebindVolume(t *testing.T) {
 				{
 					verb:     "delete",
 					resource: "pods",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-delete-error")
 					},
 				},
@@ -342,7 +342,7 @@ func TestRebindVolume(t *testing.T) {
 				{
 					verb:     "delete",
 					resource: "persistentvolumeclaims",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-delete-error")
 					},
 				},
@@ -364,7 +364,7 @@ func TestRebindVolume(t *testing.T) {
 				{
 					verb:     "patch",
 					resource: "persistentvolumeclaims",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-patch-error")
 					},
 				},
@@ -386,7 +386,7 @@ func TestRebindVolume(t *testing.T) {
 				{
 					verb:     "patch",
 					resource: "persistentvolumes",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						if hookCount == 0 {
 							hookCount++
 							return false, nil, nil

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -178,7 +178,7 @@ func DeploymentIsReady(factory client.DynamicFactory, namespace string) (bool, e
 	// declare this variable out of scope so we can return it
 	var isReady bool
 	var readyObservations int32
-	err = wait.PollUntilContextTimeout(context.Background(), time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), time.Second, 3*time.Minute, true, func(context.Context) (bool, error) {
 		unstructuredDeployment, err := c.Get("velero", metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return false, nil
@@ -234,7 +234,7 @@ func daemonSetIsReady(factory client.DynamicFactory, namespace string, name stri
 	var isReady bool
 	var readyObservations int32
 
-	err = wait.PollUntilContextTimeout(context.Background(), time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), time.Second, time.Minute, true, func(context.Context) (bool, error) {
 		unstructuredDaemonSet, err := c.Get(name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return false, nil

--- a/pkg/itemblock/actions/pod_action.go
+++ b/pkg/itemblock/actions/pod_action.go
@@ -38,7 +38,7 @@ func NewPodAction(logger logrus.FieldLogger) *PodAction {
 }
 
 // AppliesTo returns a ResourceSelector that applies only to pods.
-func (a *PodAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*PodAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"pods"},
 	}, nil
@@ -47,7 +47,7 @@ func (a *PodAction) AppliesTo() (velero.ResourceSelector, error) {
 // GetRelatedItems scans the pod's spec.volumes for persistentVolumeClaim volumes and returns a
 // ResourceIdentifier list containing references to all of the persistentVolumeClaim volumes used by
 // the pod. This ensures that when a pod is backed up, all referenced PVCs are backed up along with the pod.
-func (a *PodAction) GetRelatedItems(item runtime.Unstructured, backup *v1.Backup) ([]velero.ResourceIdentifier, error) {
+func (a *PodAction) GetRelatedItems(item runtime.Unstructured, _ *v1.Backup) ([]velero.ResourceIdentifier, error) {
 	a.log.Info("Executing pod ItemBlockAction")
 	defer a.log.Info("Done executing pod ItemBlockAction")
 
@@ -58,6 +58,6 @@ func (a *PodAction) GetRelatedItems(item runtime.Unstructured, backup *v1.Backup
 	return actionhelpers.RelatedItemsForPod(pod, a.log), nil
 }
 
-func (a *PodAction) Name() string {
+func (*PodAction) Name() string {
 	return "PodItemBlockAction"
 }

--- a/pkg/itemblock/actions/pvc_action.go
+++ b/pkg/itemblock/actions/pvc_action.go
@@ -55,7 +55,7 @@ func NewPVCAction(f client.Factory) plugincommon.HandlerInitializer {
 	}
 }
 
-func (a *PVCAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*PVCAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"persistentvolumeclaims"},
 	}, nil
@@ -117,7 +117,7 @@ func (a *PVCAction) GetRelatedItems(item runtime.Unstructured, backup *v1.Backup
 	return relatedItems, nil
 }
 
-func (a *PVCAction) Name() string {
+func (*PVCAction) Name() string {
 	return "PVCItemBlockAction"
 }
 

--- a/pkg/itemblock/actions/service_account_action.go
+++ b/pkg/itemblock/actions/service_account_action.go
@@ -48,7 +48,7 @@ func NewServiceAccountAction(logger logrus.FieldLogger, clusterRoleBindingLister
 }
 
 // AppliesTo returns a ResourceSelector that applies only to service accounts.
-func (a *ServiceAccountAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*ServiceAccountAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"serviceaccounts"},
 	}, nil
@@ -56,7 +56,7 @@ func (a *ServiceAccountAction) AppliesTo() (velero.ResourceSelector, error) {
 
 // GetRelatedItems checks for any ClusterRoleBindings that have this service account as a subject, and
 // returns the ClusterRoleBinding and associated ClusterRole.
-func (a *ServiceAccountAction) GetRelatedItems(item runtime.Unstructured, backup *v1.Backup) ([]velero.ResourceIdentifier, error) {
+func (a *ServiceAccountAction) GetRelatedItems(item runtime.Unstructured, _ *v1.Backup) ([]velero.ResourceIdentifier, error) {
 	a.log.Info("Running ServiceAccount ItemBlockAction")
 	defer a.log.Info("Done running ServiceAccount ItemBlockAction")
 
@@ -68,6 +68,6 @@ func (a *ServiceAccountAction) GetRelatedItems(item runtime.Unstructured, backup
 	return actionhelpers.RelatedItemsForServiceAccount(objectMeta, a.clusterRoleBindings, a.log), nil
 }
 
-func (a *ServiceAccountAction) Name() string {
+func (*ServiceAccountAction) Name() string {
 	return "ServiceAccountItemBlockAction"
 }

--- a/pkg/kopia/kopia_log.go
+++ b/pkg/kopia/kopia_log.go
@@ -111,11 +111,11 @@ func (kl *kopiaLog) Write(ent zapcore.Entry, fields []zapcore.Field) error {
 }
 
 // Sync flushes buffered logs (if any).
-func (kl *kopiaLog) Sync() error {
+func (*kopiaLog) Sync() error {
 	return nil
 }
 
-func (kl *kopiaLog) logrusFields(fields []zapcore.Field) logrus.Fields {
+func (*kopiaLog) logrusFields(fields []zapcore.Field) logrus.Fields {
 	if fields == nil {
 		return logrus.Fields{}
 	}

--- a/pkg/nodeagent/node_agent_test.go
+++ b/pkg/nodeagent/node_agent_test.go
@@ -70,7 +70,7 @@ func TestIsRunning(t *testing.T) {
 				{
 					verb:     "get",
 					resource: "daemonsets",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-get-error")
 					},
 				},
@@ -264,7 +264,7 @@ func TestGetConfigs(t *testing.T) {
 				{
 					verb:     "get",
 					resource: "configmaps",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-get-error")
 					},
 				},

--- a/pkg/persistence/in_memory_object_store.go
+++ b/pkg/persistence/in_memory_object_store.go
@@ -152,7 +152,7 @@ func (o *inMemoryObjectStore) DeleteObject(bucket, key string) error {
 	return nil
 }
 
-func (o *inMemoryObjectStore) CreateSignedURL(bucket, key string, ttl time.Duration) (string, error) {
+func (o *inMemoryObjectStore) CreateSignedURL(bucket, key string, _ time.Duration) (string, error) {
 	bucketData, ok := o.Data[bucket]
 	if !ok {
 		return "", errors.New("bucket not found")

--- a/pkg/persistence/object_store.go
+++ b/pkg/persistence/object_store.go
@@ -582,11 +582,11 @@ func (s *objectBackupStore) DeleteRestore(name string) error {
 	return errors.WithStack(kerrors.NewAggregate(errs))
 }
 
-func (s *objectBackupStore) PutRestoreLog(backup string, restore string, log io.Reader) error {
+func (s *objectBackupStore) PutRestoreLog(_ string, restore string, log io.Reader) error {
 	return s.objectStore.PutObject(s.bucket, s.layout.getRestoreLogKey(restore), log)
 }
 
-func (s *objectBackupStore) PutRestoreResults(backup string, restore string, results io.Reader) error {
+func (s *objectBackupStore) PutRestoreResults(_ string, restore string, results io.Reader) error {
 	return s.objectStore.PutObject(s.bucket, s.layout.getRestoreResultsKey(restore), results)
 }
 

--- a/pkg/persistence/object_store_test.go
+++ b/pkg/persistence/object_store_test.go
@@ -1232,12 +1232,12 @@ func newStringReadSeeker(s string) *stringReadSeeker {
 	}
 }
 
-func (srs *stringReadSeeker) Seek(offset int64, whence int) (int64, error) {
+func (*stringReadSeeker) Seek(int64, int) (int64, error) {
 	return 0, nil
 }
 
 type errorReader struct{}
 
-func (r *errorReader) Read([]byte) (int, error) {
+func (*errorReader) Read([]byte) (int, error) {
 	return 0, errors.New("error readers return errors")
 }

--- a/pkg/plugin/clientmgmt/backupitemaction/v2/restartable_backup_item_action.go
+++ b/pkg/plugin/clientmgmt/backupitemaction/v2/restartable_backup_item_action.go
@@ -171,11 +171,11 @@ func (r *AdaptedV1RestartableBackupItemAction) Execute(item runtime.Unstructured
 
 // Progress returns with an error since v1 plugins will never return an operationID, which means that
 // any operationID passed in here will be invalid.
-func (r *AdaptedV1RestartableBackupItemAction) Progress(operationID string, backup *api.Backup) (velero.OperationProgress, error) {
+func (*AdaptedV1RestartableBackupItemAction) Progress(string, *api.Backup) (velero.OperationProgress, error) {
 	return velero.OperationProgress{}, biav2.AsyncOperationsNotSupportedError()
 }
 
 // Cancel just returns without error since v1 plugins don't implement it.
-func (r *AdaptedV1RestartableBackupItemAction) Cancel(operationID string, backup *api.Backup) error {
+func (*AdaptedV1RestartableBackupItemAction) Cancel(string, *api.Backup) error {
 	return nil
 }

--- a/pkg/plugin/clientmgmt/process/logrus_adapter.go
+++ b/pkg/plugin/clientmgmt/process/logrus_adapter.go
@@ -154,17 +154,17 @@ func (l *logrusAdapter) ResetNamed(name string) hclog.Logger {
 }
 
 // StandardLogger returns a value that conforms to the stdlib log.Logger interface
-func (l *logrusAdapter) StandardLogger(opts *hclog.StandardLoggerOptions) *log.Logger {
+func (*logrusAdapter) StandardLogger(*hclog.StandardLoggerOptions) *log.Logger {
 	panic("not implemented")
 }
 
 // Updates the level. This should affect all sub-loggers as well. If an
 // implementation cannot update the level on the fly, it should no-op.
-func (l *logrusAdapter) SetLevel(_ hclog.Level) {
+func (*logrusAdapter) SetLevel(hclog.Level) {
 }
 
 // ImpliedArgs returns With key/value pairs
-func (l *logrusAdapter) ImpliedArgs() []any {
+func (*logrusAdapter) ImpliedArgs() []any {
 	panic("not implemented")
 }
 
@@ -193,6 +193,6 @@ func (l *logrusAdapter) Name() string {
 }
 
 // Return a value that conforms to io.Writer, which can be passed into log.SetOutput()
-func (l *logrusAdapter) StandardWriter(opts *hclog.StandardLoggerOptions) io.Writer {
+func (*logrusAdapter) StandardWriter(*hclog.StandardLoggerOptions) io.Writer {
 	panic("not implemented")
 }

--- a/pkg/plugin/clientmgmt/process/process.go
+++ b/pkg/plugin/clientmgmt/process/process.go
@@ -35,7 +35,7 @@ func newProcessFactory() Factory {
 	return &processFactory{}
 }
 
-func (pf *processFactory) newProcess(command string, logger logrus.FieldLogger, logLevel logrus.Level) (Process, error) {
+func (*processFactory) newProcess(command string, logger logrus.FieldLogger, logLevel logrus.Level) (Process, error) {
 	return newProcess(command, logger, logLevel)
 }
 

--- a/pkg/plugin/clientmgmt/process/restartable_process.go
+++ b/pkg/plugin/clientmgmt/process/restartable_process.go
@@ -34,7 +34,7 @@ func NewRestartableProcessFactory() RestartableProcessFactory {
 	return &restartableProcessFactory{}
 }
 
-func (rpf *restartableProcessFactory) NewRestartableProcess(command string, logger logrus.FieldLogger, logLevel logrus.Level) (RestartableProcess, error) {
+func (*restartableProcessFactory) NewRestartableProcess(command string, logger logrus.FieldLogger, logLevel logrus.Level) (RestartableProcess, error) {
 	return newRestartableProcess(command, logger, logLevel)
 }
 

--- a/pkg/plugin/clientmgmt/restartable_object_store.go
+++ b/pkg/plugin/clientmgmt/restartable_object_store.go
@@ -108,7 +108,7 @@ func (r *restartableObjectStore) Init(config map[string]string) error {
 
 // init calls Init on objectStore with config. This is split out from Init() so that both Init() and reinitialize() may
 // call it using a specific ObjectStore.
-func (r *restartableObjectStore) init(objectStore velero.ObjectStore, config map[string]string) error {
+func (*restartableObjectStore) init(objectStore velero.ObjectStore, config map[string]string) error {
 	return objectStore.Init(config)
 }
 

--- a/pkg/plugin/clientmgmt/restoreitemaction/v2/restartable_restore_item_action.go
+++ b/pkg/plugin/clientmgmt/restoreitemaction/v2/restartable_restore_item_action.go
@@ -179,16 +179,16 @@ func (r *AdaptedV1RestartableRestoreItemAction) Execute(input *velero.RestoreIte
 
 // Progress returns with an error since v1 plugins will never return an operationID, which means that
 // any operationID passed in here will be invalid.
-func (r *AdaptedV1RestartableRestoreItemAction) Progress(operationID string, restore *api.Restore) (velero.OperationProgress, error) {
+func (*AdaptedV1RestartableRestoreItemAction) Progress(string, *api.Restore) (velero.OperationProgress, error) {
 	return velero.OperationProgress{}, riav2.AsyncOperationsNotSupportedError()
 }
 
 // Cancel just returns without error since v1 plugins don't implement it.
-func (r *AdaptedV1RestartableRestoreItemAction) Cancel(operationID string, restore *api.Restore) error {
+func (*AdaptedV1RestartableRestoreItemAction) Cancel(string, *api.Restore) error {
 	return nil
 }
 
 // AreAdditionalItemsReady just returns true since v1 plugins don't wait for items.
-func (r *AdaptedV1RestartableRestoreItemAction) AreAdditionalItemsReady(additionalItems []velero.ResourceIdentifier, restore *api.Restore) (bool, error) {
+func (*AdaptedV1RestartableRestoreItemAction) AreAdditionalItemsReady([]velero.ResourceIdentifier, *api.Restore) (bool, error) {
 	return true, nil
 }

--- a/pkg/plugin/clientmgmt/volumesnapshotter/v1/restartable_volume_snapshotter.go
+++ b/pkg/plugin/clientmgmt/volumesnapshotter/v1/restartable_volume_snapshotter.go
@@ -122,7 +122,7 @@ func (r *RestartableVolumeSnapshotter) Init(config map[string]string) error {
 
 // init calls Init on volumeSnapshotter with config. This is split out from Init() so that both Init() and reinitialize() may
 // call it using a specific VolumeSnapshotter.
-func (r *RestartableVolumeSnapshotter) init(volumeSnapshotter vsv1.VolumeSnapshotter, config map[string]string) error {
+func (*RestartableVolumeSnapshotter) init(volumeSnapshotter vsv1.VolumeSnapshotter, config map[string]string) error {
 	return volumeSnapshotter.Init(config)
 }
 

--- a/pkg/plugin/framework/action_resolver.go
+++ b/pkg/plugin/framework/action_resolver.go
@@ -149,7 +149,7 @@ type BackupItemActionResolver struct {
 	actions []biav1.BackupItemAction
 }
 
-func (recv BackupItemActionResolver) ResolveActions(helper discovery.Helper, log logrus.FieldLogger) ([]BackupItemResolvedAction, error) {
+func (recv BackupItemActionResolver) ResolveActions(helper discovery.Helper, _ logrus.FieldLogger) ([]BackupItemResolvedAction, error) {
 	var resolved []BackupItemResolvedAction
 	for _, action := range recv.actions {
 		resources, namespaces, selector, err := resolveAction(helper, action)
@@ -209,7 +209,7 @@ type RestoreItemActionResolver struct {
 	actions []riav1.RestoreItemAction
 }
 
-func (recv RestoreItemActionResolver) ResolveActions(helper discovery.Helper, log logrus.FieldLogger) ([]RestoreItemResolvedAction, error) {
+func (recv RestoreItemActionResolver) ResolveActions(helper discovery.Helper, _ logrus.FieldLogger) ([]RestoreItemResolvedAction, error) {
 	var resolved []RestoreItemResolvedAction
 	for _, action := range recv.actions {
 		resources, namespaces, selector, err := resolveAction(helper, action)
@@ -233,7 +233,7 @@ type RestoreItemActionResolverV2 struct {
 	actions []riav2.RestoreItemAction
 }
 
-func (recv RestoreItemActionResolverV2) ResolveActions(helper discovery.Helper, log logrus.FieldLogger) ([]RestoreItemResolvedActionV2, error) {
+func (recv RestoreItemActionResolverV2) ResolveActions(helper discovery.Helper, _ logrus.FieldLogger) ([]RestoreItemResolvedActionV2, error) {
 	var resolved []RestoreItemResolvedActionV2
 	for _, action := range recv.actions {
 		resources, namespaces, selector, err := resolveAction(helper, action)
@@ -262,7 +262,7 @@ type DeleteItemActionResolver struct {
 	actions []velero.DeleteItemAction
 }
 
-func (recv DeleteItemActionResolver) ResolveActions(helper discovery.Helper, log logrus.FieldLogger) ([]DeleteItemResolvedAction, error) {
+func (recv DeleteItemActionResolver) ResolveActions(helper discovery.Helper, _ logrus.FieldLogger) ([]DeleteItemResolvedAction, error) {
 	var resolved []DeleteItemResolvedAction
 	for _, action := range recv.actions {
 		resources, namespaces, selector, err := resolveAction(helper, action)
@@ -297,7 +297,7 @@ func NewItemBlockActionResolver(actions []ibav1.ItemBlockAction) ItemBlockAction
 	}
 }
 
-func (recv ItemBlockActionResolver) ResolveActions(helper discovery.Helper, log logrus.FieldLogger) ([]ItemBlockResolvedAction, error) {
+func (recv ItemBlockActionResolver) ResolveActions(helper discovery.Helper, _ logrus.FieldLogger) ([]ItemBlockResolvedAction, error) {
 	var resolved []ItemBlockResolvedAction
 	for _, action := range recv.actions {
 		resources, namespaces, selector, err := resolveAction(helper, action)

--- a/pkg/plugin/framework/backup_item_action_server.go
+++ b/pkg/plugin/framework/backup_item_action_server.go
@@ -51,7 +51,7 @@ func (s *BackupItemActionGRPCServer) getImpl(name string) (biav1.BackupItemActio
 }
 
 func (s *BackupItemActionGRPCServer) AppliesTo(
-	ctx context.Context, req *proto.BackupItemActionAppliesToRequest) (
+	_ context.Context, req *proto.BackupItemActionAppliesToRequest) (
 	response *proto.BackupItemActionAppliesToResponse, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
@@ -81,7 +81,7 @@ func (s *BackupItemActionGRPCServer) AppliesTo(
 }
 
 func (s *BackupItemActionGRPCServer) Execute(
-	ctx context.Context, req *proto.ExecuteRequest) (response *proto.ExecuteResponse, err error) {
+	_ context.Context, req *proto.ExecuteRequest) (response *proto.ExecuteResponse, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
 			err = recoveredErr

--- a/pkg/plugin/framework/backupitemaction/v2/backup_item_action_client.go
+++ b/pkg/plugin/framework/backupitemaction/v2/backup_item_action_client.go
@@ -185,6 +185,6 @@ func (c *BackupItemActionGRPCClient) Cancel(operationID string, backup *api.Back
 
 // This shouldn't be called on the GRPC client since the RestartableBackupItemAction won't delegate
 // this method
-func (c *BackupItemActionGRPCClient) Name() string {
+func (*BackupItemActionGRPCClient) Name() string {
 	return ""
 }

--- a/pkg/plugin/framework/backupitemaction/v2/backup_item_action_server.go
+++ b/pkg/plugin/framework/backupitemaction/v2/backup_item_action_server.go
@@ -55,7 +55,7 @@ func (s *BackupItemActionGRPCServer) getImpl(name string) (biav2.BackupItemActio
 }
 
 func (s *BackupItemActionGRPCServer) AppliesTo(
-	ctx context.Context, req *protobiav2.BackupItemActionAppliesToRequest) (
+	_ context.Context, req *protobiav2.BackupItemActionAppliesToRequest) (
 	response *protobiav2.BackupItemActionAppliesToResponse, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
@@ -85,7 +85,7 @@ func (s *BackupItemActionGRPCServer) AppliesTo(
 }
 
 func (s *BackupItemActionGRPCServer) Execute(
-	ctx context.Context, req *protobiav2.ExecuteRequest) (response *protobiav2.ExecuteResponse, err error) {
+	_ context.Context, req *protobiav2.ExecuteRequest) (response *protobiav2.ExecuteResponse, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
 			err = recoveredErr
@@ -140,7 +140,7 @@ func (s *BackupItemActionGRPCServer) Execute(
 }
 
 func (s *BackupItemActionGRPCServer) Progress(
-	ctx context.Context, req *protobiav2.BackupItemActionProgressRequest) (
+	_ context.Context, req *protobiav2.BackupItemActionProgressRequest) (
 	response *protobiav2.BackupItemActionProgressResponse, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
@@ -179,7 +179,7 @@ func (s *BackupItemActionGRPCServer) Progress(
 }
 
 func (s *BackupItemActionGRPCServer) Cancel(
-	ctx context.Context, req *protobiav2.BackupItemActionCancelRequest) (
+	_ context.Context, req *protobiav2.BackupItemActionCancelRequest) (
 	response *emptypb.Empty, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
@@ -216,6 +216,6 @@ func backupResourceIdentifierToProto(id velero.ResourceIdentifier) *proto.Resour
 
 // This shouldn't be called on the GRPC server since the server won't ever receive this request, as
 // the RestartableBackupItemAction in Velero won't delegate this to the server
-func (s *BackupItemActionGRPCServer) Name() string {
+func (*BackupItemActionGRPCServer) Name() string {
 	return ""
 }

--- a/pkg/plugin/framework/common/client_dispenser_test.go
+++ b/pkg/plugin/framework/common/client_dispenser_test.go
@@ -36,7 +36,7 @@ func TestNewClientDispenser(t *testing.T) {
 	clientConn := new(grpc.ClientConn)
 
 	c := 3
-	initFunc := func(base *ClientBase, clientConn *grpc.ClientConn) any {
+	initFunc := func(*ClientBase, *grpc.ClientConn) any {
 		return c
 	}
 

--- a/pkg/plugin/framework/delete_item_action_server.go
+++ b/pkg/plugin/framework/delete_item_action_server.go
@@ -49,7 +49,7 @@ func (s *DeleteItemActionGRPCServer) getImpl(name string) (velero.DeleteItemActi
 	return itemAction, nil
 }
 
-func (s *DeleteItemActionGRPCServer) AppliesTo(ctx context.Context, req *proto.DeleteItemActionAppliesToRequest) (response *proto.DeleteItemActionAppliesToResponse, err error) {
+func (s *DeleteItemActionGRPCServer) AppliesTo(_ context.Context, req *proto.DeleteItemActionAppliesToRequest) (response *proto.DeleteItemActionAppliesToResponse, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
 			err = recoveredErr
@@ -77,7 +77,7 @@ func (s *DeleteItemActionGRPCServer) AppliesTo(ctx context.Context, req *proto.D
 	}, nil
 }
 
-func (s *DeleteItemActionGRPCServer) Execute(ctx context.Context, req *proto.DeleteItemActionExecuteRequest) (_ *proto.Empty, err error) {
+func (s *DeleteItemActionGRPCServer) Execute(_ context.Context, req *proto.DeleteItemActionExecuteRequest) (_ *proto.Empty, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
 			err = recoveredErr

--- a/pkg/plugin/framework/itemblockaction/v1/item_block_action_client.go
+++ b/pkg/plugin/framework/itemblockaction/v1/item_block_action_client.go
@@ -117,6 +117,6 @@ func (c *ItemBlockActionGRPCClient) GetRelatedItems(item runtime.Unstructured, b
 
 // This shouldn't be called on the GRPC client since the RestartableItemBlockAction won't delegate
 // this method
-func (c *ItemBlockActionGRPCClient) Name() string {
+func (*ItemBlockActionGRPCClient) Name() string {
 	return ""
 }

--- a/pkg/plugin/framework/itemblockaction/v1/item_block_action_server.go
+++ b/pkg/plugin/framework/itemblockaction/v1/item_block_action_server.go
@@ -52,7 +52,7 @@ func (s *ItemBlockActionGRPCServer) getImpl(name string) (ibav1.ItemBlockAction,
 }
 
 func (s *ItemBlockActionGRPCServer) AppliesTo(
-	ctx context.Context, req *protoibav1.ItemBlockActionAppliesToRequest) (
+	_ context.Context, req *protoibav1.ItemBlockActionAppliesToRequest) (
 	response *protoibav1.ItemBlockActionAppliesToResponse, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
@@ -82,7 +82,7 @@ func (s *ItemBlockActionGRPCServer) AppliesTo(
 }
 
 func (s *ItemBlockActionGRPCServer) GetRelatedItems(
-	ctx context.Context, req *protoibav1.ItemBlockActionGetRelatedItemsRequest) (response *protoibav1.ItemBlockActionGetRelatedItemsResponse, err error) {
+	_ context.Context, req *protoibav1.ItemBlockActionGetRelatedItemsRequest) (response *protoibav1.ItemBlockActionGetRelatedItemsResponse, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
 			err = recoveredErr
@@ -129,6 +129,6 @@ func backupResourceIdentifierToProto(id velero.ResourceIdentifier) *proto.Resour
 
 // This shouldn't be called on the GRPC server since the server won't ever receive this request, as
 // the RestartableItemBlockAction in Velero won't delegate this to the server
-func (s *ItemBlockActionGRPCServer) Name() string {
+func (*ItemBlockActionGRPCServer) Name() string {
 	return ""
 }

--- a/pkg/plugin/framework/object_store_server.go
+++ b/pkg/plugin/framework/object_store_server.go
@@ -51,7 +51,7 @@ func (s *ObjectStoreGRPCServer) getImpl(name string) (velero.ObjectStore, error)
 // Init prepares the ObjectStore for usage using the provided map of
 // configuration key-value pairs. It returns an error if the ObjectStore
 // cannot be initialized from the provided config.
-func (s *ObjectStoreGRPCServer) Init(ctx context.Context, req *proto.ObjectStoreInitRequest) (response *proto.Empty, err error) {
+func (s *ObjectStoreGRPCServer) Init(_ context.Context, req *proto.ObjectStoreInitRequest) (response *proto.Empty, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
 			err = recoveredErr
@@ -130,7 +130,7 @@ func (s *ObjectStoreGRPCServer) PutObject(stream proto.ObjectStore_PutObjectServ
 }
 
 // ObjectExists checks if there is an object with the given key in the object storage bucket.
-func (s *ObjectStoreGRPCServer) ObjectExists(ctx context.Context, req *proto.ObjectExistsRequest) (response *proto.ObjectExistsResponse, err error) {
+func (s *ObjectStoreGRPCServer) ObjectExists(_ context.Context, req *proto.ObjectExistsRequest) (response *proto.ObjectExistsResponse, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
 			err = recoveredErr
@@ -189,7 +189,7 @@ func (s *ObjectStoreGRPCServer) GetObject(req *proto.GetObjectRequest, stream pr
 // ListCommonPrefixes gets a list of all object key prefixes that start with
 // the specified prefix and stop at the next instance of the provided delimiter
 // (this is often used to simulate a directory hierarchy in object storage).
-func (s *ObjectStoreGRPCServer) ListCommonPrefixes(ctx context.Context, req *proto.ListCommonPrefixesRequest) (response *proto.ListCommonPrefixesResponse, err error) {
+func (s *ObjectStoreGRPCServer) ListCommonPrefixes(_ context.Context, req *proto.ListCommonPrefixesRequest) (response *proto.ListCommonPrefixesResponse, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
 			err = recoveredErr
@@ -210,7 +210,7 @@ func (s *ObjectStoreGRPCServer) ListCommonPrefixes(ctx context.Context, req *pro
 }
 
 // ListObjects gets a list of all objects in bucket that have the same prefix.
-func (s *ObjectStoreGRPCServer) ListObjects(ctx context.Context, req *proto.ListObjectsRequest) (response *proto.ListObjectsResponse, err error) {
+func (s *ObjectStoreGRPCServer) ListObjects(_ context.Context, req *proto.ListObjectsRequest) (response *proto.ListObjectsResponse, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
 			err = recoveredErr
@@ -232,7 +232,7 @@ func (s *ObjectStoreGRPCServer) ListObjects(ctx context.Context, req *proto.List
 
 // DeleteObject removes object with the specified key from the given
 // bucket.
-func (s *ObjectStoreGRPCServer) DeleteObject(ctx context.Context, req *proto.DeleteObjectRequest) (response *proto.Empty, err error) {
+func (s *ObjectStoreGRPCServer) DeleteObject(_ context.Context, req *proto.DeleteObjectRequest) (response *proto.Empty, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
 			err = recoveredErr
@@ -252,7 +252,7 @@ func (s *ObjectStoreGRPCServer) DeleteObject(ctx context.Context, req *proto.Del
 }
 
 // CreateSignedURL creates a pre-signed URL for the given bucket and key that expires after ttl.
-func (s *ObjectStoreGRPCServer) CreateSignedURL(ctx context.Context, req *proto.CreateSignedURLRequest) (response *proto.CreateSignedURLResponse, err error) {
+func (s *ObjectStoreGRPCServer) CreateSignedURL(_ context.Context, req *proto.CreateSignedURLRequest) (response *proto.CreateSignedURLResponse, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
 			err = recoveredErr

--- a/pkg/plugin/framework/plugin_lister.go
+++ b/pkg/plugin/framework/plugin_lister.go
@@ -69,7 +69,7 @@ func NewPluginListerPlugin(impl PluginLister) *PluginListerPlugin {
 //////////////////////////////////////////////////////////////////////////////
 
 // GRPCClient returns a PluginLister gRPC client.
-func (p *PluginListerPlugin) GRPCClient(_ context.Context, _ *plugin.GRPCBroker, clientConn *grpc.ClientConn) (any, error) {
+func (*PluginListerPlugin) GRPCClient(_ context.Context, _ *plugin.GRPCBroker, clientConn *grpc.ClientConn) (any, error) {
 	return &PluginListerGRPCClient{grpcClient: proto.NewPluginListerClient(clientConn)}, nil
 }
 
@@ -119,7 +119,7 @@ type PluginListerGRPCServer struct {
 }
 
 // ListPlugins returns a list of registered plugins, delegating to s.impl to perform the listing.
-func (s *PluginListerGRPCServer) ListPlugins(ctx context.Context, req *proto.Empty) (*proto.ListPluginsResponse, error) {
+func (s *PluginListerGRPCServer) ListPlugins(context.Context, *proto.Empty) (*proto.ListPluginsResponse, error) {
 	list, err := s.impl.ListPlugins()
 	if err != nil {
 		return nil, err

--- a/pkg/plugin/framework/restore_item_action_server.go
+++ b/pkg/plugin/framework/restore_item_action_server.go
@@ -50,7 +50,7 @@ func (s *RestoreItemActionGRPCServer) getImpl(name string) (riav1.RestoreItemAct
 	return itemAction, nil
 }
 
-func (s *RestoreItemActionGRPCServer) AppliesTo(ctx context.Context, req *proto.RestoreItemActionAppliesToRequest) (response *proto.RestoreItemActionAppliesToResponse, err error) {
+func (s *RestoreItemActionGRPCServer) AppliesTo(_ context.Context, req *proto.RestoreItemActionAppliesToRequest) (response *proto.RestoreItemActionAppliesToResponse, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
 			err = recoveredErr
@@ -78,7 +78,7 @@ func (s *RestoreItemActionGRPCServer) AppliesTo(ctx context.Context, req *proto.
 	}, nil
 }
 
-func (s *RestoreItemActionGRPCServer) Execute(ctx context.Context, req *proto.RestoreItemActionExecuteRequest) (response *proto.RestoreItemActionExecuteResponse, err error) {
+func (s *RestoreItemActionGRPCServer) Execute(_ context.Context, req *proto.RestoreItemActionExecuteRequest) (response *proto.RestoreItemActionExecuteResponse, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
 			err = recoveredErr

--- a/pkg/plugin/framework/restoreitemaction/v2/restore_item_action_client.go
+++ b/pkg/plugin/framework/restoreitemaction/v2/restore_item_action_client.go
@@ -202,6 +202,6 @@ func (c *RestoreItemActionGRPCClient) AreAdditionalItemsReady(additionalItems []
 
 // This shouldn't be called on the GRPC client since the RestartableRestoreItemAction won't delegate
 // this method
-func (c *RestoreItemActionGRPCClient) Name() string {
+func (*RestoreItemActionGRPCClient) Name() string {
 	return ""
 }

--- a/pkg/plugin/framework/restoreitemaction/v2/restore_item_action_server.go
+++ b/pkg/plugin/framework/restoreitemaction/v2/restore_item_action_server.go
@@ -55,7 +55,7 @@ func (s *RestoreItemActionGRPCServer) getImpl(name string) (riav2.RestoreItemAct
 	return itemAction, nil
 }
 
-func (s *RestoreItemActionGRPCServer) AppliesTo(ctx context.Context, req *protoriav2.RestoreItemActionAppliesToRequest) (response *protoriav2.RestoreItemActionAppliesToResponse, err error) {
+func (s *RestoreItemActionGRPCServer) AppliesTo(_ context.Context, req *protoriav2.RestoreItemActionAppliesToRequest) (response *protoriav2.RestoreItemActionAppliesToResponse, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
 			err = recoveredErr
@@ -83,7 +83,7 @@ func (s *RestoreItemActionGRPCServer) AppliesTo(ctx context.Context, req *protor
 	}, nil
 }
 
-func (s *RestoreItemActionGRPCServer) Execute(ctx context.Context, req *protoriav2.RestoreItemActionExecuteRequest) (response *protoriav2.RestoreItemActionExecuteResponse, err error) {
+func (s *RestoreItemActionGRPCServer) Execute(_ context.Context, req *protoriav2.RestoreItemActionExecuteRequest) (response *protoriav2.RestoreItemActionExecuteResponse, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
 			err = recoveredErr
@@ -149,7 +149,7 @@ func (s *RestoreItemActionGRPCServer) Execute(ctx context.Context, req *protoria
 	return res, nil
 }
 
-func (s *RestoreItemActionGRPCServer) Progress(ctx context.Context, req *protoriav2.RestoreItemActionProgressRequest) (
+func (s *RestoreItemActionGRPCServer) Progress(_ context.Context, req *protoriav2.RestoreItemActionProgressRequest) (
 	response *protoriav2.RestoreItemActionProgressResponse, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
@@ -188,7 +188,7 @@ func (s *RestoreItemActionGRPCServer) Progress(ctx context.Context, req *protori
 }
 
 func (s *RestoreItemActionGRPCServer) Cancel(
-	ctx context.Context, req *protoriav2.RestoreItemActionCancelRequest) (
+	_ context.Context, req *protoriav2.RestoreItemActionCancelRequest) (
 	response *emptypb.Empty, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
@@ -214,7 +214,7 @@ func (s *RestoreItemActionGRPCServer) Cancel(
 	return &emptypb.Empty{}, nil
 }
 
-func (s *RestoreItemActionGRPCServer) AreAdditionalItemsReady(ctx context.Context, req *protoriav2.RestoreItemActionItemsReadyRequest) (
+func (s *RestoreItemActionGRPCServer) AreAdditionalItemsReady(_ context.Context, req *protoriav2.RestoreItemActionItemsReadyRequest) (
 	response *protoriav2.RestoreItemActionItemsReadyResponse, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
@@ -266,6 +266,6 @@ func restoreResourceIdentifierToProto(id velero.ResourceIdentifier) *proto.Resou
 
 // This shouldn't be called on the GRPC server since the server won't ever receive this request, as
 // the RestartableRestoreItemAction in Velero won't delegate this to the server
-func (s *RestoreItemActionGRPCServer) Name() string {
+func (*RestoreItemActionGRPCServer) Name() string {
 	return ""
 }

--- a/pkg/plugin/framework/volume_snapshotter_server.go
+++ b/pkg/plugin/framework/volume_snapshotter_server.go
@@ -51,7 +51,7 @@ func (s *VolumeSnapshotterGRPCServer) getImpl(name string) (vsv1.VolumeSnapshott
 // Init prepares the VolumeSnapshotter for usage using the provided map of
 // configuration key-value pairs. It returns an error if the VolumeSnapshotter
 // cannot be initialized from the provided config.
-func (s *VolumeSnapshotterGRPCServer) Init(ctx context.Context, req *proto.VolumeSnapshotterInitRequest) (response *proto.Empty, err error) {
+func (s *VolumeSnapshotterGRPCServer) Init(_ context.Context, req *proto.VolumeSnapshotterInitRequest) (response *proto.Empty, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
 			err = recoveredErr
@@ -72,7 +72,7 @@ func (s *VolumeSnapshotterGRPCServer) Init(ctx context.Context, req *proto.Volum
 
 // CreateVolumeFromSnapshot creates a new block volume, initialized from the provided snapshot,
 // and with the specified type and IOPS (if using provisioned IOPS).
-func (s *VolumeSnapshotterGRPCServer) CreateVolumeFromSnapshot(ctx context.Context, req *proto.CreateVolumeRequest) (response *proto.CreateVolumeResponse, err error) {
+func (s *VolumeSnapshotterGRPCServer) CreateVolumeFromSnapshot(_ context.Context, req *proto.CreateVolumeRequest) (response *proto.CreateVolumeResponse, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
 			err = recoveredErr
@@ -103,7 +103,7 @@ func (s *VolumeSnapshotterGRPCServer) CreateVolumeFromSnapshot(ctx context.Conte
 
 // GetVolumeInfo returns the type and IOPS (if using provisioned IOPS) for a specified block
 // volume.
-func (s *VolumeSnapshotterGRPCServer) GetVolumeInfo(ctx context.Context, req *proto.GetVolumeInfoRequest) (response *proto.GetVolumeInfoResponse, err error) {
+func (s *VolumeSnapshotterGRPCServer) GetVolumeInfo(_ context.Context, req *proto.GetVolumeInfoRequest) (response *proto.GetVolumeInfoResponse, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
 			err = recoveredErr
@@ -133,7 +133,7 @@ func (s *VolumeSnapshotterGRPCServer) GetVolumeInfo(ctx context.Context, req *pr
 
 // CreateSnapshot creates a snapshot of the specified block volume, and applies the provided
 // set of tags to the snapshot.
-func (s *VolumeSnapshotterGRPCServer) CreateSnapshot(ctx context.Context, req *proto.CreateSnapshotRequest) (response *proto.CreateSnapshotResponse, err error) {
+func (s *VolumeSnapshotterGRPCServer) CreateSnapshot(_ context.Context, req *proto.CreateSnapshotRequest) (response *proto.CreateSnapshotResponse, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
 			err = recoveredErr
@@ -154,7 +154,7 @@ func (s *VolumeSnapshotterGRPCServer) CreateSnapshot(ctx context.Context, req *p
 }
 
 // DeleteSnapshot deletes the specified volume snapshot.
-func (s *VolumeSnapshotterGRPCServer) DeleteSnapshot(ctx context.Context, req *proto.DeleteSnapshotRequest) (response *proto.Empty, err error) {
+func (s *VolumeSnapshotterGRPCServer) DeleteSnapshot(_ context.Context, req *proto.DeleteSnapshotRequest) (response *proto.Empty, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
 			err = recoveredErr
@@ -173,7 +173,7 @@ func (s *VolumeSnapshotterGRPCServer) DeleteSnapshot(ctx context.Context, req *p
 	return &proto.Empty{}, nil
 }
 
-func (s *VolumeSnapshotterGRPCServer) GetVolumeID(ctx context.Context, req *proto.GetVolumeIDRequest) (response *proto.GetVolumeIDResponse, err error) {
+func (s *VolumeSnapshotterGRPCServer) GetVolumeID(_ context.Context, req *proto.GetVolumeIDRequest) (response *proto.GetVolumeIDResponse, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
 			err = recoveredErr
@@ -199,7 +199,7 @@ func (s *VolumeSnapshotterGRPCServer) GetVolumeID(ctx context.Context, req *prot
 	return &proto.GetVolumeIDResponse{VolumeID: volumeID}, nil
 }
 
-func (s *VolumeSnapshotterGRPCServer) SetVolumeID(ctx context.Context, req *proto.SetVolumeIDRequest) (response *proto.SetVolumeIDResponse, err error) {
+func (s *VolumeSnapshotterGRPCServer) SetVolumeID(_ context.Context, req *proto.SetVolumeIDRequest) (response *proto.SetVolumeIDResponse, err error) {
 	defer func() {
 		if recoveredErr := common.HandlePanic(recover()); recoveredErr != nil {
 			err = recoveredErr

--- a/pkg/podexec/pod_command_executor.go
+++ b/pkg/podexec/pod_command_executor.go
@@ -209,6 +209,6 @@ type streamExecutorFactory interface {
 
 type defaultStreamExecutorFactory struct{}
 
-func (f *defaultStreamExecutorFactory) NewSPDYExecutor(config *rest.Config, method string, url *url.URL) (remotecommand.Executor, error) {
+func (*defaultStreamExecutorFactory) NewSPDYExecutor(config *rest.Config, method string, url *url.URL) (remotecommand.Executor, error) {
 	return remotecommand.NewSPDYExecutor(config, method, url)
 }

--- a/pkg/podvolume/backup_micro_service.go
+++ b/pkg/podvolume/backup_micro_service.go
@@ -237,7 +237,7 @@ func (r *BackupMicroService) Shutdown() {
 
 var funcMarshal = json.Marshal
 
-func (r *BackupMicroService) OnDataPathCompleted(ctx context.Context, namespace string, pvbName string, result datapath.Result) {
+func (r *BackupMicroService) OnDataPathCompleted(_ context.Context, _ string, pvbName string, result datapath.Result) {
 	log := r.logger.WithField("PVB", pvbName)
 
 	backupBytes, err := funcMarshal(result.Backup)
@@ -256,7 +256,7 @@ func (r *BackupMicroService) OnDataPathCompleted(ctx context.Context, namespace 
 	log.Info("Async fs backup completed")
 }
 
-func (r *BackupMicroService) OnDataPathFailed(ctx context.Context, namespace string, pvbName string, err error) {
+func (r *BackupMicroService) OnDataPathFailed(_ context.Context, _ string, pvbName string, err error) {
 	log := r.logger.WithField("PVB", pvbName)
 	log.WithError(err).Error("Async fs backup data path failed")
 
@@ -266,7 +266,7 @@ func (r *BackupMicroService) OnDataPathFailed(ctx context.Context, namespace str
 	}
 }
 
-func (r *BackupMicroService) OnDataPathCancelled(ctx context.Context, namespace string, pvbName string) {
+func (r *BackupMicroService) OnDataPathCancelled(_ context.Context, _ string, pvbName string) {
 	log := r.logger.WithField("PVB", pvbName)
 	log.Warn("Async fs backup data path canceled")
 
@@ -276,7 +276,7 @@ func (r *BackupMicroService) OnDataPathCancelled(ctx context.Context, namespace 
 	}
 }
 
-func (r *BackupMicroService) OnDataPathProgress(ctx context.Context, namespace string, pvbName string, progress *uploader.Progress) {
+func (r *BackupMicroService) OnDataPathProgress(_ context.Context, _ string, pvbName string, progress *uploader.Progress) {
 	log := r.logger.WithFields(logrus.Fields{
 		"PVB": pvbName,
 	})

--- a/pkg/podvolume/backup_micro_service_test.go
+++ b/pkg/podvolume/backup_micro_service_test.go
@@ -71,9 +71,9 @@ func (bt *backupMsTestHelper) EndingEvent(_ runtime.Object, _ bool, reason strin
 	bt.eventReason = reason
 	bt.eventMsg = fmt.Sprintf(message, a...)
 }
-func (bt *backupMsTestHelper) Shutdown() {}
+func (*backupMsTestHelper) Shutdown() {}
 
-func (bt *backupMsTestHelper) Marshal(v any) ([]byte, error) {
+func (bt *backupMsTestHelper) Marshal(any) ([]byte, error) {
 	if bt.marshalErr != nil {
 		return nil, bt.marshalErr
 	}

--- a/pkg/podvolume/backupper_test.go
+++ b/pkg/podvolume/backupper_test.go
@@ -696,7 +696,7 @@ type logHook struct {
 	entry *logrus.Entry
 }
 
-func (l *logHook) Levels() []logrus.Level {
+func (*logHook) Levels() []logrus.Level {
 	return []logrus.Level{logrus.ErrorLevel}
 }
 func (l *logHook) Fire(entry *logrus.Entry) error {

--- a/pkg/podvolume/restore_micro_service.go
+++ b/pkg/podvolume/restore_micro_service.go
@@ -221,7 +221,7 @@ func (r *RestoreMicroService) Shutdown() {
 
 var funcWriteCompletionMark = writeCompletionMark
 
-func (r *RestoreMicroService) OnPvrCompleted(ctx context.Context, namespace string, pvrName string, result datapath.Result) {
+func (r *RestoreMicroService) OnPvrCompleted(_ context.Context, _ string, pvrName string, result datapath.Result) {
 	log := r.logger.WithField("PVR", pvrName)
 
 	err := funcWriteCompletionMark(r.pvr, result.Restore, log)
@@ -251,14 +251,14 @@ func (r *RestoreMicroService) recordPvrFailed(msg string, err error) {
 	}
 }
 
-func (r *RestoreMicroService) OnPvrFailed(ctx context.Context, namespace string, pvrName string, err error) {
+func (r *RestoreMicroService) OnPvrFailed(_ context.Context, _ string, pvrName string, err error) {
 	log := r.logger.WithField("PVR", pvrName)
 	log.WithError(err).Error("Async fs restore data path failed")
 
 	r.recordPvrFailed(fmt.Sprintf("Data path for PVR %s failed", pvrName), err)
 }
 
-func (r *RestoreMicroService) OnPvrCancelled(ctx context.Context, namespace string, pvrName string) {
+func (r *RestoreMicroService) OnPvrCancelled(_ context.Context, _ string, pvrName string) {
 	log := r.logger.WithField("PVR", pvrName)
 	log.Warn("Async fs restore data path canceled")
 
@@ -268,7 +268,7 @@ func (r *RestoreMicroService) OnPvrCancelled(ctx context.Context, namespace stri
 	}
 }
 
-func (r *RestoreMicroService) OnPvrProgress(ctx context.Context, namespace string, pvrName string, progress *uploader.Progress) {
+func (r *RestoreMicroService) OnPvrProgress(_ context.Context, _ string, pvrName string, progress *uploader.Progress) {
 	log := r.logger.WithFields(logrus.Fields{
 		"PVR": pvrName,
 	})

--- a/pkg/podvolume/restore_micro_service_test.go
+++ b/pkg/podvolume/restore_micro_service_test.go
@@ -75,9 +75,9 @@ func (rt *restoreMsTestHelper) EndingEvent(_ runtime.Object, _ bool, reason stri
 	rt.eventReason = reason
 	rt.eventMsg = fmt.Sprintf(message, a...)
 }
-func (rt *restoreMsTestHelper) Shutdown() {}
+func (*restoreMsTestHelper) Shutdown() {}
 
-func (rt *restoreMsTestHelper) Marshal(v any) ([]byte, error) {
+func (rt *restoreMsTestHelper) Marshal(any) ([]byte, error) {
 	if rt.marshalErr != nil {
 		return nil, rt.marshalErr
 	}

--- a/pkg/repository/config/aws_test.go
+++ b/pkg/repository/config/aws_test.go
@@ -36,7 +36,7 @@ func TestGetS3ResticEnvVars(t *testing.T) {
 			name:     "when config is empty, no env vars are returned",
 			config:   map[string]string{},
 			expected: map[string]string{},
-			getS3Credentials: func(config map[string]string) (*aws.Credentials, error) {
+			getS3Credentials: func(map[string]string) (*aws.Credentials, error) {
 				return nil, nil
 			},
 		},
@@ -57,7 +57,7 @@ func TestGetS3ResticEnvVars(t *testing.T) {
 			expected: map[string]string{
 				"AWS_SHARED_CREDENTIALS_FILE": "/tmp/credentials/path/to/secret",
 			},
-			getS3Credentials: func(config map[string]string) (*aws.Credentials, error) {
+			getS3Credentials: func(map[string]string) (*aws.Credentials, error) {
 				return nil, nil
 			},
 		},

--- a/pkg/repository/config/config_test.go
+++ b/pkg/repository/config/config_test.go
@@ -102,7 +102,7 @@ func TestGetRepoIdentifier(t *testing.T) {
 				},
 			},
 			repoName: "repo-1",
-			getAWSBucketRegion: func(s string, config map[string]string) (string, error) {
+			getAWSBucketRegion: func(string, map[string]string) (string, error) {
 				return "", errors.New("no region found")
 			},
 			expected:    "",
@@ -140,7 +140,7 @@ func TestGetRepoIdentifier(t *testing.T) {
 				},
 			},
 			repoName: "repo-1",
-			getAWSBucketRegion: func(s string, config map[string]string) (string, error) {
+			getAWSBucketRegion: func(string, map[string]string) (string, error) {
 				return "eu-west-1", nil
 			},
 			expected: "s3:s3-eu-west-1.amazonaws.com/bucket/prefix/restic/repo-1",
@@ -162,7 +162,7 @@ func TestGetRepoIdentifier(t *testing.T) {
 				},
 			},
 			repoName: "repo-1",
-			getAWSBucketRegion: func(s string, config map[string]string) (string, error) {
+			getAWSBucketRegion: func(string, map[string]string) (string, error) {
 				return "eu-west-1", nil
 			},
 			expected: "s3:alternate-url/bucket/prefix/restic/repo-1",
@@ -184,7 +184,7 @@ func TestGetRepoIdentifier(t *testing.T) {
 				},
 			},
 			repoName: "aws-repo",
-			getAWSBucketRegion: func(s string, config map[string]string) (string, error) {
+			getAWSBucketRegion: func(string, map[string]string) (string, error) {
 				return "eu-west-1", nil
 			},
 			expected: "s3:s3-us-west-1.amazonaws.com/bucket/prefix/restic/aws-repo",
@@ -206,7 +206,7 @@ func TestGetRepoIdentifier(t *testing.T) {
 				},
 			},
 			repoName: "aws-repo",
-			getAWSBucketRegion: func(s string, config map[string]string) (string, error) {
+			getAWSBucketRegion: func(string, map[string]string) (string, error) {
 				return "eu-west-1", nil
 			},
 			expected: "s3:alternate-url-with-trailing-slash/bucket/prefix/restic/aws-repo",

--- a/pkg/repository/manager/manager.go
+++ b/pkg/repository/manager/manager.go
@@ -181,7 +181,7 @@ func (m *manager) UnlockRepo(repo *velerov1api.BackupRepository) error {
 	return prd.EnsureUnlockRepo(context.Background(), param)
 }
 
-func (m *manager) Forget(ctx context.Context, repo *velerov1api.BackupRepository, snapshot string) error {
+func (m *manager) Forget(_ context.Context, repo *velerov1api.BackupRepository, snapshot string) error {
 	m.repoLocker.LockExclusive(repo.Name)
 	defer m.repoLocker.UnlockExclusive(repo.Name)
 
@@ -201,7 +201,7 @@ func (m *manager) Forget(ctx context.Context, repo *velerov1api.BackupRepository
 	return prd.Forget(context.Background(), snapshot, param)
 }
 
-func (m *manager) BatchForget(ctx context.Context, repo *velerov1api.BackupRepository, snapshots []string) []error {
+func (m *manager) BatchForget(_ context.Context, repo *velerov1api.BackupRepository, snapshots []string) []error {
 	m.repoLocker.LockExclusive(repo.Name)
 	defer m.repoLocker.UnlockExclusive(repo.Name)
 

--- a/pkg/repository/provider/restic.go
+++ b/pkg/repository/provider/restic.go
@@ -38,11 +38,11 @@ type resticRepositoryProvider struct {
 	svc *restic.RepositoryService
 }
 
-func (r *resticRepositoryProvider) InitRepo(ctx context.Context, param RepoParam) error {
+func (r *resticRepositoryProvider) InitRepo(_ context.Context, param RepoParam) error {
 	return r.svc.InitRepo(param.BackupLocation, param.BackupRepo)
 }
 
-func (r *resticRepositoryProvider) ConnectToRepo(ctx context.Context, param RepoParam) error {
+func (r *resticRepositoryProvider) ConnectToRepo(_ context.Context, param RepoParam) error {
 	return r.svc.ConnectToRepo(param.BackupLocation, param.BackupRepo)
 }
 
@@ -62,19 +62,19 @@ func (r *resticRepositoryProvider) PrepareRepo(ctx context.Context, param RepoPa
 	return nil
 }
 
-func (r *resticRepositoryProvider) BoostRepoConnect(ctx context.Context, param RepoParam) error {
+func (*resticRepositoryProvider) BoostRepoConnect(context.Context, RepoParam) error {
 	return nil
 }
 
-func (r *resticRepositoryProvider) PruneRepo(ctx context.Context, param RepoParam) error {
+func (r *resticRepositoryProvider) PruneRepo(_ context.Context, param RepoParam) error {
 	return r.svc.PruneRepo(param.BackupLocation, param.BackupRepo)
 }
 
-func (r *resticRepositoryProvider) EnsureUnlockRepo(ctx context.Context, param RepoParam) error {
+func (r *resticRepositoryProvider) EnsureUnlockRepo(_ context.Context, param RepoParam) error {
 	return r.svc.UnlockRepo(param.BackupLocation, param.BackupRepo)
 }
 
-func (r *resticRepositoryProvider) Forget(ctx context.Context, snapshotID string, param RepoParam) error {
+func (r *resticRepositoryProvider) Forget(_ context.Context, snapshotID string, param RepoParam) error {
 	return r.svc.Forget(param.BackupLocation, param.BackupRepo, snapshotID)
 }
 
@@ -90,6 +90,6 @@ func (r *resticRepositoryProvider) BatchForget(ctx context.Context, snapshotIDs 
 	return errs
 }
 
-func (r *resticRepositoryProvider) DefaultMaintenanceFrequency(ctx context.Context, param RepoParam) time.Duration {
+func (r *resticRepositoryProvider) DefaultMaintenanceFrequency(context.Context, RepoParam) time.Duration {
 	return r.svc.DefaultMaintenanceFrequency()
 }

--- a/pkg/repository/provider/unified_repo.go
+++ b/pkg/repository/provider/unified_repo.go
@@ -271,7 +271,7 @@ func (urp *unifiedRepoProvider) PruneRepo(ctx context.Context, param RepoParam) 
 	return nil
 }
 
-func (urp *unifiedRepoProvider) EnsureUnlockRepo(ctx context.Context, param RepoParam) error {
+func (*unifiedRepoProvider) EnsureUnlockRepo(context.Context, RepoParam) error {
 	return nil
 }
 
@@ -372,7 +372,7 @@ func (urp *unifiedRepoProvider) BatchForget(ctx context.Context, snapshotIDs []s
 	return errs
 }
 
-func (urp *unifiedRepoProvider) DefaultMaintenanceFrequency(ctx context.Context, param RepoParam) time.Duration {
+func (urp *unifiedRepoProvider) DefaultMaintenanceFrequency(context.Context, RepoParam) time.Duration {
 	return urp.repoService.DefaultMaintenanceFrequency()
 }
 
@@ -390,7 +390,7 @@ func (urp *unifiedRepoProvider) GetPassword(param any) (string, error) {
 	return repoPassword, nil
 }
 
-func (urp *unifiedRepoProvider) GetStoreType(param any) (string, error) {
+func (*unifiedRepoProvider) GetStoreType(param any) (string, error) {
 	repoParam, ok := param.(RepoParam)
 	if !ok {
 		return "", errors.Errorf("invalid parameter, expect %T, actual %T", RepoParam{}, param)

--- a/pkg/repository/provider/unified_repo_test.go
+++ b/pkg/repository/provider/unified_repo_test.go
@@ -139,7 +139,7 @@ func TestGetStorageCredentials(t *testing.T) {
 					},
 				},
 			},
-			getS3Credentials: func(config map[string]string) (*aws.Credentials, error) {
+			getS3Credentials: func(map[string]string) (*aws.Credentials, error) {
 				return nil, errors.New("fake error")
 			},
 			credFileStore: new(credmock.FileStore),
@@ -154,7 +154,7 @@ func TestGetStorageCredentials(t *testing.T) {
 					Config:   map[string]string{},
 				},
 			},
-			getS3Credentials: func(config map[string]string) (*aws.Credentials, error) {
+			getS3Credentials: func(map[string]string) (*aws.Credentials, error) {
 				return nil, nil
 			},
 			credFileStore: new(credmock.FileStore),
@@ -181,7 +181,7 @@ func TestGetStorageCredentials(t *testing.T) {
 					},
 				},
 			},
-			getGCPCredentials: func(config map[string]string) string {
+			getGCPCredentials: func(_ map[string]string) string {
 				return "credentials-from-config-map"
 			},
 			credFileStore: new(credmock.FileStore),
@@ -292,7 +292,7 @@ func TestGetStorageVariables(t *testing.T) {
 					},
 				},
 			},
-			getS3BucketRegion: func(bucket string, config map[string]string) (string, error) {
+			getS3BucketRegion: func(bucket string, _ map[string]string) (string, error) {
 				return "region from bucket: " + bucket, nil
 			},
 			repoBackend: "fake-repo-type",
@@ -314,7 +314,7 @@ func TestGetStorageVariables(t *testing.T) {
 					Config:   map[string]string{},
 				},
 			},
-			getS3BucketRegion: func(bucket string, config map[string]string) (string, error) {
+			getS3BucketRegion: func(string, map[string]string) (string, error) {
 				return "", errors.New("fake error")
 			},
 			expected:    map[string]string{},
@@ -340,7 +340,7 @@ func TestGetStorageVariables(t *testing.T) {
 					},
 				},
 			},
-			getS3BucketRegion: func(bucket string, config map[string]string) (string, error) {
+			getS3BucketRegion: func(bucket string, _ map[string]string) (string, error) {
 				return "region from bucket: " + bucket, nil
 			},
 			repoBackend: "fake-repo-type",
@@ -375,7 +375,7 @@ func TestGetStorageVariables(t *testing.T) {
 					},
 				},
 			},
-			getS3BucketRegion: func(bucket string, config map[string]string) (string, error) {
+			getS3BucketRegion: func(bucket string, _ map[string]string) (string, error) {
 				return "region from bucket: " + bucket, nil
 			},
 			repoBackend: "fake-repo-type",
@@ -656,7 +656,7 @@ func TestPrepareRepo(t *testing.T) {
 				},
 			},
 			repoService: new(reposervicenmocks.BackupRepoService),
-			retFuncInit: func(ctx context.Context, repoOption udmrepo.RepoOptions, createNew bool) error {
+			retFuncInit: func(_ context.Context, _ udmrepo.RepoOptions, createNew bool) error {
 				if !createNew {
 					return nil
 				}
@@ -677,7 +677,7 @@ func TestPrepareRepo(t *testing.T) {
 				},
 			},
 			repoService: new(reposervicenmocks.BackupRepoService),
-			retFuncInit: func(ctx context.Context, repoOption udmrepo.RepoOptions, createNew bool) error {
+			retFuncInit: func(_ context.Context, _ udmrepo.RepoOptions, createNew bool) error {
 				if !createNew {
 					return repo.ErrRepositoryNotInitialized
 				}
@@ -698,7 +698,7 @@ func TestPrepareRepo(t *testing.T) {
 				},
 			},
 			repoService: new(reposervicenmocks.BackupRepoService),
-			retFuncInit: func(ctx context.Context, repoOption udmrepo.RepoOptions, createNew bool) error {
+			retFuncInit: func(_ context.Context, _ udmrepo.RepoOptions, createNew bool) error {
 				if !createNew {
 					return errors.New("fake-error-1")
 				}
@@ -719,7 +719,7 @@ func TestPrepareRepo(t *testing.T) {
 				},
 			},
 			repoService: new(reposervicenmocks.BackupRepoService),
-			retFuncInit: func(ctx context.Context, repoOption udmrepo.RepoOptions, createNew bool) error {
+			retFuncInit: func(_ context.Context, _ udmrepo.RepoOptions, createNew bool) error {
 				if !createNew {
 					return repo.ErrRepositoryNotInitialized
 				}
@@ -740,7 +740,7 @@ func TestPrepareRepo(t *testing.T) {
 				},
 			},
 			repoService: new(reposervicenmocks.BackupRepoService),
-			retFuncInit: func(ctx context.Context, repoOption udmrepo.RepoOptions, createNew bool) error {
+			retFuncInit: func(_ context.Context, _ udmrepo.RepoOptions, createNew bool) error {
 				if !createNew {
 					return repo.ErrRepositoryNotInitialized
 				}

--- a/pkg/repository/restic/repository.go
+++ b/pkg/repository/restic/repository.go
@@ -72,7 +72,7 @@ func (r *RepositoryService) Forget(bsl *velerov1api.BackupStorageLocation, repo 
 	return r.exec(restic.ForgetCommand(repo.Spec.ResticIdentifier, snapshotID), bsl)
 }
 
-func (r *RepositoryService) DefaultMaintenanceFrequency() time.Duration {
+func (*RepositoryService) DefaultMaintenanceFrequency() time.Duration {
 	return restic.DefaultMaintenanceFrequency
 }
 

--- a/pkg/repository/udmrepo/kopialib/backend/azure.go
+++ b/pkg/repository/udmrepo/kopialib/backend/azure.go
@@ -43,7 +43,7 @@ func (c *AzureBackend) Setup(ctx context.Context, flags map[string]string, logge
 	return nil
 }
 
-func (c *AzureBackend) Connect(ctx context.Context, isCreate bool, logger logrus.FieldLogger) (blob.Storage, error) {
+func (c *AzureBackend) Connect(ctx context.Context, _ bool, logger logrus.FieldLogger) (blob.Storage, error) {
 	c.option.Logger = logger
 	return azure.NewStorage(ctx, &c.option, false)
 }

--- a/pkg/repository/udmrepo/kopialib/backend/azure/azure_storage_wrapper.go
+++ b/pkg/repository/udmrepo/kopialib/backend/azure/azure_storage_wrapper.go
@@ -55,7 +55,7 @@ func (s *Storage) ConnectionInfo() blob.ConnectionInfo {
 	}
 }
 
-func NewStorage(ctx context.Context, option *Option, isCreate bool) (blob.Storage, error) {
+func NewStorage(ctx context.Context, option *Option, _ bool) (blob.Storage, error) {
 	cfg := option.Config
 
 	client, _, err := azureutil.NewStorageClient(option.Logger, cfg)

--- a/pkg/repository/udmrepo/kopialib/backend/file_system.go
+++ b/pkg/repository/udmrepo/kopialib/backend/file_system.go
@@ -38,7 +38,7 @@ const (
 	defaultDirMode  = 0o700
 )
 
-func (c *FsBackend) Setup(ctx context.Context, flags map[string]string, logger logrus.FieldLogger) error {
+func (c *FsBackend) Setup(ctx context.Context, flags map[string]string, _ logrus.FieldLogger) error {
 	path, err := mustHaveString(udmrepo.StoreOptionFsPath, flags)
 	if err != nil {
 		return err
@@ -55,7 +55,7 @@ func (c *FsBackend) Setup(ctx context.Context, flags map[string]string, logger l
 	return nil
 }
 
-func (c *FsBackend) Connect(ctx context.Context, isCreate bool, logger logrus.FieldLogger) (blob.Storage, error) {
+func (c *FsBackend) Connect(ctx context.Context, isCreate bool, _ logrus.FieldLogger) (blob.Storage, error) {
 	if !filepath.IsAbs(c.options.Path) {
 		return nil, errors.Errorf("filesystem repository path is not absolute, path: %s", c.options.Path)
 	}

--- a/pkg/repository/udmrepo/kopialib/backend/gcs.go
+++ b/pkg/repository/udmrepo/kopialib/backend/gcs.go
@@ -31,7 +31,7 @@ type GCSBackend struct {
 	options gcs.Options
 }
 
-func (c *GCSBackend) Setup(ctx context.Context, flags map[string]string, logger logrus.FieldLogger) error {
+func (c *GCSBackend) Setup(ctx context.Context, flags map[string]string, _ logrus.FieldLogger) error {
 	var err error
 	c.options.BucketName, err = mustHaveString(udmrepo.StoreOptionOssBucket, flags)
 	if err != nil {
@@ -51,6 +51,6 @@ func (c *GCSBackend) Setup(ctx context.Context, flags map[string]string, logger 
 	return nil
 }
 
-func (c *GCSBackend) Connect(ctx context.Context, isCreate bool, logger logrus.FieldLogger) (blob.Storage, error) {
+func (c *GCSBackend) Connect(ctx context.Context, _ bool, _ logrus.FieldLogger) (blob.Storage, error) {
 	return gcs.New(ctx, &c.options, false)
 }

--- a/pkg/repository/udmrepo/kopialib/backend/s3.go
+++ b/pkg/repository/udmrepo/kopialib/backend/s3.go
@@ -31,7 +31,7 @@ type S3Backend struct {
 	options s3.Options
 }
 
-func (c *S3Backend) Setup(ctx context.Context, flags map[string]string, logger logrus.FieldLogger) error {
+func (c *S3Backend) Setup(ctx context.Context, flags map[string]string, _ logrus.FieldLogger) error {
 	var err error
 	c.options.BucketName, err = mustHaveString(udmrepo.StoreOptionOssBucket, flags)
 	if err != nil {
@@ -53,6 +53,6 @@ func (c *S3Backend) Setup(ctx context.Context, flags map[string]string, logger l
 	return nil
 }
 
-func (c *S3Backend) Connect(ctx context.Context, isCreate bool, logger logrus.FieldLogger) (blob.Storage, error) {
+func (c *S3Backend) Connect(ctx context.Context, _ bool, _ logrus.FieldLogger) (blob.Storage, error) {
 	return s3.New(ctx, &c.options, false)
 }

--- a/pkg/repository/udmrepo/kopialib/backend/utils_test.go
+++ b/pkg/repository/udmrepo/kopialib/backend/utils_test.go
@@ -78,7 +78,7 @@ func TestOptionalHaveBool(t *testing.T) {
 				tc.logger.On("Check", mock.Anything, mock.Anything).Run(tc.retFuncCheck).Return(&zapcore.CheckedEntry{})
 			}
 
-			ctx := logging.WithLogger(t.Context(), func(module string) logging.Logger {
+			ctx := logging.WithLogger(t.Context(), func(string) logging.Logger {
 				return zap.New(tc.logger).Sugar()
 			})
 
@@ -143,7 +143,7 @@ func TestOptionalHaveIntWithDefault(t *testing.T) {
 				tc.logger.On("Check", mock.Anything, mock.Anything).Run(tc.retFuncCheck).Return(&zapcore.CheckedEntry{})
 			}
 
-			ctx := logging.WithLogger(t.Context(), func(module string) logging.Logger {
+			ctx := logging.WithLogger(t.Context(), func(string) logging.Logger {
 				return zap.New(tc.logger).Sugar()
 			})
 

--- a/pkg/repository/udmrepo/kopialib/lib_repo.go
+++ b/pkg/repository/udmrepo/kopialib/lib_repo.go
@@ -207,7 +207,7 @@ func (ks *kopiaRepoService) Maintain(ctx context.Context, repoOption udmrepo.Rep
 	return nil
 }
 
-func (ks *kopiaRepoService) DefaultMaintenanceFrequency() time.Duration {
+func (*kopiaRepoService) DefaultMaintenanceFrequency() time.Duration {
 	return defaultMaintainCheckPeriod
 }
 
@@ -373,7 +373,7 @@ func (kr *kopiaRepository) Flush(ctx context.Context) error {
 	return nil
 }
 
-func (kr *kopiaRepository) GetAdvancedFeatures() udmrepo.AdvancedFeatureInfo {
+func (*kopiaRepository) GetAdvancedFeatures() udmrepo.AdvancedFeatureInfo {
 	return udmrepo.AdvancedFeatureInfo{
 		MultiPartBackup: true,
 	}
@@ -470,7 +470,7 @@ func (kow *kopiaObjectWriter) Write(p []byte) (int, error) {
 	return kow.rawWriter.Write(p)
 }
 
-func (kow *kopiaObjectWriter) Seek(offset int64, whence int) (int64, error) {
+func (*kopiaObjectWriter) Seek(int64, int) (int64, error) {
 	return -1, errors.New("not supported")
 }
 

--- a/pkg/repository/udmrepo/kopialib/repo_init.go
+++ b/pkg/repository/udmrepo/kopialib/repo_init.go
@@ -150,7 +150,7 @@ func connectWithStorage(ctx context.Context, st blob.Storage, repoOption udmrepo
 func ensureEmpty(ctx context.Context, s blob.Storage) error {
 	hasDataError := errors.Errorf("has data")
 
-	err := s.ListBlobs(ctx, "", func(cb blob.Metadata) error {
+	err := s.ListBlobs(ctx, "", func(blob.Metadata) error {
 		return hasDataError
 	})
 

--- a/pkg/restore/actions/add_pvc_from_pod_action.go
+++ b/pkg/restore/actions/add_pvc_from_pod_action.go
@@ -34,7 +34,7 @@ func NewAddPVCFromPodAction(logger logrus.FieldLogger) *AddPVCFromPodAction {
 	return &AddPVCFromPodAction{logger: logger}
 }
 
-func (a *AddPVCFromPodAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*AddPVCFromPodAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"pods"},
 	}, nil

--- a/pkg/restore/actions/admissionwebhook_config_action.go
+++ b/pkg/restore/actions/admissionwebhook_config_action.go
@@ -38,7 +38,7 @@ func NewAdmissionWebhookConfigurationAction(logger logrus.FieldLogger) *Admissio
 }
 
 // AppliesTo implements the RestoreItemAction plugin interface method.
-func (a *AdmissionWebhookConfigurationAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*AdmissionWebhookConfigurationAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"mutatingwebhookconfigurations", "validatingwebhookconfigurations"},
 	}, nil

--- a/pkg/restore/actions/apiservice_action.go
+++ b/pkg/restore/actions/apiservice_action.go
@@ -35,7 +35,7 @@ func NewAPIServiceAction(logger logrus.FieldLogger) *APIServiceAction {
 	return &APIServiceAction{logger: logger}
 }
 
-func (a *APIServiceAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*APIServiceAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"apiservices"},
 		LabelSelector:     autoregister.AutoRegisterManagedLabel,

--- a/pkg/restore/actions/change_image_name_action.go
+++ b/pkg/restore/actions/change_image_name_action.go
@@ -56,7 +56,7 @@ func NewChangeImageNameAction(
 
 // AppliesTo returns the resources that ChangeImageNameAction should
 // be run for.
-func (a *ChangeImageNameAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*ChangeImageNameAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"deployments", "statefulsets", "daemonsets", "replicasets", "replicationcontrollers", "jobs", "cronjobs", "pods"},
 	}, nil
@@ -179,7 +179,7 @@ func (a *ChangeImageNameAction) replaceImageName(obj *unstructured.Unstructured,
 	return nil
 }
 
-func (a *ChangeImageNameAction) isImageReplaceRuleExist(log *logrus.Entry, oldImageName string, cm *corev1api.ConfigMap) (exists bool, newImageName string, err error) {
+func (*ChangeImageNameAction) isImageReplaceRuleExist(log *logrus.Entry, oldImageName string, cm *corev1api.ConfigMap) (exists bool, newImageName string, err error) {
 	if oldImageName == "" {
 		log.Infoln("Item has no old image name specified")
 		return false, "", nil

--- a/pkg/restore/actions/change_storageclass_action.go
+++ b/pkg/restore/actions/change_storageclass_action.go
@@ -56,7 +56,7 @@ func NewChangeStorageClassAction(
 
 // AppliesTo returns the resources that ChangeStorageClassAction should
 // be run for.
-func (a *ChangeStorageClassAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*ChangeStorageClassAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"persistentvolumeclaims", "persistentvolumes", "statefulsets"},
 	}, nil

--- a/pkg/restore/actions/clusterrolebinding_action.go
+++ b/pkg/restore/actions/clusterrolebinding_action.go
@@ -35,13 +35,13 @@ func NewClusterRoleBindingAction(logger logrus.FieldLogger) *ClusterRoleBindingA
 	return &ClusterRoleBindingAction{logger: logger}
 }
 
-func (a *ClusterRoleBindingAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*ClusterRoleBindingAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"clusterrolebindings"},
 	}, nil
 }
 
-func (a *ClusterRoleBindingAction) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
+func (*ClusterRoleBindingAction) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
 	namespaceMapping := input.Restore.Spec.NamespaceMapping
 	if len(namespaceMapping) == 0 {
 		return velero.NewRestoreItemActionExecuteOutput(&unstructured.Unstructured{Object: input.Item.UnstructuredContent()}), nil

--- a/pkg/restore/actions/crd_v1_preserve_unknown_fields_action.go
+++ b/pkg/restore/actions/crd_v1_preserve_unknown_fields_action.go
@@ -39,7 +39,7 @@ func NewCRDV1PreserveUnknownFieldsAction(logger logrus.FieldLogger) *CRDV1Preser
 	return &CRDV1PreserveUnknownFieldsAction{logger: logger}
 }
 
-func (c *CRDV1PreserveUnknownFieldsAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*CRDV1PreserveUnknownFieldsAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"customresourcedefinition.apiextensions.k8s.io"},
 	}, nil

--- a/pkg/restore/actions/csi/pvc_action.go
+++ b/pkg/restore/actions/csi/pvc_action.go
@@ -59,7 +59,7 @@ type pvcRestoreItemAction struct {
 
 // AppliesTo returns information indicating that the
 // PVCRestoreItemAction should be run while restoring PVCs.
-func (p *pvcRestoreItemAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*pvcRestoreItemAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"persistentvolumeclaims"},
 		//TODO: add label selector volumeSnapshotLabel
@@ -205,7 +205,7 @@ func resetPVCSourceToVolumeSnapshot(pvc *corev1api.PersistentVolumeClaim, vsName
 	pvc.Spec.DataSourceRef = nil
 }
 
-func (p *pvcRestoreItemAction) Name() string {
+func (*pvcRestoreItemAction) Name() string {
 	return "PVCRestoreItemAction"
 }
 
@@ -295,9 +295,9 @@ func (p *pvcRestoreItemAction) Cancel(
 	return err
 }
 
-func (p *pvcRestoreItemAction) AreAdditionalItemsReady(
-	additionalItems []velero.ResourceIdentifier,
-	restore *velerov1api.Restore,
+func (*pvcRestoreItemAction) AreAdditionalItemsReady(
+	[]velero.ResourceIdentifier,
+	*velerov1api.Restore,
 ) (bool, error) {
 	return true, nil
 }

--- a/pkg/restore/actions/csi/volumesnapshot_action.go
+++ b/pkg/restore/actions/csi/volumesnapshot_action.go
@@ -45,7 +45,7 @@ type volumeSnapshotRestoreItemAction struct {
 // AppliesTo returns information indicating that
 // VolumeSnapshotRestoreItemAction should be invoked while
 // restoring volumesnapshots.snapshot.storage.k8s.io resources.
-func (p *volumeSnapshotRestoreItemAction) AppliesTo() (
+func (*volumeSnapshotRestoreItemAction) AppliesTo() (
 	velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"volumesnapshots.snapshot.storage.k8s.io"},
@@ -129,28 +129,28 @@ func (p *volumeSnapshotRestoreItemAction) Execute(
 	}, nil
 }
 
-func (p *volumeSnapshotRestoreItemAction) Name() string {
+func (*volumeSnapshotRestoreItemAction) Name() string {
 	return "VolumeSnapshotRestoreItemAction"
 }
 
-func (p *volumeSnapshotRestoreItemAction) Progress(
-	operationID string,
-	restore *velerov1api.Restore,
+func (*volumeSnapshotRestoreItemAction) Progress(
+	string,
+	*velerov1api.Restore,
 ) (velero.OperationProgress, error) {
 	return velero.OperationProgress{}, nil
 }
 
-func (p *volumeSnapshotRestoreItemAction) Cancel(
-	operationID string,
-	restore *velerov1api.Restore,
+func (*volumeSnapshotRestoreItemAction) Cancel(
+	string,
+	*velerov1api.Restore,
 ) error {
 	// CSI Specification doesn't support canceling a snapshot creation.
 	return nil
 }
 
-func (p *volumeSnapshotRestoreItemAction) AreAdditionalItemsReady(
-	additionalItems []velero.ResourceIdentifier,
-	restore *velerov1api.Restore,
+func (*volumeSnapshotRestoreItemAction) AreAdditionalItemsReady(
+	[]velero.ResourceIdentifier,
+	*velerov1api.Restore,
 ) (bool, error) {
 	return true, nil
 }

--- a/pkg/restore/actions/csi/volumesnapshotclass_action.go
+++ b/pkg/restore/actions/csi/volumesnapshotclass_action.go
@@ -37,7 +37,7 @@ type volumeSnapshotClassRestoreItemAction struct {
 
 // AppliesTo returns information indicating that VolumeSnapshotClassRestoreItemAction
 // should be invoked while restoring volumesnapshotclass.snapshot.storage.k8s.io resources.
-func (p *volumeSnapshotClassRestoreItemAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*volumeSnapshotClassRestoreItemAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"volumesnapshotclasses.snapshot.storage.k8s.io"},
 	}, nil
@@ -80,27 +80,27 @@ func (p *volumeSnapshotClassRestoreItemAction) Execute(
 	}, nil
 }
 
-func (p *volumeSnapshotClassRestoreItemAction) Name() string {
+func (*volumeSnapshotClassRestoreItemAction) Name() string {
 	return "VolumeSnapshotClassRestoreItemAction"
 }
 
-func (p *volumeSnapshotClassRestoreItemAction) Progress(
-	operationID string,
-	restore *velerov1api.Restore,
+func (*volumeSnapshotClassRestoreItemAction) Progress(
+	string,
+	*velerov1api.Restore,
 ) (velero.OperationProgress, error) {
 	return velero.OperationProgress{}, nil
 }
 
-func (p *volumeSnapshotClassRestoreItemAction) Cancel(
-	operationID string,
-	restore *velerov1api.Restore,
+func (*volumeSnapshotClassRestoreItemAction) Cancel(
+	string,
+	*velerov1api.Restore,
 ) error {
 	return nil
 }
 
-func (p *volumeSnapshotClassRestoreItemAction) AreAdditionalItemsReady(
-	additionalItems []velero.ResourceIdentifier,
-	restore *velerov1api.Restore,
+func (*volumeSnapshotClassRestoreItemAction) AreAdditionalItemsReady(
+	[]velero.ResourceIdentifier,
+	*velerov1api.Restore,
 ) (bool, error) {
 	return true, nil
 }

--- a/pkg/restore/actions/csi/volumesnapshotcontent_action.go
+++ b/pkg/restore/actions/csi/volumesnapshotcontent_action.go
@@ -44,7 +44,7 @@ type volumeSnapshotContentRestoreItemAction struct {
 // AppliesTo returns information indicating VolumeSnapshotContentRestoreItemAction
 // action should be invoked while restoring
 // volumesnapshotcontent.snapshot.storage.k8s.io resources
-func (p *volumeSnapshotContentRestoreItemAction) AppliesTo() (
+func (*volumeSnapshotContentRestoreItemAction) AppliesTo() (
 	velero.ResourceSelector, error,
 ) {
 	return velero.ResourceSelector{
@@ -132,27 +132,27 @@ func (p *volumeSnapshotContentRestoreItemAction) Execute(
 	}, nil
 }
 
-func (p *volumeSnapshotContentRestoreItemAction) Name() string {
+func (*volumeSnapshotContentRestoreItemAction) Name() string {
 	return "VolumeSnapshotContentRestoreItemAction"
 }
 
-func (p *volumeSnapshotContentRestoreItemAction) Progress(
-	operationID string,
-	restore *velerov1api.Restore,
+func (*volumeSnapshotContentRestoreItemAction) Progress(
+	string,
+	*velerov1api.Restore,
 ) (velero.OperationProgress, error) {
 	return velero.OperationProgress{}, nil
 }
 
-func (p *volumeSnapshotContentRestoreItemAction) Cancel(
-	operationID string,
-	restore *velerov1api.Restore,
+func (*volumeSnapshotContentRestoreItemAction) Cancel(
+	string,
+	*velerov1api.Restore,
 ) error {
 	return nil
 }
 
-func (p *volumeSnapshotContentRestoreItemAction) AreAdditionalItemsReady(
-	additionalItems []velero.ResourceIdentifier,
-	restore *velerov1api.Restore,
+func (*volumeSnapshotContentRestoreItemAction) AreAdditionalItemsReady(
+	[]velero.ResourceIdentifier,
+	*velerov1api.Restore,
 ) (bool, error) {
 	return true, nil
 }

--- a/pkg/restore/actions/dataupload_retrieve_action.go
+++ b/pkg/restore/actions/dataupload_retrieve_action.go
@@ -47,7 +47,7 @@ func NewDataUploadRetrieveAction(logger logrus.FieldLogger, client client.Client
 	}
 }
 
-func (d *DataUploadRetrieveAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*DataUploadRetrieveAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"datauploads.velero.io"},
 	}, nil

--- a/pkg/restore/actions/init_restorehook_pod_action.go
+++ b/pkg/restore/actions/init_restorehook_pod_action.go
@@ -38,7 +38,7 @@ func NewInitRestoreHookPodAction(logger logrus.FieldLogger) *InitRestoreHookPodA
 }
 
 // AppliesTo implements the RestoreItemAction plugin interface method.
-func (a *InitRestoreHookPodAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*InitRestoreHookPodAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"pods"},
 	}, nil

--- a/pkg/restore/actions/job_action.go
+++ b/pkg/restore/actions/job_action.go
@@ -39,13 +39,13 @@ func NewJobAction(logger logrus.FieldLogger) *JobAction {
 	return &JobAction{logger: logger}
 }
 
-func (a *JobAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*JobAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"jobs"},
 	}, nil
 }
 
-func (a *JobAction) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
+func (*JobAction) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
 	job := new(batchv1api.Job)
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(input.Item.UnstructuredContent(), job); err != nil {
 		return nil, errors.WithStack(err)

--- a/pkg/restore/actions/pod_action.go
+++ b/pkg/restore/actions/pod_action.go
@@ -37,7 +37,7 @@ func NewPodAction(logger logrus.FieldLogger) *PodAction {
 	return &PodAction{logger: logger}
 }
 
-func (a *PodAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*PodAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"pods"},
 	}, nil

--- a/pkg/restore/actions/pod_volume_restore_action.go
+++ b/pkg/restore/actions/pod_volume_restore_action.go
@@ -73,7 +73,7 @@ func NewPodVolumeRestoreAction(logger logrus.FieldLogger, client corev1client.Co
 	}, nil
 }
 
-func (a *PodVolumeRestoreAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*PodVolumeRestoreAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"pods"},
 	}, nil

--- a/pkg/restore/actions/pvc_action.go
+++ b/pkg/restore/actions/pvc_action.go
@@ -65,7 +65,7 @@ func NewPVCAction(
 }
 
 // AppliesTo returns the resources that PVCAction should be run for
-func (p *PVCAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*PVCAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"persistentvolumeclaims"},
 	}, nil

--- a/pkg/restore/actions/rolebinding_action.go
+++ b/pkg/restore/actions/rolebinding_action.go
@@ -35,13 +35,13 @@ func NewRoleBindingAction(logger logrus.FieldLogger) *RoleBindingAction {
 	return &RoleBindingAction{logger: logger}
 }
 
-func (a *RoleBindingAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*RoleBindingAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"rolebindings"},
 	}, nil
 }
 
-func (a *RoleBindingAction) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
+func (*RoleBindingAction) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
 	namespaceMapping := input.Restore.Spec.NamespaceMapping
 	if len(namespaceMapping) == 0 {
 		return velero.NewRestoreItemActionExecuteOutput(&unstructured.Unstructured{Object: input.Item.UnstructuredContent()}), nil

--- a/pkg/restore/actions/secret_action.go
+++ b/pkg/restore/actions/secret_action.go
@@ -47,7 +47,7 @@ func NewSecretAction(logger logrus.FieldLogger, client client.Client) *SecretAct
 }
 
 // AppliesTo indicates which resources this action applies
-func (s *SecretAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*SecretAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"secrets"},
 	}, nil

--- a/pkg/restore/actions/service_account_action.go
+++ b/pkg/restore/actions/service_account_action.go
@@ -37,7 +37,7 @@ func NewServiceAccountAction(logger logrus.FieldLogger) *ServiceAccountAction {
 	return &ServiceAccountAction{logger: logger}
 }
 
-func (a *ServiceAccountAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*ServiceAccountAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"serviceaccounts"},
 	}, nil

--- a/pkg/restore/actions/service_action.go
+++ b/pkg/restore/actions/service_action.go
@@ -42,7 +42,7 @@ func NewServiceAction(logger logrus.FieldLogger) *ServiceAction {
 	return &ServiceAction{log: logger}
 }
 
-func (a *ServiceAction) AppliesTo() (velero.ResourceSelector, error) {
+func (*ServiceAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"services"},
 	}, nil

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -954,7 +954,7 @@ func (ctx *restoreContext) crdAvailable(name string, crdClient client.Dynamic) (
 
 	var available bool
 
-	err := wait.PollUntilContextTimeout(go_context.Background(), time.Second, ctx.resourceTimeout, true, func(ctx go_context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(go_context.Background(), time.Second, ctx.resourceTimeout, true, func(go_context.Context) (bool, error) {
 		unstructuredCRD, err := crdClient.Get(name, metav1.GetOptions{})
 		if err != nil {
 			return true, err

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -1429,7 +1429,7 @@ type recordResourcesAction struct {
 	additionalItemsReadyTimeout time.Duration
 }
 
-func (a *recordResourcesAction) Name() string {
+func (*recordResourcesAction) Name() string {
 	return ""
 }
 
@@ -1459,15 +1459,15 @@ func (a *recordResourcesAction) Execute(input *velero.RestoreItemActionExecuteIn
 	}, nil
 }
 
-func (a *recordResourcesAction) Progress(operationID string, restore *velerov1api.Restore) (velero.OperationProgress, error) {
+func (*recordResourcesAction) Progress(string, *velerov1api.Restore) (velero.OperationProgress, error) {
 	return velero.OperationProgress{}, nil
 }
 
-func (a *recordResourcesAction) Cancel(operationID string, restore *velerov1api.Restore) error {
+func (*recordResourcesAction) Cancel(string, *velerov1api.Restore) error {
 	return nil
 }
 
-func (a *recordResourcesAction) AreAdditionalItemsReady(additionalItems []velero.ResourceIdentifier, restore *velerov1api.Restore) (bool, error) {
+func (*recordResourcesAction) AreAdditionalItemsReady([]velero.ResourceIdentifier, *velerov1api.Restore) (bool, error) {
 	return true, nil
 }
 
@@ -1686,7 +1686,7 @@ func (a *pluggableAction) Execute(input *velero.RestoreItemActionExecuteInput) (
 	return a.executeFunc(input)
 }
 
-func (a *pluggableAction) Name() string {
+func (*pluggableAction) Name() string {
 	return ""
 }
 
@@ -1694,11 +1694,11 @@ func (a *pluggableAction) AppliesTo() (velero.ResourceSelector, error) {
 	return a.selector, nil
 }
 
-func (a *pluggableAction) Progress(operationID string, restore *velerov1api.Restore) (velero.OperationProgress, error) {
+func (*pluggableAction) Progress(string, *velerov1api.Restore) (velero.OperationProgress, error) {
 	return velero.OperationProgress{}, nil
 }
 
-func (a *pluggableAction) Cancel(operationID string, restore *velerov1api.Restore) error {
+func (*pluggableAction) Cancel(string, *velerov1api.Restore) error {
 	return nil
 }
 
@@ -1707,7 +1707,7 @@ func (a *pluggableAction) addSelector(selector velero.ResourceSelector) *pluggab
 	return a
 }
 
-func (a *pluggableAction) AreAdditionalItemsReady(additionalItems []velero.ResourceIdentifier, restore *velerov1api.Restore) (bool, error) {
+func (*pluggableAction) AreAdditionalItemsReady([]velero.ResourceIdentifier, *velerov1api.Restore) (bool, error) {
 	return true, nil
 }
 
@@ -1860,7 +1860,7 @@ func TestRestoreWithAsyncOperations(t *testing.T) {
 				OperationID: obj.GetName() + "-1",
 			}, nil
 		},
-		progressFunc: func(operationID string, restore *velerov1api.Restore) (velero.OperationProgress, error) {
+		progressFunc: func(string, *velerov1api.Restore) (velero.OperationProgress, error) {
 			return velero.OperationProgress{
 				Completed:   true,
 				Description: "Done!",
@@ -1881,7 +1881,7 @@ func TestRestoreWithAsyncOperations(t *testing.T) {
 				OperationID: obj.GetName() + "-1",
 			}, nil
 		},
-		progressFunc: func(operationID string, restore *velerov1api.Restore) (velero.OperationProgress, error) {
+		progressFunc: func(string, *velerov1api.Restore) (velero.OperationProgress, error) {
 			return velero.OperationProgress{
 				Completed:   false,
 				Description: "Working...",
@@ -2397,13 +2397,13 @@ type volumeSnapshotter struct {
 }
 
 // Init is a no-op.
-func (vs *volumeSnapshotter) Init(config map[string]string) error {
+func (*volumeSnapshotter) Init(map[string]string) error {
 	return nil
 }
 
 // CreateVolumeFromSnapshot looks up the specified snapshotID in the snapshotVolumes
 // map and returns the corresponding volumeID if it exists, or an error otherwise.
-func (vs *volumeSnapshotter) CreateVolumeFromSnapshot(snapshotID, volumeType, volumeAZ string, iops *int64) (volumeID string, err error) {
+func (vs *volumeSnapshotter) CreateVolumeFromSnapshot(snapshotID, _, _ string, _ *int64) (volumeID string, err error) {
 	volumeID, ok := vs.snapshotVolumes[snapshotID]
 	if !ok {
 		return "", errors.New("snapshot not found")
@@ -2427,22 +2427,22 @@ func (vs *volumeSnapshotter) SetVolumeID(pv runtime.Unstructured, volumeID strin
 }
 
 // GetVolumeID panics because it's not expected to be used for restores.
-func (*volumeSnapshotter) GetVolumeID(pv runtime.Unstructured) (string, error) {
+func (*volumeSnapshotter) GetVolumeID(_ runtime.Unstructured) (string, error) {
 	panic("GetVolumeID should not be used for restores")
 }
 
 // CreateSnapshot panics because it's not expected to be used for restores.
-func (*volumeSnapshotter) CreateSnapshot(volumeID, volumeAZ string, tags map[string]string) (snapshotID string, err error) {
+func (*volumeSnapshotter) CreateSnapshot(string, string, map[string]string) (snapshotID string, err error) {
 	panic("CreateSnapshot should not be used for restores")
 }
 
 // GetVolumeInfo panics because it's not expected to be used for restores.
-func (*volumeSnapshotter) GetVolumeInfo(volumeID, volumeAZ string) (string, *int64, error) {
+func (*volumeSnapshotter) GetVolumeInfo(_, _ string) (string, *int64, error) {
 	panic("GetVolumeInfo should not be used for restores")
 }
 
 // DeleteSnapshot panics because it's not expected to be used for restores.
-func (*volumeSnapshotter) DeleteSnapshot(snapshotID string) error {
+func (*volumeSnapshotter) DeleteSnapshot(string) error {
 	panic("DeleteSnapshot should not be used for backups")
 }
 

--- a/pkg/test/fake_discovery_helper.go
+++ b/pkg/test/fake_discovery_helper.go
@@ -35,7 +35,7 @@ type FakeDiscoveryHelper struct {
 	ServerVersionData  *version.Info
 }
 
-func (dh *FakeDiscoveryHelper) KindFor(input schema.GroupVersionKind) (schema.GroupVersionResource, metav1.APIResource, error) {
+func (*FakeDiscoveryHelper) KindFor(schema.GroupVersionKind) (schema.GroupVersionResource, metav1.APIResource, error) {
 	panic("implement me")
 }
 
@@ -99,7 +99,7 @@ func (dh *FakeDiscoveryHelper) Resources() []*metav1.APIResourceList {
 	return dh.ResourceList
 }
 
-func (dh *FakeDiscoveryHelper) Refresh() error {
+func (*FakeDiscoveryHelper) Refresh() error {
 	return nil
 }
 

--- a/pkg/test/fake_namespace.go
+++ b/pkg/test/fake_namespace.go
@@ -34,57 +34,57 @@ type FakeNamespaceClient struct {
 
 var _ corev1.NamespaceInterface = &FakeNamespaceClient{}
 
-func (c *FakeNamespaceClient) List(ctx context.Context, options metav1.ListOptions) (*corev1api.NamespaceList, error) {
+func (c *FakeNamespaceClient) List(_ context.Context, options metav1.ListOptions) (*corev1api.NamespaceList, error) {
 	args := c.Called(options)
 	return args.Get(0).(*corev1api.NamespaceList), args.Error(1)
 }
 
-func (c *FakeNamespaceClient) Create(ctx context.Context, obj *corev1api.Namespace, options metav1.CreateOptions) (*corev1api.Namespace, error) {
+func (c *FakeNamespaceClient) Create(_ context.Context, obj *corev1api.Namespace, _ metav1.CreateOptions) (*corev1api.Namespace, error) {
 	args := c.Called(obj)
 	return args.Get(0).(*corev1api.Namespace), args.Error(1)
 }
 
-func (c *FakeNamespaceClient) Watch(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+func (c *FakeNamespaceClient) Watch(_ context.Context, options metav1.ListOptions) (watch.Interface, error) {
 	args := c.Called(options)
 	return args.Get(0).(watch.Interface), args.Error(1)
 }
 
-func (c *FakeNamespaceClient) Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1api.Namespace, error) {
+func (c *FakeNamespaceClient) Get(_ context.Context, name string, opts metav1.GetOptions) (*corev1api.Namespace, error) {
 	args := c.Called(name, opts)
 	return args.Get(0).(*corev1api.Namespace), args.Error(1)
 }
 
-func (c *FakeNamespaceClient) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*corev1api.Namespace, error) {
+func (c *FakeNamespaceClient) Patch(_ context.Context, name string, pt types.PatchType, data []byte, _ metav1.PatchOptions, subresources ...string) (*corev1api.Namespace, error) {
 	args := c.Called(name, pt, data, subresources)
 	return args.Get(0).(*corev1api.Namespace), args.Error(1)
 }
 
-func (c *FakeNamespaceClient) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+func (c *FakeNamespaceClient) Delete(_ context.Context, name string, opts metav1.DeleteOptions) error {
 	args := c.Called(name, opts)
 	return args.Error(1)
 }
 
-func (c *FakeNamespaceClient) Finalize(ctx context.Context, item *corev1api.Namespace, options metav1.UpdateOptions) (*corev1api.Namespace, error) {
+func (c *FakeNamespaceClient) Finalize(_ context.Context, item *corev1api.Namespace, _ metav1.UpdateOptions) (*corev1api.Namespace, error) {
 	args := c.Called(item)
 	return args.Get(0).(*corev1api.Namespace), args.Error(1)
 }
 
-func (c *FakeNamespaceClient) Update(ctx context.Context, namespace *corev1api.Namespace, options metav1.UpdateOptions) (*corev1api.Namespace, error) {
+func (c *FakeNamespaceClient) Update(_ context.Context, namespace *corev1api.Namespace, _ metav1.UpdateOptions) (*corev1api.Namespace, error) {
 	args := c.Called(namespace)
 	return args.Get(0).(*corev1api.Namespace), args.Error(1)
 }
 
-func (c *FakeNamespaceClient) UpdateStatus(ctx context.Context, namespace *corev1api.Namespace, options metav1.UpdateOptions) (*corev1api.Namespace, error) {
+func (c *FakeNamespaceClient) UpdateStatus(_ context.Context, namespace *corev1api.Namespace, _ metav1.UpdateOptions) (*corev1api.Namespace, error) {
 	args := c.Called(namespace)
 	return args.Get(0).(*corev1api.Namespace), args.Error(1)
 }
 
-func (c *FakeNamespaceClient) Apply(ctx context.Context, namespace *v1.NamespaceApplyConfiguration, opts metav1.ApplyOptions) (result *corev1api.Namespace, err error) {
+func (c *FakeNamespaceClient) Apply(_ context.Context, namespace *v1.NamespaceApplyConfiguration, _ metav1.ApplyOptions) (result *corev1api.Namespace, err error) {
 	args := c.Called(namespace)
 	return args.Get(0).(*corev1api.Namespace), args.Error(1)
 }
 
-func (c *FakeNamespaceClient) ApplyStatus(ctx context.Context, namespace *v1.NamespaceApplyConfiguration, opts metav1.ApplyOptions) (result *corev1api.Namespace, err error) {
+func (c *FakeNamespaceClient) ApplyStatus(_ context.Context, namespace *v1.NamespaceApplyConfiguration, _ metav1.ApplyOptions) (result *corev1api.Namespace, err error) {
 	args := c.Called(namespace)
 	return args.Get(0).(*corev1api.Namespace), args.Error(1)
 }

--- a/pkg/test/fake_volume_snapshotter.go
+++ b/pkg/test/fake_volume_snapshotter.go
@@ -46,11 +46,11 @@ type FakeVolumeSnapshotter struct {
 	Error error
 }
 
-func (bs *FakeVolumeSnapshotter) Init(config map[string]string) error {
+func (*FakeVolumeSnapshotter) Init(map[string]string) error {
 	return nil
 }
 
-func (bs *FakeVolumeSnapshotter) CreateSnapshot(volumeID, volumeAZ string, tags map[string]string) (string, error) {
+func (bs *FakeVolumeSnapshotter) CreateSnapshot(volumeID, _ string, _ map[string]string) (string, error) {
 	if bs.Error != nil {
 		return "", bs.Error
 	}
@@ -96,7 +96,7 @@ func (bs *FakeVolumeSnapshotter) DeleteSnapshot(snapshotID string) error {
 	return nil
 }
 
-func (bs *FakeVolumeSnapshotter) GetVolumeInfo(volumeID, volumeAZ string) (string, *int64, error) {
+func (bs *FakeVolumeSnapshotter) GetVolumeInfo(volumeID, _ string) (string, *int64, error) {
 	if bs.Error != nil {
 		return "", nil, bs.Error
 	}
@@ -108,7 +108,7 @@ func (bs *FakeVolumeSnapshotter) GetVolumeInfo(volumeID, volumeAZ string) (strin
 	return volumeInfo.Type, volumeInfo.Iops, nil
 }
 
-func (bs *FakeVolumeSnapshotter) GetVolumeID(pv runtime.Unstructured) (string, error) {
+func (bs *FakeVolumeSnapshotter) GetVolumeID(runtime.Unstructured) (string, error) {
 	return bs.VolumeID, nil
 }
 

--- a/pkg/types/priority.go
+++ b/pkg/types/priority.go
@@ -87,6 +87,6 @@ func (p *Priorities) Set(s string) error {
 }
 
 // Type specifies the flag type
-func (p *Priorities) Type() string {
+func (*Priorities) Type() string {
 	return "stringArray"
 }

--- a/pkg/uploader/kopia/block_restore.go
+++ b/pkg/uploader/kopia/block_restore.go
@@ -41,7 +41,7 @@ var _ restore.Output = &BlockOutput{}
 
 const bufferSize = 128 * 1024
 
-func (o *BlockOutput) WriteFile(ctx context.Context, relativePath string, remoteFile fs.File, progressCb restore.FileWriteProgress) error {
+func (o *BlockOutput) WriteFile(ctx context.Context, _ string, remoteFile fs.File, progressCb restore.FileWriteProgress) error {
 	remoteReader, err := remoteFile.Open(ctx)
 	if err != nil {
 		return errors.Wrapf(err, "failed to open remote file %s", remoteFile.Name())
@@ -83,7 +83,7 @@ func (o *BlockOutput) WriteFile(ctx context.Context, relativePath string, remote
 	return nil
 }
 
-func (o *BlockOutput) BeginDirectory(ctx context.Context, relativePath string, e fs.Directory) error {
+func (o *BlockOutput) BeginDirectory(context.Context, string, fs.Directory) error {
 	var err error
 	o.targetFileName, err = filepath.EvalSymlinks(o.TargetPath)
 	if err != nil {

--- a/pkg/uploader/kopia/progress.go
+++ b/pkg/uploader/kopia/progress.go
@@ -116,10 +116,10 @@ func (p *Progress) UpdateProgress() {
 }
 
 // UploadStarted statistic the total Error has occurred
-func (p *Progress) UploadStarted() {}
+func (*Progress) UploadStarted() {}
 
 // CachedFile statistic the total bytes been cached currently
-func (p *Progress) CachedFile(fname string, numBytes int64) {
+func (p *Progress) CachedFile(_ string, numBytes int64) {
 	atomic.AddInt64(&p.cachedBytes, numBytes)
 	p.UpdateProgress()
 }
@@ -132,10 +132,10 @@ func (p *Progress) HashedBytes(numBytes int64) {
 }
 
 // HashingFile statistic the file been hashed currently
-func (p *Progress) HashingFile(fname string) {}
+func (*Progress) HashingFile(string) {}
 
 // ExcludedFile statistic the file been excluded currently
-func (p *Progress) ExcludedFile(fname string, numBytes int64) {}
+func (*Progress) ExcludedFile(string, int64) {}
 
 // ExcludedDir statistic the dir been excluded currently
 func (p *Progress) ExcludedDir(dirname string) {
@@ -143,15 +143,15 @@ func (p *Progress) ExcludedDir(dirname string) {
 }
 
 // FinishedHashingFile which will called when specific file finished hash
-func (p *Progress) FinishedHashingFile(fname string, numBytes int64) {
+func (p *Progress) FinishedHashingFile(string, int64) {
 	p.UpdateProgress()
 }
 
 // StartedDirectory called when begin to upload one directory
-func (p *Progress) StartedDirectory(dirname string) {}
+func (*Progress) StartedDirectory(string) {}
 
 // FinishedDirectory called when finish to upload one directory
-func (p *Progress) FinishedDirectory(dirname string) {
+func (p *Progress) FinishedDirectory(string) {
 	p.UpdateProgress()
 }
 
@@ -167,12 +167,12 @@ func (p *Progress) ProgressBytes(processedBytes int64, totalBytes int64) {
 	p.UpdateProgress()
 }
 
-func (p *Progress) FinishedFile(fname string, err error) {}
+func (*Progress) FinishedFile(string, error) {}
 
 func (p *Progress) EstimationParameters() upload.EstimationParameters {
 	return p.estimationParam
 }
 
-func (p *Progress) Enabled() bool {
+func (*Progress) Enabled() bool {
 	return true
 }

--- a/pkg/uploader/kopia/progress_test.go
+++ b/pkg/uploader/kopia/progress_test.go
@@ -28,7 +28,7 @@ import (
 
 type fakeProgressUpdater struct{}
 
-func (f *fakeProgressUpdater) UpdateProgress(p *uploader.Progress) {}
+func (*fakeProgressUpdater) UpdateProgress(*uploader.Progress) {}
 
 func TestThrottle_ShouldOutput(t *testing.T) {
 	testCases := []struct {
@@ -60,7 +60,7 @@ func TestThrottle_ShouldOutput(t *testing.T) {
 	}
 }
 
-func TestProgress(t *testing.T) {
+func TestProgress(*testing.T) {
 	fileName := "test-filename"
 	var numBytes int64 = 1
 	testCases := []struct {

--- a/pkg/uploader/kopia/shim.go
+++ b/pkg/uploader/kopia/shim.go
@@ -70,7 +70,7 @@ func (sr *shimRepository) OpenObject(ctx context.Context, id object.ID) (object.
 }
 
 // VerifyObject not supported
-func (sr *shimRepository) VerifyObject(ctx context.Context, id object.ID) ([]content.ID, error) {
+func (*shimRepository) VerifyObject(context.Context, object.ID) ([]content.ID, error) {
 	return nil, errors.New("VerifyObject is not supported")
 }
 
@@ -130,36 +130,36 @@ func (sr *shimRepository) Time() time.Time {
 }
 
 // ClientOptions is not supported by unified repo
-func (sr *shimRepository) ClientOptions() repo.ClientOptions {
+func (*shimRepository) ClientOptions() repo.ClientOptions {
 	return repo.ClientOptions{}
 }
 
 // Refresh not supported
-func (sr *shimRepository) Refresh(ctx context.Context) error {
+func (*shimRepository) Refresh(context.Context) error {
 	return errors.New("Refresh is not supported")
 }
 
 // ContentInfo not supported
-func (sr *shimRepository) ContentInfo(ctx context.Context, contentID content.ID) (content.Info, error) {
+func (*shimRepository) ContentInfo(context.Context, content.ID) (content.Info, error) {
 	return index.Info{}, errors.New("ContentInfo is not supported")
 }
 
 // PrefetchContents is not supported by unified repo
-func (sr *shimRepository) PrefetchContents(ctx context.Context, contentIDs []content.ID, hint string) []content.ID {
+func (*shimRepository) PrefetchContents(context.Context, []content.ID, string) []content.ID {
 	return nil
 }
 
 // PrefetchObjects is not supported by unified repo
-func (sr *shimRepository) PrefetchObjects(ctx context.Context, objectIDs []object.ID, hint string) ([]content.ID, error) {
+func (*shimRepository) PrefetchObjects(context.Context, []object.ID, string) ([]content.ID, error) {
 	return nil, errors.New("PrefetchObjects is not supported")
 }
 
 // UpdateDescription is not supported by unified repo
-func (sr *shimRepository) UpdateDescription(d string) {
+func (*shimRepository) UpdateDescription(string) {
 }
 
 // NewWriter is not supported by unified repo
-func (sr *shimRepository) NewWriter(ctx context.Context, option repo.WriteSessionOptions) (context.Context, repo.RepositoryWriter, error) {
+func (*shimRepository) NewWriter(context.Context, repo.WriteSessionOptions) (context.Context, repo.RepositoryWriter, error) {
 	return nil, nil, errors.New("NewWriter is not supported")
 }
 
@@ -237,7 +237,7 @@ func (sr *shimRepository) Flush(ctx context.Context) error {
 	return sr.udmRepo.Flush(ctx)
 }
 
-func (sr *shimRepository) ConcatenateObjects(ctx context.Context, objectIDs []object.ID, opt repo.ConcatenateOptions) (object.ID, error) {
+func (sr *shimRepository) ConcatenateObjects(ctx context.Context, objectIDs []object.ID, _ repo.ConcatenateOptions) (object.ID, error) {
 	if len(objectIDs) == 0 {
 		return object.EmptyID, errors.New("object list is empty")
 	}
@@ -255,7 +255,7 @@ func (sr *shimRepository) ConcatenateObjects(ctx context.Context, objectIDs []ob
 	return object.ParseID(string(id))
 }
 
-func (sr *shimRepository) OnSuccessfulFlush(callback repo.RepositoryWriterCallback) {
+func (*shimRepository) OnSuccessfulFlush(repo.RepositoryWriterCallback) {
 }
 
 // Flush all the unifited repository data

--- a/pkg/uploader/kopia/shim_test.go
+++ b/pkg/uploader/kopia/shim_test.go
@@ -50,7 +50,7 @@ func TestShimRepo(t *testing.T) {
 	shim.PrefetchObjects(ctx, []object.ID{}, "hint")
 	shim.UpdateDescription("desc")
 	shim.NewWriter(ctx, repo.WriteSessionOptions{})
-	shim.OnSuccessfulFlush(func(ctx context.Context, w repo.RepositoryWriter) error { return nil })
+	shim.OnSuccessfulFlush(func(context.Context, repo.RepositoryWriter) error { return nil })
 
 	backupRepo.On("Close", mock.Anything).Return(nil)
 	NewShimRepo(backupRepo).Close(ctx)
@@ -160,7 +160,7 @@ func TestFindManifests(t *testing.T) {
 	}
 }
 
-func TestShimObjReader(t *testing.T) {
+func TestShimObjReader(_ *testing.T) {
 	reader := new(shimObjectReader)
 	objReader := &mocks.ObjectReader{}
 	reader.repoReader = objReader
@@ -179,7 +179,7 @@ func TestShimObjReader(t *testing.T) {
 	reader.Length()
 }
 
-func TestShimObjWriter(t *testing.T) {
+func TestShimObjWriter(_ *testing.T) {
 	writer := new(shimObjectWriter)
 	objWriter := &mocks.ObjectWriter{}
 	writer.repoWriter = objWriter

--- a/pkg/uploader/kopia/snapshot.go
+++ b/pkg/uploader/kopia/snapshot.go
@@ -445,7 +445,7 @@ func Restore(ctx context.Context, rep repo.RepositoryWriter, progress *Progress,
 		Parallel:               restoreConcurrency,
 		RestoreDirEntryAtDepth: math.MaxInt32,
 		Cancel:                 cancleCh,
-		ProgressCallback: func(ctx context.Context, stats restore.Stats) {
+		ProgressCallback: func(_ context.Context, stats restore.Stats) {
 			progress.ProgressBytes(stats.RestoredTotalFileSize, stats.EnqueuedTotalFileSize)
 		},
 	})

--- a/pkg/uploader/kopia/snapshot_test.go
+++ b/pkg/uploader/kopia/snapshot_test.go
@@ -299,7 +299,7 @@ func TestFindPreviousSnapshotManifest(t *testing.T) {
 		// No matching snapshots
 		{
 			name: "No matching snapshots",
-			listSnapshotsFunc: func(ctx context.Context, rep repo.Repository, si snapshot.SourceInfo) ([]*snapshot.Manifest, error) {
+			listSnapshotsFunc: func(context.Context, repo.Repository, snapshot.SourceInfo) ([]*snapshot.Manifest, error) {
 				return []*snapshot.Manifest{}, nil
 			},
 			expectedSnapshots: []*snapshot.Manifest{},
@@ -307,7 +307,7 @@ func TestFindPreviousSnapshotManifest(t *testing.T) {
 		},
 		{
 			name: "Error getting manifest",
-			listSnapshotsFunc: func(ctx context.Context, rep repo.Repository, si snapshot.SourceInfo) ([]*snapshot.Manifest, error) {
+			listSnapshotsFunc: func(context.Context, repo.Repository, snapshot.SourceInfo) ([]*snapshot.Manifest, error) {
 				return []*snapshot.Manifest{}, errors.New("Error getting manifest")
 			},
 			expectedSnapshots: []*snapshot.Manifest{},
@@ -316,7 +316,7 @@ func TestFindPreviousSnapshotManifest(t *testing.T) {
 		// Only one matching snapshot
 		{
 			name: "One matching snapshot",
-			listSnapshotsFunc: func(ctx context.Context, rep repo.Repository, si snapshot.SourceInfo) ([]*snapshot.Manifest, error) {
+			listSnapshotsFunc: func(context.Context, repo.Repository, snapshot.SourceInfo) ([]*snapshot.Manifest, error) {
 				return []*snapshot.Manifest{
 					{
 						Tags: map[string]string{
@@ -347,7 +347,7 @@ func TestFindPreviousSnapshotManifest(t *testing.T) {
 		// Multiple matching snapshots
 		{
 			name: "Multiple matching snapshots",
-			listSnapshotsFunc: func(ctx context.Context, rep repo.Repository, si snapshot.SourceInfo) ([]*snapshot.Manifest, error) {
+			listSnapshotsFunc: func(context.Context, repo.Repository, snapshot.SourceInfo) ([]*snapshot.Manifest, error) {
 				return []*snapshot.Manifest{
 					{
 						Tags: map[string]string{
@@ -385,7 +385,7 @@ func TestFindPreviousSnapshotManifest(t *testing.T) {
 		// Snapshot with different requester
 		{
 			name: "Snapshot with different requester",
-			listSnapshotsFunc: func(ctx context.Context, rep repo.Repository, si snapshot.SourceInfo) ([]*snapshot.Manifest, error) {
+			listSnapshotsFunc: func(context.Context, repo.Repository, snapshot.SourceInfo) ([]*snapshot.Manifest, error) {
 				return []*snapshot.Manifest{
 					{
 						Tags: map[string]string{
@@ -404,7 +404,7 @@ func TestFindPreviousSnapshotManifest(t *testing.T) {
 		// Snapshot with different uploader
 		{
 			name: "Snapshot with different uploader",
-			listSnapshotsFunc: func(ctx context.Context, rep repo.Repository, si snapshot.SourceInfo) ([]*snapshot.Manifest, error) {
+			listSnapshotsFunc: func(context.Context, repo.Repository, snapshot.SourceInfo) ([]*snapshot.Manifest, error) {
 				return []*snapshot.Manifest{
 					{
 						Tags: map[string]string{
@@ -423,7 +423,7 @@ func TestFindPreviousSnapshotManifest(t *testing.T) {
 		// Snapshot with a later start time
 		{
 			name: "Snapshot with a later start time",
-			listSnapshotsFunc: func(ctx context.Context, rep repo.Repository, si snapshot.SourceInfo) ([]*snapshot.Manifest, error) {
+			listSnapshotsFunc: func(context.Context, repo.Repository, snapshot.SourceInfo) ([]*snapshot.Manifest, error) {
 				return []*snapshot.Manifest{
 					{
 						Tags: map[string]string{
@@ -443,7 +443,7 @@ func TestFindPreviousSnapshotManifest(t *testing.T) {
 		// Snapshot with incomplete reason
 		{
 			name: "Snapshot with incomplete reason",
-			listSnapshotsFunc: func(ctx context.Context, rep repo.Repository, si snapshot.SourceInfo) ([]*snapshot.Manifest, error) {
+			listSnapshotsFunc: func(context.Context, repo.Repository, snapshot.SourceInfo) ([]*snapshot.Manifest, error) {
 				return []*snapshot.Manifest{
 					{
 						Tags: map[string]string{
@@ -463,7 +463,7 @@ func TestFindPreviousSnapshotManifest(t *testing.T) {
 		// Multiple snapshots with some matching conditions
 		{
 			name: "Multiple snapshots with matching conditions",
-			listSnapshotsFunc: func(ctx context.Context, rep repo.Repository, si snapshot.SourceInfo) ([]*snapshot.Manifest, error) {
+			listSnapshotsFunc: func(context.Context, repo.Repository, snapshot.SourceInfo) ([]*snapshot.Manifest, error) {
 				return []*snapshot.Manifest{
 					{
 						Tags: map[string]string{
@@ -514,7 +514,7 @@ func TestFindPreviousSnapshotManifest(t *testing.T) {
 		// Snapshot with manifest SnapshotRequesterTag not found
 		{
 			name: "Snapshot with manifest SnapshotRequesterTag not found",
-			listSnapshotsFunc: func(ctx context.Context, rep repo.Repository, si snapshot.SourceInfo) ([]*snapshot.Manifest, error) {
+			listSnapshotsFunc: func(context.Context, repo.Repository, snapshot.SourceInfo) ([]*snapshot.Manifest, error) {
 				return []*snapshot.Manifest{
 					{
 						Tags: map[string]string{
@@ -534,7 +534,7 @@ func TestFindPreviousSnapshotManifest(t *testing.T) {
 		// Snapshot with manifest SnapshotRequesterTag not found
 		{
 			name: "Snapshot with manifest SnapshotUploaderTag not found",
-			listSnapshotsFunc: func(ctx context.Context, rep repo.Repository, si snapshot.SourceInfo) ([]*snapshot.Manifest, error) {
+			listSnapshotsFunc: func(context.Context, repo.Repository, snapshot.SourceInfo) ([]*snapshot.Manifest, error) {
 				return []*snapshot.Manifest{
 					{
 						Tags: map[string]string{
@@ -697,10 +697,10 @@ func TestRestore(t *testing.T) {
 		},
 		{
 			name: "Failed to restore with filesystem entry",
-			filesystemEntryFunc: func(ctx context.Context, rep repo.Repository, rootID string, consistentAttributes bool) (fs.Entry, error) {
+			filesystemEntryFunc: func(_ context.Context, rep repo.Repository, _ string, _ bool) (fs.Entry, error) {
 				return snapshotfs.EntryFromDirEntry(rep, &snapshot.DirEntry{Type: snapshot.EntryTypeFile}), nil
 			},
-			restoreEntryFunc: func(ctx context.Context, rep repo.Repository, output restore.Output, rootEntry fs.Entry, options restore.Options) (restore.Stats, error) {
+			restoreEntryFunc: func(context.Context, repo.Repository, restore.Output, fs.Entry, restore.Options) (restore.Stats, error) {
 				return restore.Stats{}, errors.New("Unable to get filesystem entry")
 			},
 			snapshotID:    "snapshot-123",
@@ -708,10 +708,10 @@ func TestRestore(t *testing.T) {
 		},
 		{
 			name: "Expect successful",
-			filesystemEntryFunc: func(ctx context.Context, rep repo.Repository, rootID string, consistentAttributes bool) (fs.Entry, error) {
+			filesystemEntryFunc: func(_ context.Context, rep repo.Repository, _ string, _ bool) (fs.Entry, error) {
 				return snapshotfs.EntryFromDirEntry(rep, &snapshot.DirEntry{Type: snapshot.EntryTypeFile}), nil
 			},
-			restoreEntryFunc: func(ctx context.Context, rep repo.Repository, output restore.Output, rootEntry fs.Entry, options restore.Options) (restore.Stats, error) {
+			restoreEntryFunc: func(context.Context, repo.Repository, restore.Output, fs.Entry, restore.Options) (restore.Stats, error) {
 				return restore.Stats{}, nil
 			},
 			snapshotID:    "snapshot-123",
@@ -719,10 +719,10 @@ func TestRestore(t *testing.T) {
 		},
 		{
 			name: "Expect block volume successful",
-			filesystemEntryFunc: func(ctx context.Context, rep repo.Repository, rootID string, consistentAttributes bool) (fs.Entry, error) {
+			filesystemEntryFunc: func(_ context.Context, rep repo.Repository, _ string, _ bool) (fs.Entry, error) {
 				return snapshotfs.EntryFromDirEntry(rep, &snapshot.DirEntry{Type: snapshot.EntryTypeFile}), nil
 			},
-			restoreEntryFunc: func(ctx context.Context, rep repo.Repository, output restore.Output, rootEntry fs.Entry, options restore.Options) (restore.Stats, error) {
+			restoreEntryFunc: func(context.Context, repo.Repository, restore.Output, fs.Entry, restore.Options) (restore.Stats, error) {
 				return restore.Stats{}, nil
 			},
 			snapshotID:    "snapshot-123",
@@ -731,10 +731,10 @@ func TestRestore(t *testing.T) {
 		},
 		{
 			name: "Unable to evaluate symlinks for block volume",
-			filesystemEntryFunc: func(ctx context.Context, rep repo.Repository, rootID string, consistentAttributes bool) (fs.Entry, error) {
+			filesystemEntryFunc: func(_ context.Context, rep repo.Repository, _ string, _ bool) (fs.Entry, error) {
 				return snapshotfs.EntryFromDirEntry(rep, &snapshot.DirEntry{Type: snapshot.EntryTypeFile}), nil
 			},
-			restoreEntryFunc: func(ctx context.Context, rep repo.Repository, output restore.Output, rootEntry fs.Entry, options restore.Options) (restore.Stats, error) {
+			restoreEntryFunc: func(ctx context.Context, _ repo.Repository, output restore.Output, _ fs.Entry, _ restore.Options) (restore.Stats, error) {
 				err := output.BeginDirectory(ctx, "fake-dir", virtualfs.NewStaticDirectory("fake-dir", nil))
 				return restore.Stats{}, err
 			},
@@ -745,10 +745,10 @@ func TestRestore(t *testing.T) {
 		},
 		{
 			name: "Target file is not a block device",
-			filesystemEntryFunc: func(ctx context.Context, rep repo.Repository, rootID string, consistentAttributes bool) (fs.Entry, error) {
+			filesystemEntryFunc: func(_ context.Context, rep repo.Repository, _ string, _ bool) (fs.Entry, error) {
 				return snapshotfs.EntryFromDirEntry(rep, &snapshot.DirEntry{Type: snapshot.EntryTypeFile}), nil
 			},
-			restoreEntryFunc: func(ctx context.Context, rep repo.Repository, output restore.Output, rootEntry fs.Entry, options restore.Options) (restore.Stats, error) {
+			restoreEntryFunc: func(ctx context.Context, _ repo.Repository, output restore.Output, _ fs.Entry, _ restore.Options) (restore.Stats, error) {
 				err := output.BeginDirectory(ctx, "fake-dir", virtualfs.NewStaticDirectory("fake-dir", nil))
 				return restore.Stats{}, err
 			},

--- a/pkg/uploader/provider/kopia.go
+++ b/pkg/uploader/provider/kopia.go
@@ -192,7 +192,7 @@ func (kp *kopiaProvider) RunBackup(
 	return snapshotInfo.ID, false, snapshotInfo.Size, nil
 }
 
-func (kp *kopiaProvider) GetPassword(param any) (string, error) {
+func (kp *kopiaProvider) GetPassword(any) (string, error) {
 	if kp.credGetter.FromSecret == nil {
 		return "", errors.New("invalid credentials interface")
 	}

--- a/pkg/uploader/provider/kopia_test.go
+++ b/pkg/uploader/provider/kopia_test.go
@@ -51,7 +51,7 @@ type FakeBackupProgressUpdater struct {
 	Cli             client.Client
 }
 
-func (f *FakeBackupProgressUpdater) UpdateProgress(p *uploader.Progress) {}
+func (*FakeBackupProgressUpdater) UpdateProgress(*uploader.Progress) {}
 
 type FakeRestoreProgressUpdater struct {
 	PodVolumeRestore *velerov1api.PodVolumeRestore
@@ -60,7 +60,7 @@ type FakeRestoreProgressUpdater struct {
 	Cli              client.Client
 }
 
-func (f *FakeRestoreProgressUpdater) UpdateProgress(p *uploader.Progress) {}
+func (*FakeRestoreProgressUpdater) UpdateProgress(*uploader.Progress) {}
 
 func TestRunBackup(t *testing.T) {
 	testCases := []struct {
@@ -71,21 +71,21 @@ func TestRunBackup(t *testing.T) {
 	}{
 		{
 			name: "success to backup",
-			hookBackupFunc: func(ctx context.Context, fsUploader kopia.SnapshotUploader, repoWriter repo.RepositoryWriter, sourcePath string, realSource string, forceFull bool, parentSnapshot string, volMode uploader.PersistentVolumeMode, uploaderCfg map[string]string, tags map[string]string, log logrus.FieldLogger) (*uploader.SnapshotInfo, bool, error) {
+			hookBackupFunc: func(_ context.Context, _ kopia.SnapshotUploader, _ repo.RepositoryWriter, _ string, _ string, _ bool, _ string, _ uploader.PersistentVolumeMode, _ map[string]string, _ map[string]string, _ logrus.FieldLogger) (*uploader.SnapshotInfo, bool, error) {
 				return &uploader.SnapshotInfo{}, false, nil
 			},
 			notError: true,
 		},
 		{
 			name: "get error to backup",
-			hookBackupFunc: func(ctx context.Context, fsUploader kopia.SnapshotUploader, repoWriter repo.RepositoryWriter, sourcePath string, realSource string, forceFull bool, parentSnapshot string, volMode uploader.PersistentVolumeMode, uploaderCfg map[string]string, tags map[string]string, log logrus.FieldLogger) (*uploader.SnapshotInfo, bool, error) {
+			hookBackupFunc: func(_ context.Context, _ kopia.SnapshotUploader, _ repo.RepositoryWriter, _ string, _ string, _ bool, _ string, _ uploader.PersistentVolumeMode, _ map[string]string, _ map[string]string, _ logrus.FieldLogger) (*uploader.SnapshotInfo, bool, error) {
 				return &uploader.SnapshotInfo{}, false, errors.New("failed to backup")
 			},
 			notError: false,
 		},
 		{
 			name: "success to backup block mode volume",
-			hookBackupFunc: func(ctx context.Context, fsUploader kopia.SnapshotUploader, repoWriter repo.RepositoryWriter, sourcePath string, realSource string, forceFull bool, parentSnapshot string, volMode uploader.PersistentVolumeMode, uploaderCfg map[string]string, tags map[string]string, log logrus.FieldLogger) (*uploader.SnapshotInfo, bool, error) {
+			hookBackupFunc: func(_ context.Context, _ kopia.SnapshotUploader, _ repo.RepositoryWriter, _ string, _ string, _ bool, _ string, _ uploader.PersistentVolumeMode, _ map[string]string, _ map[string]string, _ logrus.FieldLogger) (*uploader.SnapshotInfo, bool, error) {
 				return &uploader.SnapshotInfo{}, false, nil
 			},
 			volMode:  uploader.PersistentVolumeBlock,
@@ -125,14 +125,14 @@ func TestRunRestore(t *testing.T) {
 	}{
 		{
 			name: "normal restore",
-			hookRestoreFunc: func(ctx context.Context, rep repo.RepositoryWriter, progress *kopia.Progress, snapshotID, dest string, volMode uploader.PersistentVolumeMode, uploaderCfg map[string]string, log logrus.FieldLogger, cancleCh chan struct{}) (int64, int32, error) {
+			hookRestoreFunc: func(context.Context, repo.RepositoryWriter, *kopia.Progress, string, string, uploader.PersistentVolumeMode, map[string]string, logrus.FieldLogger, chan struct{}) (int64, int32, error) {
 				return 0, 0, nil
 			},
 			notError: true,
 		},
 		{
 			name: "normal block mode restore",
-			hookRestoreFunc: func(ctx context.Context, rep repo.RepositoryWriter, progress *kopia.Progress, snapshotID, dest string, volMode uploader.PersistentVolumeMode, uploaderCfg map[string]string, log logrus.FieldLogger, cancleCh chan struct{}) (int64, int32, error) {
+			hookRestoreFunc: func(context.Context, repo.RepositoryWriter, *kopia.Progress, string, string, uploader.PersistentVolumeMode, map[string]string, logrus.FieldLogger, chan struct{}) (int64, int32, error) {
 				return 0, 0, nil
 			},
 			volMode:  uploader.PersistentVolumeBlock,
@@ -140,7 +140,7 @@ func TestRunRestore(t *testing.T) {
 		},
 		{
 			name: "failed to restore",
-			hookRestoreFunc: func(ctx context.Context, rep repo.RepositoryWriter, progress *kopia.Progress, snapshotID, dest string, volMode uploader.PersistentVolumeMode, uploaderCfg map[string]string, log logrus.FieldLogger, cancleCh chan struct{}) (int64, int32, error) {
+			hookRestoreFunc: func(context.Context, repo.RepositoryWriter, *kopia.Progress, string, string, uploader.PersistentVolumeMode, map[string]string, logrus.FieldLogger, chan struct{}) (int64, int32, error) {
 				return 0, 0, errors.New("failed to restore")
 			},
 			notError: false,
@@ -373,7 +373,7 @@ func TestNewKopiaUploaderProvider(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			credGetter := &credentials.CredentialGetter{FromSecret: tc.mockCredGetter}
-			BackupRepoServiceCreateFunc = func(logger logrus.FieldLogger) udmrepo.BackupRepoService {
+			BackupRepoServiceCreateFunc = func(_ logrus.FieldLogger) udmrepo.BackupRepoService {
 				return tc.mockBackupRepoService
 			}
 			// Call the function being tested.

--- a/pkg/uploader/provider/provider.go
+++ b/pkg/uploader/provider/provider.go
@@ -67,7 +67,7 @@ type Provider interface {
 // NewUploaderProvider initialize provider with specific uploaderType
 func NewUploaderProvider(
 	ctx context.Context,
-	client client.Client,
+	_ client.Client,
 	uploaderType string,
 	requesterType string,
 	repoIdentifier string,

--- a/pkg/uploader/provider/restic.go
+++ b/pkg/uploader/provider/restic.go
@@ -96,7 +96,7 @@ func NewResticUploaderProvider(
 	return &provider, nil
 }
 
-func (rp *resticProvider) Close(ctx context.Context) error {
+func (rp *resticProvider) Close(context.Context) error {
 	_, err := os.Stat(rp.credentialsFile)
 	if err == nil {
 		return os.Remove(rp.credentialsFile)
@@ -116,11 +116,11 @@ func (rp *resticProvider) Close(ctx context.Context) error {
 // RunBackup runs a `backup` command and watches the output to provide
 // progress updates to the caller and return snapshotID, isEmptySnapshot, error
 func (rp *resticProvider) RunBackup(
-	ctx context.Context,
+	_ context.Context,
 	path string,
 	realSource string,
 	tags map[string]string,
-	forceFull bool,
+	_ bool,
 	parentSnapshot string,
 	volMode uploader.PersistentVolumeMode,
 	uploaderCfg map[string]string,
@@ -193,7 +193,7 @@ func (rp *resticProvider) RunBackup(
 // RunRestore runs a `restore` command and monitors the volume size to
 // provide progress updates to the caller.
 func (rp *resticProvider) RunRestore(
-	ctx context.Context,
+	_ context.Context,
 	snapshotID string,
 	volumePath string,
 	volMode uploader.PersistentVolumeMode,
@@ -231,7 +231,7 @@ func (rp *resticProvider) RunRestore(
 	return 0, err
 }
 
-func (rp *resticProvider) parseRestoreExtraFlags(uploaderCfg map[string]string) ([]string, error) {
+func (*resticProvider) parseRestoreExtraFlags(uploaderCfg map[string]string) ([]string, error) {
 	extraFlags := []string{}
 	if len(uploaderCfg) == 0 {
 		return extraFlags, nil

--- a/pkg/uploader/provider/restic_test.go
+++ b/pkg/uploader/provider/restic_test.go
@@ -56,7 +56,7 @@ func TestResticRunBackup(t *testing.T) {
 			name:       "nil uploader",
 			rp:         &resticProvider{log: logrus.New()},
 			nilUpdater: true,
-			hookBackupFunc: func(repoIdentifier string, passwordFile string, path string, tags map[string]string) *restic.Command {
+			hookBackupFunc: func(_ string, _ string, _ string, _ map[string]string) *restic.Command {
 				return &restic.Command{Command: "date"}
 			},
 			errorHandleFunc: func(err error) bool {
@@ -66,7 +66,7 @@ func TestResticRunBackup(t *testing.T) {
 		{
 			name: "wrong restic execute command",
 			rp:   &resticProvider{log: logrus.New()},
-			hookBackupFunc: func(repoIdentifier string, passwordFile string, path string, tags map[string]string) *restic.Command {
+			hookBackupFunc: func(_ string, _ string, _ string, _ map[string]string) *restic.Command {
 				return &restic.Command{Command: "date"}
 			},
 			errorHandleFunc: func(err error) bool {
@@ -76,7 +76,7 @@ func TestResticRunBackup(t *testing.T) {
 			name:           "has parent snapshot",
 			rp:             &resticProvider{log: logrus.New()},
 			parentSnapshot: "parentSnapshot",
-			hookBackupFunc: func(repoIdentifier string, passwordFile string, path string, tags map[string]string) *restic.Command {
+			hookBackupFunc: func(_ string, _ string, _ string, _ map[string]string) *restic.Command {
 				return &restic.Command{Command: "date"}
 			},
 			hookResticBackupFunc: func(*restic.Command, logrus.FieldLogger, uploader.ProgressUpdater) (string, string, error) {
@@ -161,7 +161,7 @@ func TestResticRunBackup(t *testing.T) {
 }
 
 func TestResticRunRestore(t *testing.T) {
-	resticRestoreCMDFunc = func(repoIdentifier, passwordFile, snapshotID, target string) *restic.Command {
+	resticRestoreCMDFunc = func(_, _, _, _ string) *restic.Command {
 		return &restic.Command{Args: []string{""}}
 	}
 	testCases := []struct {
@@ -183,7 +183,7 @@ func TestResticRunRestore(t *testing.T) {
 		{
 			name: "has extral flags",
 			rp:   &resticProvider{log: logrus.New(), extraFlags: []string{"test-extra-flags"}},
-			hookResticRestoreFunc: func(repoIdentifier, passwordFile, snapshotID, target string) *restic.Command {
+			hookResticRestoreFunc: func(_, _, _, _ string) *restic.Command {
 				return &restic.Command{Args: []string{"date"}}
 			},
 			errorHandleFunc: func(err error) bool {
@@ -193,7 +193,7 @@ func TestResticRunRestore(t *testing.T) {
 		{
 			name: "wrong restic execute command",
 			rp:   &resticProvider{log: logrus.New()},
-			hookResticRestoreFunc: func(repoIdentifier, passwordFile, snapshotID, target string) *restic.Command {
+			hookResticRestoreFunc: func(_, _, _, _ string) *restic.Command {
 				return &restic.Command{Args: []string{"date"}}
 			},
 			errorHandleFunc: func(err error) bool {
@@ -330,7 +330,7 @@ func TestNewResticUploaderProvider(t *testing.T) {
 			mockCredFunc: func(credGetter *MockCredentialGetter, repoKeySelector *corev1api.SecretKeySelector) {
 				credGetter.On("Path", repoKeySelector).Return("temp-credentials", nil)
 			},
-			resticTempCACertFileFunc: func(caCert []byte, bsl string, fs filesystem.Interface) (string, error) {
+			resticTempCACertFileFunc: func([]byte, string, filesystem.Interface) (string, error) {
 				return "", errors.New("error writing CACert file")
 			},
 			checkFunc: func(t *testing.T, provider Provider, err error) {
@@ -343,10 +343,10 @@ func TestNewResticUploaderProvider(t *testing.T) {
 			mockCredFunc: func(credGetter *MockCredentialGetter, repoKeySelector *corev1api.SecretKeySelector) {
 				credGetter.On("Path", repoKeySelector).Return("temp-credentials", nil)
 			},
-			resticTempCACertFileFunc: func(caCert []byte, bsl string, fs filesystem.Interface) (string, error) {
+			resticTempCACertFileFunc: func([]byte, string, filesystem.Interface) (string, error) {
 				return "test-ca", nil
 			},
-			resticCmdEnvFunc: func(backupLocation *velerov1api.BackupStorageLocation, credentialFileStore credentials.FileStore) ([]string, error) {
+			resticCmdEnvFunc: func(*velerov1api.BackupStorageLocation, credentials.FileStore) ([]string, error) {
 				return nil, errors.New("error generating repository cmnd env")
 			},
 			checkFunc: func(t *testing.T, provider Provider, err error) {
@@ -359,10 +359,10 @@ func TestNewResticUploaderProvider(t *testing.T) {
 			mockCredFunc: func(credGetter *MockCredentialGetter, repoKeySelector *corev1api.SecretKeySelector) {
 				credGetter.On("Path", repoKeySelector).Return("temp-credentials", nil)
 			},
-			resticTempCACertFileFunc: func(caCert []byte, bsl string, fs filesystem.Interface) (string, error) {
+			resticTempCACertFileFunc: func([]byte, string, filesystem.Interface) (string, error) {
 				return "test-ca", nil
 			},
-			resticCmdEnvFunc: func(backupLocation *velerov1api.BackupStorageLocation, credentialFileStore credentials.FileStore) ([]string, error) {
+			resticCmdEnvFunc: func(*velerov1api.BackupStorageLocation, credentials.FileStore) ([]string, error) {
 				return nil, nil
 			},
 			checkFunc: func(t *testing.T, provider Provider, err error) {
@@ -377,10 +377,10 @@ func TestNewResticUploaderProvider(t *testing.T) {
 			mockCredFunc: func(credGetter *MockCredentialGetter, repoKeySelector *corev1api.SecretKeySelector) {
 				credGetter.On("Path", repoKeySelector).Return("temp-credentials", nil)
 			},
-			resticTempCACertFileFunc: func(caCert []byte, bsl string, fs filesystem.Interface) (string, error) {
+			resticTempCACertFileFunc: func([]byte, string, filesystem.Interface) (string, error) {
 				return "test-ca", nil
 			},
-			resticCmdEnvFunc: func(backupLocation *velerov1api.BackupStorageLocation, credentialFileStore credentials.FileStore) ([]string, error) {
+			resticCmdEnvFunc: func(*velerov1api.BackupStorageLocation, credentials.FileStore) ([]string, error) {
 				return nil, nil
 			},
 			checkFunc: func(t *testing.T, provider Provider, err error) {

--- a/pkg/util/actionhelpers/pvc_helper.go
+++ b/pkg/util/actionhelpers/pvc_helper.go
@@ -24,7 +24,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 )
 
-func RelatedItemsForPVC(pvc *corev1api.PersistentVolumeClaim, log logrus.FieldLogger) []velero.ResourceIdentifier {
+func RelatedItemsForPVC(pvc *corev1api.PersistentVolumeClaim, _ logrus.FieldLogger) []velero.ResourceIdentifier {
 	return []velero.ResourceIdentifier{
 		{
 			GroupResource: kuberesource.PersistentVolumes,

--- a/pkg/util/actionhelpers/rbac.go
+++ b/pkg/util/actionhelpers/rbac.go
@@ -38,7 +38,7 @@ type ClusterRoleBindingLister interface {
 type NoopClusterRoleBindingLister struct {
 }
 
-func (noop NoopClusterRoleBindingLister) List() ([]ClusterRoleBinding, error) {
+func (NoopClusterRoleBindingLister) List() ([]ClusterRoleBinding, error) {
 	return []ClusterRoleBinding{}, nil
 }
 

--- a/pkg/util/csi/volume_snapshot_test.go
+++ b/pkg/util/csi/volume_snapshot_test.go
@@ -337,7 +337,7 @@ func TestEnsureDeleteVS(t *testing.T) {
 				{
 					verb:     "get",
 					resource: "volumesnapshots",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-get-error")
 					},
 				},
@@ -353,7 +353,7 @@ func TestEnsureDeleteVS(t *testing.T) {
 				{
 					verb:     "delete",
 					resource: "volumesnapshots",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, nil
 					},
 				},
@@ -369,7 +369,7 @@ func TestEnsureDeleteVS(t *testing.T) {
 				{
 					verb:     "delete",
 					resource: "volumesnapshots",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, nil
 					},
 				},
@@ -435,7 +435,7 @@ func TestEnsureDeleteVSC(t *testing.T) {
 				{
 					verb:     "delete",
 					resource: "volumesnapshotcontents",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-delete-error")
 					},
 				},
@@ -450,7 +450,7 @@ func TestEnsureDeleteVSC(t *testing.T) {
 				{
 					verb:     "get",
 					resource: "volumesnapshotcontents",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-get-error")
 					},
 				},
@@ -465,7 +465,7 @@ func TestEnsureDeleteVSC(t *testing.T) {
 				{
 					verb:     "delete",
 					resource: "volumesnapshotcontents",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, nil
 					},
 				},
@@ -480,7 +480,7 @@ func TestEnsureDeleteVSC(t *testing.T) {
 				{
 					verb:     "delete",
 					resource: "volumesnapshotcontents",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, nil
 					},
 				},
@@ -535,7 +535,7 @@ func TestDeleteVolumeSnapshotContentIfAny(t *testing.T) {
 				{
 					verb:     "delete",
 					resource: "volumesnapshotcontents",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-delete-error")
 					},
 				},
@@ -599,7 +599,7 @@ func TestDeleteVolumeSnapshotIfAny(t *testing.T) {
 				{
 					verb:     "delete",
 					resource: "volumesnapshots",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-delete-error")
 					},
 				},
@@ -685,7 +685,7 @@ func TestRetainVSC(t *testing.T) {
 				{
 					verb:     "patch",
 					resource: "volumesnapshotcontents",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-patch-error")
 					},
 				},
@@ -769,7 +769,7 @@ func TestRemoveVSCProtect(t *testing.T) {
 				{
 					verb:     "update",
 					resource: "volumesnapshotcontents",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-update-error")
 					},
 				},
@@ -784,7 +784,7 @@ func TestRemoveVSCProtect(t *testing.T) {
 				{
 					verb:     "update",
 					resource: "volumesnapshotcontents",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, &apierrors.StatusError{ErrStatus: metav1.Status{
 							Reason: metav1.StatusReasonConflict,
 						}}

--- a/pkg/util/filesystem/file_system.go
+++ b/pkg/util/filesystem/file_system.go
@@ -50,31 +50,31 @@ func NewFileSystem() Interface {
 
 type osFileSystem struct{}
 
-func (fs *osFileSystem) Glob(path string) ([]string, error) {
+func (*osFileSystem) Glob(path string) ([]string, error) {
 	return filepath.Glob(path)
 }
 
-func (fs *osFileSystem) TempDir(dir, prefix string) (string, error) {
+func (*osFileSystem) TempDir(dir, prefix string) (string, error) {
 	return os.MkdirTemp(dir, prefix)
 }
 
-func (fs *osFileSystem) MkdirAll(path string, perm os.FileMode) error {
+func (*osFileSystem) MkdirAll(path string, perm os.FileMode) error {
 	return os.MkdirAll(path, perm)
 }
 
-func (fs *osFileSystem) Create(name string) (io.WriteCloser, error) {
+func (*osFileSystem) Create(name string) (io.WriteCloser, error) {
 	return os.Create(name)
 }
 
-func (fs *osFileSystem) OpenFile(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+func (*osFileSystem) OpenFile(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
 	return os.OpenFile(name, flag, perm)
 }
 
-func (fs *osFileSystem) RemoveAll(path string) error {
+func (*osFileSystem) RemoveAll(path string) error {
 	return os.RemoveAll(path)
 }
 
-func (fs *osFileSystem) ReadDir(dirname string) ([]os.FileInfo, error) {
+func (*osFileSystem) ReadDir(dirname string) ([]os.FileInfo, error) {
 	var fileInfos []os.FileInfo
 	dirInfos, ise := os.ReadDir(dirname)
 	if ise != nil {
@@ -89,11 +89,11 @@ func (fs *osFileSystem) ReadDir(dirname string) ([]os.FileInfo, error) {
 	return fileInfos, nil
 }
 
-func (fs *osFileSystem) ReadFile(filename string) ([]byte, error) {
+func (*osFileSystem) ReadFile(filename string) ([]byte, error) {
 	return os.ReadFile(filename)
 }
 
-func (fs *osFileSystem) DirExists(path string) (bool, error) {
+func (*osFileSystem) DirExists(path string) (bool, error) {
 	_, err := os.Stat(path)
 	if err == nil {
 		return true, nil
@@ -104,10 +104,10 @@ func (fs *osFileSystem) DirExists(path string) (bool, error) {
 	return false, err
 }
 
-func (fs *osFileSystem) TempFile(dir, prefix string) (NameWriteCloser, error) {
+func (*osFileSystem) TempFile(dir, prefix string) (NameWriteCloser, error) {
 	return os.CreateTemp(dir, prefix)
 }
 
-func (fs *osFileSystem) Stat(path string) (os.FileInfo, error) {
+func (*osFileSystem) Stat(path string) (os.FileInfo, error) {
 	return os.Stat(path)
 }

--- a/pkg/util/kube/node.go
+++ b/pkg/util/kube/node.go
@@ -88,7 +88,7 @@ func withOSNode(ctx context.Context, client client.Client, osType string, log lo
 	return false
 }
 
-func GetNodeOS(ctx context.Context, nodeName string, nodeClient corev1client.CoreV1Interface) (string, error) {
+func GetNodeOS(_ context.Context, nodeName string, nodeClient corev1client.CoreV1Interface) (string, error) {
 	node, err := nodeClient.Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
 	if err != nil {
 		return "", errors.Wrapf(err, "error getting node %s", nodeName)

--- a/pkg/util/kube/node_test.go
+++ b/pkg/util/kube/node_test.go
@@ -208,7 +208,7 @@ func TestHasNodeWithOS(t *testing.T) {
 				{
 					verb:     "list",
 					resource: "nodes",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-list-error")
 					},
 				},

--- a/pkg/util/kube/pod_test.go
+++ b/pkg/util/kube/pod_test.go
@@ -83,7 +83,7 @@ func TestEnsureDeletePod(t *testing.T) {
 				{
 					verb:     "delete",
 					resource: "pods",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, nil
 					},
 				},
@@ -99,7 +99,7 @@ func TestEnsureDeletePod(t *testing.T) {
 				{
 					verb:     "delete",
 					resource: "pods",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, nil
 					},
 				},
@@ -115,7 +115,7 @@ func TestEnsureDeletePod(t *testing.T) {
 				{
 					verb:     "get",
 					resource: "pods",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-get-error")
 					},
 				},
@@ -355,7 +355,7 @@ func TestDeletePodIfAny(t *testing.T) {
 				{
 					verb:     "delete",
 					resource: "pods",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-delete-error")
 					},
 				},
@@ -615,7 +615,7 @@ type fakePodLog struct {
 	readPos         int
 }
 
-func (fp *fakePodLog) GetPodLogReader(ctx context.Context, podGetter corev1client.CoreV1Interface, pod string, namespace string, logOptions *corev1api.PodLogOptions) (io.ReadCloser, error) {
+func (fp *fakePodLog) GetPodLogReader(context.Context, corev1client.CoreV1Interface, string, string, *corev1api.PodLogOptions) (io.ReadCloser, error) {
 	if fp.getError != nil {
 		return nil, fp.getError
 	}
@@ -638,7 +638,7 @@ func (fp *fakePodLog) Read(p []byte) (n int, err error) {
 	return len(fp.logMessage), nil
 }
 
-func (fp *fakePodLog) Close() error {
+func (*fakePodLog) Close() error {
 	return nil
 }
 
@@ -949,7 +949,7 @@ func (em *exitWithMessageMock) Exit(code int) {
 	em.exitCode = code
 }
 
-func (em *exitWithMessageMock) CreateFile(name string) (*os.File, error) {
+func (em *exitWithMessageMock) CreateFile(string) (*os.File, error) {
 	if em.createErr != nil {
 		return nil, em.createErr
 	}

--- a/pkg/util/kube/predicate.go
+++ b/pkg/util/kube/predicate.go
@@ -69,22 +69,22 @@ func NewAllEventPredicate(f func(object client.Object) bool) predicate.Predicate
 type FalsePredicate struct{}
 
 // Create always returns false
-func (f FalsePredicate) Create(event.CreateEvent) bool {
+func (FalsePredicate) Create(event.CreateEvent) bool {
 	return false
 }
 
 // Delete always returns false
-func (f FalsePredicate) Delete(event.DeleteEvent) bool {
+func (FalsePredicate) Delete(event.DeleteEvent) bool {
 	return false
 }
 
 // Update always returns false
-func (f FalsePredicate) Update(event.UpdateEvent) bool {
+func (FalsePredicate) Update(event.UpdateEvent) bool {
 	return false
 }
 
 // Generic always returns false
-func (f FalsePredicate) Generic(event.GenericEvent) bool {
+func (FalsePredicate) Generic(event.GenericEvent) bool {
 	return false
 }
 

--- a/pkg/util/kube/predicate_test.go
+++ b/pkg/util/kube/predicate_test.go
@@ -180,7 +180,7 @@ func TestSpecChangePredicate(t *testing.T) {
 }
 
 func TestNewAllEventPredicate(t *testing.T) {
-	predicate := NewAllEventPredicate(func(object client.Object) bool {
+	predicate := NewAllEventPredicate(func(client.Object) bool {
 		return false
 	})
 
@@ -191,7 +191,7 @@ func TestNewAllEventPredicate(t *testing.T) {
 }
 
 func TestNewGenericEventPredicate(t *testing.T) {
-	predicate := NewGenericEventPredicate(func(object client.Object) bool {
+	predicate := NewGenericEventPredicate(func(client.Object) bool {
 		return false
 	})
 

--- a/pkg/util/kube/pvc_pv_test.go
+++ b/pkg/util/kube/pvc_pv_test.go
@@ -361,7 +361,7 @@ func TestDeletePVCIfAny(t *testing.T) {
 				{
 					verb:     "get",
 					resource: "persistentvolumeclaims",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-get-error")
 					},
 				},
@@ -390,7 +390,7 @@ func TestDeletePVCIfAny(t *testing.T) {
 				{
 					verb:     "delete",
 					resource: "persistentvolumeclaims",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-delete-error")
 					},
 				},
@@ -411,7 +411,7 @@ func TestDeletePVCIfAny(t *testing.T) {
 				{
 					verb:     "get",
 					resource: "persistentvolumes",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-get-error")
 					},
 				},
@@ -436,7 +436,7 @@ func TestDeletePVCIfAny(t *testing.T) {
 				{
 					verb:     "patch",
 					resource: "persistentvolumes",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, pvObject, errors.New("fake-patch-error")
 					},
 				},
@@ -468,7 +468,7 @@ func TestDeletePVCIfAny(t *testing.T) {
 				{
 					verb:     "delete",
 					resource: "persistentvolumeclaims",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, pvcWithVolume, nil
 					},
 				},
@@ -490,7 +490,7 @@ func TestDeletePVCIfAny(t *testing.T) {
 				{
 					verb:     "delete",
 					resource: "persistentvolumeclaims",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, pvcWithVolume, nil
 					},
 				},
@@ -549,7 +549,7 @@ func TestDeletePVIfAny(t *testing.T) {
 				{
 					verb:     "delete",
 					resource: "persistentvolumes",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-delete-error")
 					},
 				},
@@ -628,7 +628,7 @@ func TestEnsureDeletePVC(t *testing.T) {
 				{
 					verb:     "delete",
 					resource: "persistentvolumeclaims",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, pvcObject, nil
 					},
 				},
@@ -644,7 +644,7 @@ func TestEnsureDeletePVC(t *testing.T) {
 				{
 					verb:     "get",
 					resource: "persistentvolumeclaims",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-get-error")
 					},
 				},
@@ -661,7 +661,7 @@ func TestEnsureDeletePVC(t *testing.T) {
 				{
 					verb:     "delete",
 					resource: "persistentvolumeclaims",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, pvcObject, nil
 					},
 				},
@@ -678,7 +678,7 @@ func TestEnsureDeletePVC(t *testing.T) {
 				{
 					verb:     "delete",
 					resource: "persistentvolumeclaims",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, pvcObject, nil
 					},
 				},
@@ -735,7 +735,7 @@ func TestEnsureDeletePV(t *testing.T) {
 				{
 					verb:     "get",
 					resource: "persistentvolumes",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, pvObject, nil
 					},
 				},
@@ -750,7 +750,7 @@ func TestEnsureDeletePV(t *testing.T) {
 				{
 					verb:     "get",
 					resource: "persistentvolumes",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-get-error")
 					},
 				},
@@ -766,7 +766,7 @@ func TestEnsureDeletePV(t *testing.T) {
 				{
 					verb:     "get",
 					resource: "persistentvolumes",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, pvObject, nil
 					},
 				},
@@ -825,7 +825,7 @@ func TestRebindPVC(t *testing.T) {
 				{
 					verb:     "patch",
 					resource: "persistentvolumeclaims",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-patch-error")
 					},
 				},
@@ -921,7 +921,7 @@ func TestResetPVBinding(t *testing.T) {
 				{
 					verb:     "patch",
 					resource: "persistentvolumes",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-patch-error")
 					},
 				},
@@ -1011,7 +1011,7 @@ func TestSetPVReclaimPolicy(t *testing.T) {
 				{
 					verb:     "patch",
 					resource: "persistentvolumes",
-					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+					reactorFunc: func(clientTesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("fake-patch-error")
 					},
 				},

--- a/pkg/util/kube/utils.go
+++ b/pkg/util/kube/utils.go
@@ -202,7 +202,7 @@ func GetVolumeMode(ctx context.Context, log logrus.FieldLogger, pod *corev1api.P
 
 // GetPodPVCVolume gets the PVC, PV and volume for a pod volume name.
 // Returns pod volume in case of ErrorPodVolumeIsNotPVC error
-func GetPodPVCVolume(ctx context.Context, log logrus.FieldLogger, pod *corev1api.Pod, volumeName string, kubeClient kubernetes.Interface) (
+func GetPodPVCVolume(ctx context.Context, _ logrus.FieldLogger, pod *corev1api.Pod, volumeName string, kubeClient kubernetes.Interface) (
 	*corev1api.PersistentVolumeClaim, *corev1api.PersistentVolume, *corev1api.Volume, error) {
 	var volume *corev1api.Volume
 

--- a/pkg/util/kube/utils_test.go
+++ b/pkg/util/kube/utils_test.go
@@ -41,7 +41,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func TestNamespaceAndName(t *testing.T) {
+func TestNamespaceAndName(_ *testing.T) {
 	//TODO
 }
 

--- a/pkg/util/logging/error_location_hook.go
+++ b/pkg/util/logging/error_location_hook.go
@@ -37,11 +37,11 @@ const (
 // typically do).
 type ErrorLocationHook struct{}
 
-func (h *ErrorLocationHook) Levels() []logrus.Level {
+func (*ErrorLocationHook) Levels() []logrus.Level {
 	return logrus.AllLevels
 }
 
-func (h *ErrorLocationHook) Fire(entry *logrus.Entry) error {
+func (*ErrorLocationHook) Fire(entry *logrus.Entry) error {
 	errObj, ok := entry.Data[logrus.ErrorKey]
 	if !ok {
 		return nil

--- a/pkg/util/logging/hclog_level_hook.go
+++ b/pkg/util/logging/hclog_level_hook.go
@@ -27,11 +27,11 @@ import (
 // overwritten.
 type HcLogLevelHook struct{}
 
-func (h *HcLogLevelHook) Levels() []logrus.Level {
+func (*HcLogLevelHook) Levels() []logrus.Level {
 	return logrus.AllLevels
 }
 
-func (h *HcLogLevelHook) Fire(entry *logrus.Entry) error {
+func (*HcLogLevelHook) Fire(entry *logrus.Entry) error {
 	switch entry.Level {
 	// logrus uses "warning" to represent WarnLevel,
 	// which is not compatible with hclog's "warn".

--- a/pkg/util/logging/log_counter_hook.go
+++ b/pkg/util/logging/log_counter_hook.go
@@ -44,7 +44,7 @@ func NewLogHook() *LogHook {
 }
 
 // Levels returns the logrus levels that the hook should be fired for.
-func (h *LogHook) Levels() []logrus.Level {
+func (*LogHook) Levels() []logrus.Level {
 	return logrus.AllLevels
 }
 

--- a/pkg/util/logging/log_location_hook.go
+++ b/pkg/util/logging/log_location_hook.go
@@ -51,7 +51,7 @@ func (h *LogLocationHook) WithLoggerName(name string) *LogLocationHook {
 	return h
 }
 
-func (h *LogLocationHook) Levels() []logrus.Level {
+func (*LogLocationHook) Levels() []logrus.Level {
 	return logrus.AllLevels
 }
 

--- a/pkg/util/logging/log_merge_hook.go
+++ b/pkg/util/logging/log_merge_hook.go
@@ -52,11 +52,11 @@ func newHookWriter(orgWriter io.Writer, source string, logger *logrus.Logger) io
 	}
 }
 
-func (h *MergeHook) Levels() []logrus.Level {
+func (*MergeHook) Levels() []logrus.Level {
 	return []logrus.Level{ListeningLevel}
 }
 
-func (h *MergeHook) Fire(entry *logrus.Entry) error {
+func (*MergeHook) Fire(entry *logrus.Entry) error {
 	if entry.Message != ListeningMessage {
 		return nil
 	}

--- a/test/e2e/schedule/in_progress.go
+++ b/test/e2e/schedule/in_progress.go
@@ -130,7 +130,7 @@ func (s *InProgressCase) Backup() error {
 			30*time.Second,
 			5*time.Minute,
 			true,
-			func(ctx context.Context) (bool, error) {
+			func(context.Context) (bool, error) {
 				backupList := new(velerov1api.BackupList)
 
 				if err := s.Client.Kubebuilder.List(

--- a/test/e2e/schedule/ordered_resources.go
+++ b/test/e2e/schedule/ordered_resources.go
@@ -168,7 +168,7 @@ func (o *OrderedResources) Backup() error {
 			30*time.Second,
 			time.Minute*5,
 			true,
-			func(ctx context.Context) (bool, error) {
+			func(context.Context) (bool, error) {
 				backupList := new(velerov1api.BackupList)
 
 				if err := o.Client.Kubebuilder.List(

--- a/test/e2e/schedule/periodical.go
+++ b/test/e2e/schedule/periodical.go
@@ -104,7 +104,7 @@ func (n *PeriodicalCase) Backup() error {
 			30*time.Second,
 			5*time.Minute,
 			true,
-			func(ctx context.Context) (bool, error) {
+			func(context.Context) (bool, error) {
 				backups, err := veleroutil.GetBackupsForSchedule(
 					n.Ctx,
 					n.Client.Kubebuilder,

--- a/test/e2e/test/test.go
+++ b/test/e2e/test/test.go
@@ -105,11 +105,11 @@ func (t *TestCase) Init() error {
 	return nil
 }
 
-func (t *TestCase) GenerateUUID() string {
+func (*TestCase) GenerateUUID() string {
 	return fmt.Sprintf("%08d", rand.IntN(100000000))
 }
 
-func (t *TestCase) CreateResources() error {
+func (*TestCase) CreateResources() error {
 	return nil
 }
 
@@ -161,7 +161,7 @@ func (t *TestCase) Restore() error {
 	return nil
 }
 
-func (t *TestCase) Verify() error {
+func (*TestCase) Verify() error {
 	return nil
 }
 

--- a/test/perf/metrics/minio.go
+++ b/test/perf/metrics/minio.go
@@ -46,6 +46,6 @@ func (m *MinioMetrics) GetMetrics() map[string]string {
 	return m.Metrics
 }
 
-func (m *MinioMetrics) GetMetricsName() string {
+func (*MinioMetrics) GetMetricsName() string {
 	return MinioDesc
 }

--- a/test/perf/metrics/nfs.go
+++ b/test/perf/metrics/nfs.go
@@ -46,6 +46,6 @@ func (n *NFSMetrics) GetMetrics() map[string]string {
 	return n.Metrics
 }
 
-func (n *NFSMetrics) GetMetricsName() string {
+func (*NFSMetrics) GetMetricsName() string {
 	return NFSDesc
 }

--- a/test/perf/metrics/pod.go
+++ b/test/perf/metrics/pod.go
@@ -81,7 +81,7 @@ func (p *PodMetrics) GetMetrics() map[string]string {
 	return tmpMetrics
 }
 
-func (p *PodMetrics) GetMetricsName() string {
+func (*PodMetrics) GetMetricsName() string {
 	return PodResourceDesc
 }
 

--- a/test/perf/metrics/time.go
+++ b/test/perf/metrics/time.go
@@ -62,10 +62,10 @@ func (t *TimeMetrics) End(name string) {
 	t.TimeInfo[name] = timeSpan
 }
 
-func (t *TimeMetrics) Update() error {
+func (*TimeMetrics) Update() error {
 	return nil
 }
 
-func (t *TimeMetrics) GetMetricsName() string {
+func (*TimeMetrics) GetMetricsName() string {
 	return TimeCaseDesc
 }

--- a/test/perf/restore/restore.go
+++ b/test/perf/restore/restore.go
@@ -88,6 +88,6 @@ func (r *RestoreTest) Restore() error {
 
 	return r.TestCase.Restore()
 }
-func (r *RestoreTest) Destroy() error {
+func (*RestoreTest) Destroy() error {
 	return nil
 }

--- a/test/perf/test/test.go
+++ b/test/perf/test/test.go
@@ -108,12 +108,12 @@ func (t *TestCase) Init() error {
 	return nil
 }
 
-func (t *TestCase) GenerateUUID() string {
+func (*TestCase) GenerateUUID() string {
 	rand.Seed(time.Now().UnixNano())
 	return fmt.Sprintf("%08d", rand.Intn(100000000))
 }
 
-func (t *TestCase) CreateResources() error {
+func (*TestCase) CreateResources() error {
 	return nil
 }
 
@@ -156,7 +156,7 @@ func (t *TestCase) Restore() error {
 	return nil
 }
 
-func (t *TestCase) Verify() error {
+func (*TestCase) Verify() error {
 	return nil
 }
 

--- a/test/util/common/common.go
+++ b/test/util/common/common.go
@@ -22,7 +22,7 @@ type OsCommandLine struct {
 	Args []string
 }
 
-func GetListByCmdPipes(ctx context.Context, cmdLines []*OsCommandLine) ([]string, error) {
+func GetListByCmdPipes(_ context.Context, cmdLines []*OsCommandLine) ([]string, error) {
 	var buf bytes.Buffer
 	var err error
 	var cmds []*exec.Cmd

--- a/test/util/csi/common.go
+++ b/test/util/csi/common.go
@@ -53,7 +53,7 @@ func GetClients() (*kubernetes.Clientset, *snapshotterClientSet.Clientset, error
 	return client, snapshotterClient, nil
 }
 
-func GetCsiSnapshotHandle(client TestClient, apiVersion string, index map[string]string) ([]string, error) {
+func GetCsiSnapshotHandle(_ TestClient, apiVersion string, index map[string]string) ([]string, error) {
 	_, snapshotClient, err := GetClients()
 
 	var vscList *volumeSnapshotV1.VolumeSnapshotContentList

--- a/test/util/k8s/common.go
+++ b/test/util/k8s/common.go
@@ -56,7 +56,7 @@ func CreateSecretFromFiles(ctx context.Context, client TestClient, namespace str
 }
 
 // WaitForPods waits until all of the pods have gone to PodRunning state
-func WaitForPods(ctx context.Context, client TestClient, namespace string, pods []string) error {
+func WaitForPods(_ context.Context, client TestClient, namespace string, pods []string) error {
 	timeout := 5 * time.Minute
 	interval := 5 * time.Second
 	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
@@ -329,7 +329,7 @@ func CreateFileToPod(
 	containerName string,
 	volume string,
 	filename string,
-	content string,
+	_ string,
 	workerOS string,
 ) error {
 	filePath := fmt.Sprintf("/%s/%s", volume, filename)
@@ -449,7 +449,7 @@ func WaitForCRDEstablished(crdName string) error {
 	return nil
 }
 
-func GetAllService(ctx context.Context) (string, error) {
+func GetAllService(_ context.Context) (string, error) {
 	args := []string{"get", "service", "-A"}
 	cmd := exec.CommandContext(context.Background(), "kubectl", args...)
 	fmt.Printf("Kubectl exec cmd =%v\n", cmd)

--- a/test/util/k8s/namespace.go
+++ b/test/util/k8s/namespace.go
@@ -35,7 +35,7 @@ import (
 	veleroexec "github.com/vmware-tanzu/velero/pkg/util/exec"
 )
 
-func CreateNamespace(ctx context.Context, client TestClient, namespace string) error {
+func CreateNamespace(_ context.Context, client TestClient, namespace string) error {
 	ns := builder.ForNamespace(namespace).Result()
 	// Add label to avoid PSA check.
 	ns.Labels = map[string]string{
@@ -62,7 +62,7 @@ func CreateNamespaceWithLabel(ctx context.Context, client TestClient, namespace 
 	return err
 }
 
-func CreateNamespaceWithAnnotation(ctx context.Context, client TestClient, namespace string, annotation map[string]string) error {
+func CreateNamespaceWithAnnotation(_ context.Context, client TestClient, namespace string, annotation map[string]string) error {
 	ns := builder.ForNamespace(namespace).Result()
 	// Add label to avoid PSA check.
 	ns.Labels = map[string]string{
@@ -95,7 +95,7 @@ func KubectlDeleteNamespace(ctx context.Context, namespace string) error {
 	return err
 }
 
-func DeleteNamespace(ctx context.Context, client TestClient, namespace string, wait bool) error {
+func DeleteNamespace(_ context.Context, _ TestClient, namespace string, wait bool) error {
 	tenMinuteTimeout, ctxCancel := context.WithTimeout(context.Background(), time.Minute*10)
 	defer ctxCancel()
 

--- a/test/util/k8s/persistentvolumes.go
+++ b/test/util/k8s/persistentvolumes.go
@@ -48,11 +48,11 @@ func CreatePersistentVolume(client TestClient, name string) (*corev1api.Persiste
 	return client.ClientGo.CoreV1().PersistentVolumes().Create(context.TODO(), p, metav1.CreateOptions{})
 }
 
-func GetPersistentVolume(ctx context.Context, client TestClient, namespace string, persistentVolume string) (*corev1api.PersistentVolume, error) {
+func GetPersistentVolume(ctx context.Context, client TestClient, _ string, persistentVolume string) (*corev1api.PersistentVolume, error) {
 	return client.ClientGo.CoreV1().PersistentVolumes().Get(ctx, persistentVolume, metav1.GetOptions{})
 }
 
-func AddAnnotationToPersistentVolume(ctx context.Context, client TestClient, namespace string, persistentVolume, key string) (*corev1api.PersistentVolume, error) {
+func AddAnnotationToPersistentVolume(ctx context.Context, client TestClient, _ string, persistentVolume, key string) (*corev1api.PersistentVolume, error) {
 	newPV, err := GetPersistentVolume(ctx, client, "", persistentVolume)
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("Fail to ge PV %s", persistentVolume))

--- a/test/util/k8s/serviceaccount.go
+++ b/test/util/k8s/serviceaccount.go
@@ -72,7 +72,7 @@ func PatchServiceAccountWithImagePullSecret(ctx context.Context, client TestClie
 	return nil
 }
 
-func CreateServiceAccount(ctx context.Context, client TestClient, namespace string, serviceaccount string) error {
+func CreateServiceAccount(_ context.Context, client TestClient, namespace string, serviceaccount string) error {
 	sa := &corev1api.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: serviceaccount,
@@ -88,6 +88,6 @@ func CreateServiceAccount(ctx context.Context, client TestClient, namespace stri
 	return nil
 }
 
-func GetServiceAccount(ctx context.Context, client TestClient, namespace string, serviceAccount string) (*corev1api.ServiceAccount, error) {
+func GetServiceAccount(_ context.Context, client TestClient, namespace string, serviceAccount string) (*corev1api.ServiceAccount, error) {
 	return client.ClientGo.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), serviceAccount, metav1.GetOptions{})
 }

--- a/test/util/kibishii/kibishii_utils.go
+++ b/test/util/kibishii/kibishii_utils.go
@@ -627,7 +627,7 @@ spec:
 func generateData(ctx context.Context, namespace string, kibishiiData *KibishiiData) error {
 	timeout := 30 * time.Minute
 	interval := 1 * time.Second
-	err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(context.Context) (bool, error) {
 		timeout, ctxCancel := context.WithTimeout(context.Background(), time.Minute*20)
 		defer ctxCancel()
 		kibishiiGenerateCmd := exec.CommandContext(
@@ -671,7 +671,7 @@ func verifyData(ctx context.Context, namespace string, kibishiiData *KibishiiDat
 		interval,
 		timeout,
 		true,
-		func(ctx context.Context) (bool, error) {
+		func(context.Context) (bool, error) {
 			timeout, ctxCancel := context.WithTimeout(context.Background(), time.Minute*20)
 			defer ctxCancel()
 			kibishiiVerifyCmd := exec.CommandContext(

--- a/test/util/providers/aws_utils.go
+++ b/test/util/providers/aws_utils.go
@@ -156,7 +156,7 @@ func IsValidS3URLScheme(s3URL string) bool {
 	return true
 }
 
-func (s AWSStorage) ListItems(client *s3.Client, objectsV2Input *s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error) {
+func (AWSStorage) ListItems(client *s3.Client, objectsV2Input *s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error) {
 	res, err := client.ListObjectsV2(context.Background(), objectsV2Input)
 	if err != nil {
 		return nil, err
@@ -165,7 +165,7 @@ func (s AWSStorage) ListItems(client *s3.Client, objectsV2Input *s3.ListObjectsV
 	return res, nil
 }
 
-func (s AWSStorage) DeleteItem(client *s3.Client, deleteObjectV2Input *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
+func (AWSStorage) DeleteItem(client *s3.Client, deleteObjectV2Input *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
 	res, err := client.DeleteObject(context.Background(), deleteObjectV2Input)
 	if err != nil {
 		return nil, err
@@ -238,7 +238,7 @@ func (s AWSStorage) IsObjectsInBucket(cloudCredentialsFile, bslBucket, bslPrefix
 	return false, nil
 }
 
-func (s AWSStorage) DeleteObjectsInBucket(cloudCredentialsFile, bslBucket, bslPrefix, bslConfig, backupObject string) error {
+func (AWSStorage) DeleteObjectsInBucket(cloudCredentialsFile, bslBucket, bslPrefix, bslConfig, backupObject string) error {
 	config := flag.NewMap()
 	config.Set(bslConfig)
 
@@ -300,7 +300,7 @@ func (s AWSStorage) DeleteObjectsInBucket(cloudCredentialsFile, bslBucket, bslPr
 	return nil
 }
 
-func (s AWSStorage) IsSnapshotExisted(cloudCredentialsFile, bslConfig, backupObject string, snapshotCheck test.SnapshotCheckPoint) error {
+func (AWSStorage) IsSnapshotExisted(cloudCredentialsFile, bslConfig, backupObject string, snapshotCheck test.SnapshotCheckPoint) error {
 	config := flag.NewMap()
 	config.Set(bslConfig)
 	region := config.Data()["region"]
@@ -368,7 +368,7 @@ func (s AWSStorage) IsSnapshotExisted(cloudCredentialsFile, bslConfig, backupObj
 	}
 }
 
-func (s AWSStorage) GetMinioBucketSize(cloudCredentialsFile, bslBucket, bslPrefix, bslConfig string) (int64, error) {
+func (AWSStorage) GetMinioBucketSize(cloudCredentialsFile, bslBucket, bslPrefix, bslConfig string) (int64, error) {
 	config := flag.NewMap()
 	config.Set(bslConfig)
 	region := config.Data()["region"]
@@ -416,7 +416,7 @@ func (s AWSStorage) GetMinioBucketSize(cloudCredentialsFile, bslBucket, bslPrefi
 	return totalSize, nil
 }
 
-func (s AWSStorage) GetObject(cloudCredentialsFile, bslBucket, bslPrefix, bslConfig, objectKey string) (io.ReadCloser, error) {
+func (AWSStorage) GetObject(cloudCredentialsFile, bslBucket, bslPrefix, bslConfig, objectKey string) (io.ReadCloser, error) {
 	config := flag.NewMap()
 	config.Set(bslConfig)
 	objectsInput := s3.ListObjectsV2Input{}

--- a/test/util/providers/azure_utils.go
+++ b/test/util/providers/azure_utils.go
@@ -248,7 +248,7 @@ func deleteBlob(client *azblob.Client, containerName, blobName string) error {
 	return err
 }
 
-func (s AzureStorage) IsObjectsInBucket(cloudCredentialsFile, bslBucket, bslPrefix, bslConfig, backupName string) (bool, error) {
+func (AzureStorage) IsObjectsInBucket(cloudCredentialsFile, bslBucket, _, bslConfig, backupName string) (bool, error) {
 	ctx := context.Background()
 	accountName, accountKey, err := getStorageCredential(cloudCredentialsFile, bslConfig)
 	if err != nil {
@@ -288,7 +288,7 @@ func (s AzureStorage) IsObjectsInBucket(cloudCredentialsFile, bslBucket, bslPref
 	return false, nil
 }
 
-func (s AzureStorage) DeleteObjectsInBucket(cloudCredentialsFile, bslBucket, bslPrefix, bslConfig, backupObject string) error {
+func (AzureStorage) DeleteObjectsInBucket(cloudCredentialsFile, bslBucket, bslPrefix, bslConfig, backupObject string) error {
 	ctx := context.Background()
 	accountName, accountKey, err := getStorageCredential(cloudCredentialsFile, bslConfig)
 	if err != nil {
@@ -331,7 +331,7 @@ func (s AzureStorage) DeleteObjectsInBucket(cloudCredentialsFile, bslBucket, bsl
 	return nil
 }
 
-func (s AzureStorage) IsSnapshotExisted(cloudCredentialsFile, bslConfig, backupName string, snapshotCheck SnapshotCheckPoint) error {
+func (AzureStorage) IsSnapshotExisted(cloudCredentialsFile, _, backupName string, snapshotCheck SnapshotCheckPoint) error {
 	ctx := context.Background()
 
 	if err := loadCredentialsIntoEnv(cloudCredentialsFile); err != nil {
@@ -411,7 +411,7 @@ func (s AzureStorage) IsSnapshotExisted(cloudCredentialsFile, bslConfig, backupN
 	}
 }
 
-func (s AzureStorage) GetObject(cloudCredentialsFile, bslBucket, bslPrefix, bslConfig, objectKey string) (io.ReadCloser, error) {
+func (AzureStorage) GetObject(cloudCredentialsFile, bslBucket, bslPrefix, bslConfig, objectKey string) (io.ReadCloser, error) {
 	ctx := context.Background()
 	accountName, accountKey, err := getStorageCredential(cloudCredentialsFile, bslConfig)
 	if err != nil {

--- a/test/util/providers/gcloud_utils.go
+++ b/test/util/providers/gcloud_utils.go
@@ -36,7 +36,7 @@ import (
 
 type GCSStorage string
 
-func (s GCSStorage) IsObjectsInBucket(cloudCredentialsFile, bslBucket, bslPrefix, bslConfig, backupObject string) (bool, error) {
+func (GCSStorage) IsObjectsInBucket(cloudCredentialsFile, bslBucket, bslPrefix, _, backupObject string) (bool, error) {
 	q := &storage.Query{
 		Prefix: bslPrefix,
 	}
@@ -67,7 +67,7 @@ func (s GCSStorage) IsObjectsInBucket(cloudCredentialsFile, bslBucket, bslPrefix
 	}
 }
 
-func (s GCSStorage) DeleteObjectsInBucket(cloudCredentialsFile, bslBucket, bslPrefix, bslConfig, backupObject string) error {
+func (GCSStorage) DeleteObjectsInBucket(cloudCredentialsFile, bslBucket, bslPrefix, _, backupObject string) error {
 	q := &storage.Query{
 		Prefix: bslPrefix,
 	}
@@ -103,7 +103,7 @@ func (s GCSStorage) DeleteObjectsInBucket(cloudCredentialsFile, bslBucket, bslPr
 	}
 }
 
-func (s GCSStorage) IsSnapshotExisted(cloudCredentialsFile, bslConfig, backupObject string, snapshotCheck test.SnapshotCheckPoint) error {
+func (GCSStorage) IsSnapshotExisted(cloudCredentialsFile, _, backupObject string, snapshotCheck test.SnapshotCheckPoint) error {
 	ctx := context.Background()
 	data, err := os.ReadFile(cloudCredentialsFile)
 	if err != nil {
@@ -144,7 +144,7 @@ func (s GCSStorage) IsSnapshotExisted(cloudCredentialsFile, bslConfig, backupObj
 	}
 }
 
-func (s GCSStorage) GetObject(cloudCredentialsFile, bslBucket, bslPrefix, bslConfig, objectKey string) (io.ReadCloser, error) {
+func (GCSStorage) GetObject(cloudCredentialsFile, bslBucket, bslPrefix, _, objectKey string) (io.ReadCloser, error) {
 	ctx := context.Background()
 	client, err := storage.NewClient(ctx, option.WithCredentialsFile(cloudCredentialsFile))
 	if err != nil {

--- a/test/util/velero/install.go
+++ b/test/util/velero/install.go
@@ -782,7 +782,7 @@ func checkBSL(ctx context.Context, veleroCfg *test.VeleroConfig) error {
 	return nil
 }
 
-func PrepareVelero(ctx context.Context, caseName string, veleroCfg test.VeleroConfig) error {
+func PrepareVelero(_ context.Context, caseName string, veleroCfg test.VeleroConfig) error {
 	ready, err := IsVeleroReady(context.Background(), &veleroCfg)
 	if err != nil {
 		fmt.Printf("error in checking velero status with %v", err)

--- a/test/util/velero/velero_utils.go
+++ b/test/util/velero/velero_utils.go
@@ -611,7 +611,7 @@ func VeleroBackupLogs(ctx context.Context, veleroCLI string, veleroNamespace str
 	return VeleroCmdExec(ctx, veleroCLI, args)
 }
 
-func RunDebug(ctx context.Context, veleroCLI, veleroNamespace, backup, restore string) {
+func RunDebug(ctx context.Context, veleroCLI, veleroNamespace, backup, _ string) {
 	output := fmt.Sprintf("debug-bundle-%d.tar.gz", time.Now().UnixNano())
 	args := []string{"debug", "--namespace", veleroNamespace, "--output", output, "--verbose"}
 	if len(backup) > 0 {
@@ -817,7 +817,7 @@ func WaitForVSphereUploadCompletion(ctx context.Context, timeout time.Duration, 
 	return err
 }
 
-func GetVsphereSnapshotIDs(ctx context.Context, timeout time.Duration, namespace string, pvcNameList []string) ([]string, error) {
+func GetVsphereSnapshotIDs(ctx context.Context, _ time.Duration, namespace string, pvcNameList []string) ([]string, error) {
 	checkSnapshotCmd := exec.CommandContext(ctx, "kubectl",
 		"get", "-n", namespace, "snapshots.backupdriver.cnsdp.vmware.com", "-o=jsonpath='{range .items[*]}{.spec.resourceHandle.name}{\"=\"}{.status.snapshotID}{\"\\n\"}{end}'")
 	fmt.Printf("checkSnapshotCmd cmd =%v\n", checkSnapshotCmd)
@@ -1285,7 +1285,7 @@ func BuildSnapshotCheckPointFromVolumeInfo(
 	backupVolumeInfo []*volume.BackupVolumeInfo,
 	expectCount int,
 	namespaceBackedUp string,
-	backupName string,
+	_ string,
 	KibishiiPVCNameList []string) (SnapshotCheckPoint, error) {
 	var snapshotCheckPoint SnapshotCheckPoint
 
@@ -1481,7 +1481,7 @@ func UpdateVeleroDeployment(ctx context.Context, veleroCfg VeleroConfig) ([]stri
 	return common.GetListByCmdPipes(ctx, cmds)
 }
 
-func UpdateNodeAgent(ctx context.Context, veleroCfg VeleroConfig, dsjson string) ([]string, error) {
+func UpdateNodeAgent(ctx context.Context, _ VeleroConfig, dsjson string) ([]string, error) {
 	cmds := []*common.OsCommandLine{}
 
 	cmd := &common.OsCommandLine{
@@ -1638,7 +1638,7 @@ func InstallStorageClasses(provider string) error {
 	return InstallStorageClass(ctx, tmpFile.Name())
 }
 
-func GetPvName(ctx context.Context, client TestClient, pvcName, namespace string) (string, error) {
+func GetPvName(_ context.Context, _ TestClient, pvcName, namespace string) (string, error) {
 	pvcList, err := GetPvcByPVCName(context.Background(), namespace, pvcName)
 	if err != nil {
 		return "", err
@@ -1658,7 +1658,7 @@ func GetPvName(ctx context.Context, client TestClient, pvcName, namespace string
 
 	return pvList[0], nil
 }
-func DeletePVs(ctx context.Context, client TestClient, pvList []string) error {
+func DeletePVs(ctx context.Context, _ TestClient, pvList []string) error {
 	for _, pv := range pvList {
 		args := []string{"delete", "pv", pv, "--timeout=0s"}
 		fmt.Println(args)


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

Enables [unused-parameter](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#unused-parameter) and [unused-receiver](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#unused-receiver) rules from revive

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
