### PR TITLE
Fix prow-action workflow permissions for issue commands

### DIFF
--- a/.github/workflows/prow-action.yml
+++ b/.github/workflows/prow-action.yml
@@ -5,6 +5,10 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   execute:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Summary

The prow-action workflow (`/assign`, `/close`, `/reopen`, `/cc`, etc.) was failing with:

```
Error: could not self assign: HttpError: Resource not accessible by integration
```

This happens because the workflow's `GITHUB_TOKEN` defaults to read-only permissions and lacks write access to issues and pull requests.

This PR adds an explicit `permissions` block to the workflow granting the minimum required access:
- `issues: write` for `/assign`, `/unassign`, `/close`, `/reopen`, `/milestone`
- `pull-requests: write` for `/approve`, `/cc`, `/uncc`, `/hold`

# Does your change fix a particular issue?

N/A this is a CI/workflow fix, not tied to a specific feature issue.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.