### PR TITLE
Cherry-pick from  #9024 from amastbau/issue-8816

### DIFF
--- a/changelogs/unreleased/9024-amastbau
+++ b/changelogs/unreleased/9024-amastbau
@@ -1,0 +1,1 @@
+Fix Issue 8816 When specifying LabelSelector on restore, related items such as PVC and VolumeSnapshot are not included

--- a/pkg/backup/actions/csi/pvc_action.go
+++ b/pkg/backup/actions/csi/pvc_action.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strconv"
 
-	snapshotv1api "github.com/kubernetes-csi/external-snapshotter/client/v7/apis/volumesnapshot/v1"
+	snapshotv1api "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	corev1api "k8s.io/api/core/v1"
@@ -35,9 +35,11 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	velerov2alpha1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v2alpha1"
-	"github.com/vmware-tanzu/velero/pkg/client"
+	veleroclient "github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/kuberesource"
 	"github.com/vmware-tanzu/velero/pkg/label"
 	plugincommon "github.com/vmware-tanzu/velero/pkg/plugin/framework/common"
@@ -252,6 +254,21 @@ func (p *pvcBackupItemAction) Execute(
 		return nil, nil, "", nil, err
 	}
 
+	// Wait until VS associated VSC snapshot handle created before
+	// continue.we later require the vsc restore size
+	vsc, err := csi.WaitUntilVSCHandleIsReady(
+		vs,
+		p.crClient,
+		p.log,
+		backup.Spec.CSISnapshotTimeout.Duration,
+	)
+	if err != nil {
+		p.log.Errorf("Failed to wait for VolumeSnapshot %s/%s to become ReadyToUse within timeout %v: %s",
+			vs.Namespace, vs.Name, backup.Spec.CSISnapshotTimeout.Duration, err.Error())
+		csi.CleanupVolumeSnapshot(vs, p.crClient, p.log)
+		return nil, nil, "", nil, errors.WithStack(err)
+	}
+
 	labels := map[string]string{
 		velerov1api.VolumeSnapshotLabel: vs.Name,
 		velerov1api.BackupNameLabel:     backup.Name,
@@ -278,24 +295,6 @@ func (p *pvcBackupItemAction) Execute(
 			"Operation ID":   operationID,
 			"Backup":         backup.Name,
 		})
-
-		// Wait until VS associated VSC snapshot handle created before
-		// returning with the Async operation for data mover.
-		_, err := csi.WaitUntilVSCHandleIsReady(
-			vs,
-			p.crClient,
-			p.log,
-			true,
-			backup.Spec.CSISnapshotTimeout.Duration,
-		)
-		if err != nil {
-			dataUploadLog.Errorf(
-				"Fail to wait VolumeSnapshot turned to ReadyToUse: %s",
-				err.Error(),
-			)
-			csi.CleanupVolumeSnapshot(vs, p.crClient, p.log)
-			return nil, nil, "", nil, errors.WithStack(err)
-		}
 
 		dataUploadLog.Info("Starting data upload of backup")
 
