### PR TITLE
Update debug bundle artifact name to include Kubernetes version and job index

### DIFF
--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -187,5 +187,5 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v5
         with:
-          name: DebugBundle
+          name: DebugBundle-k8s-${{ matrix.k8s }}-job-${{ strategy.job-index }}
           path: /home/runner/work/velero/velero/test/e2e/debug-bundle*


### PR DESCRIPTION
# Summary

Fix artifact upload conflicts in the e2e-test-kind workflow by making artifact names unique for each matrix job.

## Problem

The e2e-test-kind workflow uses a matrix strategy to test against multiple Kubernetes versions and test label combinations. When jobs fail, they attempt to upload debug bundles using `actions/upload-artifact@v5`. However, all jobs were using the same artifact name "DebugBundle", causing a 409 Conflict error:

```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

This prevents debug bundles from multiple failed jobs from being uploaded, making it difficult to diagnose failures across different test configurations.

## Solution

Changed the artifact name to include the Kubernetes version and job index:
```yaml
name: DebugBundle-k8s-${{ matrix.k8s }}-job-${{ strategy.job-index }}
```

This ensures each matrix job creates a uniquely named artifact, such as:
- `DebugBundle-k8s-1.28.0-job-0`
- `DebugBundle-k8s-1.29.0-job-1`

## Testing

The fix can be verified by:
1. Triggering the workflow with multiple matrix jobs
2. Simulating or encountering test failures
3. Confirming that multiple debug bundle artifacts are uploaded without conflicts

# Checklist

- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Created a changelog file (`make new-changelog`) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main` (not applicable for CI workflow changes).