### PR TITLE
Fix ListBackups to skip directories without metadata file

### DIFF
--- a/changelogs/unreleased/9511-mpryc
+++ b/changelogs/unreleased/9511-mpryc
@@ -1,0 +1,1 @@
+Fix ListBackups to skip directories without metadata file

--- a/pkg/persistence/object_store.go
+++ b/pkg/persistence/object_store.go
@@ -190,6 +190,20 @@ func (s *objectBackupStore) ListBackups() ([]string, error) {
 		// each of those off to get the backup name.
 		backupName := strings.TrimSuffix(strings.TrimPrefix(prefix, s.layout.subdirs["backups"]), "/")
 
+		// Verify that the backup metadata file exists before including this backup.
+		// This filters out empty directories that can persist in object stores with
+		// suspended versioning (e.g., MinIO) after backup deletion.
+		metadataKey := s.layout.getBackupMetadataKey(backupName)
+		exists, err := s.objectStore.ObjectExists(s.bucket, metadataKey)
+		if err != nil {
+			s.logger.WithError(err).WithField("backup", backupName).Warning("Failed to check backup metadata existence")
+			continue
+		}
+		if !exists {
+			s.logger.WithField("backup", backupName).Debug("Skipping backup directory without metadata file")
+			continue
+		}
+
 		output = append(output, backupName)
 	}
 

--- a/pkg/persistence/object_store_test.go
+++ b/pkg/persistence/object_store_test.go
@@ -190,6 +190,35 @@ func TestListBackups(t *testing.T) {
 			},
 			expectedRes: []string{"backup-1", "backup-2"},
 		},
+		{
+			name: "backup directories without metadata file are excluded",
+			storageData: map[string][]byte{
+				"backups/backup-1/velero-backup.json": []byte("{}"),
+				// backup-2 has only a log file, no metadata - simulates empty directory with suspended versioning
+				"backups/backup-2/backup-2-logs.gz": []byte("log data"),
+			},
+			expectedRes: []string{"backup-1"},
+		},
+		{
+			name: "all backup directories without metadata file returns empty list",
+			storageData: map[string][]byte{
+				// Both backups have only log files, no metadata
+				"backups/backup-1/backup-1-logs.gz": []byte("log data"),
+				"backups/backup-2/backup-2-logs.gz": []byte("log data"),
+			},
+			expectedRes: []string{},
+		},
+		{
+			name:   "backup directories without metadata file are excluded with prefix",
+			prefix: "velero-backups/",
+			storageData: map[string][]byte{
+				"velero-backups/backups/backup-1/velero-backup.json": []byte("{}"),
+				// backup-2 has only a log file, no metadata
+				"velero-backups/backups/backup-2/backup-2-logs.gz":   []byte("log data"),
+				"velero-backups/backups/backup-3/velero-backup.json": []byte("{}"),
+			},
+			expectedRes: []string{"backup-1", "backup-3"},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
When using object stores with suspended versioning (e.g., MinIO), deleted backup folders persist as empty directories. The S3 API returns these directories, but they lack the velero-backup.json metadata file.

This change adds a check in ListBackups() to verify that the backup metadata file exists before including a backup in the results. Empty directories without metadata are now logged at debug level and skipped.

Suggested-by: @chrisamti

Fixes #8466 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.