### PR TITLE
 Enhanced Plugin Management — Design Proposal

### DIFF
--- a/design/plugin-management-improvements.md
+++ b/design/plugin-management-improvements.md
@@ -1,0 +1,184 @@
+# Enhanced Plugin Management Design
+
+## Glossary & Abbreviation
+
+**Plugin**: A Velero plugin is a binary that implements one or more of Velero's plugin interfaces (e.g., ObjectStore, VolumeSnapshotter, BackupItemAction).
+
+**Built-in Plugin**: A plugin registered by the Velero server binary itself at startup, as opposed to a plugin provided by an external init container.
+
+**Init Container**: A Kubernetes init container added to the Velero deployment to install an external plugin binary before the server starts.
+
+**ServerStatusRequest (SSR)**: A Velero CRD used to query live metadata about the running Velero server, including its version and the list of registered plugins. See [ServerStatusRequest types][1].
+
+**PluginInfo**: The struct within `ServerStatusRequestStatus` that describes a single registered plugin (name and kind).
+
+## Background
+
+Velero supports a plugin system where external plugins are installed by adding init containers to the Velero deployment.
+Some plugins are built into the server binary itself (e.g., all `velero.io/*` BackupItemActions and RestoreItemActions).
+`velero plugin get` shows all registered plugins regardless of origin, but currently gives users no way to distinguish built-in plugins from external ones.
+
+This leads to two concrete problems.
+First, users cannot tell which plugins can be safely removed:
+
+```console
+$ velero plugin get
+NAME                              KIND
+velero.io/pod                     BackupItemAction
+velero.io/pv                      BackupItemAction
+velero.io/service-account         BackupItemAction
+velero.io/aws                     ObjectStore
+velero.io/aws                     VolumeSnapshotter
+...
+```
+
+Second, `velero plugin remove` requires the exact init container name or image string, not the plugin name visible in `velero plugin get`.
+Attempting to use the friendly name fails with a confusing error:
+
+```console
+$ velero plugin remove velero.io/aws
+An error occurred: init container velero.io/aws not found in Velero server deployment
+```
+
+Users expect `velero plugin remove velero.io/aws` to work, and they expect a clear error when trying to remove a plugin that cannot be removed (see [issue 3210][3]).
+
+## Goals
+
+- Expose whether each plugin is built-in via the `ServerStatusRequest` API.
+- Display built-in status in `velero plugin get` CLI output.
+- Allow `velero plugin remove <plugin-name>` to resolve a plugin name to its backing init container.
+- Refuse removal of built-in plugins with a descriptive error message.
+- Preserve backwards compatibility for `velero plugin remove <image|container-name>`.
+
+## Non-Goals
+
+- Changing how plugins are discovered or registered at runtime.
+- Adding a plugin package or registry system.
+- Redesigning how external plugins are distributed or packaged.
+- Supporting removal of multiple plugins in a single command invocation.
+
+## Solution
+
+### Built-in Plugin Detection
+
+The Velero plugin framework already tracks which binary registered each plugin via `PluginIdentifier.Command`.
+At `ServerStatusRequest` processing time, the server compares each plugin's `Command` to `os.Args[0]`.
+If they match, the plugin was registered by the server binary and is marked built-in.
+External plugins are always registered by init container binaries, which have distinct binary paths from the server binary.
+
+### Plugin Removal by Name
+
+Plugin names shown in `velero plugin get` contain a `/` (e.g., `velero.io/aws`).
+Init container names and images may also contain `/` (e.g., `docker.io/myrepo/plugin:v1`), so the presence of `/` alone does not identify an argument as a plugin name.
+The removal command therefore always attempts an exact match on container name or image first.
+Only when no exact match is found and the argument contains `/` does the command perform a server status lookup and name-to-container resolution using heuristics.
+
+The resolution falls back gracefully: if the server is unavailable or does not respond, the command skips the built-in check and proceeds directly to container matching.
+This preserves compatibility with environments where the server is temporarily unreachable.
+
+### CLI Output
+
+A `BuiltIn` column is added to `velero plugin get` to give operators an at-a-glance view of which plugins are mandatory and which can be removed.
+The column displays `true` for built-in plugins and is empty for external plugins, avoiding visual noise for the common case.
+
+## Detailed Design
+
+### API Changes
+
+Two optional fields are added to `PluginInfo` in `pkg/apis/velero/v1/server_status_request_types.go`.
+Both are `omitempty` to preserve API compatibility with older clients and servers:
+
+```go
+type PluginInfo struct {
+    Name string `json:"name"`
+    Kind string `json:"kind"`
+
+    // Command is the command/binary that registered the plugin on the server.
+    // For built-in Velero plugins this will be the Velero server binary.
+    // This field is for informational/diagnostic purposes.
+    // +optional
+    Command string `json:"command,omitempty"`
+
+    // BuiltIn indicates whether the plugin is provided by the Velero server
+    // binary and cannot be removed by changing init containers.
+    // +optional
+    BuiltIn bool `json:"builtIn,omitempty"`
+}
+```
+
+### Server-Side Detection
+
+`GetInstalledPluginInfo` in `internal/velero/serverstatusrequest.go` is updated to populate the new fields.
+For each registered plugin, `Command` is set to the binary path that registered it, and `BuiltIn` is set to `true` when that path matches `os.Args[0]` (the running server binary).
+
+### CLI Output Changes
+
+The plugin table printer in `pkg/cmd/util/output/plugin_printer.go` adds a `BuiltIn` column.
+The value is rendered as a boolean; because `BuiltIn` uses `omitempty` in JSON, external plugins will show an empty cell rather than `false`, keeping the output readable:
+
+```console
+NAME                              KIND                  BUILTIN
+velero.io/pod                     BackupItemAction      true
+velero.io/pv                      BackupItemAction      true
+velero.io/service-account         BackupItemAction      true
+velero.io/aws                     ObjectStore
+velero.io/aws                     VolumeSnapshotter
+```
+
+### Plugin Removal Workflow
+
+`velero plugin remove` ([remove.go][2]) accepts `NAME | IMAGE | PLUGIN-NAME`.
+The full resolution sequence is:
+
+**Step 1 — Exact match (always runs first):**
+Scan the Velero deployment's init containers for a container whose `name` or `image` exactly equals the argument.
+If found, remove it immediately using the existing patch behavior.
+
+**Step 2 — Name resolution (only when no exact match and argument contains `/`):**
+
+1. Query the server via `ServerStatusRequest`.
+   - If the request fails or times out, skip the built-in check and proceed to step 2b.
+   - If the named plugin is found and `BuiltIn == true`, refuse with:
+     `"plugin <name> is built-in and cannot be removed"`
+   - If the named plugin is not found in the server status, proceed to step 2b.
+
+2. Apply heuristics to find an init container for the plugin:
+   - Sanitized name: replace `/`, `_`, `.` with `-` in the argument and compare to container name.
+   - Last-segment substring: extract the final path segment (e.g., `aws` from `velero.io/aws`) and check whether it appears as a substring in any container name or image.
+
+3. If zero candidates match, error with the list of current init containers and their images.
+4. If multiple candidates match, error requesting the user to specify the container name or image directly.
+5. If exactly one candidate matches, remove it using the existing patch behavior.
+
+The heuristic substring match on the last path segment can produce false positives when multiple init containers share a common word.
+Users can always fall back to the exact image or container name form to disambiguate.
+
+## Alternatives Considered
+
+### Built-in detection: explicit annotation vs. `os.Args[0]` comparison
+
+An alternative is to require plugin authors to annotate or register their plugins with an explicit `BuiltIn: true` field, rather than inferring it from the binary path.
+This was rejected because it requires changes to the plugin registration API and backward-incompatible updates to all plugin implementations.
+The `os.Args[0]` comparison requires no changes outside the server itself and is reliable in practice: init container binaries run from different paths than the server binary.
+
+### Name resolution: explicit mapping annotation vs. heuristic matching
+
+An alternative is to require operators to annotate each init container with the plugin names it provides (e.g., `velero.io/plugin-names: "velero.io/aws"`).
+This would give deterministic, zero-ambiguity resolution.
+It was deferred rather than rejected: it requires user-visible configuration changes and documentation updates, whereas heuristic matching covers the common case (one plugin per init container, image name mirrors plugin name) with no operator action.
+Explicit annotation support can be added later without breaking the heuristic path.
+
+## Compatibility
+
+- **API**: The new `Command` and `BuiltIn` fields on `PluginInfo` are optional with `omitempty`. Older clients that do not know about these fields will receive them silently and can ignore them. A new client talking to an old server will receive neither field and should treat absent `BuiltIn` as `false`.
+- **CLI**: `velero plugin remove <image|container-name>` continues to function exactly as before. The new resolution path is only reached when no exact match is found and the argument contains `/`.
+
+## Security Considerations
+
+- The `Command` field exposes the binary path used to register each plugin (e.g., `/usr/local/bin/velero`). This is path metadata already visible to anyone with access to the Velero pod, and adds no new attack surface.
+- The `ServerStatusRequest` is a read-only status resource. Adding informational fields does not introduce elevated privileges.
+- The built-in guard prevents accidental removal of mandatory plugins. Removal still requires permissions to patch the Velero `Deployment`, which is an existing cluster-admin-level requirement.
+
+[1]: pkg/apis/velero/v1/server_status_request_types.go
+[2]: pkg/cmd/cli/plugin/remove.go
+[3]: https://github.com/vmware-tanzu/velero/issues/3210