@@ -340,6 +339,8 @@ func (p *pvcBackupItemAction) Execute(
 			dataUploadLog.Info("DataUpload is submitted successfully.")
 		}
 	} else {
+		setPVCRequestSizeToVSRestoreSize(&pvc, vsc, p.log)
+
 		additionalItems = []velero.ResourceIdentifier{
 			{
 				GroupResource: kuberesource.VolumeSnapshots,
@@ -551,7 +552,7 @@ func cancelDataUpload(
 	return nil
 }
 
-func NewPvcBackupItemAction(f client.Factory) plugincommon.HandlerInitializer {
+func NewPvcBackupItemAction(f veleroclient.Factory) plugincommon.HandlerInitializer {
 	return func(logger logrus.FieldLogger) (any, error) {
 		crClient, err := f.KubebuilderClient()
 		if err != nil {
@@ -562,5 +563,499 @@ func NewPvcBackupItemAction(f client.Factory) plugincommon.HandlerInitializer {
 			log:      logger,
 			crClient: crClient,
 		}, nil
+	}
+}
+
+func (p *pvcBackupItemAction) getVolumeSnapshotReference(
+	ctx context.Context,
+	pvc corev1api.PersistentVolumeClaim,
+	backup *velerov1api.Backup,
+) (*snapshotv1api.VolumeSnapshot, error) {
+	vgsLabelKey := backup.Spec.VolumeGroupSnapshotLabelKey
+	group, hasLabel := pvc.Labels[vgsLabelKey]
+
+	if vgsLabelKey != "" && hasLabel && group != "" {
+		p.log.Infof("PVC %s/%s is part of VolumeGroupSnapshot group %q via label %q", pvc.Namespace, pvc.Name, group, vgsLabelKey)
+
+		// Try to find an existing VS created via a previous VGS in the current backup
+		existingVS, err := p.findExistingVSForBackup(ctx, backup.UID, backup.Name, pvc.Name, pvc.Namespace)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to find existing VolumeSnapshot for PVC %s/%s", pvc.Namespace, pvc.Name)
+		}
+
+		if existingVS != nil {
+			if existingVS.Status != nil && existingVS.Status.VolumeGroupSnapshotName != nil {
+				p.log.Infof("Reusing existing VolumeSnapshot %s for PVC %s", existingVS.Name, pvc.Name)
+				return existingVS, nil
+			} else {
+				return nil, errors.Errorf("found VolumeSnapshot %s for PVC %s, but it was not created via VolumeGroupSnapshot (missing volumeGroupSnapshotName)", existingVS.Name, pvc.Name)
+			}
+		}
+
+		p.log.Infof("No existing VS found for PVC %s; creating new VGS", pvc.Name)
+
+		// List all PVCs in the VGS group
+		groupedPVCs, err := p.listGroupedPVCs(ctx, pvc.Namespace, vgsLabelKey, group)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to list PVCs in VolumeGroupSnapshot group %q in namespace %q", group, pvc.Namespace)
+		}
+
+		// Determine the CSI driver for the grouped PVCs
+		driver, err := p.determineCSIDriver(groupedPVCs)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to determine CSI driver for PVCs in VolumeGroupSnapshot group %q", group)
+		}
+		if driver == "" {
+			return nil, errors.New("no csi driver found, failing the backup")
+		}
+
+		// Determine the VGSClass to be used for the VGS object to be created
+		vgsClass, err := p.determineVGSClass(ctx, driver, backup, &pvc)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to determine VolumeGroupSnapshotClass for CSI driver %q", driver)
+		}
+
+		// Create the VGS object
+		newVGS, err := p.createVolumeGroupSnapshot(ctx, backup, pvc, vgsLabelKey, group, vgsClass)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create VolumeGroupSnapshot for PVC %s/%s", pvc.Namespace, pvc.Name)
+		}
+
+		// Wait for all the VS objects associated with the VGS to have status and VGS Name (VS readiness is checked in legacy flow) and get the PVC-to-VS map
+		vsMap, err := p.waitForVGSAssociatedVS(ctx, groupedPVCs, newVGS, backup.Spec.CSISnapshotTimeout.Duration)
+		if err != nil {
+			return nil, errors.Wrapf(err, "timeout waiting for VolumeSnapshots to have status created via VolumeGroupSnapshot %s", newVGS.Name)
+		}
+
+		// Update the VS objects: remove VGS owner references and finalizers; add backup metadata labels.
+		err = p.updateVGSCreatedVS(ctx, vsMap, newVGS, backup)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to update VolumeSnapshots created by VolumeGroupSnapshot %s", newVGS.Name)
+		}
+
+		// Wait for VGSC binding in the VGS status
+		err = p.waitForVGSCBinding(ctx, newVGS, backup.Spec.CSISnapshotTimeout.Duration)
+		if err != nil {
+			return nil, errors.Wrapf(err, "timeout waiting for VolumeGroupSnapshotContent binding for VolumeGroupSnapshot %s", newVGS.Name)
+		}
+
+		// Re-fetch latest VGS to ensure status is populated after VGSC binding
+		latestVGS := &volumegroupsnapshotv1beta1.VolumeGroupSnapshot{}
+		if err := p.crClient.Get(ctx, crclient.ObjectKeyFromObject(newVGS), latestVGS); err != nil {
+			return nil, errors.Wrapf(err, "failed to re-fetch VolumeGroupSnapshot %s after VGSC binding wait", newVGS.Name)
+		}
+
+		// Patch the VGSC deletionPolicy to Retain.
+		err = p.patchVGSCDeletionPolicy(ctx, latestVGS)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to patch VolumeGroupSnapshotContent Deletion Policy for VolumeGroupSnapshot %s", newVGS.Name)
+		}
+
+		// Delete the VGS and VGSC
+		err = p.deleteVGSAndVGSC(ctx, latestVGS)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get VolumeSnapshot for PVC %s/%s created by VolumeGroupSnapshot %s", pvc.Namespace, pvc.Name, newVGS.Name)
+		}
+
+		// Use the VS that was created for this PVC via VGS.
+		vs, found := vsMap[pvc.Name]
+		if !found {
+			return nil, errors.Wrapf(err, "failed to get VolumeSnapshot for PVC %s/%s created by VolumeGroupSnapshot %s", pvc.Namespace, pvc.Name, newVGS.Name)
+		}
+
+		return vs, nil
+	}
+
+	// Legacy fallback: create individual VS
+	return p.createVolumeSnapshot(pvc, backup)
+}
+
+func (p *pvcBackupItemAction) findExistingVSForBackup(
+	ctx context.Context,
+	backupUID types.UID,
+	backupName, pvcName, namespace string,
+) (*snapshotv1api.VolumeSnapshot, error) {
+	vsList := &snapshotv1api.VolumeSnapshotList{}
+
+	labelSelector := labels.SelectorFromSet(map[string]string{
+		velerov1api.BackupNameLabel: label.GetValidName(backupName),
+		velerov1api.BackupUIDLabel:  string(backupUID),
+	})
+
+	if err := p.crClient.List(ctx, vsList,
+		crclient.InNamespace(namespace),
+		crclient.MatchingLabelsSelector{Selector: labelSelector},
+	); err != nil {
+		return nil, errors.Wrap(err, "failed to list VolumeSnapshots with backup labels")
+	}
+
+	for _, vs := range vsList.Items {
+		if vs.Spec.Source.PersistentVolumeClaimName != nil &&
+			*vs.Spec.Source.PersistentVolumeClaimName == pvcName {
+			return &vs, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (p *pvcBackupItemAction) listGroupedPVCs(ctx context.Context, namespace, labelKey, groupValue string) ([]corev1api.PersistentVolumeClaim, error) {
+	pvcList := new(corev1api.PersistentVolumeClaimList)
+	if err := p.crClient.List(
+		ctx,
+		pvcList,
+		crclient.InNamespace(namespace),
+		crclient.MatchingLabels{labelKey: groupValue},
+	); err != nil {
+		return nil, errors.Wrap(err, "failed to list grouped PVCs")
+	}
+
+	return pvcList.Items, nil
+}
+
+func (p *pvcBackupItemAction) determineCSIDriver(
+	pvcs []corev1api.PersistentVolumeClaim,
+) (string, error) {
+	var driver string
+
+	for _, pvc := range pvcs {
+		pv, err := kubeutil.GetPVForPVC(&pvc, p.crClient)
+		if err != nil {
+			return "", err
+		}
+		if pv.Spec.CSI == nil {
+			return "", errors.Errorf("PV %s for PVC %s is not CSI provisioned", pv.Name, pvc.Name)
+		}
+		current := pv.Spec.CSI.Driver
+		if driver == "" {
+			driver = current
+		} else if driver != current {
+			return "", errors.Errorf("found multiple CSI drivers: %s and %s", driver, current)
+		}
+	}
+	return driver, nil
+}
+
+func (p *pvcBackupItemAction) determineVGSClass(
+	ctx context.Context,
+	driver string,
+	backup *velerov1api.Backup,
+	pvc *corev1api.PersistentVolumeClaim,
+) (string, error) {
+	// 1. PVC-level override
+	if pvc != nil {
+		if val, ok := pvc.Annotations[velerov1api.VolumeGroupSnapshotClassAnnotationPVC]; ok && val != "" {
+			return val, nil
+		}
+	}
+
+	// 2. Backup-level override
+	key := fmt.Sprintf(velerov1api.VolumeGroupSnapshotClassAnnotationBackupPrefix+"%s", driver)
+	if val, ok := backup.Annotations[key]; ok && val != "" {
+		return val, nil
+	}
+
+	// 3. Fallback to label-based default
+	vgsClassList := &volumegroupsnapshotv1beta1.VolumeGroupSnapshotClassList{}
+	if err := p.crClient.List(ctx, vgsClassList); err != nil {
+		return "", errors.Wrap(err, "failed to list VolumeGroupSnapshotClasses")
+	}
+
+	var matched []string
+	for _, class := range vgsClassList.Items {
+		if class.Driver != driver {
+			continue
+		}
+		if val, ok := class.Labels[velerov1api.VolumeGroupSnapshotClassDefaultLabel]; ok && val == "true" {
+			matched = append(matched, class.Name)
+		}
+	}
+
+	if len(matched) == 1 {
+		return matched[0], nil
+	} else if len(matched) == 0 {
+		return "", errors.Errorf("no VolumeGroupSnapshotClass found for driver %q for PVC %s", driver, pvc.Name)
+	} else {
+		return "", errors.Errorf("multiple VolumeGroupSnapshotClasses found for driver %q with label velero.io/csi-volumegroupsnapshot-class=true", driver)
+	}
+}
+
+func (p *pvcBackupItemAction) createVolumeGroupSnapshot(
+	ctx context.Context,
+	backup *velerov1api.Backup,
+	pvc corev1api.PersistentVolumeClaim,
+	vgsLabelKey, vgsLabelValue, vgsClassName string,
+) (*volumegroupsnapshotv1beta1.VolumeGroupSnapshot, error) {
+	vgsLabels := map[string]string{
+		velerov1api.BackupNameLabel: label.GetValidName(backup.Name),
+		velerov1api.BackupUIDLabel:  string(backup.UID),
+		vgsLabelKey:                 vgsLabelValue,
+	}
+
+	vgs := &volumegroupsnapshotv1beta1.VolumeGroupSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: fmt.Sprintf("velero-%s-", vgsLabelValue),
+			Namespace:    pvc.Namespace,
+			Labels:       vgsLabels,
+		},
+		Spec: volumegroupsnapshotv1beta1.VolumeGroupSnapshotSpec{
+			VolumeGroupSnapshotClassName: &vgsClassName,
+			Source: volumegroupsnapshotv1beta1.VolumeGroupSnapshotSource{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						vgsLabelKey: vgsLabelValue,
+					},
+				},
+			},
+		},
+	}
+
+	if err := p.crClient.Create(ctx, vgs); err != nil {
+		return nil, errors.Wrap(err, "failed to create VolumeGroupSnapshot")
+	}
+
+	refetchedVGS, err := p.getVGSByLabels(ctx, pvc.Namespace, vgsLabels)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to re-fetch VGS after creation")
+	}
+
+	p.log.Infof("Re-fetched Created VolumeGroupSnapshot %s/%s for PVC group label %s=%s",
+		refetchedVGS.Namespace, refetchedVGS.Name, vgsLabelKey, vgsLabelValue)
+
+	return refetchedVGS, nil
+}
+
+func (p *pvcBackupItemAction) waitForVGSAssociatedVS(
+	ctx context.Context,
+	groupedPVCs []corev1api.PersistentVolumeClaim,
+	vgs *volumegroupsnapshotv1beta1.VolumeGroupSnapshot,
+	timeout time.Duration,
+) (map[string]*snapshotv1api.VolumeSnapshot, error) {
+	expected := len(groupedPVCs)
+
+	vsMap := make(map[string]*snapshotv1api.VolumeSnapshot)
+
+	err := wait.PollUntilContextTimeout(ctx, time.Second, timeout, true, func(ctx context.Context) (done bool, err error) {
+		vsList := &snapshotv1api.VolumeSnapshotList{}
+		if err := p.crClient.List(ctx, vsList, crclient.InNamespace(vgs.Namespace)); err != nil {
+			return false, err
+		}
+
+		vsMap = make(map[string]*snapshotv1api.VolumeSnapshot)
+
+		for _, vs := range vsList.Items {
+			if !hasOwnerReference(&vs, vgs) {
+				continue
+			}
+			if vs.Status != nil && vs.Status.VolumeGroupSnapshotName != nil &&
+				*vs.Status.VolumeGroupSnapshotName == vgs.Name {
+				if vs.Spec.Source.PersistentVolumeClaimName != nil {
+					vsMap[*vs.Spec.Source.PersistentVolumeClaimName] = vs.DeepCopy()
+				}
+			}
+		}
+
+		if expected == 0 {
+			return false, nil
+		}
+		if len(vsMap) == expected {
+			return true, nil
+		}
+		return false, nil
+	})
+
+	if err != nil {
+		return nil, errors.Wrapf(err, "timeout waiting for VolumeSnapshots associated with VGS %s", vgs.Name)
+	}
+
+	return vsMap, nil
+}
+
+func hasOwnerReference(obj metav1.Object, vgs *volumegroupsnapshotv1beta1.VolumeGroupSnapshot) bool {
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.Kind == kuberesource.VGSKind &&
+			ref.APIVersion == volumegroupsnapshotv1beta1.GroupName+"/"+volumegroupsnapshotv1beta1.SchemeGroupVersion.Version &&
+			ref.UID == vgs.UID {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *pvcBackupItemAction) updateVGSCreatedVS(
+	ctx context.Context,
+	vsMap map[string]*snapshotv1api.VolumeSnapshot,
+	vgs *volumegroupsnapshotv1beta1.VolumeGroupSnapshot,
+	backup *velerov1api.Backup,
+) error {
+	for pvcName, vs := range vsMap {
+		if vs == nil || vs.Status == nil || vs.Status.VolumeGroupSnapshotName == nil ||
+			*vs.Status.VolumeGroupSnapshotName != vgs.Name {
+			continue
+		}
+
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			// Re-fetch the latest VS to avoid conflict
+			latestVS := &snapshotv1api.VolumeSnapshot{}
+			if err := p.crClient.Get(ctx, crclient.ObjectKeyFromObject(vs), latestVS); err != nil {
+				return errors.Wrapf(err, "failed to get latest VolumeSnapshot %s (PVC %s)", vs.Name, pvcName)
+			}
+
+			// Remove VGS owner ref
+			if err := controllerutil.RemoveOwnerReference(vgs, latestVS, p.crClient.Scheme()); err != nil {
+				return errors.Wrapf(err, "failed to remove VGS owner reference from VS %s", vs.Name)
+			}
+
+			// Remove known finalizers
+			controllerutil.RemoveFinalizer(latestVS, VolumeSnapshotFinalizerGroupProtection)
+			controllerutil.RemoveFinalizer(latestVS, VolumeSnapshotFinalizerSourceProtection)
+
+			// Add Velero labels
+			if latestVS.Labels == nil {
+				latestVS.Labels = make(map[string]string)
+			}
+			latestVS.Labels[velerov1api.BackupNameLabel] = backup.Name
+			latestVS.Labels[velerov1api.BackupUIDLabel] = string(backup.UID)
+
+			// Attempt to update
+			return p.crClient.Update(ctx, latestVS)
+		})
+		if err != nil {
+			return errors.Wrapf(err, "failed to update VS %s (PVC %s) after retrying on conflict", vs.Name, pvcName)
+		}
+	}
+
+	return nil
+}
+
+func (p *pvcBackupItemAction) patchVGSCDeletionPolicy(ctx context.Context, vgs *volumegroupsnapshotv1beta1.VolumeGroupSnapshot) error {
+	if vgs == nil || vgs.Status == nil || vgs.Status.BoundVolumeGroupSnapshotContentName == nil {
+		return errors.New("VolumeGroupSnapshotContent name not found in VGS status")
+	}
+
+	vgscName := vgs.Status.BoundVolumeGroupSnapshotContentName
+
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		vgsc := &volumegroupsnapshotv1beta1.VolumeGroupSnapshotContent{}
+		if err := p.crClient.Get(ctx, crclient.ObjectKey{Name: *vgscName}, vgsc); err != nil {
+			return errors.Wrapf(err, "failed to get VolumeGroupSnapshotContent %s for VolumeGroupSnapshot %s/%s", *vgscName, vgs.Namespace, vgs.Name)
+		}
+
+		if vgsc.Spec.DeletionPolicy == snapshotv1api.VolumeSnapshotContentDelete {
+			p.log.Infof("Patching VGSC %s to Retain deletionPolicy", *vgscName)
+			vgsc.Spec.DeletionPolicy = snapshotv1api.VolumeSnapshotContentRetain
+			if err := p.crClient.Update(ctx, vgsc); err != nil {
+				return errors.Wrapf(err, "failed to update VGSC %s deletionPolicy", *vgscName)
+			}
+		} else {
+			p.log.Infof("VGSC %s already set to deletionPolicy=%s", *vgscName, vgsc.Spec.DeletionPolicy)
+		}
+
+		return nil
+	})
+}
+
+func (p *pvcBackupItemAction) deleteVGSAndVGSC(ctx context.Context, vgs *volumegroupsnapshotv1beta1.VolumeGroupSnapshot) error {
+	if vgs.Status != nil && vgs.Status.BoundVolumeGroupSnapshotContentName != nil {
+		vgsc := &volumegroupsnapshotv1beta1.VolumeGroupSnapshotContent{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: *vgs.Status.BoundVolumeGroupSnapshotContentName,
+			},
+		}
+		p.log.Infof("Deleting VolumeGroupSnapshotContent %s", vgsc.Name)
+		if err := p.crClient.Delete(ctx, vgsc); err != nil && !apierrors.IsNotFound(err) {
+			p.log.Warnf("Failed to delete VolumeGroupSnapshotContent %s: %v", vgsc.Name, err)
+			return errors.Wrapf(err, "failed to delete VolumeGroupSnapshotContent %s", vgsc.Name)
+		}
+	} else {
+		p.log.Infof("No BoundVolumeGroupSnapshotContentName set in VolumeGroupSnapshot %s/%s", vgs.Namespace, vgs.Name)
+	}
+
+	p.log.Infof("Deleting VolumeGroupSnapshot %s/%s", vgs.Namespace, vgs.Name)
+	if err := p.crClient.Delete(ctx, vgs); err != nil && !apierrors.IsNotFound(err) {
+		p.log.Warnf("Failed to delete VolumeGroupSnapshot %s/%s: %v", vgs.Namespace, vgs.Name, err)
+		return errors.Wrapf(err, "failed to delete VolumeGroupSnapshot %s/%s", vgs.Namespace, vgs.Name)
+	}
+
+	return nil
+}
+
+func (p *pvcBackupItemAction) waitForVGSCBinding(
+	ctx context.Context,
+	vgs *volumegroupsnapshotv1beta1.VolumeGroupSnapshot,
+	timeout time.Duration,
+) error {
+	return wait.PollUntilContextTimeout(ctx, time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		vgsRef := &volumegroupsnapshotv1beta1.VolumeGroupSnapshot{}
+		if err := p.crClient.Get(ctx, crclient.ObjectKeyFromObject(vgs), vgsRef); err != nil {
+			return false, err
+		}
+
+		if vgsRef.Status != nil && vgsRef.Status.BoundVolumeGroupSnapshotContentName != nil {
+			return true, nil
+		}
+
+		return false, nil
+	})
+}
+
+func (p *pvcBackupItemAction) getVGSByLabels(ctx context.Context, namespace string, labels map[string]string) (*volumegroupsnapshotv1beta1.VolumeGroupSnapshot, error) {
+	vgsList := &volumegroupsnapshotv1beta1.VolumeGroupSnapshotList{}
+	if err := p.crClient.List(ctx, vgsList,
+		crclient.InNamespace(namespace),
+		crclient.MatchingLabels(labels),
+	); err != nil {
+		return nil, errors.Wrap(err, "failed to list VolumeGroupSnapshots by labels")
+	}
+
+	if len(vgsList.Items) == 0 {
+		return nil, errors.New("no VolumeGroupSnapshot found matching labels")
+	}
+	if len(vgsList.Items) > 1 {
+		return nil, errors.New("multiple VolumeGroupSnapshots found matching labels")
+	}
+
+	return &vgsList.Items[0], nil
+}
+
+func setPVCRequestSizeToVSRestoreSize(
+	pvc *corev1api.PersistentVolumeClaim,
+	vsc *snapshotv1api.VolumeSnapshotContent,
+	logger logrus.FieldLogger,
+) {
+	if vsc.Status.RestoreSize != nil {
+		logger.Debugf("Patching PVC request size to fit the volumesnapshot restore size %d", vsc.Status.RestoreSize)
+		restoreSize := *resource.NewQuantity(*vsc.Status.RestoreSize, resource.BinarySI)
+
+		// It is possible that the volume provider allocated a larger
+		// capacity volume than what was requested in the backed up PVC.
+		// In this scenario the volumesnapshot of the PVC will end being
+		// larger than its requested storage size.  Such a PVC, on restore
+		// as-is, will be stuck attempting to use a VolumeSnapshot as a
+		// data source for a PVC that is not large enough.
+		// To counter that, here we set the storage request on the PVC
+		// to the larger of the PVC's storage request and the size of the
+		// VolumeSnapshot
+		setPVCStorageResourceRequest(pvc, restoreSize, logger)
+	}
+}
+
+func setPVCStorageResourceRequest(
+	pvc *corev1api.PersistentVolumeClaim,
+	restoreSize resource.Quantity,
+	log logrus.FieldLogger,
+) {
+	{
+		if pvc.Spec.Resources.Requests == nil {
+			pvc.Spec.Resources.Requests = corev1api.ResourceList{}
+		}
+
+		storageReq, exists := pvc.Spec.Resources.Requests[corev1api.ResourceStorage]
+		if !exists || storageReq.Cmp(restoreSize) < 0 {
+			pvc.Spec.Resources.Requests[corev1api.ResourceStorage] = restoreSize
+			rs := pvc.Spec.Resources.Requests[corev1api.ResourceStorage]
+			log.Infof("Resetting storage requests for PVC %s/%s to %s",
+				pvc.Namespace, pvc.Name, rs.String())
+		}
 	}
 }

