### PR TITLE
Fix: use POSIX path separators for node-agent hostPath volumes. Fix issue #9415

### DIFF
--- a/pkg/install/daemonset.go
+++ b/pkg/install/daemonset.go
@@ -68,8 +68,11 @@ func DaemonSet(namespace string, opts ...podTemplateOption) *appsv1api.DaemonSet
 	if c.forWindows {
 		dsName = "node-agent-windows"
 	}
-	hostPodsVolumePath := filepath.Join(c.kubeletRootDir, "pods")
-	hostPluginsVolumePath := filepath.Join(c.kubeletRootDir, "plugins")
+	// Use forward slashes for hostPath paths to ensure POSIX-style paths in generated manifests
+	// even when velero CLI runs on Windows. Kubernetes hostPath.path must use '/' separator.
+	kubeletRoot := strings.TrimRight(c.kubeletRootDir, "/\\")
+	hostPodsVolumePath := kubeletRoot + "/pods"
+	hostPluginsVolumePath := kubeletRoot + "/plugins"
 	volumes := []corev1api.Volume{}
 	volumeMounts := []corev1api.VolumeMount{}
 	if !c.nodeAgentDisableHostPath {


### PR DESCRIPTION
# Please add a summary of your change

When running velero install from Windows CLI, filepath.Join() was generating Windows-style paths with backslashes (e.g., \var\lib\kubelet\pods) in the generated DaemonSet manifest. However, these manifests are applied to Linux Kubernetes clusters which require forward slashes.

This fix ensures hostPath.path always uses forward slashes by replacing filepath.Join() with string concatenation, so the generated manifests work correctly regardless of the CLI host OS.


# Does your change fix a particular issue?


Fixes #(9415)


