### PR TITLE
Add concurrency limit to go-releaser

### DIFF
--- a/hack/release-tools/goreleaser.sh
+++ b/hack/release-tools/goreleaser.sh
@@ -51,11 +51,13 @@ if [[ "${PUBLISH:-}" != "TRUE" ]]; then
     echo "Not set to publish"
     goreleaser release \
         --clean \
+        --parallelism 2 \
         --release-notes="${RELEASE_NOTES_FILE}" \
         --snapshot # Generate an unversioned snapshot release, skipping all validations and without publishing any artifacts (implies --skip-publish, --skip-announce and --skip-validate)
 else
     echo "Getting ready to publish"
     goreleaser release \
         --clean \
+        --parallelism 2 \
         --release-notes="${RELEASE_NOTES_FILE}"
 fi


### PR DESCRIPTION
Add concurrency limit to go-releaser to avoid to hit github secondary rate limit