--- a/pkg/backup/actions/csi/pvc_action_test.go
+++ b/pkg/backup/actions/csi/pvc_action_test.go
@@ -24,12 +24,14 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	snapshotv1api "github.com/kubernetes-csi/external-snapshotter/client/v7/apis/volumesnapshot/v1"
-	v1 "github.com/kubernetes-csi/external-snapshotter/client/v7/apis/volumesnapshot/v1"
+	snapshotv1api "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
+	corev1api "k8s.io/api/core/v1"
+	storagev1api "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -44,39 +46,78 @@ import (
 	factorymocks "github.com/vmware-tanzu/velero/pkg/client/mocks"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	velerotest "github.com/vmware-tanzu/velero/pkg/test"
-	"github.com/vmware-tanzu/velero/pkg/util/boolptr"
 )
+
+const testDriver = "csi.example.com"
+
+// errorInjectingClient is a wrapper around a normal client that injects an error
+// when a specific resource type (VolumeSnapshot) is created.
+type errorInjectingClient struct {
+	crclient.Client
+}
+
+// Create overrides the embedded client's Create method.
+func (c *errorInjectingClient) Create(ctx context.Context, obj crclient.Object, opts ...crclient.CreateOption) error {
+	// Check if the object being created is a VolumeSnapshot.
+	if _, ok := obj.(*snapshotv1api.VolumeSnapshot); ok {
+		// If it is, return our injected error instead of proceeding.
+		return errors.New("injected error on create")
+	}
+	// For all other object types, call the original, embedded Create method.
+	return c.Client.Create(ctx, obj, opts...)
+}
 
 func TestExecute(t *testing.T) {
 	boolTrue := true
 	tests := []struct {
 		name               string
 		backup             *velerov1api.Backup
-		pvc                *corev1.PersistentVolumeClaim
-		pv                 *corev1.PersistentVolume
-		sc                 *storagev1.StorageClass
+		pvc                *corev1api.PersistentVolumeClaim
+		pv                 *corev1api.PersistentVolume
+		sc                 *storagev1api.StorageClass
 		vsClass            *snapshotv1api.VolumeSnapshotClass
 		operationID        string
 		expectedErr        error
+		expectErr          bool // Use bool for cases where we just need to check for any error
 		expectedBackup     *velerov1api.Backup
 		expectedDataUpload *velerov2alpha1.DataUpload
-		expectedPVC        *corev1.PersistentVolumeClaim
-		resourcePolicy     *corev1.ConfigMap
+		expectedPVC        *corev1api.PersistentVolumeClaim
+		resourcePolicy     *corev1api.ConfigMap
+		failVSCreate       bool
+		skipVSReadyUpdate  bool // New flag to control VS readiness
 	}{
 		{
-			name:        "Skip PVC BIA when backup is in finalizing phase",
-			backup:      builder.ForBackup("velero", "test").Phase(velerov1api.BackupPhaseFinalizing).Result(),
-			expectedErr: nil,
+			name:   "Skip PVC BIA when backup is in finalizing phase",
+			backup: builder.ForBackup("velero", "test").Phase(velerov1api.BackupPhaseFinalizing).Result(),
+		},
+		{
+			name:         "Fail when creating volumesnapshot returns error",
+			backup:       builder.ForBackup("velero", "test").CSISnapshotTimeout(1 * time.Minute).Result(),
+			pvc:          builder.ForPersistentVolumeClaim("velero", "testPVC").VolumeName("testPV").StorageClass("testSC").Phase(corev1api.ClaimBound).Result(),
+			pv:           builder.ForPersistentVolume("testPV").CSI("hostpath", "testVolume").Result(),
+			sc:           builder.ForStorageClass("testSC").Provisioner("hostpath").Result(),
+			vsClass:      builder.ForVolumeSnapshotClass("testVSClass").Driver("hostpath").ObjectMeta(builder.WithLabels(velerov1api.VolumeSnapshotClassSelectorLabel, "")).Result(),
+			failVSCreate: true,
+			expectedErr:  errors.New("error creating volume snapshot: injected error on create"),
+		},
+		{
+			name:              "Fail when waiting for VolumeSnapshot to be ready times out",
+			backup:            builder.ForBackup("velero", "test").CSISnapshotTimeout(20 * time.Millisecond).Result(), // Short timeout
+			pvc:               builder.ForPersistentVolumeClaim("velero", "testPVC").VolumeName("testPV").StorageClass("testSC").Phase(corev1api.ClaimBound).Result(),
+			pv:                builder.ForPersistentVolume("testPV").CSI("hostpath", "testVolume").Result(),
+			sc:                builder.ForStorageClass("testSC").Provisioner("hostpath").Result(),
+			vsClass:           builder.ForVolumeSnapshotClass("testVSClass").Driver("hostpath").ObjectMeta(builder.WithLabels(velerov1api.VolumeSnapshotClassSelectorLabel, "")).Result(),
+			skipVSReadyUpdate: true, // This will cause the timeout
+			expectErr:         true, // Expect an error, but the exact message can vary
 		},
 		{
 			name:        "Test SnapshotMoveData",
 			backup:      builder.ForBackup("velero", "test").SnapshotMoveData(true).CSISnapshotTimeout(1 * time.Minute).Result(),
-			pvc:         builder.ForPersistentVolumeClaim("velero", "testPVC").VolumeName("testPV").StorageClass("testSC").Phase(corev1.ClaimBound).Result(),
+			pvc:         builder.ForPersistentVolumeClaim("velero", "testPVC").VolumeName("testPV").StorageClass("testSC").Phase(corev1api.ClaimBound).Result(),
 			pv:          builder.ForPersistentVolume("testPV").CSI("hostpath", "testVolume").Result(),
 			sc:          builder.ForStorageClass("testSC").Provisioner("hostpath").Result(),
 			vsClass:     builder.ForVolumeSnapshotClass("testVSClass").Driver("hostpath").ObjectMeta(builder.WithLabels(velerov1api.VolumeSnapshotClassSelectorLabel, "")).Result(),
 			operationID: ".",
-			expectedErr: nil,
 			expectedDataUpload: &velerov2alpha1.DataUpload{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DataUpload",
@@ -117,32 +158,29 @@ func TestExecute(t *testing.T) {
 		{
 			name:        "Verify PVC is modified as expected",
 			backup:      builder.ForBackup("velero", "test").SnapshotMoveData(true).CSISnapshotTimeout(1 * time.Minute).Result(),
-			pvc:         builder.ForPersistentVolumeClaim("velero", "testPVC").VolumeName("testPV").StorageClass("testSC").Phase(corev1.ClaimBound).Result(),
+			pvc:         builder.ForPersistentVolumeClaim("velero", "testPVC").VolumeName("testPV").StorageClass("testSC").Phase(corev1api.ClaimBound).Result(),
 			pv:          builder.ForPersistentVolume("testPV").CSI("hostpath", "testVolume").Result(),
 			sc:          builder.ForStorageClass("testSC").Provisioner("hostpath").Result(),
 			vsClass:     builder.ForVolumeSnapshotClass("tescVSClass").Driver("hostpath").ObjectMeta(builder.WithLabels(velerov1api.VolumeSnapshotClassSelectorLabel, "")).Result(),
 			operationID: ".",
-			expectedErr: nil,
 			expectedPVC: builder.ForPersistentVolumeClaim("velero", "testPVC").
 				ObjectMeta(builder.WithAnnotations(velerov1api.MustIncludeAdditionalItemAnnotation, "true", velerov1api.DataUploadNameAnnotation, "velero/"),
 					builder.WithLabels(velerov1api.BackupNameLabel, "test")).
-				VolumeName("testPV").StorageClass("testSC").Phase(corev1.ClaimBound).Result(),
+				VolumeName("testPV").StorageClass("testSC").Phase(corev1api.ClaimBound).Result(),
 		},
 		{
 			name:           "Test ResourcePolicy",
-			backup:         builder.ForBackup("velero", "test").ResourcePolicies("resourcePolicy").SnapshotVolumes(false).Result(),
+			backup:         builder.ForBackup("velero", "test").ResourcePolicies("resourcePolicy").SnapshotVolumes(false).CSISnapshotTimeout(time.Duration(3600) * time.Second).Result(),
 			resourcePolicy: builder.ForConfigMap("velero", "resourcePolicy").Data("policy", "{\"version\":\"v1\", \"volumePolicies\":[{\"conditions\":{\"csi\": {}},\"action\":{\"type\":\"snapshot\"}}]}").Result(),
-			pvc:            builder.ForPersistentVolumeClaim("velero", "testPVC").VolumeName("testPV").StorageClass("testSC").Phase(corev1.ClaimBound).Result(),
+			pvc:            builder.ForPersistentVolumeClaim("velero", "testPVC").VolumeName("testPV").StorageClass("testSC").Phase(corev1api.ClaimBound).Result(),
 			pv:             builder.ForPersistentVolume("testPV").CSI("hostpath", "testVolume").Result(),
 			sc:             builder.ForStorageClass("testSC").Provisioner("hostpath").Result(),
 			vsClass:        builder.ForVolumeSnapshotClass("tescVSClass").Driver("hostpath").ObjectMeta(builder.WithLabels(velerov1api.VolumeSnapshotClassSelectorLabel, "")).Result(),
-			expectedErr:    nil,
 		},
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(*testing.T) {
-			crClient := velerotest.NewFakeControllerRuntimeClient(t)
+		t.Run(tc.name, func(t *testing.T) {
 			logger := logrus.New()
 			logger.Level = logrus.DebugLevel
 
@@ -162,6 +200,14 @@ func TestExecute(t *testing.T) {
 				require.NoError(t, crClient.Create(context.Background(), tc.resourcePolicy))
 			}
 
+			var crClient crclient.Client
+			if tc.failVSCreate {
+				realFakeClient := velerotest.NewFakeControllerRuntimeClient(t, objects...)
+				crClient = &errorInjectingClient{Client: realFakeClient}
+			} else {
+				crClient = velerotest.NewFakeControllerRuntimeClient(t, objects...)
+			}
+
 			pvcBIA := pvcBackupItemAction{
 				log:      logger,
 				crClient: crClient,
@@ -170,16 +216,15 @@ func TestExecute(t *testing.T) {
 			pvcMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&tc.pvc)
 			require.NoError(t, err)
 
-			if boolptr.IsSetToTrue(tc.backup.Spec.SnapshotMoveData) == true {
+			if tc.pvc != nil && !tc.failVSCreate && !tc.skipVSReadyUpdate {
 				go func() {
-					var vsList v1.VolumeSnapshotList
+					var vsList snapshotv1api.VolumeSnapshotList
 					err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 						err = pvcBIA.crClient.List(ctx, &vsList, &crclient.ListOptions{Namespace: tc.pvc.Namespace})
 
 						require.NoError(t, err)
 						if err != nil || len(vsList.Items) == 0 {
-							//lint:ignore nilerr reason
-							return false, nil // ignore
+							return false, err
 						}
 						return true, nil
 					})
@@ -187,7 +232,7 @@ func TestExecute(t *testing.T) {
 					require.NoError(t, err)
 					vscName := "testVSC"
 					readyToUse := true
-					vsList.Items[0].Status = &v1.VolumeSnapshotStatus{
+					vsList.Items[0].Status = &snapshotv1api.VolumeSnapshotStatus{
 						BoundVolumeSnapshotContentName: &vscName,
 						ReadyToUse:                     &readyToUse,
 					}
@@ -202,8 +247,18 @@ func TestExecute(t *testing.T) {
 			}
 
 			resultUnstructed, _, _, _, err := pvcBIA.Execute(&unstructured.Unstructured{Object: pvcMap}, tc.backup)
+
 			if tc.expectedErr != nil {
 				require.EqualError(t, err, tc.expectedErr.Error())
+			} else if tc.expectErr {
+				require.Error(t, err)
+				// On timeout failure, check that the cleanup logic was called
+				if tc.skipVSReadyUpdate {
+					vsList := new(snapshotv1api.VolumeSnapshotList)
+					errList := crClient.List(t.Context(), vsList, &crclient.ListOptions{Namespace: tc.pvc.Namespace})
+					require.NoError(t, errList)
+					require.Empty(t, vsList.Items, "VolumeSnapshot should have been cleaned up after readiness check failed")
+				}
 			} else {
 				require.NoError(t, err)
 			}
@@ -217,10 +272,9 @@ func TestExecute(t *testing.T) {
 			}
 
 			if tc.expectedPVC != nil {
-				resultPVC := new(corev1.PersistentVolumeClaim)
+				resultPVC := new(corev1api.PersistentVolumeClaim)
 				runtime.DefaultUnstructuredConverter.FromUnstructured(resultUnstructed.UnstructuredContent(), resultPVC)
-
-				require.True(t, cmp.Equal(tc.expectedPVC, resultPVC, cmpopts.IgnoreFields(corev1.PersistentVolumeClaim{}, "ResourceVersion", "Annotations", "Labels")))
+				require.True(t, cmp.Equal(tc.expectedPVC, resultPVC, cmpopts.IgnoreFields(corev1api.PersistentVolumeClaim{}, "ResourceVersion", "Annotations", "Labels")))
 			}
 		})
 	}
@@ -283,7 +337,7 @@ func TestProgress(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(*testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			crClient := velerotest.NewFakeControllerRuntimeClient(t)
 			logger := logrus.New()
 
@@ -332,7 +386,6 @@ func TestCancel(t *testing.T) {
 				},
 			},
 			operationID: "testing",
-			expectedErr: nil,
 			expectedDataUpload: velerov2alpha1.DataUpload{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DataUpload",
@@ -353,7 +406,7 @@ func TestCancel(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(*testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			crClient := velerotest.NewFakeControllerRuntimeClient(t)
 			logger := logrus.New()
 
@@ -366,9 +419,7 @@ func TestCancel(t *testing.T) {
 			require.NoError(t, err)
 
 			err = pvcBIA.Cancel(tc.operationID, tc.backup)
-			if tc.expectedErr != nil {
-				require.EqualError(t, err, tc.expectedErr.Error())
-			}
+			require.NoError(t, err)
 
 			du := new(velerov2alpha1.DataUpload)
 			err = crClient.Get(context.Background(), crclient.ObjectKey{Namespace: tc.dataUpload.Namespace, Name: tc.dataUpload.Name}, du)
@@ -388,7 +439,7 @@ func TestPVCAppliesTo(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(
-		t,
+		t, 
 		velero.ResourceSelector{
 			IncludedResources: []string{"persistentvolumeclaims"},
 		},
@@ -411,4 +462,1215 @@ func TestNewPVCBackupItemAction(t *testing.T) {
 	plugin1 := NewPvcBackupItemAction(f1)
 	_, err1 := plugin1(logger)
 	require.NoError(t, err1)
+}
+
+func TestListGroupedPVCs(t *testing.T) {
+	tests := []struct {
+		name        string
+		namespace   string
+		labelKey    string
+		groupValue  string
+		pvcs        []corev1api.PersistentVolumeClaim
+		expectCount int
+		expectError bool
+	}{
+		{
+			name:       "Match single PVC with label",
+			namespace:  "ns1",
+			labelKey:   "vgs-key",
+			groupValue: "group-a",
+			pvcs: []corev1api.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc1",
+						Namespace: "ns1",
+						Labels: map[string]string{
+							"vgs-key": "group-a",
+						},
+					},
+				},
+			},
+			expectCount: 1,
+		},
+		{
+			name:       "No matching PVCs",
+			namespace:  "ns1",
+			labelKey:   "vgs-key",
+			groupValue: "group-b",
+			pvcs: []corev1api.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc1",
+						Namespace: "ns1",
+						Labels: map[string]string{
+							"vgs-key": "group-a",
+						},
+					},
+				},
+			},
+			expectCount: 0,
+		},
+		{
+			name:       "Match multiple PVCs",
+			namespace:  "ns1",
+			labelKey:   "vgs-key",
+			groupValue: "group-a",
+			pvcs: []corev1api.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc1",
+						Namespace: "ns1",
+						Labels:    map[string]string{"vgs-key": "group-a"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc2",
+						Namespace: "ns1",
+						Labels:    map[string]string{"vgs-key": "group-a"},
+					},
+				},
+			},
+			expectCount: 2,
+		},
+		{
+			name:       "Different namespace",
+			namespace:  "ns2",
+			labelKey:   "vgs-key",
+			groupValue: "group-a",
+			pvcs: []corev1api.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc1",
+						Namespace: "ns1",
+						Labels:    map[string]string{"vgs-key": "group-a"},
+					},
+				},
+			},
+			expectCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var objs []runtime.Object
+			for i := range tt.pvcs {
+				objs = append(objs, &tt.pvcs[i])
+			}
+			client := velerotest.NewFakeControllerRuntimeClient(t, objs...)
+
+			action := &pvcBackupItemAction{
+				log:      logrus.New(),
+				crClient: client,
+			}
+
+			result, err := action.listGroupedPVCs(t.Context(), tt.namespace, tt.labelKey, tt.groupValue)
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Len(t, result, tt.expectCount)
+			}
+		})
+	}
+}
+
+func TestDetermineCSIDriver(t *testing.T) {
+	tests := []struct {
+		name           string
+		pvcs           []corev1api.PersistentVolumeClaim
+		pvs            []corev1api.PersistentVolume
+		expectError    bool
+		expectedDriver string
+	}{
+		{
+			name: "Single PVC with CSI PV",
+			pvcs: []corev1api.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pvc-1", Namespace: "ns-1"},
+					Spec:       corev1api.PersistentVolumeClaimSpec{VolumeName: "pv-1"},
+					Status:     corev1api.PersistentVolumeClaimStatus{Phase: corev1api.ClaimBound},
+				},
+			},
+			pvs: []corev1api.PersistentVolume{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pv-1"},
+					Spec: corev1api.PersistentVolumeSpec{
+						PersistentVolumeSource: corev1api.PersistentVolumeSource{
+							CSI: &corev1api.CSIPersistentVolumeSource{Driver: "csi-driver"},
+						},
+					},
+				},
+			},
+			expectedDriver: "csi-driver",
+		},
+		{
+			name: "Multiple PVCs with same CSI driver",
+			pvcs: []corev1api.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pvc-1", Namespace: "ns-1"},
+					Spec:       corev1api.PersistentVolumeClaimSpec{VolumeName: "pv-1"},
+					Status:     corev1api.PersistentVolumeClaimStatus{Phase: corev1api.ClaimBound},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pvc-2", Namespace: "ns-1"},
+					Spec:       corev1api.PersistentVolumeClaimSpec{VolumeName: "pv-2"},
+					Status:     corev1api.PersistentVolumeClaimStatus{Phase: corev1api.ClaimBound},
+				},
+			},
+			pvs: []corev1api.PersistentVolume{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pv-1"},
+					Spec: corev1api.PersistentVolumeSpec{
+						PersistentVolumeSource: corev1api.PersistentVolumeSource{
+							CSI: &corev1api.CSIPersistentVolumeSource{Driver: "csi-driver"},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pv-2"},
+					Spec: corev1api.PersistentVolumeSpec{
+						PersistentVolumeSource: corev1api.PersistentVolumeSource{
+							CSI: &corev1api.CSIPersistentVolumeSource{Driver: "csi-driver"},
+						},
+					},
+				},
+			},
+			expectedDriver: "csi-driver",
+		},
+		{
+			name: "PV not CSI provisioned",
+			pvcs: []corev1api.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pvc-1", Namespace: "ns-1"},
+					Spec:       corev1api.PersistentVolumeClaimSpec{VolumeName: "pv-1"},
+					Status:     corev1api.PersistentVolumeClaimStatus{Phase: corev1api.ClaimBound},
+				},
+			},
+			pvs: []corev1api.PersistentVolume{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pv-1"},
+					Spec:       corev1api.PersistentVolumeSpec{},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "Multiple PVCs with different CSI drivers",
+			pvcs: []corev1api.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pvc-1", Namespace: "ns-1"},
+					Spec:       corev1api.PersistentVolumeClaimSpec{VolumeName: "pv-1"},
+					Status:     corev1api.PersistentVolumeClaimStatus{Phase: corev1api.ClaimBound},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pvc-2", Namespace: "ns-1"},
+					Spec:       corev1api.PersistentVolumeClaimSpec{VolumeName: "pv-2"},
+					Status:     corev1api.PersistentVolumeClaimStatus{Phase: corev1api.ClaimBound},
+				},
+			},
+			pvs: []corev1api.PersistentVolume{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pv-1"},
+					Spec: corev1api.PersistentVolumeSpec{
+						PersistentVolumeSource: corev1api.PersistentVolumeSource{
+							CSI: &corev1api.CSIPersistentVolumeSource{Driver: "csi-driver-1"},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pv-2"},
+					Spec: corev1api.PersistentVolumeSpec{
+						PersistentVolumeSource: corev1api.PersistentVolumeSource{
+							CSI: &corev1api.CSIPersistentVolumeSource{Driver: "csi-driver-2"},
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var initObjs []runtime.Object
+			for i := range tt.pvcs {
+				pvc := tt.pvcs[i]
+				initObjs = append(initObjs, &pvc)
+			}
+			for i := range tt.pvs {
+				pv := tt.pvs[i]
+				initObjs = append(initObjs, &pv)
+			}
+
+			client := velerotest.NewFakeControllerRuntimeClient(t, initObjs...)
+			action := &pvcBackupItemAction{
+				log:      logrus.New(),
+				crClient: client,
+			}
+
+			driver, err := action.determineCSIDriver(tt.pvcs)
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedDriver, driver)
+			}
+		})
+	}
+}
+
+func TestDetermineVGSClass(t *testing.T) {
+	tests := []struct {
+		name             string
+		backup           *velerov1api.Backup
+		pvc              *corev1api.PersistentVolumeClaim
+		existingVGSClass []volumegroupsnapshotv1beta1.VolumeGroupSnapshotClass
+		expectError      bool
+		expectResult     string
+	}{
+		{
+			name: "PVC annotation override",
+			pvc: &corev1api.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						velerov1api.VolumeGroupSnapshotClassAnnotationPVC: "pvc-class",
+					},
+				},
+			},
+			backup:       &velerov1api.Backup{},
+			expectResult: "pvc-class",
+		},
+		{
+			name: "Backup annotation override",
+			pvc:  &corev1api.PersistentVolumeClaim{},
+			backup: &velerov1api.Backup{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						fmt.Sprintf("%s%s", velerov1api.VolumeGroupSnapshotClassAnnotationBackupPrefix, testDriver): "backup-class",
+					},
+				},
+			},
+			expectResult: "backup-class",
+		},
+		{
+			name:   "Default label-based match",
+			pvc:    &corev1api.PersistentVolumeClaim{},
+			backup: &velerov1api.Backup{},
+			existingVGSClass: []volumegroupsnapshotv1beta1.VolumeGroupSnapshotClass{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "default-class",
+						Labels: map[string]string{velerov1api.VolumeGroupSnapshotClassDefaultLabel: "true"},
+					},
+					Driver: testDriver,
+				},
+			},
+			expectResult: "default-class",
+		},
+		{
+			name:        "No matching VGS class",
+			pvc:         &corev1api.PersistentVolumeClaim{},
+			backup:      &velerov1api.Backup{},
+			expectError: true,
+		},
+		{
+			name:   "Multiple matching VGS classes",
+			pvc:    &corev1api.PersistentVolumeClaim{},
+			backup: &velerov1api.Backup{},
+			existingVGSClass: []volumegroupsnapshotv1beta1.VolumeGroupSnapshotClass{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "class1",
+						Labels: map[string]string{velerov1api.VolumeGroupSnapshotClassDefaultLabel: "true"},
+					},
+					Driver: testDriver,
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "class2",
+						Labels: map[string]string{velerov1api.VolumeGroupSnapshotClassDefaultLabel: "true"},
+					},
+					Driver: testDriver,
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var initObjs []runtime.Object
+			for _, vgsClass := range tt.existingVGSClass {
+				vgsClassCopy := vgsClass
+				initObjs = append(initObjs, &vgsClassCopy)
+			}
+
+			client := velerotest.NewFakeControllerRuntimeClient(t, initObjs...)
+			logger := logrus.New()
+			require.NoError(t, volumegroupsnapshotv1beta1.AddToScheme(client.Scheme()))
+
+			action := &pvcBackupItemAction{crClient: client, log: logger}
+
+			result, err := action.determineVGSClass(t.Context(), testDriver, tt.backup, tt.pvc)
+
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectResult, result)
+			}
+		})
+	}
+}
+
+func TestCreateVolumeGroupSnapshot(t *testing.T) {
+	testNamespace := "test-ns"
+	testLabelKey := "velero.io/test-vgs-label"
+	testLabelValue := "group-1"
+	testVGSClass := "test-class"
+	testBackup := &velerov1api.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-backup",
+			UID:  "test-uid",
+		},
+	}
+	testPVC := corev1api.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				testLabelKey: testLabelValue,
+			},
+		},
+	}
+
+	crClient := velerotest.NewFakeControllerRuntimeClient(t)
+	log := logrus.New()
+	action := &pvcBackupItemAction{
+		log:      log,
+		crClient: crClient,
+	}
+
+	vgs, err := action.createVolumeGroupSnapshot(t.Context(), testBackup, testPVC, testLabelKey, testLabelValue, testVGSClass)
+	require.NoError(t, err)
+	require.NotNil(t, vgs)
+
+	// Verify VGS fields
+	assert.Equal(t, testNamespace, vgs.Namespace)
+	assert.NotEmpty(t, vgs.GenerateName)
+	assert.Equal(t, testVGSClass, *vgs.Spec.VolumeGroupSnapshotClassName)
+	assert.NotNil(t, vgs.Spec.Source.Selector)
+	assert.Equal(t, testLabelValue, vgs.Spec.Source.Selector.MatchLabels[testLabelKey])
+	assert.Equal(t, testLabelValue, vgs.Labels[testLabelKey])
+	assert.Equal(t, label.GetValidName(testBackup.Name), vgs.Labels[velerov1api.BackupNameLabel])
+	assert.Equal(t, string(testBackup.UID), vgs.Labels[velerov1api.BackupUIDLabel])
+
+	// Check that it exists in fake client
+	retrieved := &volumegroupsnapshotv1beta1.VolumeGroupSnapshot{}
+	err = crClient.Get(t.Context(), crclient.ObjectKey{Name: vgs.Name, Namespace: vgs.Namespace}, retrieved)
+	require.NoError(t, err)
+}
+
+func TestWaitForVGSAssociatedVS(t *testing.T) {
+	vgs := &volumegroupsnapshotv1beta1.VolumeGroupSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-vgs",
+			Namespace: "test-ns",
+			UID:       types.UID("1234-5678-uuid"),
+		},
+	}
+
+	makeVS := func(name string, hasStatus bool, hasVGSName bool, owned bool, pvcName string) *snapshotv1api.VolumeSnapshot {
+		var refs []metav1.OwnerReference
+		if owned {
+			refs = []metav1.OwnerReference{
+				{
+					APIVersion: "groupsnapshot.storage.k8s.io/v1beta1",
+					Kind:       "VolumeGroupSnapshot",
+					Name:       vgs.Name,
+					UID:        vgs.UID,
+				},
+			}
+		}
+
+		vs := &snapshotv1api.VolumeSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            name,
+				Namespace:       vgs.Namespace,
+				OwnerReferences: refs,
+			},
+			Spec: snapshotv1api.VolumeSnapshotSpec{
+				Source: snapshotv1api.VolumeSnapshotSource{
+					PersistentVolumeClaimName: pointer.String(pvcName),
+				},
+			},
+		}
+
+		if hasStatus {
+			vs.Status = &snapshotv1api.VolumeSnapshotStatus{}
+			if hasVGSName {
+				vs.Status.VolumeGroupSnapshotName = pointer.String(vgs.Name)
+			}
+		}
+
+		return vs
+	}
+
+	makePVC := func(name string) corev1api.PersistentVolumeClaim {
+		return corev1api.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: vgs.Namespace,
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		vsList      []*snapshotv1api.VolumeSnapshot
+		groupedPVCs []corev1api.PersistentVolumeClaim
+		expectErr   bool
+		expectVSMap int
+	}{
+		{
+			name: "all owned VS have VGS name",
+			vsList: []*snapshotv1api.VolumeSnapshot{
+				makeVS("vs1", true, true, true, "pvc1"),
+				makeVS("vs2", true, true, true, "pvc2"),
+			},
+			groupedPVCs: []corev1api.PersistentVolumeClaim{
+				makePVC("pvc1"),
+				makePVC("pvc2"),
+			},
+			expectErr:   false,
+			expectVSMap: 2,
+		},
+		{
+			name: "one owned VS missing VGS name",
+			vsList: []*snapshotv1api.VolumeSnapshot{
+				makeVS("vs1", true, true, true, "pvc1"),
+				makeVS("vs2", true, false, true, "pvc2"),
+			},
+			groupedPVCs: []corev1api.PersistentVolumeClaim{
+				makePVC("pvc1"),
+				makePVC("pvc2"),
+			},
+			expectErr: true,
+		},
+		{
+			name: "owned VS has no status",
+			vsList: []*snapshotv1api.VolumeSnapshot{
+				makeVS("vs1", false, false, true, "pvc1"),
+			},
+			groupedPVCs: []corev1api.PersistentVolumeClaim{
+				makePVC("pvc1"),
+			},
+			expectErr: true,
+		},
+		{
+			name: "unrelated VS ignored",
+			vsList: []*snapshotv1api.VolumeSnapshot{
+				makeVS("vs1", true, true, false, "pvc1"),
+			},
+			groupedPVCs: []corev1api.PersistentVolumeClaim{
+				makePVC("pvc1"),
+			},
+			expectErr: true,
+		},
+		{
+			name: "no owned VS present",
+			vsList: []*snapshotv1api.VolumeSnapshot{
+				makeVS("vs1", true, true, false, "pvc1"),
+			},
+			groupedPVCs: []corev1api.PersistentVolumeClaim{
+				makePVC("pvc1"),
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var objs []runtime.Object
+			objs = append(objs, vgs)
+			for _, vs := range tt.vsList {
+				objs = append(objs, vs)
+			}
+			for _, pvc := range tt.groupedPVCs {
+				objs = append(objs, &pvc)
+			}
+
+			client := velerotest.NewFakeControllerRuntimeClient(t, objs...)
+			action := &pvcBackupItemAction{
+				log:      velerotest.NewLogger(),
+				crClient: client,
+			}
+
+			vsMap, err := action.waitForVGSAssociatedVS(t.Context(), tt.groupedPVCs, vgs, 2*time.Second)
+
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if len(vsMap) != tt.expectVSMap {
+					t.Errorf("expected vsMap length %d, got %d", tt.expectVSMap, len(vsMap))
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateVGSCreatedVS(t *testing.T) {
+	backup := &velerov1api.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "backup-1",
+			UID:  "backup-uid-123",
+		},
+	}
+
+	vgs := &volumegroupsnapshotv1beta1.VolumeGroupSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-vgs",
+			Namespace: "ns",
+			UID:       "vgs-uid-123",
+		},
+	}
+
+	makeVS := func(name string, withVGSOwner bool, vgsNamePtr *string, pvcName string) *snapshotv1api.VolumeSnapshot {
+		var refs []metav1.OwnerReference
+		if withVGSOwner {
+			refs = []metav1.OwnerReference{
+				{
+					APIVersion: "groupsnapshot.storage.k8s.io/v1beta1",
+					Kind:       "VolumeGroupSnapshot",
+					Name:       vgs.Name,
+					UID:        vgs.UID,
+				},
+			}
+		}
+		return &snapshotv1api.VolumeSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            name,
+				Namespace:       vgs.Namespace,
+				OwnerReferences: refs,
+				Finalizers: []string{
+					VolumeSnapshotFinalizerGroupProtection,
+					VolumeSnapshotFinalizerSourceProtection,
+				},
+			},
+			Status: &snapshotv1api.VolumeSnapshotStatus{
+				ReadyToUse:              pointer.Bool(true),
+				VolumeGroupSnapshotName: vgsNamePtr,
+			},
+			Spec: snapshotv1api.VolumeSnapshotSpec{
+				Source: snapshotv1api.VolumeSnapshotSource{
+					PersistentVolumeClaimName: pointer.String(pvcName),
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name                    string
+		vs                      *snapshotv1api.VolumeSnapshot
+		expectOwnerCleared      bool
+		expectFinalizersCleared bool
+		expectLabelPatched      bool
+	}{
+		{
+			name:                    "should update owned VS",
+			vs:                      makeVS("vs-owned", true, pointer.String(vgs.Name), "pvc-1"),
+			expectOwnerCleared:      true,
+			expectFinalizersCleared: true,
+			expectLabelPatched:      true,
+		},
+		{
+			name:                    "should skip VS not owned by VGS",
+			vs:                      makeVS("vs-unowned", false, nil, "pvc-1"),
+			expectOwnerCleared:      false,
+			expectFinalizersCleared: false,
+			expectLabelPatched:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := velerotest.NewFakeControllerRuntimeClient(t, vgs, tt.vs)
+			action := &pvcBackupItemAction{
+				log:      velerotest.NewLogger(),
+				crClient: client,
+			}
+
+			// Build vsMap using the PVC name from the VS
+			vsMap := map[string]*snapshotv1api.VolumeSnapshot{
+				*tt.vs.Spec.Source.PersistentVolumeClaimName: tt.vs,
+			}
+
+			err := action.updateVGSCreatedVS(t.Context(), vsMap, vgs, backup)
+			require.NoError(t, err)
+
+			// Fetch updated VS
+			updated := &snapshotv1api.VolumeSnapshot{}
+			err = client.Get(t.Context(), crclient.ObjectKey{Name: tt.vs.Name, Namespace: tt.vs.Namespace}, updated)
+			require.NoError(t, err)
+
+			if tt.expectOwnerCleared {
+				assert.Empty(t, updated.OwnerReferences, "expected ownerReferences to be cleared")
+			} else {
+				assert.Equal(t, tt.vs.OwnerReferences, updated.OwnerReferences, "expected ownerReferences to remain unchanged")
+			}
+
+			if tt.expectFinalizersCleared {
+				assert.Empty(t, updated.Finalizers, "expected finalizers to be cleared")
+			} else {
+				assert.Equal(t, tt.vs.Finalizers, updated.Finalizers, "expected finalizers to remain unchanged")
+			}
+
+			if tt.expectLabelPatched {
+				assert.Equal(t, "backup-1", updated.Labels[velerov1api.BackupNameLabel])
+				assert.Equal(t, "backup-uid-123", updated.Labels[velerov1api.BackupUIDLabel])
+			} else {
+				assert.Nil(t, updated.Labels, "expected no labels to be patched")
+			}
+		})
+	}
+}
+
+func TestPatchVGSCDeletionPolicy(t *testing.T) {
+	tests := []struct {
+		name           string
+		initialPolicy  snapshotv1api.DeletionPolicy
+		expectedPolicy snapshotv1api.DeletionPolicy
+		expectPatch    bool
+		expectErr      bool
+	}{
+		{
+			name:           "patches Delete to Retain",
+			initialPolicy:  snapshotv1api.VolumeSnapshotContentDelete,
+			expectedPolicy: snapshotv1api.VolumeSnapshotContentRetain,
+			expectPatch:    true,
+		},
+		{
+			name:           "no patch if already Retain",
+			initialPolicy:  snapshotv1api.VolumeSnapshotContentRetain,
+			expectedPolicy: snapshotv1api.VolumeSnapshotContentRetain,
+			expectPatch:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vgsc := &volumegroupsnapshotv1beta1.VolumeGroupSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-vgsc"},
+				Spec: volumegroupsnapshotv1beta1.VolumeGroupSnapshotContentSpec{
+					DeletionPolicy: tt.initialPolicy,
+				},
+			}
+			vgs := &volumegroupsnapshotv1beta1.VolumeGroupSnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vgs",
+					Namespace: "ns",
+				},
+				Status: &volumegroupsnapshotv1beta1.VolumeGroupSnapshotStatus{
+					BoundVolumeGroupSnapshotContentName: pointer.String("test-vgsc"),
+				},
+			}
+
+			client := velerotest.NewFakeControllerRuntimeClient(t, vgs, vgsc)
+			action := &pvcBackupItemAction{
+				log:      velerotest.NewLogger(),
+				crClient: client,
+			}
+
+			err := action.patchVGSCDeletionPolicy(t.Context(), vgs)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			updated := &volumegroupsnapshotv1beta1.VolumeGroupSnapshotContent{}
+			err = client.Get(t.Context(), crclient.ObjectKey{Name: "test-vgsc"}, updated)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedPolicy, updated.Spec.DeletionPolicy)
+		})
+	}
+}
+
+func TestDeleteVGSAndVGSC(t *testing.T) {
+	makeVGS := func(name, namespace string, boundVGSCName *string) *volumegroupsnapshotv1beta1.VolumeGroupSnapshot {
+		return &volumegroupsnapshotv1beta1.VolumeGroupSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Status: &volumegroupsnapshotv1beta1.VolumeGroupSnapshotStatus{
+				BoundVolumeGroupSnapshotContentName: boundVGSCName,
+			},
+		}
+	}
+
+	makeVGSC := func(name string) *volumegroupsnapshotv1beta1.VolumeGroupSnapshotContent {
+		return &volumegroupsnapshotv1beta1.VolumeGroupSnapshotContent{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		}
+	}
+
+	tests := []struct {
+		name             string
+		vgs              *volumegroupsnapshotv1beta1.VolumeGroupSnapshot
+		existingVGSC     *volumegroupsnapshotv1beta1.VolumeGroupSnapshotContent
+		expectVGSCDelete bool
+		expectVGSDelete  bool
+	}{
+		{
+			name:             "deletes both VGSC and VGS",
+			vgs:              makeVGS("test-vgs", "ns", pointer.String("test-vgsc")),
+			existingVGSC:     makeVGSC("test-vgsc"),
+			expectVGSCDelete: true,
+			expectVGSDelete:  true,
+		},
+		{
+			name:             "VGSC not found, still deletes VGS",
+			vgs:              makeVGS("test-vgs", "ns", pointer.String("missing-vgsc")),
+			existingVGSC:     nil,
+			expectVGSCDelete: false,
+			expectVGSDelete:  true,
+		},
+		{
+			name:             "no BoundVGSCName set, only deletes VGS",
+			vgs:              makeVGS("test-vgs", "ns", nil),
+			existingVGSC:     nil,
+			expectVGSCDelete: false,
+			expectVGSDelete:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var objs []runtime.Object
+			objs = append(objs, tt.vgs)
+			if tt.existingVGSC != nil {
+				objs = append(objs, tt.existingVGSC)
+			}
+
+			client := velerotest.NewFakeControllerRuntimeClient(t, objs...)
+			action := &pvcBackupItemAction{
+				log:      velerotest.NewLogger(),
+				crClient: client,
+			}
+
+			err := action.deleteVGSAndVGSC(t.Context(), tt.vgs)
+			require.NoError(t, err)
+
+			// Check VGSC is deleted
+			if tt.expectVGSCDelete {
+				got := &volumegroupsnapshotv1beta1.VolumeGroupSnapshotContent{}
+				err = client.Get(t.Context(), crclient.ObjectKey{Name: "test-vgsc"}, got)
+				assert.True(t, apierrors.IsNotFound(err), "expected VGSC to be deleted")
+			}
+
+			// Check VGS is deleted
+			gotVGS := &volumegroupsnapshotv1beta1.VolumeGroupSnapshot{}
+			err = client.Get(t.Context(), crclient.ObjectKey{Name: "test-vgs", Namespace: "ns"}, gotVGS)
+			assert.True(t, apierrors.IsNotFound(err), "expected VGS to be deleted")
+		})
+	}
+}
+
+func TestFindExistingVSForBackup(t *testing.T) {
+	backupUID := types.UID("backup-uid-123")
+	backupName := "backup-1"
+	pvcName := "pvc-1"
+	namespace := "ns"
+
+	makeVS := func(name, pvc string, match bool) *snapshotv1api.VolumeSnapshot {
+		labels := map[string]string{}
+		if match {
+			labels[velerov1api.BackupNameLabel] = label.GetValidName(backupName)
+			labels[velerov1api.BackupUIDLabel] = string(backupUID)
+		}
+		return &snapshotv1api.VolumeSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels:    labels,
+			},
+			Spec: snapshotv1api.VolumeSnapshotSpec{
+				Source: snapshotv1api.VolumeSnapshotSource{
+					PersistentVolumeClaimName: pointer.String(pvc),
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		vsList     []*snapshotv1api.VolumeSnapshot
+		expectName string
+		expectNil  bool
+	}{
+		{
+			name: "should find matching VS",
+			vsList: []*snapshotv1api.VolumeSnapshot{
+				makeVS("vs-match", pvcName, true),
+			},
+			expectName: "vs-match",
+			expectNil:  false,
+		},
+		{
+			name: "should skip VS with non-matching labels",
+			vsList: []*snapshotv1api.VolumeSnapshot{
+				makeVS("vs-nolabel", pvcName, false),
+			},
+			expectNil: true,
+		},
+		{
+			name: "should skip VS with different PVC name",
+			vsList: []*snapshotv1api.VolumeSnapshot{
+				makeVS("vs-other-pvc", "other-pvc", true),
+			},
+			expectNil: true,
+		},
+		{
+			name:      "should return nil if VS list is empty",
+			vsList:    []*snapshotv1api.VolumeSnapshot{},
+			expectNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var objs []runtime.Object
+			for _, vs := range tt.vsList {
+				objs = append(objs, vs)
+			}
+
+			client := velerotest.NewFakeControllerRuntimeClient(t, objs...)
+			action := &pvcBackupItemAction{
+				log:      velerotest.NewLogger(),
+				crClient: client,
+			}
+
+			vs, err := action.findExistingVSForBackup(t.Context(), backupUID, backupName, pvcName, namespace)
+			require.NoError(t, err)
+
+			if tt.expectNil {
+				assert.Nil(t, vs)
+			} else {
+				require.NotNil(t, vs)
+				assert.Equal(t, tt.expectName, vs.Name)
+			}
+		})
+	}
+}
+
+func TestWaitForVGSCBinding(t *testing.T) {
+	makeVGS := func(name string, withStatus bool) *volumegroupsnapshotv1beta1.VolumeGroupSnapshot {
+		vgs := &volumegroupsnapshotv1beta1.VolumeGroupSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "ns",
+			},
+		}
+		if withStatus {
+			contentName := "vgsc-123"
+			vgs.Status = &volumegroupsnapshotv1beta1.VolumeGroupSnapshotStatus{
+				BoundVolumeGroupSnapshotContentName: &contentName,
+			}
+		}
+		return vgs
+	}
+
+	tests := []struct {
+		name      string
+		vgs       *volumegroupsnapshotv1beta1.VolumeGroupSnapshot
+		expectErr bool
+	}{
+		{
+			name:      "status is already bound",
+			vgs:       makeVGS("vgs1", true),
+			expectErr: false,
+		},
+		{
+			name:      "status is nil",
+			vgs:       makeVGS("vgs2", false),
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := velerotest.NewFakeControllerRuntimeClient(t, tt.vgs.DeepCopy())
+
+			action := &pvcBackupItemAction{
+				log:      velerotest.NewLogger(),
+				crClient: client,
+			}
+
+			err := action.waitForVGSCBinding(t.Context(), tt.vgs, 1*time.Second)
+
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, tt.vgs.Status)
+				require.NotNil(t, tt.vgs.Status.BoundVolumeGroupSnapshotContentName)
+				require.Equal(t, "vgsc-123", *tt.vgs.Status.BoundVolumeGroupSnapshotContentName)
+			}
+		})
+	}
+}
+
+func TestGetVGSByLabels(t *testing.T) {
+	labelKey := "velero.io/backup-name"
+	labelVal := "backup-123"
+	testLabels := map[string]string{labelKey: labelVal}
+
+	makeVGS := func(name string, labels map[string]string) *volumegroupsnapshotv1beta1.VolumeGroupSnapshot {
+		return &volumegroupsnapshotv1beta1.VolumeGroupSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "test-ns",
+				Labels:    labels,
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		vgsObjects  []runtime.Object
+		expectError string
+		expectName  string
+	}{
+		{
+			name: "exactly one matching VGS",
+			vgsObjects: []runtime.Object{
+				makeVGS("vgs1", testLabels),
+			},
+			expectName: "vgs1",
+		},
+		{
+			name:        "no matching VGS",
+			vgsObjects:  []runtime.Object{},
+			expectError: "no VolumeGroupSnapshot found matching labels",
+		},
+		{
+			name: "multiple matching VGS",
+			vgsObjects: []runtime.Object{
+				makeVGS("vgs1", testLabels),
+				makeVGS("vgs2", testLabels),
+			},
+			expectError: "multiple VolumeGroupSnapshots found matching labels",
+		},
+		{
+			name:        "client list error",
+			vgsObjects:  []runtime.Object{},
+			expectError: "failed to list VolumeGroupSnapshots by labels",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var client crclient.Client
+			if tt.name == "client list error" {
+				// Inject a client that always errors on List
+				client = &failingClient{}
+			} else {
+				client = velerotest.NewFakeControllerRuntimeClient(t, tt.vgsObjects...)
+			}
+
+			action := &pvcBackupItemAction{
+				log:      velerotest.NewLogger(),
+				crClient: client,
+			}
+
+			vgs, err := action.getVGSByLabels(t.Context(), "test-ns", testLabels)
+
+			if tt.expectError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.expectError) {
+					t.Errorf("expected error containing '%s', got: %v", tt.expectError, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if vgs == nil || vgs.Name != tt.expectName {
+					t.Errorf("expected VGS name %s, got %v", tt.expectName, vgs)
+				}
+			}
+		})
+	}
+}
+
+// failingClient is a dummy client that fails on List
+type failingClient struct {
+	crclient.Client
+}
+
+func (f *failingClient) List(ctx context.Context, list crclient.ObjectList, opts ...crclient.ListOption) error {
+	return fmt.Errorf("simulated list error")
+}
+
+func TestHasOwnerReference(t *testing.T) {
+	vgs := &volumegroupsnapshotv1beta1.VolumeGroupSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-vgs",
+			Namespace: "test-ns",
+			UID:       types.UID("1234-uid"),
+		},
+	}
+
+	tests := []struct {
+		name     string
+		ownerRef metav1.OwnerReference
+		expect   bool
+	}{
+		{
+			name: "match kind, apiversion, uid",
+			ownerRef: metav1.OwnerReference{
+				Kind:       kuberesource.VGSKind,
+				APIVersion: volumegroupsnapshotv1beta1.GroupName + "/" + volumegroupsnapshotv1beta1.SchemeGroupVersion.Version,
+				UID:        vgs.UID,
+			},
+			expect: true,
+		},
+		{
+			name: "mismatch kind",
+			ownerRef: metav1.OwnerReference{
+				Kind:       "other-kind",
+				APIVERSION: volumegroupsnapshotv1beta1.GroupName + "/" + volumegroupsnapshotv1beta1.SchemeGroupVersion.Version,
+				UID:        vgs.UID,
+			},
+			expect: false,
+		},
+		{
+			name: "mismatch apiversion",
+			ownerRef: metav1.OwnerReference{
+				Kind:       kuberesource.VGSKind,
+				APIVERSION: "wrong.group/v1",
+				UID:        vgs.UID,
+			},
+			expect: false,
+		},
+		{
+			name: "mismatch uid",
+			ownerRef: metav1.OwnerReference{
+				Kind:       kuberesource.VGSKind,
+				APIVERSION: volumegroupsnapshotv1beta1.GroupName + "/" + volumegroupsnapshotv1beta1.SchemeGroupVersion.Version,
+				UID:        "wrong-uid",
+			},
+			expect: false,
+		},
+		{
+			name:     "no owner references",
+			ownerRef: metav1.OwnerReference{},
+			expect:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &metav1.ObjectMeta{
+				Name:      "dummy",
+				Namespace: "test-ns",
+			}
+
+			if tt.name != "no owner references" {
+				obj.OwnerReferences = []metav1.OwnerReference{tt.ownerRef}
+			}
+
+			found := hasOwnerReference(obj, vgs)
+			assert.Equal(t, tt.expect, found)
+		})
+	}
+}
+
+func TestPVCRequestSize(t *testing.T) {
+	logger := logrus.New()
+
+	tests := []struct {
+		name         string
+		pvcInitial   *corev1api.PersistentVolumeClaim // Use full PVC to allow for nil Requests
+		restoreSize  string
+		expectedSize string
+	}{
+		{
+			name: "UpdateRequired: PVC request is lower than restore size",
+			pvcInitial: func() *corev1api.PersistentVolumeClaim {
+				pvc := builder.ForPersistentVolumeClaim("velero", "testPVC").Result()
+				pvc.Spec.Resources.Requests = corev1api.ResourceList{
+					corev1api.ResourceStorage: resource.MustParse("1Gi"),
+				}
+				return pvc
+			}(),
+			restoreSize:  "2Gi",
+			expectedSize: "2Gi",
+		},
+		{
+			name: "NoUpdateRequired: PVC request is larger than restore size",
+			pvcInitial: func() *corev1api.PersistentVolumeClaim {
+				pvc := builder.ForPersistentVolumeClaim("velero", "testPVC").Result()
+				pvc.Spec.Resources.Requests = corev1api.ResourceList{
+					corev1api.ResourceStorage: resource.MustParse("3Gi"),
+				}
+				return pvc
+			}(),
+			restoreSize:  "2Gi",
+			expectedSize: "3Gi",
+		},
+		{
+			name: "PVC has no initial storage request",
+			pvcInitial: func() *corev1api.PersistentVolumeClaim {
+				pvc := builder.ForPersistentVolumeClaim("velero", "testPVC").Result()
+				pvc.Spec.Resources.Requests = corev1api.ResourceList{} // Empty request list
+				return pvc
+			}(),
+			restoreSize:  "2Gi",
+			expectedSize: "2Gi",
+		},
+		{
+			name: "PVC has no initial Resources.Requests map",
+			pvcInitial: func() *corev1api.PersistentVolumeClaim {
+				pvc := builder.ForPersistentVolumeClaim("velero", "testPVC").Result()
+				pvc.Spec.Resources.Requests = nil // This will trigger the line to be covered
+				return pvc
+			}(),
+			restoreSize:  "2Gi",
+			expectedSize: "2Gi",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a VolumeSnapshotContent with restore size
+			rsQty := resource.MustParse(tc.restoreSize)
+
+			vsc := &snapshotv1api.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testVSC",
+				},
+				Status: &snapshotv1api.VolumeSnapshotContentStatus{
+					RestoreSize: pointer.Int64(rsQty.Value()),
+				},
+			}
+
+			// Call the function under test
+			pvc := tc.pvcInitial
+			setPVCRequestSizeToVSRestoreSize(pvc, vsc, logger)
+
+			// Verify that the PVC storage request is updated as expected.
+			updatedSize := pvc.Spec.Resources.Requests[corev1api.ResourceStorage]
+			expected := resource.MustParse(tc.expectedSize)
+			// Corrected line below:
+			require.Equal(t, 0, expected.Cmp(updatedSize), "Expected size %s, but got %s", expected.String(), updatedSize.String())
+		})
+	}
 }

