### PR TITLE
Add dynamic resource autocompletion to Velero CLI

### DIFF
--- a/changelogs/unreleased/9720-Joeavaikath
+++ b/changelogs/unreleased/9720-Joeavaikath
@@ -1,0 +1,1 @@
+Add dynamic resource autocompletion to Velero CLI

--- a/design/cli-dynamic-resource-completion_design.md
+++ b/design/cli-dynamic-resource-completion_design.md
@@ -1,0 +1,157 @@
+# Dynamic Resource Autocompletion for Velero CLI
+
+## Abstract
+
+Velero CLI currently has no dynamic shell completion for resource names.
+Tab-completing `velero backup describe <TAB>` produces no suggestions, even when backups exist on the cluster.
+This proposal adds dynamic completion for all commands that take Velero resource names as positional arguments or flag values, using cobra's `ValidArgsFunction` and `RegisterFlagCompletionFunc` mechanisms.
+
+## Background
+
+Shell completion is a standard UX feature in Kubernetes CLI tooling.
+Tools like `kubectl`, `oc`, and `helm` all provide dynamic completions that query the cluster to suggest resource names.
+Velero's `velero completion` command generates static completion scripts using cobra's v1 API (`GenBashCompletion`), which only completes command and flag names.
+Cobra v1.8.1 (Velero's current version) supports dynamic completion via `ValidArgsFunction` on `cobra.Command` and `RegisterFlagCompletionFunc` for flag values, but Velero does not use either.
+
+The bash v1 completion generator (`GenBashCompletion`) does not invoke `ValidArgsFunction` callbacks.
+Cobra provides a v2 generator (`GenBashCompletionV2`) that does.
+The zsh and fish generators already support `ValidArgsFunction` natively.
+
+## Goals
+
+- Add dynamic shell completion for all 20 commands that accept existing Velero resource names as positional arguments.
+- Add dynamic flag completion for 5 flags that reference existing Velero resources (`--from-backup`, `--from-schedule`, `--storage-location`, `--volume-snapshot-locations`).
+- Fail silently when the cluster is unreachable, matching the behavior of `oc` and `kubectl`.
+
+## Non Goals
+
+- Completing positional arguments for commands that take new resource names (e.g., `velero backup create <new-name>`).
+- Completing flags that take non-resource values (e.g., `--include-namespaces`, `--labels`).
+- Adding completion for hidden internal commands (`data-mover`, `pod-volume`, `repo-maintenance`).
+- Caching cluster state across tab presses.
+
+## High-Level Design
+
+A centralized set of completion functions is added to `pkg/cmd/cli/completion_functions.go`.
+Each function takes a `client.Factory`, returns a closure matching cobra's `ValidArgsFunction` signature, and lists resources of a specific type from the cluster.
+Each command constructor wires the appropriate completion function onto its `cobra.Command` via `ValidArgsFunction` or `RegisterFlagCompletionFunc`.
+The bash completion generator is switched from v1 to v2 to enable dynamic completion support.
+
+## Detailed Design
+
+### Completion functions
+
+A new file `pkg/cmd/cli/completion_functions.go` in the `cli` package provides six public functions:
+
+| Function | Resource listed |
+|---|---|
+| `CompleteBackupNames(f client.Factory)` | `velerov1api.BackupList` |
+| `CompleteRestoreNames(f client.Factory)` | `velerov1api.RestoreList` |
+| `CompleteScheduleNames(f client.Factory)` | `velerov1api.ScheduleList` |
+| `CompleteBackupStorageLocationNames(f client.Factory)` | `velerov1api.BackupStorageLocationList` |
+| `CompleteVolumeSnapshotLocationNames(f client.Factory)` | `velerov1api.VolumeSnapshotLocationList` |
+| `CompleteBackupRepositoryNames(f client.Factory)` | `velerov1api.BackupRepositoryList` |
+
+Each function returns a `func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)` closure.
+The closure:
+
+1. Calls `f.KubebuilderClient()` to get a controller-runtime client.
+2. Lists resources in `f.Namespace()`.
+3. Filters names by `strings.HasPrefix(name, toComplete)`.
+4. Returns the matching names with `cobra.ShellCompDirectiveNoFileComp`.
+
+If either the client construction or the list call fails, the function returns `nil, cobra.ShellCompDirectiveNoFileComp` (silent failure, no file completion fallback).
+
+A package-level type alias keeps the function signatures readable:
+
+```go
+type completionFunc = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
+```
+
+Note: `cobra.ValidArgsFunction` is not an exported type in cobra v1.8.1.
+It is only the inline type of the `ValidArgsFunction` field on `cobra.Command`.
+The type alias is used for return types of the completion helper functions and is directly assignable to the field.
+
+### Commands wired with `ValidArgsFunction`
+
+Each `New*Command` constructor sets `c.ValidArgsFunction` after creating the command and before returning it.
+Because Velero exposes both `velero backup get` and `velero get backups` via the same constructor function (`backup.NewGetCommand`), both command trees get completion automatically.
+
+| Package | Commands | Completion function |
+|---|---|---|
+| `backup` | get, describe, delete, logs, download | `CompleteBackupNames` |
+| `restore` | get, describe, delete, logs | `CompleteRestoreNames` |
+| `schedule` | get, describe, delete, pause, unpause | `CompleteScheduleNames` |
+| `backuplocation` | get, set, delete | `CompleteBackupStorageLocationNames` |
+| `snapshotlocation` | get, set | `CompleteVolumeSnapshotLocationNames` |
+| `repo` | get | `CompleteBackupRepositoryNames` |
+
+### Flags wired with `RegisterFlagCompletionFunc`
+
+| Command | Flag | Completion function |
+|---|---|---|
+| `backup create` | `--from-schedule` | `CompleteScheduleNames` |
+| `backup create` | `--storage-location` | `CompleteBackupStorageLocationNames` |
+| `backup create` | `--volume-snapshot-locations` | `CompleteVolumeSnapshotLocationNames` |
+| `restore create` | `--from-backup` | `CompleteBackupNames` |
+| `restore create` | `--from-schedule` | `CompleteScheduleNames` |
+
+The return value of `RegisterFlagCompletionFunc` is discarded (`_ =`) because it only fails if the named flag does not exist, which would be a compile-time coding error.
+
+### Bash completion v1 to v2 migration
+
+In `pkg/cmd/cli/completion/completion.go`, the bash case is changed from:
+
+```go
+cmd.Root().GenBashCompletion(os.Stdout)
+```
+
+to:
+
+```go
+cmd.Root().GenBashCompletionV2(os.Stdout, true)
+```
+
+The `true` parameter includes completion descriptions.
+Zsh and fish generators are unchanged as they already support `ValidArgsFunction`.
+
+### Client construction
+
+Completion functions use `f.KubebuilderClient()`, which constructs a REST config and a controller-runtime client with the Velero scheme on each invocation.
+This is the same client used by the commands themselves.
+The factory is captured by closure from the command constructor, so no changes to `completion.NewCommand()` or the root command wiring are needed.
+
+## Alternatives Considered
+
+### Generic completion function using Go generics
+
+A single generic function parameterized by list type and item type was considered to avoid the six similar functions.
+This was rejected because the list types do not share a common interface for extracting item names (no `GetItems()` method), so the generic version would need function parameters for constructing the list and extracting names, making it no simpler than individual functions.
+
+### Passing the factory to the completion command
+
+It was considered whether `completion.NewCommand()` should receive `client.Factory` to register completion callbacks centrally.
+This is unnecessary because `ValidArgsFunction` is set per-command-instance in each constructor, and cobra's hidden `__complete` command handles runtime dispatch.
+The completion command only generates the shell script.
+
+## Security Considerations
+
+Completion functions issue read-only list requests to the Kubernetes API server using the user's existing kubeconfig credentials.
+No new permissions are required beyond what the user already has for the commands themselves.
+No data is written, cached, or transmitted to external services.
+
+## Compatibility
+
+The bash completion output format changes from v1 to v2.
+Users who have previously generated and sourced bash completion scripts will need to regenerate them with `velero completion bash`.
+This is the expected workflow when upgrading any CLI tool.
+Zsh and fish completion scripts are unchanged in format.
+
+Existing command behavior is unaffected.
+The `ValidArgsFunction` field is only invoked during shell completion; it has no effect on normal command execution.
+
+## Implementation
+
+The implementation is contained in a single commit on the `feature/dynamic-cli-completion` branch.
+It touches 24 files (1 new, 23 modified) with 201 insertions and 1 deletion.
+All existing tests pass without modification.

--- a/pkg/cmd/cli/backup/create.go
+++ b/pkg/cmd/cli/backup/create.go
@@ -32,6 +32,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/builder"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
+	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/flag"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/output"
 	"github.com/vmware-tanzu/velero/pkg/util/collections"
@@ -74,6 +75,10 @@ func NewCreateCommand(f client.Factory, use string) *cobra.Command {
 	o.BindFromSchedule(c.Flags())
 	output.BindFlags(c.Flags())
 	output.ClearOutputFlagDefault(c)
+
+	_ = c.RegisterFlagCompletionFunc("from-schedule", cli.CompleteScheduleNames(f))
+	_ = c.RegisterFlagCompletionFunc("storage-location", cli.CompleteBackupStorageLocationNames(f))
+	_ = c.RegisterFlagCompletionFunc("volume-snapshot-locations", cli.CompleteVolumeSnapshotLocationNames(f))
 
 	return c
 }

--- a/pkg/cmd/cli/backup/delete.go
+++ b/pkg/cmd/cli/backup/delete.go
@@ -64,6 +64,7 @@ func NewDeleteCommand(f client.Factory, use string) *cobra.Command {
 		},
 	}
 
