### PR TITLE
Replace manual disk cleanup with quick-cleanup

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -51,13 +51,14 @@ jobs:
           files: coverage.out
           verbose: true
       # Only try to publish the container image from the root repo; forks don't have permission to do so and will always get failures.
+      - name: Free up disk space
+        if: github.repository == 'vmware-tanzu/velero'
+        uses: palmsoftware/quick-cleanup@v0
+        with:
+          cleanup-mode: aggressive
       - name: Publish container image
         if: github.repository == 'vmware-tanzu/velero'
         run: |
-          sudo swapoff -a
-          sudo rm -f /mnt/swapfile
-          docker system prune -a --force
-              
           # Build and push Velero image to docker registry
           docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
           ./hack/docker-push.sh


### PR DESCRIPTION
## Summary

Replace manual disk cleanup scripts with the shared [`palmsoftware/quick-cleanup`](https://github.com/palmsoftware/quick-cleanup) GitHub Action.

This consolidates the manual cleanup (swapoff, swap removal, docker system prune) into a single maintained action as a separate step before the publish step. It also provides automatic Docker storage relocation to the larger `/mnt` partition — a feature none of the manual scripts currently implement.

## Already in use

`quick-cleanup` is already adopted in production workflows across multiple projects:

- [`crc-org/crc`](https://github.com/crc-org/crc/blob/main/.github/workflows/make-rpm.yml#L19) — OpenShift Local (CRC)
- [`palmsoftware/quick-ocp`](https://github.com/palmsoftware/quick-ocp/blob/main/action.yml#L94) — OpenShift cluster deployment action
- [`palmsoftware/quick-k8s`](https://github.com/palmsoftware/quick-k8s/blob/main/action.yml#L509) — Kubernetes cluster deployment action (KinD/Minikube)

## Tracking

- [palmsoftware/quick-cleanup#3](https://github.com/palmsoftware/quick-cleanup/issues/3) — Tracking issue



## Related PRs

- https://github.com/crc-org/crc/pull/5145
- https://github.com/openshift-kni/openperouter/pull/159
- https://github.com/metallb/metallb-operator/pull/537
- https://github.com/prometheus-operator/prometheus-operator/pull/8389
- https://github.com/topolvm/topolvm/pull/1151
- https://github.com/vmware-tanzu/velero/pull/9550

## Changes

- Updated `.github/workflows/push.yml` — extracted cleanup into separate `palmsoftware/quick-cleanup@v0` step before publish

## Benefits

- **Less boilerplate** — replaces manual swap/prune commands
- **Docker relocation** — automatically moves Docker storage to `/mnt` (larger partition)
- **Adaptive cleanup** — adjusts intensity based on available space
- **Disk reporting** — built-in before/after `df -h` output
- **Maintained upstream** — cleanup targets updated as runner images change
- **Apache 2.0 licensed**