### PR TITLE
Update Go to 1.25.5 to fix CVE-2025-61729 and enable Dependabot Docker monitoring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,12 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]
+  # Docker base images in Dockerfiles
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "Dependencies"
+      - "docker"
+      - "kind/changelog-not-required"

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Velero binary build section
-FROM --platform=$BUILDPLATFORM golang:1.25-bookworm AS velero-builder
+FROM --platform=$BUILDPLATFORM golang:1.25.5-bookworm AS velero-builder
 
 ARG GOPROXY
 ARG BIN
@@ -49,7 +49,7 @@ RUN mkdir -p /output/usr/bin && \
     go clean -modcache -cache
 
 # Restic binary build section
-FROM --platform=$BUILDPLATFORM golang:1.25-bookworm AS restic-builder
+FROM --platform=$BUILDPLATFORM golang:1.25.5-bookworm AS restic-builder
 
 ARG GOPROXY
 ARG BIN

--- a/changelogs/unreleased/go-1.25.5-security-fix
+++ b/changelogs/unreleased/go-1.25.5-security-fix
@@ -1,0 +1,1 @@
+Update Dockerfile to use Go 1.25.5 to fix CVE-2025-61729 (HIGH severity crypto/x509 vulnerability)


### PR DESCRIPTION
# Summary

This PR addresses a HIGH severity security vulnerability and improves our dependency management:

1. **Security Fix**: Updated Dockerfile to use `golang:1.25.5-bookworm` in both `velero-builder` and `restic-builder` stages to fix CVE-2025-61729 (crypto/x509 excessive resource consumption vulnerability)
2. **Dependabot Enhancement**: Added Docker package ecosystem monitoring to Dependabot configuration to automatically track Docker base image updates

Trivy scan of velero/velero:v1.17.1 identified CVE-2025-61729 affecting all Go binaries (velero, velero-helper, velero-restore-helper, restic). The vulnerability was present because binaries were built with Go 1.24.9; fixed in Go 1.25.5.

# Does your change fix a particular issue?

This addresses CVE-2025-61729 (security vulnerability) but is not linked to a specific GitHub issue.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.