### PR TITLE
[1.17] VerifyJSONConfigs verify every elements in Data.

### DIFF
--- a/changelogs/unreleased/9303-blackpiglet
+++ b/changelogs/unreleased/9303-blackpiglet
@@ -1,0 +1,1 @@
+VerifyJSONConfigs verify every elements in Data.

--- a/pkg/cmd/cli/install/install.go
+++ b/pkg/cmd/cli/install/install.go
@@ -545,24 +545,22 @@ func (o *Options) Validate(c *cobra.Command, args []string, f client.Factory) er
 		return fmt.Errorf("fail to create go-client %w", err)
 	}
 
-	// If either Linux or Windows node-agent is installed, and the node-agent-configmap
-	// is specified, need to validate the ConfigMap.
-	if (o.UseNodeAgent || o.UseNodeAgentWindows) && len(o.NodeAgentConfigMap) > 0 {
+	if len(o.NodeAgentConfigMap) > 0 {
 		if err := kubeutil.VerifyJSONConfigs(c.Context(), o.Namespace, crClient, o.NodeAgentConfigMap, &velerotypes.NodeAgentConfigs{}); err != nil {
-			return fmt.Errorf("--node-agent-configmap specified ConfigMap %s is invalid", o.NodeAgentConfigMap)
+			return fmt.Errorf("--node-agent-configmap specified ConfigMap %s is invalid: %w", o.NodeAgentConfigMap, err)
 		}
 	}
 
 	if len(o.RepoMaintenanceJobConfigMap) > 0 {
 		if err := kubeutil.VerifyJSONConfigs(c.Context(), o.Namespace, crClient, o.RepoMaintenanceJobConfigMap, &velerotypes.JobConfigs{}); err != nil {
-			return fmt.Errorf("--repo-maintenance-job-configmap specified ConfigMap %s is invalid", o.RepoMaintenanceJobConfigMap)
+			return fmt.Errorf("--repo-maintenance-job-configmap specified ConfigMap %s is invalid: %w", o.RepoMaintenanceJobConfigMap, err)
 		}
 	}
 
 	if len(o.BackupRepoConfigMap) > 0 {
 		config := make(map[string]any)
 		if err := kubeutil.VerifyJSONConfigs(c.Context(), o.Namespace, crClient, o.BackupRepoConfigMap, &config); err != nil {
-			return fmt.Errorf("--backup-repository-configmap specified ConfigMap %s is invalid", o.BackupRepoConfigMap)
+			return fmt.Errorf("--backup-repository-configmap specified ConfigMap %s is invalid: %w", o.BackupRepoConfigMap, err)
 		}
 	}
 

--- a/pkg/util/kube/utils.go
+++ b/pkg/util/kube/utils.go
@@ -371,15 +371,16 @@ func VerifyJSONConfigs(ctx context.Context, namespace string, crClient client.Cl
 		return errors.Errorf("data is not available in ConfigMap %s", configName)
 	}
 
+	// Verify all the keys in ConfigMap's data.
 	jsonString := ""
 	for _, v := range cm.Data {
 		jsonString = v
-	}
 
-	configs := configType
-	err = json.Unmarshal([]byte(jsonString), configs)
-	if err != nil {
-		return errors.Wrapf(err, "error to unmarshall data from ConfigMap %s", configName)
+		configs := configType
+		err = json.Unmarshal([]byte(jsonString), configs)
+		if err != nil {
+			return errors.Wrapf(err, "error to unmarshall data from ConfigMap %s", configName)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Add error message in the velero install CLI output if VerifyJSONConfigs fail.

Remove the node-agent-configmap verification logic from #9302 to make sure there will be no breaking change in the released branches.

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #9238 on release-1.17

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
