### PR TITLE
fix: improve error handling for discarded hooks in WaitExecHookHandler

### DIFF
--- a/changelogs/unreleased/9750-priyansh17
+++ b/changelogs/unreleased/9750-priyansh17
@@ -1,0 +1,1 @@
+Fix multi hook tracker to discard hooks when not executable

--- a/internal/hook/wait_exec_hook_handler.go
+++ b/internal/hook/wait_exec_hook_handler.go
@@ -82,17 +82,38 @@ func (e *DefaultWaitExecHookHandler) HandleHooks(
 		return nil
 	}
 
+	var errors []error
 	// If hooks are defined for a container that does not exist in the pod log a warning and discard
 	// those hooks to avoid waiting for a container that will never become ready. After that if
 	// there are no hooks left to be executed return immediately.
-	for containerName := range byContainer {
+	// Discarded hooks must be recorded as failed in the hook tracker, otherwise the tracker
+	// will never reach completion and the restore finalizer will poll forever waiting on hooks
+	// that can never run.
+	for containerName, hooks := range byContainer {
 		if !podHasContainer(pod, containerName) {
-			log.Warningf("Pod %s does not have container %s: discarding post-restore exec hooks", kube.NamespaceAndName(pod), containerName)
+			discardErr := fmt.Errorf("pod %s does not have container %s: discarding post-restore exec hooks", kube.NamespaceAndName(pod), containerName)
+			log.Warning(discardErr)
+			for i, hook := range hooks {
+				hookLog := log.WithFields(
+					logrus.Fields{
+						"hookSource": hook.HookSource,
+						"hookType":   "exec",
+						"hookPhase":  "post",
+						"hookName":   hook.HookName,
+						"container":  hook.Hook.Container,
+					},
+				)
+				errTracker := multiHookTracker.Record(restoreName, pod.Namespace, pod.Name, hook.Hook.Container, hook.HookSource, hook.HookName, HookPhase(""), i, true, discardErr)
+				if errTracker != nil {
+					hookLog.WithError(errTracker).Warn("Error recording the discarded hook in hook tracker")
+				}
+			}
+			errors = append(errors, discardErr)
 			delete(byContainer, containerName)
 		}
 	}
 	if len(byContainer) == 0 {
-		return nil
+		return errors
 	}
 
 	// Every hook in every container can have its own wait timeout. Rather than setting up separate
@@ -107,8 +128,6 @@ func (e *DefaultWaitExecHookHandler) HandleHooks(
 		ctx, cancel = context.WithTimeout(ctx, maxWait)
 	}
 	waitStart := time.Now()
-
-	var errors []error
 
 	// The first time this handler is called after a container starts running it will execute all
 	// pending hooks for that container. Subsequent invocations of this handler will never execute

--- a/pkg/controller/restore_finalizer_controller.go
+++ b/pkg/controller/restore_finalizer_controller.go
@@ -561,7 +561,8 @@ func (ctx *finalizerContext) WaitRestoreExecHook() (errs results.Result) {
 
 	// wait for restore exec hooks to finish
 	err := wait.PollUntilContextCancel(context.Background(), 1*time.Second, true, func(context.Context) (bool, error) {
-		log.Debug("Checking the progress of hooks execution")
+		attempted, failed := ctx.multiHookTracker.Stat(ctx.restore.Name)
+		log.Debugf("Checking the progress of hooks execution: attempted=%d, failed=%d", attempted, failed)
 		if ctx.multiHookTracker.IsComplete(ctx.restore.Name) {
 			return true, nil
 		}


### PR DESCRIPTION
Signed-off-by: Priyansh Choudhary <im1706@gmail.com>

Thank you for contributing to Velero!

# Please add a summary of your change
The early-return in HandleHooks (when byContainer empty or pod==nil) should Record(... hookFailed=true ...) in the multiHookTracker, or else never Add such hooks in the first place. Otherwise, tracker cannot complete, and the restore gets stuck forever.

# Does your change fix a particular issue?
Yes
Fixes #(issue)
#9749 

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
