### PR TITLE
Reduce binary size using -s -w ldflags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,7 +44,7 @@ builds:
       - goos: windows
         goarch: s390x
     ldflags:
-      - -X "github.com/vmware-tanzu/velero/pkg/buildinfo.Version={{ .Tag }}" -X "github.com/vmware-tanzu/velero/pkg/buildinfo.GitSHA={{ .FullCommit }}" -X "github.com/vmware-tanzu/velero/pkg/buildinfo.GitTreeState={{ .Env.GIT_TREE_STATE }}" -X "github.com/vmware-tanzu/velero/pkg/buildinfo.ImageRegistry={{ .Env.REGISTRY }}"
+      - -s -w -X "github.com/vmware-tanzu/velero/pkg/buildinfo.Version={{ .Tag }}" -X "github.com/vmware-tanzu/velero/pkg/buildinfo.GitSHA={{ .FullCommit }}" -X "github.com/vmware-tanzu/velero/pkg/buildinfo.GitTreeState={{ .Env.GIT_TREE_STATE }}" -X "github.com/vmware-tanzu/velero/pkg/buildinfo.ImageRegistry={{ .Env.REGISTRY }}"
 archives:
   - name_template: "{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
     wrap_in_directory: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ENV CGO_ENABLED=0 \
     GOOS=${TARGETOS} \
     GOARCH=${TARGETARCH} \
     GOARM=${TARGETVARIANT} \
-    LDFLAGS="-X ${PKG}/pkg/buildinfo.Version=${VERSION} -X ${PKG}/pkg/buildinfo.GitSHA=${GIT_SHA} -X ${PKG}/pkg/buildinfo.GitTreeState=${GIT_TREE_STATE} -X ${PKG}/pkg/buildinfo.ImageRegistry=${REGISTRY}"
+    LDFLAGS="-s -w -X ${PKG}/pkg/buildinfo.Version=${VERSION} -X ${PKG}/pkg/buildinfo.GitSHA=${GIT_SHA} -X ${PKG}/pkg/buildinfo.GitTreeState=${GIT_TREE_STATE} -X ${PKG}/pkg/buildinfo.ImageRegistry=${REGISTRY}"
 
 WORKDIR /go/src/github.com/vmware-tanzu/velero
 

--- a/Dockerfile-Windows
+++ b/Dockerfile-Windows
@@ -34,7 +34,7 @@ ENV CGO_ENABLED=0 \
     GOOS=${TARGETOS} \
     GOARCH=${TARGETARCH} \
     GOARM=${TARGETVARIANT} \
-    LDFLAGS="-X ${PKG}/pkg/buildinfo.Version=${VERSION} -X ${PKG}/pkg/buildinfo.GitSHA=${GIT_SHA} -X ${PKG}/pkg/buildinfo.GitTreeState=${GIT_TREE_STATE} -X ${PKG}/pkg/buildinfo.ImageRegistry=${REGISTRY}"
+    LDFLAGS="-s -w -X ${PKG}/pkg/buildinfo.Version=${VERSION} -X ${PKG}/pkg/buildinfo.GitSHA=${GIT_SHA} -X ${PKG}/pkg/buildinfo.GitTreeState=${GIT_TREE_STATE} -X ${PKG}/pkg/buildinfo.ImageRegistry=${REGISTRY}"
 
 WORKDIR /go/src/github.com/vmware-tanzu/velero
 

--- a/changelogs/unreleased/9627-caxu-rh
+++ b/changelogs/unreleased/9627-caxu-rh
@@ -1,0 +1,1 @@
+Reduce binary size using -s -w ldflags

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -67,7 +67,8 @@ fi
 
 export CGO_ENABLED=0
 
-LDFLAGS="-X ${PKG}/pkg/buildinfo.Version=${VERSION}"
+LDFLAGS="-s -w"
+LDFLAGS="${LDFLAGS} -X ${PKG}/pkg/buildinfo.Version=${VERSION}"
 LDFLAGS="${LDFLAGS} -X ${PKG}/pkg/buildinfo.ImageRegistry=${REGISTRY}"
 LDFLAGS="${LDFLAGS} -X ${PKG}/pkg/buildinfo.GitSHA=${GIT_SHA}"
 LDFLAGS="${LDFLAGS} -X ${PKG}/pkg/buildinfo.GitTreeState=${GIT_TREE_STATE}"


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

This change adds the Go ldflags `-s -w` which omits the symbol table and DWARF debugging information from the resulting binaries. The flags are added in GoReleaser configuration, Dockerfile{-Windows}, and the `hack/build.sh` for consistency. This allows for some reductions in binary size. Note that the size of release tarballs might not change as much (symbol table and DWARF debug info compress well), but the size of the unpacked binary on-disk will see improvements.

From local testing:

| os/arch | `CGO_ENABLED=0 go build ./cmd/velero/velero.go` | `CGO_ENABLED=0 go build -ldflags '-s -w' ./cmd/velero/velero.go` |
| --- | --- | --- |
| darwin/arm64 | 132M | 90M |
| darwin/amd64 | 139M | 97M |
| linux/amd64 | 135M | 94M |
| linux/arm64 | 126M | 87M |
| linux/arm | 124M | 86M |
| linux/ppc64le | 131M | 92M |
| linux/s390x | 135M | 95M |
| windows/amd64 | 136M | 97M |

# Does your change fix a particular issue?

This change does not fix a particular issue.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
