### PR TITLE
Privileged fs backup pods

### DIFF
--- a/changelogs/unreleased/9295-sseago
+++ b/changelogs/unreleased/9295-sseago
@@ -1,0 +1,1 @@
+Add option for privileged fs-backup pod

--- a/pkg/controller/pod_volume_backup_controller.go
+++ b/pkg/controller/pod_volume_backup_controller.go
@@ -60,7 +60,7 @@ const (
 // NewPodVolumeBackupReconciler creates the PodVolumeBackupReconciler instance
 func NewPodVolumeBackupReconciler(client client.Client, mgr manager.Manager, kubeClient kubernetes.Interface, dataPathMgr *datapath.Manager,
 	counter *exposer.VgdpCounter, nodeName string, preparingTimeout time.Duration, resourceTimeout time.Duration, podResources corev1api.ResourceRequirements,
-	metrics *metrics.ServerMetrics, logger logrus.FieldLogger, dataMovePriorityClass string) *PodVolumeBackupReconciler {
+	metrics *metrics.ServerMetrics, logger logrus.FieldLogger, dataMovePriorityClass string, privileged bool) *PodVolumeBackupReconciler {
 	return &PodVolumeBackupReconciler{
 		client:                client,
 		mgr:                   mgr,
@@ -77,6 +77,7 @@ func NewPodVolumeBackupReconciler(client client.Client, mgr manager.Manager, kub
 		exposer:               exposer.NewPodVolumeExposer(kubeClient, logger),
 		cancelledPVB:          make(map[string]time.Time),
 		dataMovePriorityClass: dataMovePriorityClass,
+		privileged:            privileged,
 	}
 }
 
@@ -97,6 +98,7 @@ type PodVolumeBackupReconciler struct {
 	resourceTimeout       time.Duration
 	cancelledPVB          map[string]time.Time
 	dataMovePriorityClass string
+	privileged            bool
 }
 
 // +kubebuilder:rbac:groups=velero.io,resources=podvolumebackups,verbs=get;list;watch;create;update;patch;delete
@@ -837,6 +839,7 @@ func (r *PodVolumeBackupReconciler) setupExposeParam(pvb *velerov1api.PodVolumeB
 		Resources:             r.podResources,
 		// Priority class name for the data mover pod, retrieved from node-agent-configmap
 		PriorityClassName: r.dataMovePriorityClass,
+		Privileged:        r.privileged,
 	}
 }
 

--- a/pkg/controller/pod_volume_backup_controller_test.go
+++ b/pkg/controller/pod_volume_backup_controller_test.go
@@ -151,7 +151,8 @@ func initPVBReconcilerWithError(needError ...error) (*PodVolumeBackupReconciler,
 		corev1api.ResourceRequirements{},
 		metrics.NewServerMetrics(),
 		velerotest.NewLogger(),
-		"", // dataMovePriorityClass
+		"",    // dataMovePriorityClass
+		false, // privileged
 	), nil
 }
 

