### PR TITLE
Cherry pick fixes to git actions to 1.18 branch

### DIFF
--- a/.github/workflows/auto_assign_prs.yml
+++ b/.github/workflows/auto_assign_prs.yml
@@ -7,6 +7,10 @@ on:
   pull_request_target:
     types: [opened, reopened, ready_for_review]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   # Automatically assigns reviewers and owner
   add-reviews:
@@ -16,4 +20,3 @@ jobs:
         uses: kentaro-m/auto-assign-action@v2.0.0
         with:
           configuration-path: ".github/auto-assignees.yml"
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/auto_label_prs.yml
+++ b/.github/workflows/auto_label_prs.yml
@@ -8,6 +8,10 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   # Automatically labels PRs based on file globs in the change.
   triage:
@@ -15,5 +19,4 @@ jobs:
     steps:
       - uses: actions/labeler@v5
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/labeler.yml

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -18,3 +18,4 @@ jobs:
         uses: necojackarc/auto-request-review@v0.13.0
         with:
           config: .github/auto-assignees.yml
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -5,6 +5,10 @@ on:
   pull_request_target:
     types: [opened, ready_for_review, reopened]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   auto-request-review:
     name: Auto Request Review
@@ -13,5 +17,4 @@ jobs:
       - name: Request a PR review based on files types/paths, and/or groups the author belongs to
         uses: necojackarc/auto-request-review@v0.13.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           config: .github/auto-assignees.yml


### PR DESCRIPTION
This PR contains the commits to fix the errors in gitactions after the repository is migrated to "velero-io"

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
