### PR TITLE
Fix plugin init container names exceeding DNS-1123 limit

### DIFF
--- a/changelogs/unreleased/9445-mpryc
+++ b/changelogs/unreleased/9445-mpryc
@@ -1,0 +1,1 @@
+Fix plugin init container names exceeding DNS-1123 limit


### PR DESCRIPTION
Ensure plugin init container names satisfy DNS-1123 label constraints (max 63 chars). Long names are truncated with an 8-char hash suffix to maintain uniqueness.

Fixes: #9444
