### PR TITLE
fix : Mark PodVolumeRestore as Failed when target pod is deleted, preventing stuck restores

### DIFF
--- a/pkg/controller/pod_volume_restore_controller_test.go
+++ b/pkg/controller/pod_volume_restore_controller_test.go
@@ -214,6 +214,7 @@ func TestShouldProcess(t *testing.T) {
 				objs = append(objs, ts.pod)
 			}
 			cli := test.NewFakeControllerRuntimeClient(t, objs...)
+			kubeClient := clientgofake.NewSimpleClientset()
 
 			c := &PodVolumeRestoreReconciler{
 				logger: logrus.New(),
@@ -221,7 +222,7 @@ func TestShouldProcess(t *testing.T) {
 				clock:  &clocks.RealClock{},
 			}
 
-			shouldProcess, _, _ := shouldProcess(ctx, c.client, c.logger, ts.obj)
+			shouldProcess, _, _ := shouldProcess(ctx, c.client, kubeClient, c.logger, ts.obj)
 			require.Equal(t, ts.shouldProcessed, shouldProcess)
 		})
 	}


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
The current implementation of `shouldProcess` in `pod_volume_restore_controller.go` doesn't distinguish between a pod that's on another node (should skip) versus a pod that has been completely deleted from the cluster (should mark PVR as Failed). When a pod is deleted during restore (e.g., due to a Deployment rollout), the `PodVolumeRestore` gets stuck in the `New` state indefinitely because the controller just skips processing without updating the PVR status.

The fix adds logic to check the API server directly when a pod is not found in the local cache. If the pod doesn't exist anywhere in the cluster, we return a new `ErrPodDeleted` error, which is then handled in the `Reconcile` function to mark the PVR as `Failed` with an appropriate error message. This allows restores to complete (with warnings) instead of hanging indefinitely.

# Does your change fix a particular issue?

Fixes #9461

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
