### PR TITLE
Pin the sigs.k8s.io/controller-runtime to v0.23.2

### DIFF
--- a/hack/build-image/Dockerfile
+++ b/hack/build-image/Dockerfile
@@ -22,7 +22,7 @@ ENV GOPROXY=${GOPROXY}
 
 # kubebuilder test bundle is separated from kubebuilder. Need to setup it for CI test.
 # Using setup-envtest to download envtest binaries
-RUN go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest && \
+RUN go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20260305094418-8122a6266696 && \
     mkdir -p /usr/local/kubebuilder/bin && \
     ENVTEST_ASSETS_DIR=$(setup-envtest use 1.33.0 --bin-dir /usr/local/kubebuilder/bin -p path) && \
     cp -r ${ENVTEST_ASSETS_DIR}/* /usr/local/kubebuilder/bin/


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
The tag used to `latest`.
Due to `latest` tag `v0.23.3` already used Golang `v1.26`, Velero main still uses `v1.25`. 
As a result, the CI action failed. To fix this, pin the controller-runtime to `v0.23.2`.

# Does your change fix a particular issue?

Fixes GitHub CI action failures:
https://github.com/vmware-tanzu/velero/actions/runs/23843513568/job/69504945692?pr=9663

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
