### PR TITLE
fix: use consistent 'Status' column name in backup storage location output

### DIFF
--- a/pkg/cmd/util/output/backup_storage_location_printer.go
+++ b/pkg/cmd/util/output/backup_storage_location_printer.go
@@ -31,7 +31,7 @@ var (
 		{Name: "Name", Type: "string", Format: "name"},
 		{Name: "Provider"},
 		{Name: "Bucket/Prefix"},
-		{Name: "Phase"},
+		{Name: "Status"},
 		{Name: "Last Validated"},
 		{Name: "Access Mode"},
 		{Name: "Default"},


### PR DESCRIPTION
…utput

Changed BackupStorageLocation printer column from 'Phase' to 'Status' for consistency with other resource types (Backup, Restore, Schedule, BackupRepository all use 'Status').

This improves user experience by providing consistent column naming across all 'velero get' commands.

Fixes #2989

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
