### PR TITLE
Fix error in auto-request-review action

### DIFF
--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -18,3 +18,4 @@ jobs:
         uses: necojackarc/auto-request-review@v0.13.0
         with:
           config: .github/auto-assignees.yml
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Per action.yml of the action, the token is required. https://github.com/necojackarc/auto-request-review/blob/e89da1a8cd7c8c16d9de9c6e763290b6b0e3d424/action.yml#L8

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