### PR DESCRIPTION
Status: Draft  
Author: Jake Abendroth (abendrothj)  
Related issue: https://github.com/vmware-tanzu/velero/issues/3210  
Related implementation PR: https://github.com/vmware-tanzu/velero/pull/9352  
Target release: v1.19 (note: v1.18 feature freeze is near)

## Summary
This proposal improves Velero's CLI/plugin UX by clearly indicating which plugins are built into the Velero server binary and by allowing `velero plugin remove <plugin-name>` semantics that map user-facing plugin names (e.g., velero.io/aws) to init-container images/names. The changes are intentionally limited to CLI/API metadata and removal UX; they do not change plugin discovery or plugin runtime registration.

The implementation work is in vmware-tanzu/velero#9352 and this design PR is intended to let maintainers review the design independent of the implementation.

## Motivation

- Users see plugins via `velero plugin get` but cannot tell which plugins are built-in (and therefore cannot be removed).
- `velero plugin remove` currently requires the init container name or image string; users expect to use plugin names shown in `velero plugin get` instead.
- Provide clearer diagnostics and safer removal workflows.

## Goals

- Add plugin metadata indicating built-in status and registering command for diagnostics.
- Display built-in status in CLI output.
- Allow `velero plugin remove <plugin-name>` that resolves to an init container image/name and refuses removal of built-in plugins.
- Preserve existing `velero plugin remove <image|container>` behavior for backwards compatibility.

