### PR TITLE
Fix: Enable throttling parameters in BackupRepository repositoryConfig

### DIFF
--- a/changelogs/unreleased/9351-kvaps
+++ b/changelogs/unreleased/9351-kvaps
@@ -1,0 +1,1 @@
+Fix: Enable throttling parameters in BackupRepository repositoryConfig

--- a/pkg/repository/provider/unified_repo.go
+++ b/pkg/repository/provider/unified_repo.go
@@ -586,6 +586,11 @@ func getStorageVariables(backupLocation *velerov1api.BackupStorageLocation, repo
 		validParams := []string{
 			udmrepo.StoreOptionCacheLimit,
 			udmrepo.StoreOptionKeyFullMaintenanceInterval,
+			udmrepo.ThrottleOptionReadOps,
+			udmrepo.ThrottleOptionWriteOps,
+			udmrepo.ThrottleOptionListOps,
+			udmrepo.ThrottleOptionUploadBytes,
+			udmrepo.ThrottleOptionDownloadBytes,
 		}
 		for _, param := range validParams {
 			if v, found := backupRepoConfig[param]; found {

--- a/pkg/repository/provider/unified_repo_test.go
+++ b/pkg/repository/provider/unified_repo_test.go
@@ -460,6 +460,37 @@ func TestGetStorageVariables(t *testing.T) {
 				"cacheLimitMB": "1000",
 			},
 		},
+		{
+			name: "fs with throttle config",
+			backupLocation: velerov1api.BackupStorageLocation{
+				Spec: velerov1api.BackupStorageLocationSpec{
+					Provider: "velero.io/fs",
+					Config: map[string]string{
+						"fspath": "fake-path",
+						"prefix": "fake-prefix",
+					},
+				},
+			},
+			repoBackend: "fake-repo-type",
+			repoConfig: map[string]string{
+				udmrepo.ThrottleOptionUploadBytes:   "838860800",
+				udmrepo.ThrottleOptionDownloadBytes: "838860800",
+				udmrepo.ThrottleOptionReadOps:       "100",
+				udmrepo.ThrottleOptionWriteOps:      "100",
+				udmrepo.ThrottleOptionListOps:       "50",
+			},
+			expected: map[string]string{
+				"fspath":                "fake-path",
+				"bucket":                "",
+				"prefix":                "fake-prefix/fake-repo-type/",
+				"region":                "",
+				"ThrottleUploadBytes":   "838860800",
+				"ThrottleDownloadBytes": "838860800",
+				"ThrottleReadOPS":       "100",
+				"ThrottleWriteOPS":      "100",
+				"ThrottleListOPS":       "50",
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/repository/udmrepo/repo_options.go
+++ b/pkg/repository/udmrepo/repo_options.go
@@ -66,11 +66,11 @@ const (
 
 	StoreOptionCacheLimit = "cacheLimitMB"
 
-	ThrottleOptionReadOps       = "readOPS"
-	ThrottleOptionWriteOps      = "writeOPS"
-	ThrottleOptionListOps       = "listOPS"
-	ThrottleOptionUploadBytes   = "uploadBytes"
-	ThrottleOptionDownloadBytes = "downloadBytes"
+	ThrottleOptionReadOps       = "ThrottleReadOPS"
+	ThrottleOptionWriteOps      = "ThrottleWriteOPS"
+	ThrottleOptionListOps       = "ThrottleListOPS"
+	ThrottleOptionUploadBytes   = "ThrottleUploadBytes"
+	ThrottleOptionDownloadBytes = "ThrottleDownloadBytes"
 	// FullMaintenanceInterval will overwrite kopia maintenance interval
 	// options are fastGC for 12 hours, eagerGC for 6 hours, normalGC for 24 hours
 	StoreOptionKeyFullMaintenanceInterval                                = "fullMaintenanceInterval"

--- a/site/content/docs/main/backup-repository-configuration.md
+++ b/site/content/docs/main/backup-repository-configuration.md
@@ -31,7 +31,9 @@ data:
   <kopia>: |
     {
       "cacheLimitMB": 2048,
-      "fullMaintenanceInterval": "fastGC"
+      "fullMaintenanceInterval": "fastGC",
+      "ThrottleUploadBytes": "838860800",
+      "ThrottleDownloadBytes": "838860800"
     }
   <other-repository-type>: |
     {
@@ -58,6 +60,16 @@ Below is the supported configurations by Velero and the specific backup reposito
 Per kopia [Maintenance Safety](https://kopia.io/docs/advanced/maintenance/#maintenance-safety), it is expected that velero backup deletion will not result in immediate kopia repository data removal. Reducing full maintenance interval using above options should help reduce time taken to remove blobs not in use.
 
 On the other hand, the not-in-use data will be deleted permanently after the full maintenance, so shorter full maintenance intervals may weaken the data safety if they are used incorrectly.
+
+`ThrottleUploadBytes`: specifies the maximum upload speed in bytes per second for the repository. This can be used to throttle the upload bandwidth. The value should be specified as a string representing bytes per second (e.g., "838860800" for ~800 MB/s). This parameter applies during repository operations that write data.
+
+`ThrottleDownloadBytes`: specifies the maximum download speed in bytes per second for the repository. This can be used to throttle the download bandwidth. The value should be specified as a string representing bytes per second (e.g., "838860800" for ~800 MB/s). This parameter applies during repository operations that read data.
+
+`ThrottleReadOPS`: specifies the maximum number of read operations per second. This can be used to throttle the rate of read operations to the storage backend.
+
+`ThrottleWriteOPS`: specifies the maximum number of write operations per second. This can be used to throttle the rate of write operations to the storage backend.
+
+`ThrottleListOPS`: specifies the maximum number of list operations per second. This can be used to throttle the rate of list operations to the storage backend.
 
 [1]: file-system-backup.md
 [2]: csi-snapshot-data-movement.md


### PR DESCRIPTION
The throttling parameters specified in BackupRepository's `repositoryConfig` were being silently filtered out and not applied to Kopia repositories. This occurred because these parameters were missing from the whitelist in `getStorageVariables()`.

**Code:**
- Added throttling options to the valid parameters whitelist in `pkg/repository/provider/unified_repo.go`:
  - `ThrottleUploadBytes` - upload bandwidth throttling (bytes/sec)
  - `ThrottleDownloadBytes` - download bandwidth throttling (bytes/sec)
  - `ThrottleReadOPS` - read operations throttling (ops/sec)
  - `ThrottleWriteOPS` - write operations throttling (ops/sec)
  - `ThrottleListOPS` - list operations throttling (ops/sec)

- Updated parameter names in `pkg/repository/udmrepo/repo_options.go` to use "Throttle" prefix for better clarity:
  - `readOPS` → `ThrottleReadOPS`
  - `writeOPS` → `ThrottleWriteOPS`
  - `listOPS` → `ThrottleListOPS`
  - `uploadBytes` → `ThrottleUploadBytes`
  - `downloadBytes` → `ThrottleDownloadBytes`

**Documentation:**
- Updated `site/content/docs/main/backup-repository-configuration.md` with throttling parameters descriptions and examples using the new parameter names

**Tests:**
- Added test case in `pkg/repository/provider/unified_repo_test.go` to verify throttling parameters are properly passed through
- Updated test expectations to use the new parameter names

**Example Usage:**
```yaml
apiVersion: velero.io/v1
kind: BackupRepository
spec:
  repositoryConfig:
    ThrottleUploadBytes: "838860800"    # ~800 MB/s
    ThrottleDownloadBytes: "838860800"  # ~800 MB/s
    ThrottleReadOPS: "100"
    ThrottleWriteOPS: "100"
    ThrottleListOPS: "50"
```

These parameters are now properly applied to Kopia during file system backups performed by node-agent.

Signed-off-by: Andrei Kvapil <kvapss@gmail.com>