--- a/pkg/restore/actions/csi/pvc_action_test.go
+++ b/pkg/restore/actions/csi/pvc_action_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	snapshotv1api "github.com/kubernetes-csi/external-snapshotter/client/v7/apis/volumesnapshot/v1"
+	snapshotv1api "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -155,7 +155,7 @@ func TestResetPVCSpec(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			before := tc.pvc.DeepCopy()
-			resetPVCSpec(&tc.pvc, tc.vsName)
+			resetPVCSourceToVolumeSnapshot(&tc.pvc, tc.vsName)
 
 			assert.Equalf(t, tc.pvc.Name, before.Name, "unexpected change to Object.Name, Want: %s; Got %s", before.Name, tc.pvc.Name)
 			assert.Equalf(t, tc.pvc.Namespace, before.Namespace, "unexpected change to Object.Namespace, Want: %s; Got %s", before.Namespace, tc.pvc.Namespace)
@@ -167,101 +167,6 @@ func TestResetPVCSpec(t *testing.T) {
 			assert.NotNil(t, tc.pvc.Spec.DataSource, "expected change to Spec.DataSource missing")
 			assert.Equalf(t, "VolumeSnapshot", tc.pvc.Spec.DataSource.Kind, "expected change to Spec.DataSource.Kind missing, Want: VolumeSnapshot, Got: %s", tc.pvc.Spec.DataSource.Kind)
 			assert.Equalf(t, tc.pvc.Spec.DataSource.Name, tc.vsName, "expected change to Spec.DataSource.Name missing, Want: %s, Got: %s", tc.vsName, tc.pvc.Spec.DataSource.Name)
-		})
-	}
-}
-
-func TestResetPVCResourceRequest(t *testing.T) {
-	var storageReq50Mi, storageReq1Gi, cpuQty resource.Quantity
-
-	storageReq50Mi, err := resource.ParseQuantity("50Mi")
-	assert.NoError(t, err)
-	storageReq1Gi, err = resource.ParseQuantity("1Gi")
-	assert.NoError(t, err)
-	cpuQty, err = resource.ParseQuantity("100m")
-	assert.NoError(t, err)
-
-	testCases := []struct {
-		name                      string
-		pvc                       corev1api.PersistentVolumeClaim
-		restoreSize               resource.Quantity
-		expectedStorageRequestQty string
-	}{
-		{
-			name: "should set storage resource request from volumesnapshot, pvc has nil resource requests",
-			pvc: corev1api.PersistentVolumeClaim{
-				Spec: corev1api.PersistentVolumeClaimSpec{
-					Resources: corev1api.VolumeResourceRequirements{
-						Requests: nil,
-					},
-				},
-			},
-			restoreSize:               storageReq50Mi,
-			expectedStorageRequestQty: "50Mi",
-		},
-		{
-			name: "should set storage resource request from volumesnapshot, pvc has empty resource requests",
-			pvc: corev1api.PersistentVolumeClaim{
-				Spec: corev1api.PersistentVolumeClaimSpec{
-					Resources: corev1api.VolumeResourceRequirements{
-						Requests: corev1api.ResourceList{},
-					},
-				},
-			},
-			restoreSize:               storageReq50Mi,
-			expectedStorageRequestQty: "50Mi",
-		},
-		{
-			name: "should merge resource requests from volumesnapshot into pvc with no storage resource requests",
-			pvc: corev1api.PersistentVolumeClaim{
-				Spec: corev1api.PersistentVolumeClaimSpec{
-					Resources: corev1api.VolumeResourceRequirements{
-						Requests: corev1api.ResourceList{
-							corev1api.ResourceCPU: cpuQty,
-						},
-					},
-				},
-			},
-			restoreSize:               storageReq50Mi,
-			expectedStorageRequestQty: "50Mi",
-		},
-		{
-			name: "should set storage resource request from volumesnapshot, pvc requests less storage",
-			pvc: corev1api.PersistentVolumeClaim{
-				Spec: corev1api.PersistentVolumeClaimSpec{
-					Resources: corev1api.VolumeResourceRequirements{
-						Requests: corev1api.ResourceList{
-							corev1api.ResourceStorage: storageReq50Mi,
-						},
-					},
-				},
-			},
-			restoreSize:               storageReq1Gi,
-			expectedStorageRequestQty: "1Gi",
-		},
-		{
-			name: "should not set storage resource request from volumesnapshot, pvc requests more storage",
-			pvc: corev1api.PersistentVolumeClaim{
-				Spec: corev1api.PersistentVolumeClaimSpec{
-					Resources: corev1api.VolumeResourceRequirements{
-						Requests: corev1api.ResourceList{
-							corev1api.ResourceStorage: storageReq1Gi,
-						},
-					},
-				},
-			},
-			restoreSize:               storageReq50Mi,
-			expectedStorageRequestQty: "1Gi",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			log := logrus.New().WithField("unit-test", tc.name)
-			setPVCStorageResourceRequest(&tc.pvc, tc.restoreSize, log)
-			expected, err := resource.ParseQuantity(tc.expectedStorageRequestQty)
-			assert.NoError(t, err)
-			assert.Equal(t, expected, tc.pvc.Spec.Resources.Requests[corev1api.ResourceStorage])
 		})
 	}
 }
