### PR TITLE
Remove unecessary changelogs for 1.18.0

### DIFF
--- a/changelogs/unreleased/9508-kaovilai
+++ b/changelogs/unreleased/9508-kaovilai
@@ -1,1 +1,0 @@
-Fix VolumePolicy PVC phase condition filter for unbound PVCs (#9507)

--- a/changelogs/unreleased/9537-kaovilai
+++ b/changelogs/unreleased/9537-kaovilai
@@ -1,1 +1,0 @@
-Fix VolumePolicy PVC phase condition filter for unbound PVCs (#9507)

--- a/changelogs/unreleased/9539-Joeavaikath
+++ b/changelogs/unreleased/9539-Joeavaikath
@@ -1,1 +1,0 @@
-Support all glob wildcard characters in namespace validation

--- a/pkg/util/podvolume/pod_volume_test.go
+++ b/pkg/util/podvolume/pod_volume_test.go
@@ -156,7 +156,7 @@ func TestGetVolumesByPod(t *testing.T) {
 					Volumes: []corev1api.Volume{
 						// PVB Volumes
 						{Name: "pvbPV1"}, {Name: "pvbPV2"}, {Name: "pvbPV3"},
-						/// Excluded from PVB because colume mounting default service account token
+						/// Excluded from PVB because volume mounting default service account token
 						{Name: "default-token-5xq45"},
 					},
 				},


### PR DESCRIPTION
These 3 changes are bug fixes for features delivered in 1.18.0, so we don't need to have changelogs for them as the feature and fixes all go to 1.18.0
