### PR TITLE
Add e2e test case for PR 9452

### DIFF
--- a/test/e2e/nodeagentconfig/node-agent-config.go
+++ b/test/e2e/nodeagentconfig/node-agent-config.go
@@ -78,6 +78,14 @@ var LoadAffinities func() = TestFunc(&NodeAgentConfigTestCase{
 			IgnoreDelayBinding: true,
 		},
 		PriorityClassName: test.PriorityClassNameForDataMover,
+		// Explicitly add custom labels and annotations to be tested
+		PodLabels: map[string]string{
+			"spectrocloud.com/connection": "proxy", // Tests appending custom labels (Issue #9435)
+			"azure.workload.identity/use": "true",  // Tests overwriting built-in labels
+		},
+		PodAnnotations: map[string]string{
+			"test-data-mover-annotation": "true",
+		},
 	},
 	nodeAgentConfigMapName: "node-agent-config",
 })
@@ -244,6 +252,16 @@ func (n *NodeAgentConfigTestCase) Backup() error {
 
 	Expect(backupPodList.Items[0].Spec.Affinity).To(Equal(expectedAffinity))
 
+	// Verify PodLabels
+	for k, v := range n.nodeAgentConfigs.PodLabels {
+		Expect(backupPodList.Items[0].Labels[k]).To(Equal(v))
+	}
+
+	// Verify PodAnnotations
+	for k, v := range n.nodeAgentConfigs.PodAnnotations {
+		Expect(backupPodList.Items[0].Annotations[k]).To(Equal(v))
+	}
+
 	fmt.Println("backupPod content verification completed successfully.")
 
 	wait.PollUntilContextTimeout(n.Ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
@@ -320,6 +338,16 @@ func (n *NodeAgentConfigTestCase) Restore() error {
 	expectedAffinity := velerokubeutil.ToSystemAffinity(n.nodeAgentConfigs.LoadAffinity[0], nil)
 
 	Expect(restorePodList.Items[0].Spec.Affinity).To(Equal(expectedAffinity))
+
+	// Verify PodLabels
+	for k, v := range n.nodeAgentConfigs.PodLabels {
+		Expect(restorePodList.Items[0].Labels[k]).To(Equal(v))
+	}
+
+	// Verify PodAnnotations
+	for k, v := range n.nodeAgentConfigs.PodAnnotations {
+		Expect(restorePodList.Items[0].Annotations[k]).To(Equal(v))
+	}
 
 	fmt.Println("restorePod content verification completed successfully.")
 


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Add e2e test case for PR 9452:
Add maintenance job and data mover pod's labels and annotations setting.

# Does your change fix a particular issue?

Fixes #(issue)
#9452 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
