### PR TITLE
Maintenance Job only uses the first element of the LoadAffinity array

### DIFF
--- a/changelogs/unreleased/9494-blackpiglet
+++ b/changelogs/unreleased/9494-blackpiglet
@@ -1,0 +1,1 @@
+Maintenance Job only uses the first element of the LoadAffinity array

--- a/pkg/repository/maintenance/maintenance.go
+++ b/pkg/repository/maintenance/maintenance.go
@@ -671,7 +671,8 @@ func buildJob(
 	}
 
 	if config != nil && len(config.LoadAffinities) > 0 {
-		affinity := kube.ToSystemAffinity(config.LoadAffinities)
+		// Maintenance job only takes the first loadAffinity.
+		affinity := kube.ToSystemAffinity([]*kube.LoadAffinity{config.LoadAffinities[0]})
 		job.Spec.Template.Spec.Affinity = affinity
 	}
 

--- a/site/content/docs/main/repository-maintenance.md
+++ b/site/content/docs/main/repository-maintenance.md
@@ -81,19 +81,6 @@ data:
           "nodeSelector": {
             "matchExpressions": [
               {
-                "key": "cloud.google.com/machine-family",
-                "operator": "In",
-                "values": [
-                  "e2"
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "nodeSelector": {
-            "matchExpressions": [
-              {
                 "key": "topology.kubernetes.io/zone",
                 "operator": "In",
                 "values": [
@@ -119,10 +106,10 @@ data:
     }
 EOF
 ```
-This sample showcases two affinity configurations:
-- matchLabels: maintenance job runs on nodes with label key `cloud.google.com/machine-family` and value `e2`.
+Notice: although loadAffinity is an array, Velero only takes the first element of the array.
+
+This sample showcases how to use affinity configuration:
 - matchLabels: maintenance job runs on nodes located in `us-central1-a`, `us-central1-b` and `us-central1-c`.
-The nodes matching one of the two conditions are selected.
 
 To create the configMap, users need to save something like the above sample to a json file and then run below command:
 ```


### PR DESCRIPTION


Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