+	c.ValidArgsFunction = cli.CompleteBackupNames(f)
 	o.BindFlags(c.Flags())
 
 	return c

--- a/pkg/cmd/cli/backup/describe.go
+++ b/pkg/cmd/cli/backup/describe.go
@@ -29,6 +29,7 @@ import (
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
+	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/output"
 	"github.com/vmware-tanzu/velero/pkg/label"
 )
@@ -112,6 +113,7 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 		},
 	}
 
+	c.ValidArgsFunction = cli.CompleteBackupNames(f)
 	c.Flags().StringVarP(&listOptions.LabelSelector, "selector", "l", listOptions.LabelSelector, "Only show items matching this label selector.")
 	c.Flags().BoolVar(&details, "details", details, "Display additional detail in the command output.")
 	c.Flags().BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", insecureSkipTLSVerify, "If true, the object store's TLS certificate will not be checked for validity. This is insecure and susceptible to man-in-the-middle attacks. Not recommended for production.")

--- a/pkg/cmd/cli/backup/download.go
+++ b/pkg/cmd/cli/backup/download.go
@@ -31,6 +31,7 @@ import (
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
+	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/cacert"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/downloadrequest"
 )
@@ -55,6 +56,7 @@ func NewDownloadCommand(f client.Factory) *cobra.Command {
 		},
 	}
 
+	c.ValidArgsFunction = cli.CompleteBackupNames(f)
 	o.BindFlags(c.Flags())
 
 	return c

--- a/pkg/cmd/cli/backup/get.go
+++ b/pkg/cmd/cli/backup/get.go
@@ -27,6 +27,7 @@ import (
 	api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
+	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/output"
 )
 
@@ -66,6 +67,7 @@ func NewGetCommand(f client.Factory, use string) *cobra.Command {
 		},
 	}
 
+	c.ValidArgsFunction = cli.CompleteBackupNames(f)
 	c.Flags().StringVarP(&listOptions.LabelSelector, "selector", "l", listOptions.LabelSelector, "Only show items matching this label selector")
 
 	output.BindFlags(c.Flags())

--- a/pkg/cmd/cli/backup/logs.go
+++ b/pkg/cmd/cli/backup/logs.go
@@ -30,6 +30,7 @@ import (
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
+	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/cacert"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/downloadrequest"
 )
@@ -119,6 +120,7 @@ func NewLogsCommand(f client.Factory) *cobra.Command {
 		},
 	}
 
+	c.ValidArgsFunction = cli.CompleteBackupNames(f)
 	l.BindFlags(c.Flags())
 
 	return c

--- a/pkg/cmd/cli/backuplocation/delete.go
+++ b/pkg/cmd/cli/backuplocation/delete.go
@@ -62,6 +62,7 @@ func NewDeleteCommand(f client.Factory, use string) *cobra.Command {
 		},
 	}
 
+	c.ValidArgsFunction = cli.CompleteBackupStorageLocationNames(f)
 	o.BindFlags(c.Flags())
 	return c
 }

--- a/pkg/cmd/cli/backuplocation/get.go
+++ b/pkg/cmd/cli/backuplocation/get.go
@@ -27,6 +27,7 @@ import (
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
+	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/output"
 )
 
@@ -89,6 +90,7 @@ func NewGetCommand(f client.Factory, use string) *cobra.Command {
 		},
 	}
 
+	c.ValidArgsFunction = cli.CompleteBackupStorageLocationNames(f)
 	c.Flags().BoolVar(&showDefaultOnly, "default", false, "Displays the current default backup storage location.")
 	c.Flags().StringVarP(&listOptions.LabelSelector, "selector", "l", listOptions.LabelSelector, "Only show items matching this label selector.")
 

--- a/pkg/cmd/cli/backuplocation/set.go
+++ b/pkg/cmd/cli/backuplocation/set.go
@@ -33,6 +33,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/builder"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
+	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/flag"
 	"github.com/vmware-tanzu/velero/pkg/util/boolptr"
 )
@@ -51,6 +52,7 @@ func NewSetCommand(f client.Factory, use string) *cobra.Command {
 		},
 	}
 
+	c.ValidArgsFunction = cli.CompleteBackupStorageLocationNames(f)
 	o.BindFlags(c.Flags())
 
 	return c