@@ -487,13 +392,6 @@ func TestExecute(t *testing.T) {
 			expectedErr: "fail to get backup for restore: backups.velero.io \"testBackup\" not found",
 		},
 		{
-			name:        "VolumeSnapshot cannot be found",
-			backup:      builder.ForBackup("velero", "testBackup").Result(),
-			restore:     builder.ForRestore("velero", "testRestore").ObjectMeta(builder.WithUID("restoreUID")).Backup("testBackup").Result(),
-			pvc:         builder.ForPersistentVolumeClaim("velero", "testPVC").ObjectMeta(builder.WithAnnotations(velerov1api.VolumeSnapshotLabel, "vsName")).Result(),
-			expectedErr: fmt.Sprintf("Failed to get Volumesnapshot velero/%s to restore PVC velero/testPVC: volumesnapshots.snapshot.storage.k8s.io \"%s\" not found", vsName, vsName),
-		},
-		{
 			name:    "Restore from VolumeSnapshot",
 			backup:  builder.ForBackup("velero", "testBackup").Result(),
 			restore: builder.ForRestore("velero", "testRestore").ObjectMeta(builder.WithUID("restoreUID")).Backup("testBackup").Result(),
@@ -641,8 +539,7 @@ func TestPVCAppliesTo(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(
-		t,
-		velero.ResourceSelector{
+		t,velero.ResourceSelector{
 			IncludedResources: []string{"persistentvolumeclaims"},
 		},
 		selector,

--- a/pkg/restore/actions/csi/volumesnapshot_action.go
+++ b/pkg/restore/actions/csi/volumesnapshot_action.go
@@ -121,7 +121,7 @@ func (p *volumeSnapshotRestoreItemAction) Execute(
 	}
 
 	p.log.Infof(`Returning from VolumeSnapshotRestoreItemAction with 
-		no additionalItems`)
+		VolumeSnapshotContent in additionalItems`)
 
 	return &velero.RestoreItemActionExecuteOutput{
 		UpdatedItem:     &unstructured.Unstructured{Object: vsMap},


### PR DESCRIPTION
This pull request introduces several improvements to the CSI plugin's backup and restore actions to resolve issue https://github.com/vmware-tanzu/velero/issues/8816.

Key changes include:

Moves the logic for patching the PVC's request size to the backup action. This is done to resolve a dependency on the VolumeSnapshot's existence during restore, as the snapshot may not have been restored yet when the PVC action runs.
Includes the associated VolumeSnapshot as an additional item during the CSI PVC backup action to ensure it is always included, even when not applying a label selector.
Corrects a log message in the VolumeSnapshot CSI action to properly indicate that the associated VolumeSnapshotContent is also included in the backup.
Fixes https://github.com/vmware-tanzu/velero/issues/8816

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
