### PR TITLE
Fix maintenance jobs toleration inheritance from Velero deployment

### DIFF
--- a/changelogs/unreleased/9256-shubham-pampattiwar
+++ b/changelogs/unreleased/9256-shubham-pampattiwar
@@ -1,0 +1,1 @@
+Fix repository maintenance jobs to inherit allowlisted tolerations from Velero deployment


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
This PR fixes repository maintenance jobs to inherit whitelisted tolerations from the Velero deployment, resolving an issue where maintenance jobs could not be scheduled on tainted nodes.

- Added `buildTolerationsForMaintenanceJob()` function that filters Velero deployment tolerations using the existing `ThirdPartyTolerations` whitelist
- Updated `buildJob()` to use the new toleration inheritance mechanism
- Maintains backward compatibility by always including the Windows toleration
- Follows the same security pattern as existing third-party labels and annotations
  
# Does your change fix a particular issue?

Fixes https://github.com/vmware-tanzu/velero/issues/9245

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
