### PR TITLE
fix(restore_finalizer): bound WaitRestoreExecHook poll with resourceTimeout

### DIFF
--- a/changelogs/unreleased/9747-SAY-5
+++ b/changelogs/unreleased/9747-SAY-5
@@ -1,0 +1,1 @@
+Bound WaitRestoreExecHook polling with the restore resourceTimeout to avoid an infinite wait when a pod never becomes ready.

--- a/pkg/controller/restore_finalizer_controller.go
+++ b/pkg/controller/restore_finalizer_controller.go
@@ -559,8 +559,21 @@ func (ctx *finalizerContext) WaitRestoreExecHook() (errs results.Result) {
 	log := ctx.logger.WithField("restore", ctx.restore.Name)
 	log.Info("Waiting for restore exec hooks starts")
 
-	// wait for restore exec hooks to finish
-	err := wait.PollUntilContextCancel(context.Background(), 1*time.Second, true, func(context.Context) (bool, error) {
+	// Bound the wait by resourceTimeout (the same budget Velero already
+	// applies to other finalizer phases). Previously this poll had no
+	// deadline, so a hook that was registered via Add() but never
+	// recorded as executed (pod evicted, container never ready,
+	// goroutine panic, leaked tracker entry) left the restore stuck in
+	// Finalizing forever and — because the finalizer controller is a
+	// single-threaded controller-runtime reconciler — blocked every
+	// other restore on the cluster.
+	timeout := ctx.resourceTimeout
+	if timeout <= 0 {
+		timeout = 10 * time.Minute
+	}
+	pollCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	err := wait.PollUntilContextCancel(pollCtx, 1*time.Second, true, func(context.Context) (bool, error) {
 		log.Debug("Checking the progress of hooks execution")
 		if ctx.multiHookTracker.IsComplete(ctx.restore.Name) {
 			return true, nil

--- a/pkg/controller/restore_finalizer_controller.go
+++ b/pkg/controller/restore_finalizer_controller.go
@@ -564,8 +564,8 @@ func (ctx *finalizerContext) WaitRestoreExecHook() (errs results.Result) {
 	// deadline, so a hook that was registered via Add() but never
 	// recorded as executed (pod evicted, container never ready,
 	// goroutine panic, leaked tracker entry) left the restore stuck in
-	// Finalizing forever and — because the finalizer controller is a
-	// single-threaded controller-runtime reconciler — blocked every
+	// Finalizing forever and, because the finalizer controller is a
+	// single-threaded controller-runtime reconciler, blocked every
 	// other restore on the cluster.
 	timeout := ctx.resourceTimeout
 	if timeout <= 0 {

--- a/pkg/controller/restore_finalizer_controller_test.go
+++ b/pkg/controller/restore_finalizer_controller_test.go
@@ -482,6 +482,13 @@ func TestWaitRestoreExecHook(t *testing.T) {
 	hookFailed, hookErr := true, fmt.Errorf("hook failed")
 	hookTracker3.Add(restoreName3, podNs, podName, container, source, hookName, hook.PhasePre, 0)
 
+	// hookTracker4: an entry that is added but never recorded. This
+	// reproduces the hang that motivated the resourceTimeout guard —
+	// without the timeout, WaitRestoreExecHook would block forever.
+	hookTracker4 := hook.NewMultiHookTracker()
+	restoreName4 := "restore4"
+	hookTracker4.Add(restoreName4, "ns", "pod", "con1", "s1", "h1", hook.PhasePre, 0)
+
 	tests := []struct {
 		name                   string
 		hookTracker            *hook.MultiHookTracker
@@ -497,6 +504,8 @@ func TestWaitRestoreExecHook(t *testing.T) {
 		hookName               string
 		hookFailed             bool
 		hookErr                error
+		resourceTimeout        time.Duration
+		expectTimeoutErr       bool
 	}{
 		{
 			name:                   "no restore exec hooks",
@@ -530,6 +539,16 @@ func TestWaitRestoreExecHook(t *testing.T) {
 			hookFailed:             hookFailed,
 			hookErr:                hookErr,
 		},
+		{
+			name:                   "hook never recorded should timeout instead of hanging",
+			hookTracker:            hookTracker4,
+			restore:                builder.ForRestore(velerov1api.DefaultNamespace, restoreName4).Result(),
+			expectedHooksAttempted: 0,
+			expectedHooksFailed:    0,
+			expectedHookErrs:       1,
+			resourceTimeout:        3 * time.Second,
+			expectTimeoutErr:       true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -542,6 +561,7 @@ func TestWaitRestoreExecHook(t *testing.T) {
 			crClient:         fakeClient,
 			restore:          tc.restore,
 			multiHookTracker: tc.hookTracker,
+			resourceTimeout:  tc.resourceTimeout,
 		}
 		require.NoError(t, ctx.crClient.Create(t.Context(), tc.restore))
 
@@ -553,6 +573,12 @@ func TestWaitRestoreExecHook(t *testing.T) {
 		}
 
 		errs := ctx.WaitRestoreExecHook()
+		if tc.expectTimeoutErr {
+			// The poll should be bounded by resourceTimeout and surface
+			// a timeout error rather than hanging the reconciler.
+			assert.NotEmpty(t, errs.Namespaces, "expected timeout error but got none")
+			continue
+		}
 		assert.Len(t, errs.Namespaces, tc.expectedHookErrs)
 
 		updated := &velerov1api.Restore{}

--- a/pkg/controller/restore_finalizer_controller_test.go
+++ b/pkg/controller/restore_finalizer_controller_test.go
@@ -483,7 +483,7 @@ func TestWaitRestoreExecHook(t *testing.T) {
 	hookTracker3.Add(restoreName3, podNs, podName, container, source, hookName, hook.PhasePre, 0)
 
 	// hookTracker4: an entry that is added but never recorded. This
-	// reproduces the hang that motivated the resourceTimeout guard —
+	// reproduces the hang that motivated the resourceTimeout guard,
 	// without the timeout, WaitRestoreExecHook would block forever.
 	hookTracker4 := hook.NewMultiHookTracker()
 	restoreName4 := "restore4"


### PR DESCRIPTION
Fixes velero-io/velero#9744.

## Problem

`WaitRestoreExecHook` calls `wait.PollUntilContextCancel` with a background context and no deadline. A hook that was registered via `Add()` but never recorded as executed (pod evicted, container never ready, goroutine panic, leaked tracker entry) leaves the restore stuck in `Finalizing` forever. Because the finalizer controller is a single-threaded controller-runtime reconciler, one stuck restore blocks every subsequent restore on the cluster, and only a Velero pod restart recovers.

## Fix

Bound the poll by the existing `finalizerContext.resourceTimeout`, the same budget Velero already applies to other finalizer phases. Fall back to 10m when the field is unset, so production deployments (always configured) are capped at `resourceTimeout` and tests that don't populate it still complete.

On timeout the existing `err != nil` branch below records the error into the restore's `errs` so the phase transitions to `PartiallyFailed` instead of hanging.

## Test

`go test -run TestWaitRestoreExecHook -timeout 60s ./pkg/controller/...` clean.