### PR TITLE
Add backupOperationsFrequency field to Backup CRD

### DIFF
--- a/changelogs/unreleased/9582-priyansh17
+++ b/changelogs/unreleased/9582-priyansh17
@@ -1,0 +1,1 @@
+Add backupOperationsFrequency field to Backup CRD for per-backup configuration of async operation check frequency

--- a/config/crd/v1/bases/velero.io_backuprepositories.yaml
+++ b/config/crd/v1/bases/velero.io_backuprepositories.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: backuprepositories.velero.io
 spec:
   group: velero.io

--- a/config/crd/v1/bases/velero.io_backups.yaml
+++ b/config/crd/v1/bases/velero.io_backups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: backups.velero.io
 spec:
   group: velero.io
@@ -41,6 +41,11 @@ spec:
           spec:
             description: BackupSpec defines the specification for a Velero backup.
             properties:
+              backupOperationsFrequency:
+                description: |-
+                  BackupOperationsFrequency specifies the frequency for checking backup operations progress.
+                  The default value is 10 seconds.
+                type: string
               csiSnapshotTimeout:
                 description: |-
                   CSISnapshotTimeout specifies the time used to wait for CSI VolumeSnapshot status turns to

--- a/config/crd/v1/bases/velero.io_backupstoragelocations.yaml
+++ b/config/crd/v1/bases/velero.io_backupstoragelocations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: backupstoragelocations.velero.io
 spec:
   group: velero.io

--- a/config/crd/v1/bases/velero.io_deletebackuprequests.yaml
+++ b/config/crd/v1/bases/velero.io_deletebackuprequests.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: deletebackuprequests.velero.io
 spec:
   group: velero.io

--- a/config/crd/v1/bases/velero.io_downloadrequests.yaml
+++ b/config/crd/v1/bases/velero.io_downloadrequests.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: downloadrequests.velero.io
 spec:
   group: velero.io

--- a/config/crd/v1/bases/velero.io_podvolumebackups.yaml
+++ b/config/crd/v1/bases/velero.io_podvolumebackups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: podvolumebackups.velero.io
 spec:
   group: velero.io

--- a/config/crd/v1/bases/velero.io_podvolumerestores.yaml
+++ b/config/crd/v1/bases/velero.io_podvolumerestores.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: podvolumerestores.velero.io
 spec:
   group: velero.io

--- a/config/crd/v1/bases/velero.io_restores.yaml
+++ b/config/crd/v1/bases/velero.io_restores.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: restores.velero.io
 spec:
   group: velero.io

--- a/config/crd/v1/bases/velero.io_schedules.yaml
+++ b/config/crd/v1/bases/velero.io_schedules.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: schedules.velero.io
 spec:
   group: velero.io
@@ -80,6 +80,11 @@ spec:
                   Template is the definition of the Backup to be run
                   on the provided schedule
                 properties:
+                  backupOperationsFrequency:
+                    description: |-
+                      BackupOperationsFrequency specifies the frequency for checking backup operations progress.
+                      The default value is 10 seconds.
+                    type: string
                   csiSnapshotTimeout:
                     description: |-
                       CSISnapshotTimeout specifies the time used to wait for CSI VolumeSnapshot status turns to

--- a/config/crd/v1/bases/velero.io_serverstatusrequests.yaml
+++ b/config/crd/v1/bases/velero.io_serverstatusrequests.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: serverstatusrequests.velero.io
 spec:
   group: velero.io

--- a/config/crd/v1/bases/velero.io_volumesnapshotlocations.yaml
+++ b/config/crd/v1/bases/velero.io_volumesnapshotlocations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: volumesnapshotlocations.velero.io
 spec:
   group: velero.io

