### PR TITLE
Report pod.status.message when pod fails

### DIFF
--- a/pkg/util/kube/pod.go
+++ b/pkg/util/kube/pod.go
@@ -184,6 +184,10 @@ func GetPodTerminateMessage(pod *corev1api.Pod) string {
 		}
 	}
 
+	if pod.Status.Message != "" {
+		message += pod.Status.Message + "/"
+	}
+
 	return message
 }
 

--- a/pkg/util/kube/pod_test.go
+++ b/pkg/util/kube/pod_test.go
@@ -520,6 +520,27 @@ func TestGetPodTerminateMessage(t *testing.T) {
 			},
 			message: "message-1/message-2/message-3/",
 		},
+		{
+			name: "with pod status message",
+			pod: &corev1api.Pod{
+				Status: corev1api.PodStatus{
+					Message: "pod-message",
+				},
+			},
+			message: "pod-message/",
+		},
+		{
+			name: "with termination and pod status message",
+			pod: &corev1api.Pod{
+				Status: corev1api.PodStatus{
+					ContainerStatuses: []corev1api.ContainerStatus{
+						{Name: "container-1", State: corev1api.ContainerState{Terminated: &corev1api.ContainerStateTerminated{Message: "message-1"}}},
+					},
+					Message: "pod-message",
+				},
+			},
+			message: "message-1/pod-message/",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Report velero.status.message when pod fails.
For example, observed datamover pod failure like below, only status.message contains useful debugging info
```
---
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: "2026-01-07T21:13:09Z"
  deletionGracePeriodSeconds: 0
  deletionTimestamp: "2026-01-07T21:13:28Z"
  finalizers:
  - lifecycle-controller/system.vmware.com
  labels:
    velero.io/data-upload: test-backup-1-c4sbs
    velero.io/exposer-pod-group: snapshot-exposer
  name: test-backup-1-c4sbs
  namespace: velero
  ownerReferences:
  - apiVersion: velero.io/v2alpha1
    controller: true
    kind: DataUpload
    name: test-backup-1-c4sbs
    uid: 4dd7dd90-4060-4d66-9adf-31a35d760d3d
  resourceVersion: "4248380"
  uid: 9deb52c1-3d56-4d32-8f56-115d78e38c4d
...
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2026-01-07T21:13:17Z"
    status: "True"
    type: PodScheduled
  - lastProbeTime: null
    lastTransitionTime: "2026-01-07T21:13:30Z"
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2026-01-07T21:13:30Z"
    reason: UnknownContainerStatuses
    status: "False"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2026-01-07T21:13:30Z"
    reason: UnknownContainerStatuses
    status: "False"
    type: Ready
  message: |
    rpc error: code = Internal desc = Could not run pod: mountVolume.MountDevice for (4dd7dd90-4060-4d66-9adf-31a35d760d3d) failed: mount failed: exit status 32
    Mounting command: mount
    Mounting arguments: -t ext4 -o defaults /dev/disk/by-id/wwn-0x6000c296705bae7110bbd2dc558e349a /mnt/volumes/plugins/kubernetes.io/vsphere-volume/mounts/4352474f-46ec-4a6c-8a8e-874533bbcc48
    Output: mount: /mnt/volumes/plugins/kubernetes.io/vsphere-volume/mounts/4352474f-46ec-4a6c-8a8e-874533bbcc48: wrong fs type, bad option, bad superblock on /dev/sdb, missing codepage or helper program, or other error.
           dmesg(1) may have more information after failed mount system call.
  phase: Failed
  qosClass: BestEffort
  reason: ProviderFailed
---
```



# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
