### PR TITLE
[release-1.16] Fix missing defaultVolumesToFsBackup flag output in Velero describe backup cmd (#9056)

### DIFF
--- a/changelogs/unreleased/9103-shubham-pampattiwar
+++ b/changelogs/unreleased/9103-shubham-pampattiwar
@@ -1,0 +1,1 @@
+Fix missing defaultVolumesToFsBackup flag output in Velero describe backup cmd

--- a/changelogs/unreleased/9105-shubham-pampattiwar
+++ b/changelogs/unreleased/9105-shubham-pampattiwar
@@ -1,0 +1,1 @@
+Update "Default Volumes to Fs Backup" to "File System Backup (Default)"

--- a/pkg/cmd/util/output/backup_describer.go
+++ b/pkg/cmd/util/output/backup_describer.go
@@ -218,7 +218,7 @@ func DescribeBackupSpec(d *Describer, spec velerov1api.BackupSpec) {
 	d.Println()
 	d.Printf("Velero-Native Snapshot PVs:\t%s\n", BoolPointerString(spec.SnapshotVolumes, "false", "true", "auto"))
 	if spec.DefaultVolumesToFsBackup != nil {
-		d.Printf("Default Volumes to Fs Backup:\t%s\n", BoolPointerString(spec.DefaultVolumesToFsBackup, "false", "true", ""))
+		d.Printf("File System Backup (Default):\t%s\n", BoolPointerString(spec.DefaultVolumesToFsBackup, "false", "true", ""))
 	}
 	d.Printf("Snapshot Move Data:\t%s\n", BoolPointerString(spec.SnapshotMoveData, "false", "true", "auto"))
 	if len(spec.DataMover) == 0 {

--- a/pkg/cmd/util/output/backup_describer.go
+++ b/pkg/cmd/util/output/backup_describer.go
@@ -217,6 +217,9 @@ func DescribeBackupSpec(d *Describer, spec velerov1api.BackupSpec) {
 
 	d.Println()
 	d.Printf("Velero-Native Snapshot PVs:\t%s\n", BoolPointerString(spec.SnapshotVolumes, "false", "true", "auto"))
+	if spec.DefaultVolumesToFsBackup != nil {
+		d.Printf("Default Volumes to Fs Backup:\t%s\n", BoolPointerString(spec.DefaultVolumesToFsBackup, "false", "true", ""))
+	}
 	d.Printf("Snapshot Move Data:\t%s\n", BoolPointerString(spec.SnapshotMoveData, "false", "true", "auto"))
 	if len(spec.DataMover) == 0 {
 		s = defaultDataMover

--- a/pkg/cmd/util/output/backup_describer_test.go
+++ b/pkg/cmd/util/output/backup_describer_test.go
@@ -303,7 +303,7 @@ Or label selector:  <none>
 Storage Location:  backup-location
 
 Velero-Native Snapshot PVs:    auto
-Default Volumes to Fs Backup:  true
+File System Backup (Default):  true
 Snapshot Move Data:            auto
 Data Mover:                    velero
 
@@ -336,7 +336,7 @@ Or label selector:  <none>
 Storage Location:  backup-location
 
 Velero-Native Snapshot PVs:    auto
-Default Volumes to Fs Backup:  false
+File System Backup (Default):  false
 Snapshot Move Data:            auto
 Data Mover:                    velero
 

--- a/pkg/cmd/util/output/backup_describer_test.go
+++ b/pkg/cmd/util/output/backup_describer_test.go
@@ -282,6 +282,71 @@ Hooks:
 OrderedResources:
   kind1: rs1-1, rs1-2
 `
+	input4 := builder.ForBackup("test-ns", "test-backup-4").
+		DefaultVolumesToFsBackup(true).
+		StorageLocation("backup-location").
+		Result().Spec
+
+	expect4 := `Namespaces:
+  Included:  *
+  Excluded:  <none>
+
+Resources:
+  Included:        *
+  Excluded:        <none>
+  Cluster-scoped:  auto
+
+Label selector:  <none>
+
+Or label selector:  <none>
+
+Storage Location:  backup-location
+
+Velero-Native Snapshot PVs:    auto
+Default Volumes to Fs Backup:  true
+Snapshot Move Data:            auto
+Data Mover:                    velero
+
+TTL:  0s
+
+CSISnapshotTimeout:    0s
+ItemOperationTimeout:  0s
+
+Hooks:  <none>
+`
+
+	input5 := builder.ForBackup("test-ns", "test-backup-5").
+		DefaultVolumesToFsBackup(false).
+		StorageLocation("backup-location").
+		Result().Spec
+
+	expect5 := `Namespaces:
+  Included:  *
+  Excluded:  <none>
+
+Resources:
+  Included:        *
+  Excluded:        <none>
+  Cluster-scoped:  auto
+
+Label selector:  <none>
+
+Or label selector:  <none>
+
+Storage Location:  backup-location
+
+Velero-Native Snapshot PVs:    auto
+Default Volumes to Fs Backup:  false
+Snapshot Move Data:            auto
+Data Mover:                    velero
+
+TTL:  0s
+
+CSISnapshotTimeout:    0s
+ItemOperationTimeout:  0s
+
+Hooks:  <none>
+`
 
 	testcases := []struct {
 		name   string
@@ -302,6 +367,16 @@ OrderedResources:
 			name:   "old resource filter with hooks and ordered resources",
 			input:  input3,
 			expect: expect3,
+		},
+		{
+			name:   "DefaultVolumesToFsBackup is true",
+			input:  input4,
+			expect: expect4,
+		},
+		{
+			name:   "DefaultVolumesToFsBackup is false",
+			input:  input5,
+			expect: expect5,
 		},
 	}
 

--- a/pkg/cmd/util/output/schedule_describe_test.go
+++ b/pkg/cmd/util/output/schedule_describe_test.go
@@ -138,7 +138,7 @@ Backup Template:
   Storage Location:  
   
   Velero-Native Snapshot PVs:    auto
-  Default Volumes to Fs Backup:  true
+  File System Backup (Default):  true
   Snapshot Move Data:            auto
   Data Mover:                    velero
   
@@ -185,7 +185,7 @@ Backup Template:
   Storage Location:  
   
   Velero-Native Snapshot PVs:    auto
-  Default Volumes to Fs Backup:  false
+  File System Backup (Default):  false
   Snapshot Move Data:            auto
   Data Mover:                    velero
   

--- a/pkg/cmd/util/output/schedule_describe_test.go
+++ b/pkg/cmd/util/output/schedule_describe_test.go
@@ -105,6 +105,100 @@ Backup Template:
 Last Backup:  2023-06-25 15:04:05 +0000 UTC
 `
 
+	input3 := builder.ForSchedule("velero", "schedule-3").
+		Phase(velerov1api.SchedulePhaseEnabled).
+		CronSchedule("0 0 * * *").
+		Template(builder.ForBackup("velero", "backup-1").DefaultVolumesToFsBackup(true).Result().Spec).
+		LastBackupTime("2023-06-25 15:04:05").Result()
+	expect3 := `Name:         schedule-3
+Namespace:    velero
+Labels:       <none>
+Annotations:  <none>
+
+Phase:  Enabled
+
+Paused:  false
+
+Schedule:  0 0 * * *
+
+Backup Template:
+  Namespaces:
+    Included:  *
+    Excluded:  <none>
+  
+  Resources:
+    Included:        *
+    Excluded:        <none>
+    Cluster-scoped:  auto
+  
+  Label selector:  <none>
+  
+  Or label selector:  <none>
+  
+  Storage Location:  
+  
+  Velero-Native Snapshot PVs:    auto
+  Default Volumes to Fs Backup:  true
+  Snapshot Move Data:            auto
+  Data Mover:                    velero
+  
+  TTL:  0s
+  
+  CSISnapshotTimeout:    0s
+  ItemOperationTimeout:  0s
+  
+  Hooks:  <none>
+
+Last Backup:  2023-06-25 15:04:05 +0000 UTC
+`
+
+	input4 := builder.ForSchedule("velero", "schedule-4").
+		Phase(velerov1api.SchedulePhaseEnabled).
+		CronSchedule("0 0 * * *").
+		Template(builder.ForBackup("velero", "backup-1").DefaultVolumesToFsBackup(false).Result().Spec).
+		LastBackupTime("2023-06-25 15:04:05").Result()
+	expect4 := `Name:         schedule-4
+Namespace:    velero
+Labels:       <none>
+Annotations:  <none>
+
+Phase:  Enabled
+
+Paused:  false
+
+Schedule:  0 0 * * *
+
+Backup Template:
+  Namespaces:
+    Included:  *
+    Excluded:  <none>
+  
+  Resources:
+    Included:        *
+    Excluded:        <none>
+    Cluster-scoped:  auto
+  
+  Label selector:  <none>
+  
+  Or label selector:  <none>
+  
+  Storage Location:  
+  
+  Velero-Native Snapshot PVs:    auto
+  Default Volumes to Fs Backup:  false
+  Snapshot Move Data:            auto
+  Data Mover:                    velero
+  
+  TTL:  0s
+  
+  CSISnapshotTimeout:    0s
+  ItemOperationTimeout:  0s
+  
+  Hooks:  <none>
+
+Last Backup:  2023-06-25 15:04:05 +0000 UTC
+`
+
 	testcases := []struct {
 		name   string
 		input  *velerov1api.Schedule
@@ -119,6 +213,16 @@ Last Backup:  2023-06-25 15:04:05 +0000 UTC
 			name:   "schedule enabled",
 			input:  input2,
 			expect: expect2,
+		},
+		{
+			name:   "schedule with DefaultVolumesToFsBackup is true",
+			input:  input3,
+			expect: expect3,
+		},
+		{
+			name:   "schedule with DefaultVolumesToFsBackup is false",
+			input:  input4,
+			expect: expect4,
 		},
 	}
 


### PR DESCRIPTION
(cherry picked from commit 60a6c7384fc61056d9620588d22010759d8fd65d)
(cherry picked from commit aa2e09c69)
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
