### PR TITLE
Change the CreateFileToPod function's OS parameter as the E2E pass-in value

### DIFF
--- a/test/e2e/pv-backup/pv-backup-filter.go
+++ b/test/e2e/pv-backup/pv-backup-filter.go
@@ -123,7 +123,7 @@ func (p *PVBackupFiltering) CreateResources() error {
 							p.volumesList[i][j],
 							FILE_NAME,
 							CreateFileContent(ns, pod, p.volumesList[i][j]),
-							WorkerOSLinux,
+							p.VeleroCfg.WorkerOS,
 						)).To(Succeed())
 					}
 				}


### PR DESCRIPTION

Thank you for contributing to Velero!

# Please add a summary of your change
The OS parameter was set to `linux`.
That blocked the Windows E2E.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
