### PR TITLE
Fix VolumePolicy PVC phase condition filter for unbound PVCs

### DIFF
--- a/changelogs/unreleased/9541-kaovilai
+++ b/changelogs/unreleased/9541-kaovilai
@@ -1,0 +1,1 @@
+Fix VolumePolicy PVC phase condition filter for unbound PVCs (#9507)

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -687,15 +687,14 @@ func (ib *itemBackupper) getMatchAction(obj runtime.Unstructured, groupResource 
 			return nil, errors.WithStack(err)
 		}
 
-		pvName := pvc.Spec.VolumeName
-		if pvName == "" {
-			return nil, errors.Errorf("PVC has no volume backing this claim")
+		var pv *corev1api.PersistentVolume
+		if pvName := pvc.Spec.VolumeName; pvName != "" {
+			pv = &corev1api.PersistentVolume{}
+			if err := ib.kbClient.Get(context.Background(), kbClient.ObjectKey{Name: pvName}, pv); err != nil {
+				return nil, errors.WithStack(err)
+			}
 		}
-
-		pv := &corev1api.PersistentVolume{}
-		if err := ib.kbClient.Get(context.Background(), kbClient.ObjectKey{Name: pvName}, pv); err != nil {
-			return nil, errors.WithStack(err)
-		}
+		// If pv is nil for unbound PVCs - policy matching will use PVC-only conditions
 		vfd := resourcepolicies.NewVolumeFilterData(pv, nil, pvc)
 		return ib.backupRequest.ResPolicies.GetMatchAction(vfd)
 	}
@@ -709,7 +708,10 @@ func (ib *itemBackupper) trackSkippedPV(obj runtime.Unstructured, groupResource 
 	if name, err := getPVName(obj, groupResource); len(name) > 0 && err == nil {
 		ib.backupRequest.SkippedPVTracker.Track(name, approach, reason)
 	} else if err != nil {
-		log.WithError(err).Warnf("unable to get PV name, skip tracking.")
+		// Log at info level for tracking purposes. This is not an error because
+		// it's expected for some resources (e.g., PVCs in Pending or Lost phase)
+		// to not have a PV name. This occurs when volume policy skips unbound PVCs.
+		log.WithError(err).Infof("unable to get PV name, skip tracking.")
 	}
 }
 
@@ -719,6 +721,17 @@ func (ib *itemBackupper) unTrackSkippedPV(obj runtime.Unstructured, groupResourc
 	if name, err := getPVName(obj, groupResource); len(name) > 0 && err == nil {
 		ib.backupRequest.SkippedPVTracker.Untrack(name)
 	} else if err != nil {
+		// For PVCs in Pending or Lost phase, it's expected that there's no PV name.
+		// Log at debug level instead of warning to reduce noise.
+		if groupResource == kuberesource.PersistentVolumeClaims {
+			pvc := new(corev1api.PersistentVolumeClaim)
+			if convErr := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), pvc); convErr == nil {
+				if pvc.Status.Phase == corev1api.ClaimPending || pvc.Status.Phase == corev1api.ClaimLost {
+					log.WithError(err).Debugf("unable to get PV name for %s PVC, skip untracking.", pvc.Status.Phase)
+					return
+				}
+			}
+		}
 		log.WithError(err).Warnf("unable to get PV name, skip untracking.")
 	}
 }

--- a/pkg/podvolume/backupper.go
+++ b/pkg/podvolume/backupper.go
@@ -210,11 +210,9 @@ func resultsKey(ns, name string) string {
 
 func (b *backupper) getMatchAction(resPolicies *resourcepolicies.Policies, pvc *corev1api.PersistentVolumeClaim, volume *corev1api.Volume) (*resourcepolicies.Action, error) {
 	if pvc != nil {
-		pv := new(corev1api.PersistentVolume)
-		err := b.crClient.Get(context.TODO(), ctrlclient.ObjectKey{Name: pvc.Spec.VolumeName}, pv)
-		if err != nil {
-			return nil, errors.Wrapf(err, "error getting pv for pvc %s", pvc.Spec.VolumeName)
-		}
+		// Ignore err, if the PV is not available (Pending/Lost PVC or PV fetch failed) - try matching with PVC only
+		// GetPVForPVC returns nil for all error cases
+		pv, _ := kube.GetPVForPVC(pvc, b.crClient)
 		vfd := resourcepolicies.NewVolumeFilterData(pv, nil, pvc)
 		return resPolicies.GetMatchAction(vfd)
 	}

--- a/pkg/util/kube/pvc_pv.go
+++ b/pkg/util/kube/pvc_pv.go
@@ -417,19 +417,19 @@ func MakePodPVCAttachment(volumeName string, volumeMode *corev1api.PersistentVol
 	return volumeMounts, volumeDevices, volumePath
 }
 
+// GetPVForPVC returns the PersistentVolume backing a PVC
+// returns PV, error.
+// PV will be nil on error
 func GetPVForPVC(
 	pvc *corev1api.PersistentVolumeClaim,
 	crClient crclient.Client,
 ) (*corev1api.PersistentVolume, error) {
 	if pvc.Spec.VolumeName == "" {
-		return nil, errors.Errorf("PVC %s/%s has no volume backing this claim",
-			pvc.Namespace, pvc.Name)
+		return nil, errors.Errorf("PVC %s/%s has no volume backing this claim", pvc.Namespace, pvc.Name)
 	}
 	if pvc.Status.Phase != corev1api.ClaimBound {
-		// TODO: confirm if this PVC should be snapshotted if it has no PV bound
-		return nil,
-			errors.Errorf("PVC %s/%s is in phase %v and is not bound to a volume",
-				pvc.Namespace, pvc.Name, pvc.Status.Phase)
+		return nil, errors.Errorf("PVC %s/%s is in phase %v and is not bound to a volume",
+			pvc.Namespace, pvc.Name, pvc.Status.Phase)
 	}
 
 	pv := &corev1api.PersistentVolume{}


### PR DESCRIPTION
Use typed error approach: Make GetPVForPVC return ErrPVNotFoundForPVC when PV is not expected to be found (unbound PVC), then use errors.Is to check for this error type. When a matching policy exists (e.g., pvcPhase: [Pending, Lost] with action: skip), apply the action without error. When no policy matches, return the original error to preserve default behavior.

Changes:
- Add ErrPVNotFoundForPVC sentinel error to pvc_pv.go
- Update ShouldPerformSnapshot to handle unbound PVCs with policies
- Update ShouldPerformFSBackup to handle unbound PVCs with policies
- Update item_backupper.go to handle Lost PVCs in tracking functions
- Remove checkPVCOnlySkip helper (no longer needed)
- Update tests to reflect new behavior

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
