### PR TITLE
[AI-generated]Include Prepared phase tasks in periodic enqueue to prevent stalling

### DIFF
--- a/pkg/controller/data_download_controller.go
+++ b/pkg/controller/data_download_controller.go
@@ -589,6 +589,12 @@ func (r *DataDownloadReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			return true
 		}
 
+		// Include Prepared phase to ensure tasks get regular reconcile calls
+		// This prevents tasks from getting stuck when they're waiting for slots
+		if dd.Status.Phase == velerov2alpha1api.DataDownloadPhasePrepared {
+			return true
+		}
+
 		if dd.Spec.Cancel && !isDataDownloadInFinalState(dd) {
 			return true
 		}

--- a/pkg/controller/data_upload_controller.go
+++ b/pkg/controller/data_upload_controller.go
@@ -632,6 +632,12 @@ func (r *DataUploadReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			return true
 		}
 
+		// Include Prepared phase to ensure tasks get regular reconcile calls
+		// This prevents tasks from getting stuck when they're waiting for slots
+		if du.Status.Phase == velerov2alpha1api.DataUploadPhasePrepared {
+			return true
+		}
+
 		if du.Spec.Cancel && !isDataUploadInFinalState(du) {
 			return true
 		}


### PR DESCRIPTION
This is an alternative proposed solution to the issue described in https://github.com/vmware-tanzu/velero/pull/9447

## Problem

Tasks in Prepared phase were not included in periodic enqueue (only Accepted phase was included). This meant they only received reconcile calls through watch events, which could cause them to get stuck for long periods when waiting for available slots.

## Solution

This change adds Prepared phase to the periodic enqueue predicate for both DataUpload and DataDownload controllers, ensuring they get regular reconcile calls (every minute via preparingMonitorFrequency). This guarantees that tasks in Prepared phase will receive reconcile calls regularly, allowing them to check for available slots and proceed when slots become available.

## Changes

- Added Prepared phase check to periodic enqueue predicate in DataUploadReconciler
- Added Prepared phase check to periodic enqueue predicate in DataDownloadReconciler

## Alternative Approach

This is a simpler alternative to the slot reservation mechanism proposed in PR #9447. While PR #9447 focuses on optimizing the reconcile logic itself, this PR ensures tasks get regular reconcile calls in the first place.