### PR TITLE
feat: add backport GitHub Actions workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,44 @@
+name: Backport merged pull request
+on:
+  pull_request_target:
+    types: [closed]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backport:
+    name: Backport pull request
+    runs-on: ubuntu-latest
+
+    # Run when a PR is merged, or when a /backport comment is created by someone
+    # other than the backport-action bot (user id: 97796249).
+    if: >
+      (
+        github.event_name == 'pull_request_target' &&
+        github.event.pull_request.merged
+      ) || (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        github.event.comment.user.id != 97796249 &&
+        startsWith(github.event.comment.body, '/backport')
+      )
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Create backport pull requests
+        uses: korthout/backport-action@v3
+        with:
+          # Target branches to backport to when a 'backport release-X.Y' label is applied.
+          # Maintainers label PRs with e.g. 'backport release-1.7' to trigger backports.
+          label_pattern: '^backport ([\w\.\-\/]+)$'
+          # On conflict, open a draft PR so the author can resolve it manually.
+          conflict_resolution: draft_commit_conflicts
+          # Use GITHUB_TOKEN for creating PRs.
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Closes #9603.

Adds `.github/workflows/backport.yml` using [korthout/backport-action v3](https://github.com/korthout/backport-action) to automate PR backports across release branches.

## How it works

**Automatic trigger:** when a merged PR carries a `backport release-X.Y` label, the action automatically cherry-picks it onto the target branch and opens a PR.

**Manual trigger:** a maintainer (or the PR author) can comment `/backport release-X.Y` on any merged PR to kick off the same flow on demand.

**Conflict resolution:** set to `draft_commit_conflicts` — on a conflict the action opens a draft PR with conflict markers so the author can resolve it manually, rather than failing silently. (Per the approach discussed in #9603.)

## Changes

- `.github/workflows/backport.yml` — new workflow file, 44 lines