### PR TITLE
Use 1.24 instead of v1.24.0, and remove toolchain.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/velero
 
-go 1.24.0
+go 1.24
 
 require (
 	cloud.google.com/go/storage v1.55.0


### PR DESCRIPTION
The reason is toolchain cannot update automatically. If 1.24 can force CI use the latest patch version, and it will not force user to upgrade their local go version, this should be the better approach.

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
