### PR TITLE
Add priorityclasses to high priority restore list

### DIFF
--- a/changelogs/unreleased/9175-kaovilai
+++ b/changelogs/unreleased/9175-kaovilai
@@ -1,0 +1,1 @@
+Add priorityclasses to high priority restore list

--- a/pkg/cmd/server/config/config.go
+++ b/pkg/cmd/server/config/config.go
@@ -117,6 +117,7 @@ var (
 			"secrets",
 			"configmaps",
 			"limitranges",
+			"priorityclasses",
 			"pods",
 			// we fully qualify replicasets.apps because prior to Kubernetes 1.16, replicasets also
 			// existed in the extensions API group, but we back up replicasets from "apps" so we want


### PR DESCRIPTION
Ensure PriorityClasses are restored before pods that
reference them, preventing restoration failures when pods depend on
custom PriorityClasses.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #4201

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