## Non-Goals

- Changing plugin registration/discovery mechanisms.
- Adding package/registry systems for plugins.
- Major runtime or packaging redesign.

## Proposed API changes

Modify the ServerStatusRequest API plugin information to carry additional optional fields:

File: pkg/apis/velero/v1/server_status_request_types.go
- Add fields to PluginInfo:

```go
type PluginInfo struct {
  Name    string `json:"name"`
  Kind    string `json:"kind"`
  // Command is the command/binary that registered the plugin on the server.
  // +optional
  Command string `json:"command,omitempty"`
  // BuiltIn indicates whether the plugin is provided by the Velero server
  // binary (i.e. a system plugin that cannot be removed by changing init containers).
  // +optional
  BuiltIn bool `json:"builtIn,omitempty"`
}
```

These fields are optional to preserve API compatibility with older clients.

## Server-side behavior

File: internal/velero/serverstatusrequest.go
- GetInstalledPluginInfo should set PluginInfo.Command (the registering process/binary) and PluginInfo.BuiltIn.
- Heuristic for BuiltIn: plugin.Command == os.Args[0] OR another reliable indicator that the plugin was registered by the Velero server binary.

## CLI output

File: pkg/cmd/util/output/plugin_printer.go
- Add a "BuiltIn" column to the plugin table output. This gives operators a clear, at-a-glance indicator of mandatory built-in plugins vs external ones.

## Plugin removal command

File: pkg/cmd/cli/plugin/remove.go
- Accept plugin names (e.g., velero.io/aws) as input in addition to existing image/container names.
- Workflow:
  1. Query server status (ServerStatusRequest) to check whether specified plugin name exists and whether it has BuiltIn==true. If built-in — refuse removal with a clear error message.
  2. If not built-in, resolve the plugin name to an init container via heuristics:
     - Exact init container name match.
     - Exact init container image match.
     - Sanitized plugin name match (e.g., convert `velero.io/aws` -> `aws`) to container name or image substring.
     - Substring match on init container image or name.
  3. If zero matches, error with a message listing the available init containers and their images.
  4. If multiple matches, error asking for disambiguation (or accept a `--image`/`--container` flag).
  5. If a single match, remove that init container as existing behavior does (patch the Velero Deployment).

- Maintain backwards compatibility: `velero plugin remove <image|container>` remains valid.

## Compatibility

- API backward compatible: new PluginInfo fields are optional.
- CLI backward compatible: existing usage of `velero plugin remove <image|container>` continues to work.
- No changes required to existing Velero deployments.

## Security considerations

- Built-in protection prevents accidental removal of mandatory plugins that ship with the Velero server binary.
- The ServerStatusRequest remains a read-only status resource; no elevated privileges are introduced by these read-only fields.
- Removal still requires permissions to patch the Velero Deployment (existing requirement).

## Tests

- Unit tests: server-side population of PluginInfo fields; printer output; remove command heuristics and error cases.
- Integration tests: `velero plugin get` shows BuiltIn flags; `velero plugin remove <plugin-name>` resolves correctly and patches Deployment; refusing removal for BuiltIn plugins.

## Implementation references

- Implementation PR: https://github.com/vmware-tanzu/velero/pull/9352
- Related issue: https://github.com/vmware-tanzu/velero/issues/3210
- Files touched (main-branch locations):
  - pkg/apis/velero/v1/server_status_request_types.go
  - internal/velero/serverstatusrequest.go
  - pkg/cmd/util/output/plugin_printer.go
  - pkg/cmd/cli/plugin/remove.go
