### PR TITLE
clarify VolumeSnapshotClass error for mismatched driver/provisioner

### DIFF
--- a/pkg/util/csi/volume_snapshot.go
+++ b/pkg/util/csi/volume_snapshot.go
@@ -447,8 +447,13 @@ func GetVolumeSnapshotClassForStorageClass(
 		return &vsClass, nil
 	}
 	return nil, fmt.Errorf(
-		"failed to get VolumeSnapshotClass for provisioner %s, ensure that the desired VolumeSnapshot class has the %s label or %s annotation",
-		provisioner, velerov1api.VolumeSnapshotClassSelectorLabel, velerov1api.VolumeSnapshotClassKubernetesAnnotation)
+		"failed to get VolumeSnapshotClass for provisioner %s: "+
+			"ensure that the desired VolumeSnapshotClass has the %s label or %s annotation, "+
+			"and that its driver matches the StorageClass provisioner",
+		provisioner,
+		velerov1api.VolumeSnapshotClassSelectorLabel,
+		velerov1api.VolumeSnapshotClassKubernetesAnnotation,
+	)
 }
 
 // IsVolumeSnapshotClassHasListerSecret returns whether a volumesnapshotclass has a snapshotlister secret


### PR DESCRIPTION
# Please add a summary of your change

The error message returned when no suitable `VolumeSnapshotClass` is found has been updated to clarify that the class’s `driver` must also match the `StorageClass` provisioner.

This extra guidance helps users who are troubleshooting on platforms where the `StorageClass` provisioner name does **not** match the underlying CSI driver, and the driver name is instead hidden in the `csi.storage.k8s.io/csi-driver-name` parameter.  

For example, some cloud providers configure a `StorageClass` like:

```yaml
provisioner: everest-csi-provisioner
parameters:
  csi.storage.k8s.io/csi-driver-name: disk.csi.everest.io
```

…while the corresponding `VolumeSnapshotClass` uses:

```yaml
driver: disk.csi.everest.io
```

Without an explicit note about matching `driver` to `provisioner`, the mismatch can be confusing, leading to failed snapshot lookups. The revised message now points out this requirement up front, reducing trial‑and‑error for affected users.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