--- a/pkg/controller/pod_volume_restore_controller.go
+++ b/pkg/controller/pod_volume_restore_controller.go
@@ -56,7 +56,7 @@ import (
 
 func NewPodVolumeRestoreReconciler(client client.Client, mgr manager.Manager, kubeClient kubernetes.Interface, dataPathMgr *datapath.Manager,
 	counter *exposer.VgdpCounter, nodeName string, preparingTimeout time.Duration, resourceTimeout time.Duration, podResources corev1api.ResourceRequirements,
-	logger logrus.FieldLogger, dataMovePriorityClass string) *PodVolumeRestoreReconciler {
+	logger logrus.FieldLogger, dataMovePriorityClass string, privileged bool) *PodVolumeRestoreReconciler {
 	return &PodVolumeRestoreReconciler{
 		client:                client,
 		mgr:                   mgr,
@@ -72,6 +72,7 @@ func NewPodVolumeRestoreReconciler(client client.Client, mgr manager.Manager, ku
 		exposer:               exposer.NewPodVolumeExposer(kubeClient, logger),
 		cancelledPVR:          make(map[string]time.Time),
 		dataMovePriorityClass: dataMovePriorityClass,
+		privileged:            privileged,
 	}
 }
 
@@ -90,6 +91,7 @@ type PodVolumeRestoreReconciler struct {
 	resourceTimeout       time.Duration
 	cancelledPVR          map[string]time.Time
 	dataMovePriorityClass string
+	privileged            bool
 }
 
 // +kubebuilder:rbac:groups=velero.io,resources=podvolumerestores,verbs=get;list;watch;create;update;patch;delete
@@ -896,6 +898,7 @@ func (r *PodVolumeRestoreReconciler) setupExposeParam(pvr *velerov1api.PodVolume
 		Resources:             r.podResources,
 		// Priority class name for the data mover pod, retrieved from node-agent-configmap
 		PriorityClassName: r.dataMovePriorityClass,
+		Privileged:        r.privileged,
 	}
 }
 

--- a/pkg/controller/pod_volume_restore_controller_test.go
+++ b/pkg/controller/pod_volume_restore_controller_test.go
@@ -617,7 +617,7 @@ func initPodVolumeRestoreReconcilerWithError(objects []runtime.Object, cliObj []
 
 	dataPathMgr := datapath.NewManager(1)
 
-	return NewPodVolumeRestoreReconciler(fakeClient, nil, fakeKubeClient, dataPathMgr, nil, "test-node", time.Minute*5, time.Minute, corev1api.ResourceRequirements{}, velerotest.NewLogger(), ""), nil
+	return NewPodVolumeRestoreReconciler(fakeClient, nil, fakeKubeClient, dataPathMgr, nil, "test-node", time.Minute*5, time.Minute, corev1api.ResourceRequirements{}, velerotest.NewLogger(), "", false), nil
 }
 
 func TestPodVolumeRestoreReconcile(t *testing.T) {

--- a/pkg/exposer/pod_volume.go
+++ b/pkg/exposer/pod_volume.go
@@ -73,6 +73,9 @@ type PodVolumeExposeParam struct {
 
 	// PriorityClassName is the priority class name for the data mover pod
 	PriorityClassName string
+
+	// Privileged indicates whether to create the pod with a privileged container
+	Privileged bool
 }
 
 // PodVolumeExposer is the interfaces for a pod volume exposer
@@ -153,7 +156,7 @@ func (e *podVolumeExposer) Expose(ctx context.Context, ownerObject corev1api.Obj
 
 	curLog.WithField("path", path).Infof("Host path is retrieved for pod %s, volume %s", param.ClientPodName, param.ClientPodVolume)
 
-	hostingPod, err := e.createHostingPod(ctx, ownerObject, param.Type, path.ByPath, param.OperationTimeout, param.HostingPodLabels, param.HostingPodAnnotations, param.HostingPodTolerations, pod.Spec.NodeName, param.Resources, nodeOS, param.PriorityClassName)
+	hostingPod, err := e.createHostingPod(ctx, ownerObject, param.Type, path.ByPath, param.OperationTimeout, param.HostingPodLabels, param.HostingPodAnnotations, param.HostingPodTolerations, pod.Spec.NodeName, param.Resources, nodeOS, param.PriorityClassName, param.Privileged)
 	if err != nil {
 		return errors.Wrapf(err, "error to create hosting pod")
 	}
@@ -269,7 +272,7 @@ func (e *podVolumeExposer) CleanUp(ctx context.Context, ownerObject corev1api.Ob
 }
 
 func (e *podVolumeExposer) createHostingPod(ctx context.Context, ownerObject corev1api.ObjectReference, exposeType string, hostPath string,
-	operationTimeout time.Duration, label map[string]string, annotation map[string]string, toleration []corev1api.Toleration, selectedNode string, resources corev1api.ResourceRequirements, nodeOS string, priorityClassName string) (*corev1api.Pod, error) {
+	operationTimeout time.Duration, label map[string]string, annotation map[string]string, toleration []corev1api.Toleration, selectedNode string, resources corev1api.ResourceRequirements, nodeOS string, priorityClassName string, privileged bool) (*corev1api.Pod, error) {
 	hostingPodName := ownerObject.Name
 
 	containerName := string(ownerObject.UID)
@@ -327,6 +330,7 @@ func (e *podVolumeExposer) createHostingPod(ctx context.Context, ownerObject cor
 	args = append(args, podInfo.logLevelArgs...)
 
 	var securityCtx *corev1api.PodSecurityContext
+	var containerSecurityCtx *corev1api.SecurityContext
 	nodeSelector := map[string]string{}
 	podOS := corev1api.PodOS{}
 	if nodeOS == kube.NodeOSWindows {
@@ -358,6 +362,9 @@ func (e *podVolumeExposer) createHostingPod(ctx context.Context, ownerObject cor
 		userID := int64(0)
 		securityCtx = &corev1api.PodSecurityContext{
 			RunAsUser: &userID,
+		}
+		containerSecurityCtx = &corev1api.SecurityContext{
+			Privileged: &privileged,
 		}
 
 		nodeSelector[kube.NodeOSLabel] = kube.NodeOSLinux
@@ -394,6 +401,7 @@ func (e *podVolumeExposer) createHostingPod(ctx context.Context, ownerObject cor
 					Env:             podInfo.env,
 					EnvFrom:         podInfo.envFrom,
 					Resources:       resources,
+					SecurityContext: containerSecurityCtx,
 				},
 			},
 			PriorityClassName:             priorityClassName,

--- a/pkg/exposer/pod_volume_test.go
+++ b/pkg/exposer/pod_volume_test.go
@@ -190,6 +190,29 @@ func TestPodVolumeExpose(t *testing.T) {
 				return "/var/lib/kubelet/pods/pod-id-xxx/volumes/kubernetes.io~csi/pvc-id-xxx/mount", nil
 			},
 		},
+		{
+			name:        "succeed with privileged pod",
+			ownerBackup: backup,
+			exposeParam: PodVolumeExposeParam{
+				ClientNamespace: "fake-ns",
+				ClientPodName:   "fake-client-pod",
+				ClientPodVolume: "fake-client-volume",
+				Privileged:      true,
+			},
+			kubeClientObj: []runtime.Object{
+				podWithNode,
+				node,
+				daemonSet,
+			},
+			funcGetPodVolumeHostPath: func(context.Context, *corev1api.Pod, string, kubernetes.Interface, filesystem.Interface, logrus.FieldLogger) (datapath.AccessPoint, error) {
+				return datapath.AccessPoint{
+					ByPath: "/host_pods/pod-id-xxx/volumes/kubernetes.io~csi/pvc-id-xxx/mount",
+				}, nil
+			},
+			funcExtractPodVolumeHostPath: func(context.Context, string, kubernetes.Interface, string, string) (string, error) {
+				return "/var/lib/kubelet/pods/pod-id-xxx/volumes/kubernetes.io~csi/pvc-id-xxx/mount", nil
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/types/node_agent.go
+++ b/pkg/types/node_agent.go
@@ -84,4 +84,7 @@ type NodeAgentConfigs struct {
 
 	// PriorityClassName is the priority class name for data mover pods created by the node agent
 	PriorityClassName string `json:"priorityClassName,omitempty"`
+
+	// PrivilegedFsBackup determines whether to create fs-backup pods as privileged pods
+	PrivilegedFsBackup bool `json:"privilegedFsBackup,omitempty"`
 }

--- a/site/content/docs/main/customize-installation.md
+++ b/site/content/docs/main/customize-installation.md
@@ -23,6 +23,8 @@ By default, `velero install` does not install Velero's [File System Backup][3]. 
 
 If you've already run `velero install` without the `--use-node-agent` flag, you can run the same command again, including the `--use-node-agent` flag, to add the file system backup to your existing install.
 
+Note that for some use cases (including installation on OpenShift clusters) the fs-backup pods must run in a Privileged security context. This is configured through the node-agent configmap (see below) by setting `privilegedFsBackup` to `true` in the configmap.
+
 ## CSI Snapshot Data Movement
 
 Velero node-agent is required by [CSI Snapshot Data Movement][12] when Velero built-in data mover is used. By default, `velero install` does not install Velero's node-agent. To enable it, specify the `--use-node-agent` flag.


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Adds install/node-agent server arg: `--privileged-fs-backup` to enable fs-backup on OpenShift (and other k8s environments that need it)
# Does your change fix a particular issue?

Fixes #9294 

# Please indicate you've done the following:

- [ x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ x] Updated the corresponding documentation in `site/content/docs/main`.
