### PR TITLE
Remove backup from running list when backup fails validation

### DIFF
--- a/changelogs/unreleased/9498-sseago
+++ b/changelogs/unreleased/9498-sseago
@@ -1,0 +1,1 @@
+Remove backup from running list when backup fails validation

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -307,6 +307,16 @@ func (b *backupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	backupScheduleName := request.GetLabels()[velerov1api.ScheduleNameLabel]
 
+	b.backupTracker.Add(request.Namespace, request.Name)
+	defer func() {
+		switch request.Status.Phase {
+		case velerov1api.BackupPhaseCompleted, velerov1api.BackupPhasePartiallyFailed, velerov1api.BackupPhaseFailed, velerov1api.BackupPhaseFailedValidation:
+			b.backupTracker.Delete(request.Namespace, request.Name)
+		case velerov1api.BackupPhaseWaitingForPluginOperations, velerov1api.BackupPhaseWaitingForPluginOperationsPartiallyFailed, velerov1api.BackupPhaseFinalizing, velerov1api.BackupPhaseFinalizingPartiallyFailed:
+			b.backupTracker.AddPostProcessing(request.Namespace, request.Name)
+		}
+	}()
+
 	if request.Status.Phase == velerov1api.BackupPhaseFailedValidation {
 		log.Debug("failed to validate backup status")
 		b.metrics.RegisterBackupValidationFailure(backupScheduleName)
@@ -317,16 +327,6 @@ func (b *backupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	// store ref to just-updated item for creating patch
 	original = request.Backup.DeepCopy()
-
-	b.backupTracker.Add(request.Namespace, request.Name)
-	defer func() {
-		switch request.Status.Phase {
-		case velerov1api.BackupPhaseCompleted, velerov1api.BackupPhasePartiallyFailed, velerov1api.BackupPhaseFailed, velerov1api.BackupPhaseFailedValidation:
-			b.backupTracker.Delete(request.Namespace, request.Name)
-		case velerov1api.BackupPhaseWaitingForPluginOperations, velerov1api.BackupPhaseWaitingForPluginOperationsPartiallyFailed, velerov1api.BackupPhaseFinalizing, velerov1api.BackupPhaseFinalizingPartiallyFailed:
-			b.backupTracker.AddPostProcessing(request.Namespace, request.Name)
-		}
-	}()
 
 	log.Debug("Running backup")
 

--- a/pkg/controller/backup_controller_test.go
+++ b/pkg/controller/backup_controller_test.go
@@ -246,6 +246,7 @@ func TestProcessBackupValidationFailures(t *testing.T) {
 				clock:                 &clock.RealClock{},
 				formatFlag:            formatFlag,
 				metrics:               metrics.NewServerMetrics(),
+				backupTracker:         NewBackupTracker(),
 			}
 
 			require.NotNil(t, test.backup)


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
With parallel backup support, failed validation backups were not being removed from the running backup list. 
This PR updates the code so that the list is cleaned up properly when a backup fails validation
# Does your change fix a particular issue?

Fixes #9493

# Please indicate you've done the following:

- [x ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x ] Updated the corresponding documentation in `site/content/docs/main`.
