### PR TITLE
Fix: Update the logging to print correct affinity field

### DIFF
--- a/pkg/exposer/csi_snapshot.go
+++ b/pkg/exposer/csi_snapshot.go
@@ -259,13 +259,7 @@ func (e *csiSnapshotExposer) Expose(ctx context.Context, ownerObject corev1api.O
 		return errors.Wrap(err, "error to create backup pod")
 	}
 
-	curLog = curLog.WithField("pod name", backupPod.Name)
-	if affinity != nil {
-		curLog = curLog.WithField("affinity", *affinity)
-	} else {
-		curLog = curLog.WithField("affinity", "nil")
-	}
-	curLog.Info("Backup pod is created")
+	curLog.WithField("pod name", backupPod.Name).WithField("affinity", affinity).Info("Backup pod is created")
 
 	defer func() {
 		if err != nil {


### PR DESCRIPTION
# Please add a summary of your change
Update the logging when printing the affinity value used for creating backup pod. 
Previously, the log was printing the wrong variable, and it's an array of pointer which is pointless
```
time="2025-12-23T06:41:21Z" level=info msg="Backup pod is created" affinity="[0xc00084ef60]" logSource="pkg/exposer/csi_snapshot.go:262" owner=test-backup-3-ghvv7 pod name=test-backup-3-ghvv7
```
# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
