### PR TITLE
Add SFTP as a Kopia repository storage backend

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -135,6 +135,7 @@ require (
 	github.com/klauspost/crc32 v1.3.0 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/klauspost/reedsolomon v1.12.6 // indirect
+	github.com/kr/fs v0.1.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
@@ -157,6 +158,7 @@ require (
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+	github.com/pkg/sftp v1.13.10 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/common v0.67.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -496,6 +496,7 @@ github.com/klauspost/reedsolomon v1.12.6/go.mod h1:ggJT9lc71Vu+cSOPBlxGvBN6TfAS7
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kopia/htmluibuild v0.0.1-0.20251125011029-7f1c3f84f29d h1:U3VB/cDMsPW4zB4JRFbVRDzIpPytt889rJUKAG40NPA=
 github.com/kopia/htmluibuild v0.0.1-0.20251125011029-7f1c3f84f29d/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -609,6 +610,8 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
+github.com/pkg/sftp v1.13.10 h1:+5FbKNTe5Z9aspU88DPIKJ9z2KZoaGCu6Sr6kKR/5mU=
+github.com/pkg/sftp v1.13.10/go.mod h1:bJ1a7uDhrX/4OII+agvy28lzRvQrmIQuaHrcI1HbeGA=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/repository/config/config.go
+++ b/pkg/repository/config/config.go
@@ -34,6 +34,7 @@ const (
 	AzureBackend BackendType = "velero.io/azure"
 	GCPBackend   BackendType = "velero.io/gcp"
 	FSBackend    BackendType = "velero.io/fs"
+	SFTPBackend  BackendType = "velero.io/sftp"
 
 	// CredentialsFileKey is the key within a BSL config that is checked to see if
 	// the BSL is using its own credentials, rather than those in the environment
@@ -109,7 +110,7 @@ func GetBackendType(provider string, config map[string]string) BackendType {
 }
 
 func IsBackendTypeValid(backendType BackendType) bool {
-	return (backendType == AWSBackend || backendType == AzureBackend || backendType == GCPBackend || backendType == FSBackend)
+	return (backendType == AWSBackend || backendType == AzureBackend || backendType == GCPBackend || backendType == FSBackend || backendType == SFTPBackend)
 }
 
 // GetRepoIdentifier returns the string to be used as the value of the --repo flag in

--- a/pkg/repository/provider/unified_repo.go
+++ b/pkg/repository/provider/unified_repo.go
@@ -481,6 +481,8 @@ func getStorageType(backupLocation *velerov1api.BackupStorageLocation) string {
 		return udmrepo.StorageTypeGcs
 	case repoconfig.FSBackend:
 		return udmrepo.StorageTypeFs
+	case repoconfig.SFTPBackend:
+		return udmrepo.StorageTypeSftp
 	default:
 		return ""
 	}
@@ -530,6 +532,10 @@ func getStorageCredentials(backupLocation *velerov1api.BackupStorageLocation, cr
 		}
 	case repoconfig.GCPBackend:
 		result[udmrepo.StoreOptionCredentialFile] = getGCPCredentials(config)
+	case repoconfig.SFTPBackend:
+		if backupLocation.Spec.Credential != nil {
+			result[repoconfig.CredentialsFileKey] = config[repoconfig.CredentialsFileKey]
+		}
 	}
 
 	return result, nil
@@ -623,6 +629,18 @@ func getStorageVariables(backupLocation *velerov1api.BackupStorageLocation, repo
 	}
 	result[udmrepo.StoreOptionOssRegion] = strings.Trim(region, "/")
 	result[udmrepo.StoreOptionFsPath] = config["fspath"]
+
+	// SFTP backend variables
+	if backendType == repoconfig.SFTPBackend {
+		result[udmrepo.StoreOptionSFTPHost] = config["sftpHost"]
+		result[udmrepo.StoreOptionSFTPPort] = config["sftpPort"]
+		result[udmrepo.StoreOptionSFTPPath] = config["sftpPath"]
+		result[udmrepo.StoreOptionSFTPUsername] = config["sftpUsername"]
+		result[udmrepo.StoreOptionSFTPKeyPath] = config["sftpKeyPath"]
+		result[udmrepo.StoreOptionSFTPKeyData] = config["sftpKeyData"]
+		result[udmrepo.StoreOptionSFTPPassword] = config["sftpPassword"]
+		result[udmrepo.StoreOptionSFTPKnownHostsData] = config["sftpKnownHostsData"]
+	}
 
 	// We remove the unnecessary parameters and keep the modules/logics below safe
 	if backupRepoConfig != nil {

--- a/pkg/repository/udmrepo/kopialib/backend/sftp.go
+++ b/pkg/repository/udmrepo/kopialib/backend/sftp.go
@@ -1,0 +1,83 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backend
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/blob/sftp"
+
+	"github.com/vmware-tanzu/velero/pkg/repository/udmrepo"
+	"github.com/vmware-tanzu/velero/pkg/repository/udmrepo/kopialib/backend/logging"
+)
+
+// SFTPBackend implements the backend.Store interface for SFTP storage
+// using Kopia's native SFTP blob storage.
+type SFTPBackend struct {
+	options sftp.Options
+}
+
+func (c *SFTPBackend) Setup(ctx context.Context, flags map[string]string, logger logrus.FieldLogger) error {
+	host, err := mustHaveString(udmrepo.StoreOptionSFTPHost, flags)
+	if err != nil {
+		return err
+	}
+
+	c.options.Host = host
+	c.options.Username = optionalHaveString(udmrepo.StoreOptionSFTPUsername, flags)
+
+	if portStr := optionalHaveString(udmrepo.StoreOptionSFTPPort, flags); portStr != "" {
+		port, err := strconv.Atoi(portStr)
+		if err != nil {
+			return err
+		}
+		c.options.Port = port
+	} else {
+		c.options.Port = 22
+	}
+
+	sftpPath := optionalHaveString(udmrepo.StoreOptionSFTPPath, flags)
+	prefix := optionalHaveString(udmrepo.StoreOptionPrefix, flags)
+	if sftpPath != "" && prefix != "" {
+		c.options.Path = sftpPath + "/" + prefix
+	} else if sftpPath != "" {
+		c.options.Path = sftpPath
+	} else if prefix != "" {
+		c.options.Path = "/" + prefix
+	} else {
+		c.options.Path = "/"
+	}
+
+	c.options.Password = optionalHaveString(udmrepo.StoreOptionSFTPPassword, flags)
+	c.options.Keyfile = optionalHaveString(udmrepo.StoreOptionSFTPKeyPath, flags)
+	c.options.KeyData = optionalHaveString(udmrepo.StoreOptionSFTPKeyData, flags)
+	c.options.KnownHostsData = optionalHaveString(udmrepo.StoreOptionSFTPKnownHostsData, flags)
+
+	ctx = logging.WithLogger(ctx, logger)
+	c.options.Limits = setupLimits(ctx, flags)
+
+	return nil
+}
+
+func (c *SFTPBackend) Connect(ctx context.Context, isCreate bool, logger logrus.FieldLogger) (blob.Storage, error) {
+	ctx = logging.WithLogger(ctx, logger)
+	return sftp.New(ctx, &c.options, isCreate)
+}

--- a/pkg/repository/udmrepo/kopialib/repo_init.go
+++ b/pkg/repository/udmrepo/kopialib/repo_init.go
@@ -49,6 +49,7 @@ var backendStores = []kopiaBackendStore{
 	{udmrepo.StorageTypeFs, "a filesystem", &backend.FsBackend{}},
 	{udmrepo.StorageTypeGcs, "a Google Cloud Storage bucket", &backend.GCSBackend{}},
 	{udmrepo.StorageTypeS3, "an S3 bucket", &backend.S3Backend{}},
+	{udmrepo.StorageTypeSftp, "an SFTP server", &backend.SFTPBackend{}},
 }
 
 const udmRepoBlobID = "udmrepo.Repository"

--- a/pkg/repository/udmrepo/repo_options.go
+++ b/pkg/repository/udmrepo/repo_options.go
@@ -29,6 +29,7 @@ const (
 	StorageTypeAzure = "azure"
 	StorageTypeFs    = "filesystem"
 	StorageTypeGcs   = "gcs"
+	StorageTypeSftp  = "sftp"
 
 	GenOptionMaintainMode  = "mode"
 	GenOptionMaintainFull  = "full"
@@ -46,6 +47,15 @@ const (
 	StoreOptionS3DisableTLSVerify = "skipTLSVerify"
 
 	StoreOptionFsPath = "fspath"
+
+	StoreOptionSFTPHost           = "sftpHost"
+	StoreOptionSFTPPort           = "sftpPort"
+	StoreOptionSFTPPath           = "sftpPath"
+	StoreOptionSFTPUsername       = "sftpUsername"
+	StoreOptionSFTPKeyPath        = "sftpKeyPath"
+	StoreOptionSFTPKeyData        = "sftpKeyData"
+	StoreOptionSFTPPassword       = "sftpPassword"
+	StoreOptionSFTPKnownHostsData = "sftpKnownHostsData"
 
 	StoreOptionGcsReadonly = "readonly"
 


### PR DESCRIPTION
## Summary

Wire Kopia's native SFTP blob storage (`repo/blob/sftp`) through Velero's repository abstraction layer, enabling `snapshotMoveData` and `fs-backup` to store deduplicated volume data on SFTP servers.

Fixes #9617
Related: #8707 #7364

## Changes

| File | Change |
|------|--------|
| `pkg/repository/config/config.go` | Add `SFTPBackend` type, extend `IsBackendTypeValid()` |
| `pkg/repository/udmrepo/repo_options.go` | Add `StorageTypeSftp` and 8 SFTP config constants |
| `pkg/repository/provider/unified_repo.go` | Add SFTP case in `getStorageType()`, `getStorageVariables()`, `getStorageCredentials()` |
| `pkg/repository/udmrepo/kopialib/backend/sftp.go` | **New** — `SFTPBackend` implementing `Store` interface via `kopia/repo/blob/sftp` |
| `pkg/repository/udmrepo/kopialib/repo_init.go` | Register SFTP backend in `backendStores` slice |
| `go.mod` / `go.sum` | Add `github.com/pkg/sftp` dependency (already a transitive dep of Kopia) |

## Motivation

Velero supports S3, Azure, GCS, and filesystem as Kopia backends. Users with self-hosted infrastructure (Hetzner Storage Box, Synology NAS, any SSH server) cannot use any existing backend without an S3 proxy. Kopia already has a native SFTP implementation — this PR simply connects it.

## BSL Configuration

```yaml
spec:
  provider: sftp
  config:
    sftpHost: backup.example.com
    sftpPort: "23"
    sftpUsername: user
    sftpPassword: secret
    sftpPath: /backups/velero
    sftpKnownHostsData: "[backup.example.com]:23 ssh-ed25519 AAAA..."
```

Authentication supports password, key file (`sftpKeyPath`), or inline key data (`sftpKeyData`).

## Companion ObjectStore Plugin

The BSL `provider: sftp` also requires an ObjectStore plugin for backup metadata. A reference implementation is available: [Freshost/velero-plugin-for-sftp](https://github.com/Freshost/velero-plugin-for-sftp).

## Testing

- All existing unit tests pass (`go test ./pkg/repository/...`)
- End-to-end tested on K3s with Proxmox CSI snapshots + `snapshotMoveData` + SFTP (Hetzner Storage Box)
- Kopia repository encryption (AES-256-GCM) verified working over SFTP
- Backup `Completed`, data verified on remote SFTP server