### PR TITLE
Remove the WaitUntilVSCHandleIsReady from vs BIA.

### DIFF
--- a/changelogs/unreleased/9124-blackpiglet
+++ b/changelogs/unreleased/9124-blackpiglet
@@ -1,0 +1,1 @@
+Remove the WaitUntilVSCHandleIsReady from vs BIA.

--- a/pkg/backup/actions/csi/volumesnapshot_action.go
+++ b/pkg/backup/actions/csi/volumesnapshot_action.go
@@ -108,12 +108,9 @@ func (p *volumeSnapshotBackupItemAction) Execute(
 	p.log.Infof("Getting VolumesnapshotContent for Volumesnapshot %s/%s",
 		vs.Namespace, vs.Name)
 
-	vsc, err := csi.WaitUntilVSCHandleIsReady(
-		vs,
-		p.crClient,
-		p.log,
-		backup.Spec.CSISnapshotTimeout.Duration,
-	)
+	ctx := context.TODO()
+
+	vsc, err := csi.GetVSCForVS(ctx, vs, p.crClient)
 	if err != nil {
 		csi.CleanupVolumeSnapshot(vs, p.crClient, p.log)
 		return nil, nil, "", nil, errors.WithStack(err)

--- a/pkg/util/csi/volume_snapshot.go
+++ b/pkg/util/csi/volume_snapshot.go
@@ -731,3 +731,28 @@ func DiagnoseVSC(vsc *snapshotv1api.VolumeSnapshotContent) string {
 
 	return diag
 }
+
+// GetVSCForVS returns the VolumeSnapshotContent object associated with the VolumeSnapshot.
+func GetVSCForVS(
+	ctx context.Context,
+	vs *snapshotv1api.VolumeSnapshot,
+	client crclient.Client,
+) (*snapshotv1api.VolumeSnapshotContent, error) {
+	if vs.Status == nil || vs.Status.BoundVolumeSnapshotContentName == nil {
+		return nil, errors.Errorf("invalid snapshot info in volume snapshot %s", vs.Name)
+	}
+
+	vsc := new(snapshotv1api.VolumeSnapshotContent)
+
+	if err := client.Get(
+		ctx,
+		crclient.ObjectKey{
+			Name: *vs.Status.BoundVolumeSnapshotContentName,
+		},
+		vsc,
+	); err != nil {
+		return nil, errors.Wrap(err, "error getting volume snapshot content from API")
+	}
+
+	return vsc, nil
+}


### PR DESCRIPTION
Becasue the pvc BIA already run WaitUntilVSCHandleIsReady, no need to do the same work in vs BIA.

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
