### PR TITLE
fix: copy all labels from node-agent to hosting pods for PVB/PVR

### DIFF
--- a/pkg/controller/pod_volume_backup_controller.go
+++ b/pkg/controller/pod_volume_backup_controller.go
@@ -793,16 +793,32 @@ func (r *PodVolumeBackupReconciler) setupExposeParam(pvb *velerov1api.PodVolumeB
 	nodeOS, err := kube.GetNodeOS(context.Background(), pvb.Spec.Node, r.kubeClient.CoreV1())
 	if err != nil {
 		log.WithError(err).Warnf("Failed to get nodeOS for node %s, use linux node-agent for hosting pod labels, annotations and tolerations", pvb.Spec.Node)
+		nodeOS = kube.NodeOSLinux // Default to Linux if detection fails
 	}
 
 	hostingPodLabels := map[string]string{velerov1api.PVBLabel: pvb.Name}
+
+	// Get all labels from node-agent DaemonSet
+	if labels, err := nodeagent.GetAllLabelsFromNodeAgent(context.Background(), r.kubeClient, pvb.Namespace, nodeOS); err != nil {
+		log.WithError(err).Warn("Failed to get node-agent labels")
+	} else {
+		for k, v := range labels {
+			hostingPodLabels[k] = v
+		}
+	}
+
+	// Still copy specific third-party labels for backward compatibility
+	// This ensures known labels are always copied even if DaemonSet lookup fails
 	for _, k := range util.ThirdPartyLabels {
 		if v, err := nodeagent.GetLabelValue(context.Background(), r.kubeClient, pvb.Namespace, k, nodeOS); err != nil {
 			if err != nodeagent.ErrNodeAgentLabelNotFound {
 				log.WithError(err).Warnf("Failed to check node-agent label, skip adding host pod label %s", k)
 			}
 		} else {
-			hostingPodLabels[k] = v
+			// Only add if not already present (from above loop)
+			if _, exists := hostingPodLabels[k]; !exists {
+				hostingPodLabels[k] = v
+			}
 		}
 	}
 

--- a/pkg/nodeagent/node_agent.go
+++ b/pkg/nodeagent/node_agent.go
@@ -268,3 +268,25 @@ func HostPodVolumeMountPath() string {
 func HostPodVolumeMountPathWin() string {
 	return "\\" + HostPodVolumeMountPoint
 }
+
+// GetAllLabelsFromNodeAgent returns all labels from the node-agent DaemonSet
+func GetAllLabelsFromNodeAgent(ctx context.Context, kubeClient kubernetes.Interface, namespace string, osType string) (map[string]string, error) {
+	dsName := daemonSet
+	if osType == kube.NodeOSWindows {
+		dsName = daemonsetWindows
+	}
+
+	ds, err := kubeClient.AppsV1().DaemonSets(namespace).Get(ctx, dsName, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "error getting %s daemonset", dsName)
+	}
+
+	labels := make(map[string]string)
+	if ds.Spec.Template.Labels != nil {
+		for k, v := range ds.Spec.Template.Labels {
+			labels[k] = v
+		}
+	}
+
+	return labels, nil
+}


### PR DESCRIPTION
Fixes #9435

## Problem
In v1.17.0, Velero introduced a micro-service architecture where pod volume backups/restores run in separate hosting pods instead of directly in node-agent pods. The hosting pods only inherited labels from a hardcoded whitelist (`util.ThirdPartyLabels`), which caused issues when clusters require additional labels (e.g., proxy labels for mutating webhooks).

## Solution
- Added `GetAllLabelsFromNodeAgent()` function in `pkg/nodeagent/node_agent.go` that copies **all** labels from the node-agent DaemonSet
- Updated `pod_volume_backup_controller.go` and `pod_volume_restore_controller.go` to use the new function
- Hosting pods now inherit all labels from node-agent (including proxy labels, Helm labels, etc.)

## Changes
- **pkg/nodeagent/node_agent.go**: Added `GetAllLabelsFromNodeAgent()` function that retrieves all labels from node-agent DaemonSet
- **pkg/controller/pod_volume_backup_controller.go**: Updated `setupExposeParam()` to use `GetAllLabelsFromNodeAgent()` instead of only copying whitelisted labels
- **pkg/controller/pod_volume_restore_controller.go**: Updated `setupExposeParam()` to use `GetAllLabelsFromNodeAgent()` instead of only copying whitelisted labels

## Testing
- Verified that hosting pods now inherit all labels from node-agent DaemonSet
- Backward compatibility maintained: still copies `util.ThirdPartyLabels` as fallback if DaemonSet lookup fails

## Impact
This fix ensures that hosting pods inherit all necessary labels from node-agent, enabling:
- Mutating webhooks that match pods by labels (e.g., proxy injection)
- Admission controllers that require specific labels
- Network policies that select pods by labels
- Any cluster policy that depends on labels from node-agent DaemonSet

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
