### PR TITLE
Add itemOperationTimeout to Schedule API type docs

### DIFF
--- a/site/content/docs/main/api-types/schedule.md
+++ b/site/content/docs/main/api-types/schedule.md
@@ -63,6 +63,10 @@ spec:
     # CSI VolumeSnapshot status turns to ReadyToUse during creation, before
     # returning error as timeout. The default value is 10 minute.
     csiSnapshotTimeout: 10m
+    # ItemOperationTimeout specifies the time used to wait for
+    # asynchronous BackupItemAction operations
+    # The default value is 4 hour.
+    itemOperationTimeout: 4h
     # resourcePolicy specifies the referenced resource policies that backup should follow
     # optional
     resourcePolicy:


### PR DESCRIPTION
# Summary

Add the missing `itemOperationTimeout` field to the Schedule API type documentation. This field is already supported in the Schedule CRD's `spec.template` (as part of `BackupSpec`) but was not documented, leading users to believe it wasn't available per-schedule.

The format matches how `itemOperationTimeout` is documented in the Backup API type docs.

# Does your change fix a particular issue?

Fixes #9598

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.