### PR TITLE
Wildcard namespaces: Log warning on empty resolution

### DIFF
--- a/changelogs/unreleased/9558-Joeavaikath
+++ b/changelogs/unreleased/9558-Joeavaikath
@@ -1,1 +1,1 @@
-Wildcard namespaces: Log error on empty resolution
+Wildcard namespaces: Log warning on empty resolution

--- a/changelogs/unreleased/9558-Joeavaikath
+++ b/changelogs/unreleased/9558-Joeavaikath
@@ -1,0 +1,1 @@
+Wildcard namespaces: Log error on empty resolution

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -307,6 +307,10 @@ func (kb *kubernetesBackupper) BackupWithResolvers(
 			return err
 		}
 
+		if len(wildcardResult) == 0 {
+			log.Errorf("no namespaces matched the resolution of wildcard patterns")
+		}
+
 		log.WithFields(logrus.Fields{
 			"expandedIncludes": expandedIncludes,
 			"expandedExcludes": expandedExcludes,

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -308,7 +308,7 @@ func (kb *kubernetesBackupper) BackupWithResolvers(
 		}
 
 		if len(wildcardResult) == 0 {
-			log.Errorf("no namespaces matched the resolution of wildcard patterns")
+			log.Warnf("no namespaces matched the resolution of wildcard patterns ")
 		}
 
 		log.WithFields(logrus.Fields{

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -167,15 +167,15 @@ func NewKubernetesBackupper(
 	}, nil
 }
 
-// getNamespaceIncludesExcludesAndArgoCDNamespaces returns an IncludesExcludes list containing which namespaces to
-// include and exclude from the backup and a list of namespaces managed by ArgoCD.
-func getNamespaceIncludesExcludesAndArgoCDNamespaces(backup *velerov1api.Backup, kbClient kbclient.Client) (*collections.NamespaceIncludesExcludes, []string, error) {
+// getNamespaceIncludesExcludes returns an IncludesExcludes list containing which namespaces to
+// include and exclude from the backup.
+func getNamespaceIncludesExcludes(backup *velerov1api.Backup, kbClient kbclient.Client) (*collections.NamespaceIncludesExcludes, error) {
 	nsList := corev1api.NamespaceList{}
-	activeNamespaces := []string{}
-	nsManagedByArgoCD := []string{}
 	if err := kbClient.List(context.Background(), &nsList); err != nil {
-		return nil, nsManagedByArgoCD, err
+		return nil, err
 	}
+
+	activeNamespaces := []string{}
 	for _, ns := range nsList.Items {
 		activeNamespaces = append(activeNamespaces, ns.Name)
 	}
@@ -188,10 +188,20 @@ func getNamespaceIncludesExcludesAndArgoCDNamespaces(backup *velerov1api.Backup,
 
 	// Expand wildcards if needed
 	if err := includesExcludes.ExpandIncludesExcludes(); err != nil {
-		return nil, []string{}, err
+		return nil, err
 	}
 
-	// Check for ArgoCD managed namespaces in the namespaces that will be included
+	return includesExcludes, nil
+}
+
+// getArgoCDManagedNamespaces returns a list of namespaces managed by ArgoCD that should be included in the backup.
+func getArgoCDManagedNamespaces(kbClient kbclient.Client, includesExcludes *collections.NamespaceIncludesExcludes) ([]string, error) {
+	nsList := corev1api.NamespaceList{}
+	if err := kbClient.List(context.Background(), &nsList); err != nil {
+		return nil, err
+	}
+
+	nsManagedByArgoCD := []string{}
 	for _, ns := range nsList.Items {
 		nsLabels := ns.GetLabels()
 		if len(nsLabels[ArgoCDManagedByNamespaceLabel]) > 0 && includesExcludes.ShouldInclude(ns.Name) {
@@ -199,7 +209,7 @@ func getNamespaceIncludesExcludesAndArgoCDNamespaces(backup *velerov1api.Backup,
 		}
 	}
 
-	return includesExcludes, nsManagedByArgoCD, nil
+	return nsManagedByArgoCD, nil
 }
 
 func getResourceHooks(hookSpecs []velerov1api.BackupResourceHookSpec, discoveryHelper discovery.Helper) ([]hook.ResourceHook, error) {
@@ -274,10 +284,15 @@ func (kb *kubernetesBackupper) BackupWithResolvers(
 		return errors.WithStack(err)
 	}
 	var err error
-	var nsManagedByArgoCD []string
-	backupRequest.NamespaceIncludesExcludes, nsManagedByArgoCD, err = getNamespaceIncludesExcludesAndArgoCDNamespaces(backupRequest.Backup, kb.kbClient)
+	backupRequest.NamespaceIncludesExcludes, err = getNamespaceIncludesExcludes(backupRequest.Backup, kb.kbClient)
 	if err != nil {
 		log.WithError(err).Errorf("error getting namespace includes/excludes")
+		return err
+	}
+
+	nsManagedByArgoCD, err := getArgoCDManagedNamespaces(kb.kbClient, backupRequest.NamespaceIncludesExcludes)
+	if err != nil {
+		log.WithError(err).Errorf("error getting ArgoCD managed namespaces")
 		return err
 	}
 

--- a/pkg/util/collections/includes_excludes.go
+++ b/pkg/util/collections/includes_excludes.go
@@ -173,7 +173,6 @@ func (nie *NamespaceIncludesExcludes) ExpandIncludesExcludes() error {
 }
 
 // ResolveNamespaceList returns a list of all namespaces which will be backed up.
-// The second return value indicates whether wildcard expansion was performed.
 func (nie *NamespaceIncludesExcludes) ResolveNamespaceList() ([]string, error) {
 	// Check if this is being called by non-backup processing e.g. backup queue controller
 	if !nie.wildcardExpanded {

--- a/site/content/docs/main/namespace-glob-patterns.md
+++ b/site/content/docs/main/namespace-glob-patterns.md
@@ -5,6 +5,8 @@ layout: docs
 
 When using `--include-namespaces` and `--exclude-namespaces` flags with backup and restore commands, you can use glob patterns to match multiple namespaces.
 
+Note: If the resolution of namespace patterns results in no namespaces, the backup will succeed with a warning.
+
 ## Supported Patterns
 
 Velero supports the following glob pattern characters:


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
This change 
  - Cleans up an incorrect comment
  - Refactors a func into two to have single responsibility for each
  - Have a check around empty wildcardResult to log a warning, leading to Completed phase for backups with the warning counter being incremented


# Does your change fix a particular issue?

Fixes #9557 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