--- a/pkg/apis/velero/v1/backup_types.go
+++ b/pkg/apis/velero/v1/backup_types.go
@@ -166,6 +166,12 @@ type BackupSpec struct {
 	// The default value is 4 hour.
 	// +optional
 	ItemOperationTimeout metav1.Duration `json:"itemOperationTimeout,omitempty"`
+
+	// BackupOperationsFrequency specifies the frequency for checking backup operations progress.
+	// The default value is 10 seconds.
+	// +optional
+	BackupOperationsFrequency metav1.Duration `json:"backupOperationsFrequency,omitempty"`
+
 	// ResourcePolicy specifies the referenced resource policies that backup should follow
 	// +optional
 	ResourcePolicy *corev1api.TypedLocalObjectReference `json:"resourcePolicy,omitempty"`

--- a/pkg/apis/velero/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/velero/v1/zz_generated.deepcopy.go
@@ -407,6 +407,7 @@ func (in *BackupSpec) DeepCopyInto(out *BackupSpec) {
 	}
 	out.CSISnapshotTimeout = in.CSISnapshotTimeout
 	out.ItemOperationTimeout = in.ItemOperationTimeout
+	out.BackupOperationsFrequency = in.BackupOperationsFrequency
 	if in.ResourcePolicy != nil {
 		in, out := &in.ResourcePolicy, &out.ResourcePolicy
 		*out = new(corev1.TypedLocalObjectReference)

--- a/pkg/builder/backup_builder.go
+++ b/pkg/builder/backup_builder.go
@@ -294,6 +294,12 @@ func (b *BackupBuilder) ItemOperationTimeout(timeout time.Duration) *BackupBuild
 	return b
 }
 
+// BackupOperationsFrequency sets the Backup's BackupOperationsFrequency
+func (b *BackupBuilder) BackupOperationsFrequency(frequency time.Duration) *BackupBuilder {
+	b.object.Spec.BackupOperationsFrequency.Duration = frequency
+	return b
+}
+
 // ResourcePolicies sets the Backup's resource polices.
 func (b *BackupBuilder) ResourcePolicies(name string) *BackupBuilder {
 	b.object.Spec.ResourcePolicy = &corev1api.TypedLocalObjectReference{Kind: resourcepolicies.ConfigmapRefType, Name: name}

--- a/pkg/controller/backup_operations_controller.go
+++ b/pkg/controller/backup_operations_controller.go
@@ -60,6 +60,16 @@ type backupOperationsReconciler struct {
 	metrics           *metrics.ServerMetrics
 }
 
+// getBackupOperationsFrequency returns the effective backup operations frequency for a backup.
+// It uses the frequency specified in the backup spec if set, otherwise falls back to the
+// controller's default frequency.
+func (c *backupOperationsReconciler) getBackupOperationsFrequency(backup *velerov1api.Backup) time.Duration {
+	if backup.Spec.BackupOperationsFrequency.Duration > 0 {
+		return backup.Spec.BackupOperationsFrequency.Duration
+	}
+	return c.frequency
+}
+
 func NewBackupOperationsReconciler(
 	logger logrus.FieldLogger,
 	client client.Client,

--- a/pkg/controller/backup_operations_controller_test.go
+++ b/pkg/controller/backup_operations_controller_test.go
@@ -347,3 +347,46 @@ func TestWrapErrMsg(t *testing.T) {
 		})
 	}
 }
+
+func TestGetBackupOperationsFrequency(t *testing.T) {
+	tests := []struct {
+		name              string
+		backupFrequency   time.Duration
+		controllerFreq    time.Duration
+		expectedFrequency time.Duration
+	}{
+		{
+			name:              "backup with custom frequency",
+			backupFrequency:   30 * time.Second,
+			controllerFreq:    10 * time.Second,
+			expectedFrequency: 30 * time.Second,
+		},
+		{
+			name:              "backup without frequency uses controller default",
+			backupFrequency:   0,
+			controllerFreq:    10 * time.Second,
+			expectedFrequency: 10 * time.Second,
+		},
+		{
+			name:              "backup with 1 minute frequency",
+			backupFrequency:   1 * time.Minute,
+			controllerFreq:    10 * time.Second,
+			expectedFrequency: 1 * time.Minute,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			backup := builder.ForBackup(velerov1api.DefaultNamespace, "test-backup").Result()
+			if test.backupFrequency > 0 {
+				backup.Spec.BackupOperationsFrequency.Duration = test.backupFrequency
+			}
+
+			fakeClient := velerotest.NewFakeControllerRuntimeClient(t)
+			reconciler := mockBackupOperationsReconciler(fakeClient, testclocks.NewFakeClock(time.Now()), test.controllerFreq)
+
+			freq := reconciler.getBackupOperationsFrequency(backup)
+			assert.Equal(t, test.expectedFrequency, freq)
+		})
+	}
+}

--- a/site/content/docs/main/api-types/backup.md
+++ b/site/content/docs/main/api-types/backup.md
@@ -39,6 +39,10 @@ spec:
   # asynchronous BackupItemAction operations
   # The default value is 4 hour.
   itemOperationTimeout: 4h
+  # BackupOperationsFrequency specifies how often to check the status of
+  # asynchronous BackupItemAction operations during a backup.
+  # The default value is 10s.
+  backupOperationsFrequency: 10s
   # resourcePolicy specifies the referenced resource policies that backup should follow
   # optional
   resourcePolicy:


### PR DESCRIPTION
# Summary

Adds `backupOperationsFrequency` field to Backup CRD, enabling per-backup configuration of how frequently the controller checks async backup item operation progress. Currently defaults to 10s globally via server flag.

# Changes

- **API**: Added `BackupOperationsFrequency metav1.Duration` to `BackupSpec`, following pattern of `ItemOperationTimeout` and `CSISnapshotTimeout`
- **CRD**: Regenerated schema with controller-gen v0.20.0 to expose new field
- **Controller**: Added `getBackupOperationsFrequency()` helper that reads from backup spec with fallback to controller default
- **Builder**: Added convenience method for test creation
- **Tests**: Added `TestGetBackupOperationsFrequency` covering custom frequency, default fallback, and various durations

# Usage

```yaml
apiVersion: velero.io/v1
kind: Backup
metadata:
  name: my-backup
spec:
  backupOperationsFrequency: "30s"
  itemOperationTimeout: "4h"
```

# Notes

The controller currently polls all backups at a global frequency via `PeriodicalEnqueueSource`. This PR adds the field and helper infrastructure for future per-backup frequency control without changing current polling behavior.

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [X] Updated the corresponding documentation in `site/content/docs/main`.