--- a/pkg/cmd/cli/completion/completion.go
+++ b/pkg/cmd/cli/completion/completion.go
@@ -64,7 +64,7 @@ $ velero completion fish > ~/.config/fish/completions/velero.fish
 			shell := args[0]
 			switch shell {
 			case "bash":
-				if err := cmd.Root().GenBashCompletion(os.Stdout); err != nil {
+				if err := cmd.Root().GenBashCompletionV2(os.Stdout, true); err != nil {
 					fmt.Println("fail to generate bash completion script", err)
 					os.Exit(1)
 				}

--- a/pkg/cmd/cli/completion_functions.go
+++ b/pkg/cmd/cli/completion_functions.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/meta"
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -31,10 +32,9 @@ import (
 // completionFunc is the function signature for cobra's ValidArgsFunction.
 type completionFunc = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
 
-// completeNames is a generic helper that builds a completion function for any
-// Velero list type. The caller provides a constructor for the list object and a
-// callback that extracts resource names from it.
-func completeNames[L kbclient.ObjectList](f client.Factory, newList func() L, getNames func(L) []string) completionFunc {
+// completeNames builds a completion function for any Velero list type.
+// It extracts resource names via apimachinery's meta helpers.
+func completeNames(f client.Factory, list kbclient.ObjectList) completionFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		kbClient, err := f.KubebuilderClient()
 		if err != nil {
@@ -42,13 +42,21 @@ func completeNames[L kbclient.ObjectList](f client.Factory, newList func() L, ge
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel()
-		list := newList()
-		if err := kbClient.List(ctx, list, &kbclient.ListOptions{Namespace: f.Namespace()}); err != nil {
+		freshList := list.DeepCopyObject().(kbclient.ObjectList)
+		if err := kbClient.List(ctx, freshList, &kbclient.ListOptions{Namespace: f.Namespace()}); err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		items, err := meta.ExtractList(freshList)
+		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 		var filtered []string
-		for _, name := range getNames(list) {
-			if strings.HasPrefix(name, toComplete) {
+		for _, item := range items {
+			accessor, err := meta.Accessor(item)
+			if err != nil {
+				continue
+			}
+			if name := accessor.GetName(); strings.HasPrefix(name, toComplete) {
 				filtered = append(filtered, name)
 			}
 		}
@@ -57,79 +65,25 @@ func completeNames[L kbclient.ObjectList](f client.Factory, newList func() L, ge
 }
 
 func CompleteBackupNames(f client.Factory) completionFunc {
-	return completeNames(f,
-		func() *velerov1api.BackupList { return new(velerov1api.BackupList) },
-		func(l *velerov1api.BackupList) []string {
-			names := make([]string, len(l.Items))
-			for i, b := range l.Items {
-				names[i] = b.Name
-			}
-			return names
-		},
-	)
+	return completeNames(f, &velerov1api.BackupList{})
 }
 
 func CompleteRestoreNames(f client.Factory) completionFunc {
-	return completeNames(f,
-		func() *velerov1api.RestoreList { return new(velerov1api.RestoreList) },
-		func(l *velerov1api.RestoreList) []string {
-			names := make([]string, len(l.Items))
-			for i, r := range l.Items {
-				names[i] = r.Name
-			}
-			return names
-		},
-	)
+	return completeNames(f, &velerov1api.RestoreList{})
 }
 
 func CompleteScheduleNames(f client.Factory) completionFunc {
-	return completeNames(f,
-		func() *velerov1api.ScheduleList { return new(velerov1api.ScheduleList) },
-		func(l *velerov1api.ScheduleList) []string {
-			names := make([]string, len(l.Items))
-			for i, s := range l.Items {
-				names[i] = s.Name
-			}
-			return names
-		},
-	)
+	return completeNames(f, &velerov1api.ScheduleList{})
 }
 
 func CompleteBackupStorageLocationNames(f client.Factory) completionFunc {
-	return completeNames(f,
-		func() *velerov1api.BackupStorageLocationList { return new(velerov1api.BackupStorageLocationList) },
-		func(l *velerov1api.BackupStorageLocationList) []string {
-			names := make([]string, len(l.Items))
-			for i, loc := range l.Items {
-				names[i] = loc.Name
-			}
-			return names
-		},
-	)
+	return completeNames(f, &velerov1api.BackupStorageLocationList{})
 }
 
 func CompleteVolumeSnapshotLocationNames(f client.Factory) completionFunc {
-	return completeNames(f,
-		func() *velerov1api.VolumeSnapshotLocationList { return new(velerov1api.VolumeSnapshotLocationList) },
-		func(l *velerov1api.VolumeSnapshotLocationList) []string {
-			names := make([]string, len(l.Items))
-			for i, loc := range l.Items {
-				names[i] = loc.Name
-			}
-			return names
-		},
-	)
+	return completeNames(f, &velerov1api.VolumeSnapshotLocationList{})
 }
 
 func CompleteBackupRepositoryNames(f client.Factory) completionFunc {
-	return completeNames(f,
-		func() *velerov1api.BackupRepositoryList { return new(velerov1api.BackupRepositoryList) },
-		func(l *velerov1api.BackupRepositoryList) []string {
-			names := make([]string, len(l.Items))
-			for i, r := range l.Items {
-				names[i] = r.Name
-			}
-			return names
-		},
-	)
+	return completeNames(f, &velerov1api.BackupRepositoryList{})
 }

--- a/pkg/cmd/cli/completion_functions.go
+++ b/pkg/cmd/cli/completion_functions.go
@@ -19,6 +19,7 @@ package cli
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,128 +31,105 @@ import (
 // completionFunc is the function signature for cobra's ValidArgsFunction.
 type completionFunc = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
 
-// CompleteBackupNames returns a completion function that lists backup names from the cluster.
+// completeNames is a generic helper that builds a completion function for any
+// Velero list type. The caller provides a constructor for the list object and a
+// callback that extracts resource names from it.
+func completeNames[L kbclient.ObjectList](f client.Factory, newList func() L, getNames func(L) []string) completionFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		kbClient, err := f.KubebuilderClient()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		list := newList()
+		if err := kbClient.List(ctx, list, &kbclient.ListOptions{Namespace: f.Namespace()}); err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		var filtered []string
+		for _, name := range getNames(list) {
+			if strings.HasPrefix(name, toComplete) {
+				filtered = append(filtered, name)
+			}
+		}
+		return filtered, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
 func CompleteBackupNames(f client.Factory) completionFunc {
-	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		kbClient, err := f.KubebuilderClient()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		backups := new(velerov1api.BackupList)
-		if err := kbClient.List(context.TODO(), backups, &kbclient.ListOptions{Namespace: f.Namespace()}); err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		var names []string
-		for _, b := range backups.Items {
-			if strings.HasPrefix(b.Name, toComplete) {
-				names = append(names, b.Name)
+	return completeNames(f,
+		func() *velerov1api.BackupList { return new(velerov1api.BackupList) },
+		func(l *velerov1api.BackupList) []string {
+			names := make([]string, len(l.Items))
+			for i, b := range l.Items {
+				names[i] = b.Name
 			}
-		}
-		return names, cobra.ShellCompDirectiveNoFileComp
-	}
+			return names
+		},
+	)
 }
 
-// CompleteRestoreNames returns a completion function that lists restore names from the cluster.
 func CompleteRestoreNames(f client.Factory) completionFunc {
-	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		kbClient, err := f.KubebuilderClient()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		restores := new(velerov1api.RestoreList)
-		if err := kbClient.List(context.TODO(), restores, &kbclient.ListOptions{Namespace: f.Namespace()}); err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		var names []string
-		for _, r := range restores.Items {
-			if strings.HasPrefix(r.Name, toComplete) {
-				names = append(names, r.Name)
+	return completeNames(f,
+		func() *velerov1api.RestoreList { return new(velerov1api.RestoreList) },
+		func(l *velerov1api.RestoreList) []string {
+			names := make([]string, len(l.Items))
+			for i, r := range l.Items {
+				names[i] = r.Name
 			}
-		}
-		return names, cobra.ShellCompDirectiveNoFileComp
-	}
+			return names
+		},
+	)
 }
 
-// CompleteScheduleNames returns a completion function that lists schedule names from the cluster.
 func CompleteScheduleNames(f client.Factory) completionFunc {
-	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		kbClient, err := f.KubebuilderClient()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		schedules := new(velerov1api.ScheduleList)
-		if err := kbClient.List(context.TODO(), schedules, &kbclient.ListOptions{Namespace: f.Namespace()}); err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		var names []string
-		for _, s := range schedules.Items {
-			if strings.HasPrefix(s.Name, toComplete) {
-				names = append(names, s.Name)
+	return completeNames(f,
+		func() *velerov1api.ScheduleList { return new(velerov1api.ScheduleList) },
+		func(l *velerov1api.ScheduleList) []string {
+			names := make([]string, len(l.Items))
+			for i, s := range l.Items {
+				names[i] = s.Name
 			}
-		}
-		return names, cobra.ShellCompDirectiveNoFileComp
-	}
+			return names
+		},
+	)
 }
 
-// CompleteBackupStorageLocationNames returns a completion function that lists backup storage location names from the cluster.
 func CompleteBackupStorageLocationNames(f client.Factory) completionFunc {
-	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		kbClient, err := f.KubebuilderClient()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		locations := new(velerov1api.BackupStorageLocationList)
-		if err := kbClient.List(context.TODO(), locations, &kbclient.ListOptions{Namespace: f.Namespace()}); err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		var names []string
-		for _, l := range locations.Items {
-			if strings.HasPrefix(l.Name, toComplete) {
-				names = append(names, l.Name)
+	return completeNames(f,
+		func() *velerov1api.BackupStorageLocationList { return new(velerov1api.BackupStorageLocationList) },
+		func(l *velerov1api.BackupStorageLocationList) []string {
+			names := make([]string, len(l.Items))
+			for i, loc := range l.Items {
+				names[i] = loc.Name
 			}
-		}
-		return names, cobra.ShellCompDirectiveNoFileComp
-	}
+			return names
+		},
+	)
 }
 
-// CompleteVolumeSnapshotLocationNames returns a completion function that lists volume snapshot location names from the cluster.
 func CompleteVolumeSnapshotLocationNames(f client.Factory) completionFunc {
-	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		kbClient, err := f.KubebuilderClient()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		locations := new(velerov1api.VolumeSnapshotLocationList)
-		if err := kbClient.List(context.TODO(), locations, &kbclient.ListOptions{Namespace: f.Namespace()}); err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		var names []string
-		for _, l := range locations.Items {
-			if strings.HasPrefix(l.Name, toComplete) {
-				names = append(names, l.Name)
+	return completeNames(f,
+		func() *velerov1api.VolumeSnapshotLocationList { return new(velerov1api.VolumeSnapshotLocationList) },
+		func(l *velerov1api.VolumeSnapshotLocationList) []string {
+			names := make([]string, len(l.Items))
+			for i, loc := range l.Items {
+				names[i] = loc.Name
 			}
-		}
-		return names, cobra.ShellCompDirectiveNoFileComp
-	}
+			return names
+		},
+	)
 }
 
-// CompleteBackupRepositoryNames returns a completion function that lists backup repository names from the cluster.
 func CompleteBackupRepositoryNames(f client.Factory) completionFunc {
-	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		kbClient, err := f.KubebuilderClient()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		repos := new(velerov1api.BackupRepositoryList)
-		if err := kbClient.List(context.TODO(), repos, &kbclient.ListOptions{Namespace: f.Namespace()}); err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		var names []string
-		for _, r := range repos.Items {
-			if strings.HasPrefix(r.Name, toComplete) {
-				names = append(names, r.Name)
+	return completeNames(f,
+		func() *velerov1api.BackupRepositoryList { return new(velerov1api.BackupRepositoryList) },
+		func(l *velerov1api.BackupRepositoryList) []string {
+			names := make([]string, len(l.Items))
+			for i, r := range l.Items {
+				names[i] = r.Name
 			}
-		}
-		return names, cobra.ShellCompDirectiveNoFileComp
-	}
+			return names
+		},
+	)
 }

--- a/pkg/cmd/cli/completion_functions.go
+++ b/pkg/cmd/cli/completion_functions.go
@@ -1,0 +1,157 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"strings"
+
+	"github.com/spf13/cobra"
+	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/client"
+)
+
+// completionFunc is the function signature for cobra's ValidArgsFunction.
+type completionFunc = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
+
+// CompleteBackupNames returns a completion function that lists backup names from the cluster.
+func CompleteBackupNames(f client.Factory) completionFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		kbClient, err := f.KubebuilderClient()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		backups := new(velerov1api.BackupList)
+		if err := kbClient.List(context.TODO(), backups, &kbclient.ListOptions{Namespace: f.Namespace()}); err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		var names []string
+		for _, b := range backups.Items {
+			if strings.HasPrefix(b.Name, toComplete) {
+				names = append(names, b.Name)
+			}
+		}
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// CompleteRestoreNames returns a completion function that lists restore names from the cluster.
+func CompleteRestoreNames(f client.Factory) completionFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		kbClient, err := f.KubebuilderClient()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		restores := new(velerov1api.RestoreList)
+		if err := kbClient.List(context.TODO(), restores, &kbclient.ListOptions{Namespace: f.Namespace()}); err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		var names []string
+		for _, r := range restores.Items {
+			if strings.HasPrefix(r.Name, toComplete) {
+				names = append(names, r.Name)
+			}
+		}
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// CompleteScheduleNames returns a completion function that lists schedule names from the cluster.
+func CompleteScheduleNames(f client.Factory) completionFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		kbClient, err := f.KubebuilderClient()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		schedules := new(velerov1api.ScheduleList)
+		if err := kbClient.List(context.TODO(), schedules, &kbclient.ListOptions{Namespace: f.Namespace()}); err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		var names []string
+		for _, s := range schedules.Items {
+			if strings.HasPrefix(s.Name, toComplete) {
+				names = append(names, s.Name)
+			}
+		}
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// CompleteBackupStorageLocationNames returns a completion function that lists backup storage location names from the cluster.
+func CompleteBackupStorageLocationNames(f client.Factory) completionFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		kbClient, err := f.KubebuilderClient()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		locations := new(velerov1api.BackupStorageLocationList)
+		if err := kbClient.List(context.TODO(), locations, &kbclient.ListOptions{Namespace: f.Namespace()}); err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		var names []string
+		for _, l := range locations.Items {
+			if strings.HasPrefix(l.Name, toComplete) {
+				names = append(names, l.Name)
+			}
+		}
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// CompleteVolumeSnapshotLocationNames returns a completion function that lists volume snapshot location names from the cluster.
+func CompleteVolumeSnapshotLocationNames(f client.Factory) completionFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		kbClient, err := f.KubebuilderClient()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		locations := new(velerov1api.VolumeSnapshotLocationList)
+		if err := kbClient.List(context.TODO(), locations, &kbclient.ListOptions{Namespace: f.Namespace()}); err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		var names []string
+		for _, l := range locations.Items {
+			if strings.HasPrefix(l.Name, toComplete) {
+				names = append(names, l.Name)
+			}
+		}
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// CompleteBackupRepositoryNames returns a completion function that lists backup repository names from the cluster.
+func CompleteBackupRepositoryNames(f client.Factory) completionFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		kbClient, err := f.KubebuilderClient()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		repos := new(velerov1api.BackupRepositoryList)
+		if err := kbClient.List(context.TODO(), repos, &kbclient.ListOptions{Namespace: f.Namespace()}); err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		var names []string
+		for _, r := range repos.Items {
+			if strings.HasPrefix(r.Name, toComplete) {
+				names = append(names, r.Name)
+			}
+		}
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}

--- a/pkg/cmd/cli/completion_functions.go
+++ b/pkg/cmd/cli/completion_functions.go
@@ -1,0 +1,97 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/meta"
+	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/client"
+)
+
+// completionFunc is the function signature for cobra's ValidArgsFunction.
+type completionFunc = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
+
+// completeNames builds a completion function for any Velero list type.
+// It extracts resource names via apimachinery's meta helpers.
+func completeNames(f client.Factory, list kbclient.ObjectList) completionFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		kbClient, err := f.KubebuilderClient()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		freshList := list.DeepCopyObject().(kbclient.ObjectList)
+		if err := kbClient.List(ctx, freshList, &kbclient.ListOptions{Namespace: f.Namespace()}); err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		items, err := meta.ExtractList(freshList)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		seen := make(map[string]bool, len(args))
+		for _, a := range args {
+			seen[a] = true
+		}
+		var filtered []string
+		for _, item := range items {
+			accessor, err := meta.Accessor(item)
+			if err != nil {
+				continue
+			}
+			name := accessor.GetName()
+			if seen[name] {
+				continue
+			}
+			if strings.HasPrefix(name, toComplete) {
+				filtered = append(filtered, name)
+			}
+		}
+		return filtered, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+func CompleteBackupNames(f client.Factory) completionFunc {
+	return completeNames(f, &velerov1api.BackupList{})
+}
+
+func CompleteRestoreNames(f client.Factory) completionFunc {
+	return completeNames(f, &velerov1api.RestoreList{})
+}
+
+func CompleteScheduleNames(f client.Factory) completionFunc {
+	return completeNames(f, &velerov1api.ScheduleList{})
+}
+
+func CompleteBackupStorageLocationNames(f client.Factory) completionFunc {
+	return completeNames(f, &velerov1api.BackupStorageLocationList{})
+}
+
+func CompleteVolumeSnapshotLocationNames(f client.Factory) completionFunc {
+	return completeNames(f, &velerov1api.VolumeSnapshotLocationList{})
+}
+
+func CompleteBackupRepositoryNames(f client.Factory) completionFunc {
+	return completeNames(f, &velerov1api.BackupRepositoryList{})
+}

--- a/pkg/cmd/cli/completion_functions.go
+++ b/pkg/cmd/cli/completion_functions.go
@@ -40,9 +40,17 @@ func completeNames(f client.Factory, list kbclient.ObjectList) completionFunc {
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		parentCtx := context.Background()
+		if cmd != nil && cmd.Context() != nil {
+			parentCtx = cmd.Context()
+		}
+		ctx, cancel := context.WithTimeout(parentCtx, 3*time.Second)
 		defer cancel()
-		freshList := list.DeepCopyObject().(kbclient.ObjectList)
+		freshObject := list.DeepCopyObject()
+		freshList, ok := freshObject.(kbclient.ObjectList)
+		if !ok {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
 		if err := kbClient.List(ctx, freshList, &kbclient.ListOptions{Namespace: f.Namespace()}); err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}

--- a/pkg/cmd/cli/completion_functions_test.go
+++ b/pkg/cmd/cli/completion_functions_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	factorymocks "github.com/vmware-tanzu/velero/pkg/client/mocks"
+	velerotest "github.com/vmware-tanzu/velero/pkg/test"
+)
+
+// TestCompleteNames exercises the core completeNames helper with various list
+// types, prefix filters, and edge cases (empty cluster, no match).
+func TestCompleteNames(t *testing.T) {
+	tests := []struct {
+		name       string
+		objects    []runtime.Object
+		list       kbclient.ObjectList
+		toComplete string
+		want       []string
+	}{
+		{
+			name:       "no resources returns nil",
+			objects:    nil,
+			list:       &velerov1api.BackupList{},
+			toComplete: "",
+			want:       nil,
+		},
+		{
+			name: "returns all matching names",
+			objects: []runtime.Object{
+				&velerov1api.Backup{ObjectMeta: metav1.ObjectMeta{Name: "daily", Namespace: "velero"}},
+				&velerov1api.Backup{ObjectMeta: metav1.ObjectMeta{Name: "weekly", Namespace: "velero"}},
+			},
+			list:       &velerov1api.BackupList{},
+			toComplete: "",
+			want:       []string{"daily", "weekly"},
+		},
+		{
+			name: "filters by prefix",
+			objects: []runtime.Object{
+				&velerov1api.Backup{ObjectMeta: metav1.ObjectMeta{Name: "daily", Namespace: "velero"}},
+				&velerov1api.Backup{ObjectMeta: metav1.ObjectMeta{Name: "weekly", Namespace: "velero"}},
+				&velerov1api.Backup{ObjectMeta: metav1.ObjectMeta{Name: "daily-full", Namespace: "velero"}},
+			},
+			list:       &velerov1api.BackupList{},
+			toComplete: "dai",
+			want:       []string{"daily", "daily-full"},
+		},
+		{
+			name: "no prefix match returns nil",
+			objects: []runtime.Object{
+				&velerov1api.Backup{ObjectMeta: metav1.ObjectMeta{Name: "daily", Namespace: "velero"}},
+			},
+			list:       &velerov1api.BackupList{},
+			toComplete: "xyz",
+			want:       nil,
+		},
+		{
+			name: "works with RestoreList",
+			objects: []runtime.Object{
+				&velerov1api.Restore{ObjectMeta: metav1.ObjectMeta{Name: "restore-1", Namespace: "velero"}},
+				&velerov1api.Restore{ObjectMeta: metav1.ObjectMeta{Name: "restore-2", Namespace: "velero"}},
+			},
+			list:       &velerov1api.RestoreList{},
+			toComplete: "restore-",
+			want:       []string{"restore-1", "restore-2"},
+		},
+		{
+			name: "works with ScheduleList",
+			objects: []runtime.Object{
+				&velerov1api.Schedule{ObjectMeta: metav1.ObjectMeta{Name: "nightly", Namespace: "velero"}},
+			},
+			list:       &velerov1api.ScheduleList{},
+			toComplete: "",
+			want:       []string{"nightly"},
+		},
+		{
+			name: "works with BackupStorageLocationList",
+			objects: []runtime.Object{
+				&velerov1api.BackupStorageLocation{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "velero"}},
+				&velerov1api.BackupStorageLocation{ObjectMeta: metav1.ObjectMeta{Name: "secondary", Namespace: "velero"}},
+			},
+			list:       &velerov1api.BackupStorageLocationList{},
+			toComplete: "s",
+			want:       []string{"secondary"},
+		},
+		{
+			name: "works with VolumeSnapshotLocationList",
+			objects: []runtime.Object{
+				&velerov1api.VolumeSnapshotLocation{ObjectMeta: metav1.ObjectMeta{Name: "aws-snap", Namespace: "velero"}},
+			},
+			list:       &velerov1api.VolumeSnapshotLocationList{},
+			toComplete: "",
+			want:       []string{"aws-snap"},
+		},
+		{
+			name: "works with BackupRepositoryList",
+			objects: []runtime.Object{
+				&velerov1api.BackupRepository{ObjectMeta: metav1.ObjectMeta{Name: "repo-1", Namespace: "velero"}},
+			},
+			list:       &velerov1api.BackupRepositoryList{},
+			toComplete: "",
+			want:       []string{"repo-1"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			kbClient := velerotest.NewFakeControllerRuntimeClient(t, tc.objects...)
+
+			f := new(factorymocks.Factory)
+			f.On("KubebuilderClient").Return(kbClient, nil)
+			f.On("Namespace").Return("velero")
+
+			completionFn := completeNames(f, tc.list)
+			got, directive := completionFn(&cobra.Command{}, nil, tc.toComplete)
+
+			assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestCompleteNames_KubebuilderClientError verifies that a factory error
+// (e.g. no kubeconfig) returns nil completions instead of panicking.
+func TestCompleteNames_KubebuilderClientError(t *testing.T) {
+	f := new(factorymocks.Factory)
+	f.On("KubebuilderClient").Return(nil, fmt.Errorf("connection refused"))
+
+	completionFn := completeNames(f, &velerov1api.BackupList{})
+	got, directive := completionFn(&cobra.Command{}, nil, "")
+
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+	assert.Nil(t, got)
+}
+
+// TestCompleteWrappers verifies each exported Complete*Names wrapper returns
+// only its own resource type. A single fake client holds one object of every
+// type, so each wrapper must filter correctly and not leak other kinds.
+func TestCompleteWrappers(t *testing.T) {
+	objects := []runtime.Object{
+		&velerov1api.Backup{ObjectMeta: metav1.ObjectMeta{Name: "b1", Namespace: "velero"}},
+		&velerov1api.Restore{ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: "velero"}},
+		&velerov1api.Schedule{ObjectMeta: metav1.ObjectMeta{Name: "s1", Namespace: "velero"}},
+		&velerov1api.BackupStorageLocation{ObjectMeta: metav1.ObjectMeta{Name: "bsl1", Namespace: "velero"}},
+		&velerov1api.VolumeSnapshotLocation{ObjectMeta: metav1.ObjectMeta{Name: "vsl1", Namespace: "velero"}},
+		&velerov1api.BackupRepository{ObjectMeta: metav1.ObjectMeta{Name: "br1", Namespace: "velero"}},
+	}
+	kbClient := velerotest.NewFakeControllerRuntimeClient(t, objects...)
+
+	f := new(factorymocks.Factory)
+	f.On("KubebuilderClient").Return(kbClient, nil)
+	f.On("Namespace").Return("velero")
+
+	tests := []struct {
+		name     string
+		fn       completionFunc
+		expected []string
+	}{
+		{"CompleteBackupNames", CompleteBackupNames(f), []string{"b1"}},
+		{"CompleteRestoreNames", CompleteRestoreNames(f), []string{"r1"}},
+		{"CompleteScheduleNames", CompleteScheduleNames(f), []string{"s1"}},
+		{"CompleteBackupStorageLocationNames", CompleteBackupStorageLocationNames(f), []string{"bsl1"}},
+		{"CompleteVolumeSnapshotLocationNames", CompleteVolumeSnapshotLocationNames(f), []string{"vsl1"}},
+		{"CompleteBackupRepositoryNames", CompleteBackupRepositoryNames(f), []string{"br1"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, directive := tc.fn(&cobra.Command{}, nil, "")
+			require.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/pkg/cmd/cli/completion_functions_test.go
+++ b/pkg/cmd/cli/completion_functions_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	factorymocks "github.com/vmware-tanzu/velero/pkg/client/mocks"
+	velerotest "github.com/vmware-tanzu/velero/pkg/test"
+)
+
+// TestCompleteNames exercises the core completeNames helper with various list
+// types, prefix filters, and edge cases (empty cluster, no match).
+func TestCompleteNames(t *testing.T) {
+	tests := []struct {
+		name       string
+		objects    []runtime.Object
+		list       kbclient.ObjectList
+		args       []string
+		toComplete string
+		want       []string
+	}{
+		{
+			name:       "no resources returns nil",
+			objects:    nil,
+			list:       &velerov1api.BackupList{},
+			toComplete: "",
+			want:       nil,
+		},
+		{
+			name: "returns all matching names",
+			objects: []runtime.Object{
+				&velerov1api.Backup{ObjectMeta: metav1.ObjectMeta{Name: "daily", Namespace: "velero"}},
+				&velerov1api.Backup{ObjectMeta: metav1.ObjectMeta{Name: "weekly", Namespace: "velero"}},
+			},
+			list:       &velerov1api.BackupList{},
+			toComplete: "",
+			want:       []string{"daily", "weekly"},
+		},
+		{
+			name: "filters by prefix",
+			objects: []runtime.Object{
+				&velerov1api.Backup{ObjectMeta: metav1.ObjectMeta{Name: "daily", Namespace: "velero"}},
+				&velerov1api.Backup{ObjectMeta: metav1.ObjectMeta{Name: "weekly", Namespace: "velero"}},
+				&velerov1api.Backup{ObjectMeta: metav1.ObjectMeta{Name: "daily-full", Namespace: "velero"}},
+			},
+			list:       &velerov1api.BackupList{},
+			toComplete: "dai",
+			want:       []string{"daily", "daily-full"},
+		},
+		{
+			name: "no prefix match returns nil",
+			objects: []runtime.Object{
+				&velerov1api.Backup{ObjectMeta: metav1.ObjectMeta{Name: "daily", Namespace: "velero"}},
+			},
+			list:       &velerov1api.BackupList{},
+			toComplete: "xyz",
+			want:       nil,
+		},
+		{
+			name: "works with RestoreList",
+			objects: []runtime.Object{
+				&velerov1api.Restore{ObjectMeta: metav1.ObjectMeta{Name: "restore-1", Namespace: "velero"}},
+				&velerov1api.Restore{ObjectMeta: metav1.ObjectMeta{Name: "restore-2", Namespace: "velero"}},
+			},
+			list:       &velerov1api.RestoreList{},
+			toComplete: "restore-",
+			want:       []string{"restore-1", "restore-2"},
+		},
+		{
+			name: "works with ScheduleList",
+			objects: []runtime.Object{
+				&velerov1api.Schedule{ObjectMeta: metav1.ObjectMeta{Name: "nightly", Namespace: "velero"}},
+			},
+			list:       &velerov1api.ScheduleList{},
+			toComplete: "",
+			want:       []string{"nightly"},
+		},
+		{
+			name: "works with BackupStorageLocationList",
+			objects: []runtime.Object{
+				&velerov1api.BackupStorageLocation{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "velero"}},
+				&velerov1api.BackupStorageLocation{ObjectMeta: metav1.ObjectMeta{Name: "secondary", Namespace: "velero"}},
+			},
+			list:       &velerov1api.BackupStorageLocationList{},
+			toComplete: "s",
+			want:       []string{"secondary"},
+		},
+		{
+			name: "works with VolumeSnapshotLocationList",
+			objects: []runtime.Object{
+				&velerov1api.VolumeSnapshotLocation{ObjectMeta: metav1.ObjectMeta{Name: "aws-snap", Namespace: "velero"}},
+			},
+			list:       &velerov1api.VolumeSnapshotLocationList{},
+			toComplete: "",
+			want:       []string{"aws-snap"},
+		},
+		{
+			name: "works with BackupRepositoryList",
+			objects: []runtime.Object{
+				&velerov1api.BackupRepository{ObjectMeta: metav1.ObjectMeta{Name: "repo-1", Namespace: "velero"}},
+			},
+			list:       &velerov1api.BackupRepositoryList{},
+			toComplete: "",
+			want:       []string{"repo-1"},
+		},
+		{
+			name: "excludes already-typed args",
+			objects: []runtime.Object{
+				&velerov1api.Backup{ObjectMeta: metav1.ObjectMeta{Name: "daily", Namespace: "velero"}},
+				&velerov1api.Backup{ObjectMeta: metav1.ObjectMeta{Name: "weekly", Namespace: "velero"}},
+				&velerov1api.Backup{ObjectMeta: metav1.ObjectMeta{Name: "monthly", Namespace: "velero"}},
+			},
+			list:       &velerov1api.BackupList{},
+			args:       []string{"daily", "monthly"},
+			toComplete: "",
+			want:       []string{"weekly"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			kbClient := velerotest.NewFakeControllerRuntimeClient(t, tc.objects...)
+
+			f := new(factorymocks.Factory)
+			f.On("KubebuilderClient").Return(kbClient, nil)
+			f.On("Namespace").Return("velero")
+
+			completionFn := completeNames(f, tc.list)
+			got, directive := completionFn(&cobra.Command{}, tc.args, tc.toComplete)
+
+			assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestCompleteNames_KubebuilderClientError verifies that a factory error
+// (e.g. no kubeconfig) returns nil completions instead of panicking.
+func TestCompleteNames_KubebuilderClientError(t *testing.T) {
+	f := new(factorymocks.Factory)
+	f.On("KubebuilderClient").Return(nil, fmt.Errorf("connection refused"))
+
+	completionFn := completeNames(f, &velerov1api.BackupList{})
+	got, directive := completionFn(&cobra.Command{}, nil, "")
+
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+	assert.Nil(t, got)
+}
+
+// TestCompleteWrappers verifies each exported Complete*Names wrapper returns
+// only its own resource type. A single fake client holds one object of every
+// type, so each wrapper must filter correctly and not leak other kinds.
+func TestCompleteWrappers(t *testing.T) {
+	objects := []runtime.Object{
+		&velerov1api.Backup{ObjectMeta: metav1.ObjectMeta{Name: "b1", Namespace: "velero"}},
+		&velerov1api.Restore{ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: "velero"}},
+		&velerov1api.Schedule{ObjectMeta: metav1.ObjectMeta{Name: "s1", Namespace: "velero"}},
+		&velerov1api.BackupStorageLocation{ObjectMeta: metav1.ObjectMeta{Name: "bsl1", Namespace: "velero"}},
+		&velerov1api.VolumeSnapshotLocation{ObjectMeta: metav1.ObjectMeta{Name: "vsl1", Namespace: "velero"}},
+		&velerov1api.BackupRepository{ObjectMeta: metav1.ObjectMeta{Name: "br1", Namespace: "velero"}},
+	}
+	kbClient := velerotest.NewFakeControllerRuntimeClient(t, objects...)
+
+	f := new(factorymocks.Factory)
+	f.On("KubebuilderClient").Return(kbClient, nil)
+	f.On("Namespace").Return("velero")
+
+	tests := []struct {
+		name     string
+		fn       completionFunc
+		expected []string
+	}{
+		{"CompleteBackupNames", CompleteBackupNames(f), []string{"b1"}},
+		{"CompleteRestoreNames", CompleteRestoreNames(f), []string{"r1"}},
+		{"CompleteScheduleNames", CompleteScheduleNames(f), []string{"s1"}},
+		{"CompleteBackupStorageLocationNames", CompleteBackupStorageLocationNames(f), []string{"bsl1"}},
+		{"CompleteVolumeSnapshotLocationNames", CompleteVolumeSnapshotLocationNames(f), []string{"vsl1"}},
+		{"CompleteBackupRepositoryNames", CompleteBackupRepositoryNames(f), []string{"br1"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, directive := tc.fn(&cobra.Command{}, nil, "")
+			require.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/pkg/cmd/cli/completion_functions_test.go
+++ b/pkg/cmd/cli/completion_functions_test.go
@@ -153,7 +153,7 @@ func TestCompleteNames(t *testing.T) {
 			got, directive := completionFn(&cobra.Command{}, tc.args, tc.toComplete)
 
 			assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
-			assert.Equal(t, tc.want, got)
+			assert.ElementsMatch(t, tc.want, got)
 		})
 	}
 }

--- a/pkg/cmd/cli/debug/debug.go
+++ b/pkg/cmd/cli/debug/debug.go
@@ -38,6 +38,7 @@ import (
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
+	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
 )
 
 //go:embed cshd-scripts/velero.cshd
@@ -171,6 +172,10 @@ specs of resources created by velero server, and optionally the logs of backup a
 		},
 	}
 	o.bindFlags(c.Flags())
+
+	_ = c.RegisterFlagCompletionFunc("backup", cli.CompleteBackupNames(f))
+	_ = c.RegisterFlagCompletionFunc("restore", cli.CompleteRestoreNames(f))
+
 	return c
 }
 

--- a/pkg/cmd/cli/repo/get.go
+++ b/pkg/cmd/cli/repo/get.go
@@ -27,6 +27,7 @@ import (
 	api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
+	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/output"
 )
 
@@ -66,6 +67,7 @@ func NewGetCommand(f client.Factory, use string) *cobra.Command {
 		},
 	}
 
+	c.ValidArgsFunction = cli.CompleteBackupRepositoryNames(f)
 	c.Flags().StringVarP(&listOptions.LabelSelector, "selector", "l", listOptions.LabelSelector, "Only show items matching this label selector.")
 
 	output.BindFlags(c.Flags())

--- a/pkg/cmd/cli/restore/create.go
+++ b/pkg/cmd/cli/restore/create.go
@@ -35,6 +35,7 @@ import (
 	api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
+	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/flag"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/output"
 	"github.com/vmware-tanzu/velero/pkg/util/boolptr"
@@ -73,6 +74,9 @@ func NewCreateCommand(f client.Factory, use string) *cobra.Command {
 	o.BindFlags(c.Flags())
 	output.BindFlags(c.Flags())
 	output.ClearOutputFlagDefault(c)
+
+	_ = c.RegisterFlagCompletionFunc("from-backup", cli.CompleteBackupNames(f))
+	_ = c.RegisterFlagCompletionFunc("from-schedule", cli.CompleteScheduleNames(f))
 
 	return c
 }

--- a/pkg/cmd/cli/restore/create.go
+++ b/pkg/cmd/cli/restore/create.go
@@ -36,6 +36,7 @@ import (
 	api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
+	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/flag"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/output"
 	"github.com/vmware-tanzu/velero/pkg/util/boolptr"
@@ -80,6 +81,9 @@ Notes:
 	o.BindFlags(c.Flags())
 	output.BindFlags(c.Flags())
 	output.ClearOutputFlagDefault(c)
+
+	_ = c.RegisterFlagCompletionFunc("from-backup", cli.CompleteBackupNames(f))
+	_ = c.RegisterFlagCompletionFunc("from-schedule", cli.CompleteScheduleNames(f))
 
 	return c
 }

--- a/pkg/cmd/cli/restore/delete.go
+++ b/pkg/cmd/cli/restore/delete.go
@@ -61,6 +61,7 @@ func NewDeleteCommand(f client.Factory, use string) *cobra.Command {
 			cmd.CheckError(Run(o))
 		},
 	}
+	c.ValidArgsFunction = cli.CompleteRestoreNames(f)
 	o.BindFlags(c.Flags())
 	return c
 }

--- a/pkg/cmd/cli/restore/describe.go
+++ b/pkg/cmd/cli/restore/describe.go
@@ -29,6 +29,7 @@ import (
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
+	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/output"
 	"github.com/vmware-tanzu/velero/pkg/label"
 )
@@ -92,6 +93,7 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 		},
 	}
 
+	c.ValidArgsFunction = cli.CompleteRestoreNames(f)
 	c.Flags().StringVarP(&listOptions.LabelSelector, "selector", "l", listOptions.LabelSelector, "Only show items matching this label selector.")
 	c.Flags().BoolVar(&details, "details", details, "Display additional detail in the command output.")
 	c.Flags().BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", insecureSkipTLSVerify, "If true, the object store's TLS certificate will not be checked for validity. This is insecure and susceptible to man-in-the-middle attacks. Not recommended for production.")

--- a/pkg/cmd/cli/restore/get.go
+++ b/pkg/cmd/cli/restore/get.go
@@ -27,6 +27,7 @@ import (
 	api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
+	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/output"
 )
 
@@ -76,6 +77,7 @@ func NewGetCommand(f client.Factory, use string) *cobra.Command {
 		},
 	}
 
+	c.ValidArgsFunction = cli.CompleteRestoreNames(f)
 	c.Flags().StringVarP(&listOptions.LabelSelector, "selector", "l", listOptions.LabelSelector, "Only show items matching this label selector.")
 
 	output.BindFlags(c.Flags())

--- a/pkg/cmd/cli/restore/logs.go
+++ b/pkg/cmd/cli/restore/logs.go
@@ -29,6 +29,7 @@ import (
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
+	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/cacert"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/downloadrequest"
 )
@@ -82,6 +83,7 @@ func NewLogsCommand(f client.Factory) *cobra.Command {
 		},
 	}
 
+	c.ValidArgsFunction = cli.CompleteRestoreNames(f)
 	c.Flags().DurationVar(&timeout, "timeout", timeout, "How long to wait to receive logs.")
 	c.Flags().BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", insecureSkipTLSVerify, "If true, the object store's TLS certificate will not be checked for validity. This is insecure and susceptible to man-in-the-middle attacks. Not recommended for production.")
 	c.Flags().StringVar(&caCertFile, "cacert", caCertFile, "Path to a certificate bundle to use when verifying TLS connections. If not specified, the CA certificate from the BackupStorageLocation will be used if available.")

--- a/pkg/cmd/cli/schedule/create.go
+++ b/pkg/cmd/cli/schedule/create.go
@@ -30,6 +30,7 @@ import (
 	api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
+	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
 	"github.com/vmware-tanzu/velero/pkg/cmd/cli/backup"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/output"
 )
@@ -76,6 +77,9 @@ example: "@every 2h30m".`,
 	o.BindFlags(c.Flags())
 	output.BindFlags(c.Flags())
 	output.ClearOutputFlagDefault(c)
+
+	_ = c.RegisterFlagCompletionFunc("storage-location", cli.CompleteBackupStorageLocationNames(f))
+	_ = c.RegisterFlagCompletionFunc("volume-snapshot-locations", cli.CompleteVolumeSnapshotLocationNames(f))
 
 	return c
 }

--- a/pkg/cmd/cli/schedule/delete.go
+++ b/pkg/cmd/cli/schedule/delete.go
@@ -62,6 +62,7 @@ func NewDeleteCommand(f client.Factory, use string) *cobra.Command {
 		},
 	}
 
+	c.ValidArgsFunction = cli.CompleteScheduleNames(f)
 	o.BindFlags(c.Flags())
 	return c
 }

--- a/pkg/cmd/cli/schedule/describe.go
+++ b/pkg/cmd/cli/schedule/describe.go
@@ -28,6 +28,7 @@ import (
 	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
+	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/output"
 )
 
@@ -73,6 +74,7 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 		},
 	}
 
+	c.ValidArgsFunction = cli.CompleteScheduleNames(f)
 	c.Flags().StringVarP(&listOptions.LabelSelector, "selector", "l", listOptions.LabelSelector, "Only show items matching this label selector.")
 
 	return c

--- a/pkg/cmd/cli/schedule/get.go
+++ b/pkg/cmd/cli/schedule/get.go
@@ -27,6 +27,7 @@ import (
 	api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
+	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/output"
 )
 
@@ -71,6 +72,7 @@ func NewGetCommand(f client.Factory, use string) *cobra.Command {
 		},
 	}
 
+	c.ValidArgsFunction = cli.CompleteScheduleNames(f)
 	c.Flags().StringVarP(&listOptions.LabelSelector, "selector", "l", listOptions.LabelSelector, "Only show items matching this label selector.")
 
 	output.BindFlags(c.Flags())

--- a/pkg/cmd/cli/schedule/pause.go
+++ b/pkg/cmd/cli/schedule/pause.go
@@ -60,6 +60,7 @@ func NewPauseCommand(f client.Factory, use string) *cobra.Command {
 		},
 	}
 
+	c.ValidArgsFunction = cli.CompleteScheduleNames(f)
 	o.BindFlags(c.Flags())
 	pauseOpts.BindFlags(c.Flags())
 

--- a/pkg/cmd/cli/schedule/unpause.go
+++ b/pkg/cmd/cli/schedule/unpause.go
@@ -49,6 +49,7 @@ func NewUnpauseCommand(f client.Factory, use string) *cobra.Command {
 		},
 	}
 
+	c.ValidArgsFunction = cli.CompleteScheduleNames(f)
 	o.BindFlags(c.Flags())
 	pauseOpts.BindFlags(c.Flags())
 

--- a/pkg/cmd/cli/snapshotlocation/get.go
+++ b/pkg/cmd/cli/snapshotlocation/get.go
@@ -26,6 +26,7 @@ import (
 	api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
+	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/output"
 )
 
@@ -56,6 +57,7 @@ func NewGetCommand(f client.Factory, use string) *cobra.Command {
 			cmd.CheckError(err)
 		},
 	}
+	c.ValidArgsFunction = cli.CompleteVolumeSnapshotLocationNames(f)
 	c.Flags().StringVarP(&listOptions.LabelSelector, "selector", "l", listOptions.LabelSelector, "Only show items matching this label selector")
 	output.BindFlags(c.Flags())
 	return c

--- a/pkg/cmd/cli/snapshotlocation/set.go
+++ b/pkg/cmd/cli/snapshotlocation/set.go
@@ -30,6 +30,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/builder"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd"
+	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/flag"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/output"
 )
@@ -48,6 +49,7 @@ func NewSetCommand(f client.Factory, use string) *cobra.Command {
 		},
 	}
 
+	c.ValidArgsFunction = cli.CompleteVolumeSnapshotLocationNames(f)
 	o.BindFlags(c.Flags())
 	return c
 }

--- a/site/content/docs/main/customize-installation.md
+++ b/site/content/docs/main/customize-installation.md
@@ -356,7 +356,7 @@ Run `velero install --help` or see the [Helm chart documentation](https://vmware
 
 ### Enabling shell autocompletion
 
-**Velero CLI** provides autocompletion support for `Bash` and `Zsh`, which can save you a lot of typing.
+**Velero CLI** provides autocompletion support for `Bash`, `Zsh`, and `Fish`, which can save you a lot of typing. In addition to command and flag names, the CLI dynamically completes resource names (backups, restores, schedules, etc.) by querying the cluster.
 
 Below are the procedures to set up autocompletion for `Bash` (including the difference between `Linux` and `macOS`) and `Zsh`.
 


### PR DESCRIPTION
## Summary

Adds dynamic shell completion for Velero CLI commands, replacing static
completion with live resource lookups from the cluster.

- Introduces completion functions that query the Kubernetes API for
  backup, restore, schedule, BSL, VSL, and repository names
- Wires up `ValidArgsFunction` on get/describe/delete/logs commands
  and `RegisterFlagCompletionFunc` on create command flags
  (e.g. `--from-schedule`, `--storage-location`, `--from-backup`)

## Does your change fix a particular issue?

Fixes #9782

## Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.