### PR TITLE
chore: add podman support to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ ifneq (, $(shell which docker 2>/dev/null))
   DOCKER := docker
 else ifneq (, $(shell which podman 2>/dev/null))
   DOCKER := podman
+  # map host uid to container uid
+  export PODMAN_USERNS=keep-id
 else
   $(error Neither docker nor podman found)
 endif
@@ -214,6 +216,7 @@ shell: build-dirs build-env
 		-e GOPROXY \
 		-i $(TTY) \
 		--rm \
+		-u $$(id -u):$$(id -g) \
 		-v "$$(pwd):/github.com/vmware-tanzu/velero:delegated" \
 		-v "$$(pwd)/_output/bin:/output:delegated" \
 		-v "$$(pwd)/.go/pkg:/go/pkg:delegated" \


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
This PR adds support for using the "podman" CLI executable instead of docker
I did 2 things:
- replaced the `docker` CLI invocations with the `$(DOCKER)` variable, defined at the top of the file
~~- removed the `-u $$(id -u):$$(id -g)` of your docker run shell creation. I'm not sure if it was useful before, but my tests work fine without it.~~

I tested my changes on Linux, with both `podman` and `docker`, on targets `local`, `test` and `update`

# Does your change fix a particular issue?
No

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
