### PR TITLE
Fix E2E tests: Build MinIO from Bitnami Dockerfile to replace deprecated image

### DIFF
--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -11,6 +11,8 @@ jobs:
   # Build the Velero CLI and image once for all Kubernetes versions, and cache it so the fan-out workers can get it.
   build:
     runs-on: ubuntu-latest
+    outputs:
+      minio-dockerfile-sha: ${{ steps.minio-version.outputs.dockerfile_sha }}
     steps:
       - name: Check out the code
         uses: actions/checkout@v5
@@ -44,6 +46,26 @@ jobs:
         run: |
           IMAGE=velero VERSION=pr-test BUILD_OUTPUT_TYPE=docker make container
           docker save velero:pr-test-linux-amd64 -o ./velero.tar
+      # Check and build MinIO image once for all e2e tests
+      - name: Check Bitnami MinIO Dockerfile version
+        id: minio-version
+        run: |
+          DOCKERFILE_SHA=$(curl -s https://api.github.com/repos/bitnami/containers/commits?path=bitnami/minio/2025/debian-12/Dockerfile\&per_page=1 | jq -r '.[0].sha')
+          echo "dockerfile_sha=${DOCKERFILE_SHA}" >> $GITHUB_OUTPUT
+      - name: Cache MinIO Image
+        uses: actions/cache@v4
+        id: minio-cache
+        with:
+          path: ./minio-image.tar
+          key: minio-bitnami-${{ steps.minio-version.outputs.dockerfile_sha }}
+      - name: Build MinIO Image from Bitnami Dockerfile
+        if: steps.minio-cache.outputs.cache-hit != 'true'
+        run: |
+          echo "Building MinIO image from Bitnami Dockerfile..."
+          git clone --depth 1 https://github.com/bitnami/containers.git /tmp/bitnami-containers
+          cd /tmp/bitnami-containers/bitnami/minio/2025/debian-12
+          docker build -t bitnami/minio:local .
+          docker save bitnami/minio:local > ${{ github.workspace }}/minio-image.tar
   # Create json of k8s versions to test
   # from guide: https://stackoverflow.com/a/65094398/4590470
   setup-test-matrix:
@@ -86,9 +108,20 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+      # Fetch the pre-built MinIO image from the build job
+      - name: Fetch built MinIO Image
+        uses: actions/cache@v4
+        id: minio-cache
+        with:
+          path: ./minio-image.tar
+          key: minio-bitnami-${{ needs.build.outputs.minio-dockerfile-sha }}
+      - name: Load MinIO Image
+        run: |
+          echo "Loading MinIO image..."
+          docker load < ./minio-image.tar
       - name: Install MinIO
-        run:
-          docker run -d --rm -p 9000:9000 -e "MINIO_ACCESS_KEY=minio" -e "MINIO_SECRET_KEY=minio123" -e "MINIO_DEFAULT_BUCKETS=bucket,additional-bucket" bitnami/minio:2021.6.17-debian-10-r7
+        run: |
+          docker run -d --rm -p 9000:9000 -e "MINIO_ROOT_USER=minio" -e "MINIO_ROOT_PASSWORD=minio123" -e "MINIO_DEFAULT_BUCKETS=bucket,additional-bucket" bitnami/minio:local
       - uses: engineerd/setup-kind@v0.6.2
         with:
           skipClusterLogsExport: true


### PR DESCRIPTION
## Summary
- Fixes E2E tests failing due to unavailable Bitnami MinIO image
- Implements centralized MinIO image building in the build job with efficient caching
- Optimizes workflow by building MinIO image once and reusing it across all test matrix jobs

## Problem
The e2e-test-kind.yaml workflow uses `bitnami/minio:2021.6.17-debian-10-r7` which is no longer available on Docker Hub, causing E2E tests to fail.

## Solution
Build the MinIO image once in the `build` job and share it across all E2E test runs:

### Architecture Changes
- **Centralized Build**: MinIO image is now built in the `build` job alongside Velero CLI and image
- **Single Version Check**: Bitnami Dockerfile SHA is fetched once and passed as job output
- **Efficient Caching**: MinIO image cached by Dockerfile commit SHA, shared across all matrix jobs
- **Simplified Test Jobs**: Each E2E test job only fetches and loads the pre-built image

### Implementation Details
- Fetches the latest commit hash of the Bitnami MinIO Dockerfile (2025/debian-12)
- Builds from Bitnami's public Dockerfile when cache miss occurs
- Caches the built image as `minio-image.tar` keyed by Dockerfile SHA
- Each test job retrieves the cached image using the SHA from build job outputs
- Maintains compatibility with existing environment variables

## Benefits
- **Performance**: MinIO image built only once instead of potentially multiple times
- **Efficiency**: Reduces GitHub API calls and CI resource usage
- **Reliability**: Consistent MinIO version across all test runs
- **Maintainability**: Cleaner separation between build and test phases

## Test Plan
- [x] Built and tested the Bitnami MinIO image locally
- [x] Verified it accepts the required environment variables
- [x] Confirmed automatic bucket creation works
- [ ] CI/CD tests should pass with the new centralized build approach

## Related
- Fixes #9279
- Bitnami licensing changes: https://github.com/bitnami/containers/issues/83267

> [!Note]
> Responses generated with Claude