### PR TITLE
[release-1.17] don't copy securitycontext from first container if configmap found

### DIFF
--- a/changelogs/unreleased/9394-sseago
+++ b/changelogs/unreleased/9394-sseago
@@ -1,0 +1,1 @@
+don't copy securitycontext from first container if configmap found

--- a/pkg/restore/actions/pod_volume_restore_action.go
+++ b/pkg/restore/actions/pod_volume_restore_action.go
@@ -185,8 +185,8 @@ func (a *PodVolumeRestoreAction) Execute(input *velero.RestoreItemActionExecuteI
 			securityContextSet = true
 		}
 	}
-	// if first container in pod has a SecurityContext set, then copy this security context
-	if len(pod.Spec.Containers) != 0 && pod.Spec.Containers[0].SecurityContext != nil {
+	// if securityContext configmap is unavailable but first container in pod has a SecurityContext set, then copy this security context
+	if !securityContextSet && len(pod.Spec.Containers) != 0 && pod.Spec.Containers[0].SecurityContext != nil {
 		securityContext = *pod.Spec.Containers[0].SecurityContext.DeepCopy()
 		securityContextSet = true
 	}


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
When setting security context for fs restore container, don't copy from first pod container if user has provided configmap-based values to use.


# Does your change fix a particular issue?

Fixes #9372 

# Please indicate you've done the following:

- [ x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ x] Updated the corresponding documentation in `site/content/docs/main`.
