### PR TITLE
[1.17] issue 9332: make bytesDone correct for incremental backup

### DIFF
--- a/changelogs/unreleased/9341-Lyndon-Li
+++ b/changelogs/unreleased/9341-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix issue #9332, add bytesDone for cache files

--- a/pkg/uploader/kopia/progress.go
+++ b/pkg/uploader/kopia/progress.go
@@ -121,6 +121,7 @@ func (p *Progress) UploadStarted() {}
 // CachedFile statistic the total bytes been cached currently
 func (p *Progress) CachedFile(fname string, numBytes int64) {
 	atomic.AddInt64(&p.cachedBytes, numBytes)
+	atomic.AddInt64(&p.processedBytes, numBytes)
 	p.UpdateProgress()
 }
 


### PR DESCRIPTION
Fix issue https://github.com/vmware-tanzu/velero/issues/9332, add bytesDone for cache files
