### PR TITLE
fix: e2e test case for multiple fs-backup ns mapping

### DIFF
--- a/test/e2e/basic/namespace-mapping.go
+++ b/test/e2e/basic/namespace-mapping.go
@@ -86,7 +86,9 @@ func (n *NamespaceMapping) Init() error {
 
 func (n *NamespaceMapping) CreateResources() error {
 	for index, ns := range *n.NSIncluded {
-		n.kibishiiData.Levels = len(*n.NSIncluded) + index
+		if n.VeleroCfg.CloudProvider != "kind" {
+			n.kibishiiData.Levels = len(*n.NSIncluded) + index
+		}
 		By(fmt.Sprintf("Creating namespaces ...%s\n", ns), func() {
 			Expect(CreateNamespace(n.Ctx, n.Client, ns)).To(Succeed(), fmt.Sprintf("Failed to create namespace %s", ns))
 		})
@@ -109,7 +111,9 @@ func (n *NamespaceMapping) CreateResources() error {
 
 func (n *NamespaceMapping) Verify() error {
 	for index, ns := range n.MappedNamespaceList {
-		n.kibishiiData.Levels = len(*n.NSIncluded) + index
+		if n.VeleroCfg.CloudProvider != "kind" {
+			n.kibishiiData.Levels = len(*n.NSIncluded) + index
+		}
 		By(fmt.Sprintf("Verify workload %s after restore ", ns), func() {
 			Expect(KibishiiVerifyAfterRestore(n.Client, ns,
 				n.Ctx, n.kibishiiData, "")).To(Succeed(), "Fail to verify workload after restore")


### PR DESCRIPTION
 In Init(), on kind, kibishiiData is intentionally zeroed out (Levels: 0, DirsPerLevel: 0, ...) because kind doesn't support volume snapshots or fs-backup ; volumes aren't backed up (--snapshot-volumes=false without --default-volumes-to-fs-backup). However, CreateResources() and Verify() unconditionally override kibishiiData.Levels to len(*n.NSIncluded) + index, which for the Multiple test sets Levels to 2 and 3. This causes generate.sh to write data into PVCs that never gets backed up, and then verify.sh fails post-restore because the data isn't there.

Fix: Guard the Levels override so it's only applied on non-kind environments where volume data is actually backed up and restored.

Failure logs: https://github.com/vmware-tanzu/velero/actions/runs/23600057117/job/68728032211#logs

Fixes #(issue)
none, e2e test case.

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
