### PR TITLE
Add ConfigMap support for keepLatestMaintenanceJobs

### DIFF
--- a/changelogs/unreleased/9135-shubham-pampattiwar
+++ b/changelogs/unreleased/9135-shubham-pampattiwar
@@ -1,0 +1,1 @@
+Add ConfigMap support for keepLatestMaintenanceJobs with CLI parameter fallback


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

Add `KeepLatestMaintenanceJobs` field to `JobConfigs` struct

ConfigMap Example

  ```json
  {
    "global": {"keepLatestMaintenanceJobs": 5},
    "namespace-bsl-type": {"keepLatestMaintenanceJobs": 10}
  }
```

# Does your change fix a particular issue?

Fixes (https://github.com/vmware-tanzu/velero/issues/9131)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
