### PR TITLE
issue 9365: prevent multiple update of PVR

### DIFF
--- a/changelogs/unreleased/9376-Lyndon-Li
+++ b/changelogs/unreleased/9376-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix issue #9365, prevent fake completion notification due to multiple update of single PVR

--- a/pkg/podvolume/restorer.go
+++ b/pkg/podvolume/restorer.go
@@ -92,9 +92,15 @@ func newRestorer(
 
 	_, _ = pvrInformer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
-			UpdateFunc: func(_, obj any) {
-				pvr := obj.(*velerov1api.PodVolumeRestore)
+			UpdateFunc: func(oldObj, newObj any) {
+				pvr := newObj.(*velerov1api.PodVolumeRestore)
+				pvrOld := oldObj.(*velerov1api.PodVolumeRestore)
+
 				if pvr.GetLabels()[velerov1api.RestoreUIDLabel] != string(restore.UID) {
+					return
+				}
+
+				if pvr.Status.Phase == pvrOld.Status.Phase {
 					return
 				}
 


### PR DESCRIPTION
Fix issue https://github.com/vmware-tanzu/velero/issues/9365, prevent fake completion notification due to multiple update of single PVR