### PR TITLE
Return error if timeout when checking server version

### DIFF
--- a/changelogs/unreleased/9111-ywk253100
+++ b/changelogs/unreleased/9111-ywk253100
@@ -1,0 +1,1 @@
+Return error if timeout when checking server version

--- a/pkg/cmd/cli/serverstatus/server_status.go
+++ b/pkg/cmd/cli/serverstatus/server_status.go
@@ -69,5 +69,11 @@ func (g *DefaultServerStatusGetter) GetServerStatus(kbClient kbclient.Client) (*
 
 	wait.Until(checkFunc, 250*time.Millisecond, ctx.Done())
 
-	return created, nil
+	err := ctx.Err()
+	// context.Canceled error means we have received a processed ServerStatusRequest
+	if err == context.Canceled {
+		err = nil
+	}
+
+	return created, err
 }


### PR DESCRIPTION
Return error if timeout when checking server version

Fixes #8620

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
