### PR TITLE
Fix service restore with null healthCheckNodePort in last-applied-configuration label

### DIFF
--- a/changelogs/unreleased/9653-BassinD
+++ b/changelogs/unreleased/9653-BassinD
@@ -1,0 +1,1 @@
+Fix service restore with null healthCheckNodePort in last-applied-configuration label

--- a/pkg/restore/actions/service_action.go
+++ b/pkg/restore/actions/service_action.go
@@ -94,21 +94,18 @@ func deleteHealthCheckNodePort(service *corev1api.Service) error {
 
 	// Search HealthCheckNodePort from server's last-applied-configuration
 	// annotation(HealthCheckNodePort is specified by `kubectl apply` command)
-	lastAppliedConfig, ok := service.Annotations[annotationLastAppliedConfig]
-	if ok {
-		appliedServiceUnstructured := new(map[string]any)
-		if err := json.Unmarshal([]byte(lastAppliedConfig), appliedServiceUnstructured); err != nil {
+	if lastAppliedConfig, ok := service.Annotations[annotationLastAppliedConfig]; ok {
+		var appliedConfig struct {
+			Spec struct {
+				HealthCheckNodePort *int32 `json:"healthCheckNodePort"`
+			} `json:"spec"`
+		}
+
+		if err := json.Unmarshal([]byte(lastAppliedConfig), &appliedConfig); err != nil {
 			return errors.WithStack(err)
 		}
 
-		healthCheckNodePort, exist, err := unstructured.NestedFloat64(*appliedServiceUnstructured, "spec", "healthCheckNodePort")
-		if err != nil {
-			return errors.WithStack(err)
-		}
-
-		// Found healthCheckNodePort in lastAppliedConfig annotation,
-		// and the value is not 0. No need to delete, return.
-		if exist && healthCheckNodePort != 0 {
+		if appliedConfig.Spec.HealthCheckNodePort != nil && *appliedConfig.Spec.HealthCheckNodePort != 0 {
 			return nil
 		}
 	}

--- a/pkg/restore/actions/service_action_test.go
+++ b/pkg/restore/actions/service_action_test.go
@@ -644,6 +644,36 @@ func TestServiceActionExecute(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "If PreserveNodePorts is false and HealthCheckNodePort is null in last-applied-configuration, it should not crash and the port should be cleared.",
+			obj: corev1api.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "svc-1",
+					Annotations: map[string]string{
+						"kubectl.kubernetes.io/last-applied-configuration": `{"spec":{"healthCheckNodePort":null}}`,
+					},
+				},
+				Spec: corev1api.ServiceSpec{
+					HealthCheckNodePort:   8080,
+					ExternalTrafficPolicy: corev1api.ServiceExternalTrafficPolicyTypeLocal,
+					Type:                  corev1api.ServiceTypeLoadBalancer,
+				},
+			},
+			restore: builder.ForRestore(api.DefaultNamespace, "").PreserveNodePorts(false).Result(),
+			expectedRes: corev1api.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "svc-1",
+					Annotations: map[string]string{
+						"kubectl.kubernetes.io/last-applied-configuration": `{"spec":{"healthCheckNodePort":null}}`,
+					},
+				},
+				Spec: corev1api.ServiceSpec{
+					HealthCheckNodePort:   0,
+					ExternalTrafficPolicy: corev1api.ServiceExternalTrafficPolicyTypeLocal,
+					Type:                  corev1api.ServiceTypeLoadBalancer,
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
# Please add a summary of your change

## 1. Root Cause
The `deleteHealthCheckNodePort` function was previously using `unstructured.NestedFloat64` to parse the `kubectl.kubernetes.io/last-applied-configuration` annotation. Because Go unmarshals dynamic JSON numbers as float64, the accessor expected a float. However, if a service's last-applied-configuration explicitly contained `"healthCheckNodePort": null`, the underlying JSON parser evaluated it as nil. The NestedFloat64 function then attempted an unsafe type assertion on that nil value, resulting in the crash: `.spec.healthCheckNodePort accessor error: <nil> is of the type <nil>, expected float64`.

## 2. Solution
I replaced the unstructured map parsing with a strict, minimal anonymous struct utilizing a pointer for the target field (*int32). By unmarshaling the annotation directly into this minimal struct, we achieve several benefits:

* Native null handling: The encoding/json library safely interprets a JSON null as a Go nil pointer, completely eliminating the type assertion panic.

* Type safety: It maps directly to `int32` instead of relying on` float64` conversions.

* Efficiency: The JSON parser now only allocates memory for the single nested field we care about, ignoring the rest of the payload and bypassing the heavy map[string]interface{} allocations.

## 3. Testing
Added a unit test to specifically cover this edge case. 

# Does your change fix a particular issue?

Fixes #9650

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] _N/A_ Updated the corresponding documentation in `site/content/docs/main`.
