### PR TITLE
Fix backup-finalizer phase ordering on upload failure

### DIFF
--- a/pkg/controller/backup_finalizer_controller.go
+++ b/pkg/controller/backup_finalizer_controller.go
@@ -201,38 +201,52 @@ func (r *backupFinalizerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, errors.WithStack(err)
 		}
 	}
-	backupScheduleName := backupRequest.GetLabels()[velerov1api.ScheduleNameLabel]
+	// Set final phase and timestamps before encoding the backup metadata.
 	switch backup.Status.Phase {
 	case velerov1api.BackupPhaseFinalizing:
 		backup.Status.Phase = velerov1api.BackupPhaseCompleted
-		r.metrics.RegisterBackupSuccess(backupScheduleName)
-		r.metrics.RegisterBackupLastStatus(backupScheduleName, metrics.BackupLastStatusSucc)
 	case velerov1api.BackupPhaseFinalizingPartiallyFailed:
 		backup.Status.Phase = velerov1api.BackupPhasePartiallyFailed
-		r.metrics.RegisterBackupPartialFailure(backupScheduleName)
-		r.metrics.RegisterBackupLastStatus(backupScheduleName, metrics.BackupLastStatusFailure)
 	}
-
 	backup.Status.CompletionTimestamp = &metav1.Time{Time: r.clock.Now()}
 	backup.Status.CSIVolumeSnapshotsCompleted = updateCSIVolumeSnapshotsCompleted(operations)
 
-	recordBackupMetrics(log, backup, outBackupFile, r.metrics, true)
-
-	// update backup metadata in object store
+	// Encode and upload backup metadata and contents to object store.
+	// On failure, restore the original status so the deferred patch
+	// does not advance the cluster CR past Finalizing.
 	backupJSON := new(bytes.Buffer)
 	if err := encode.To(backup, "json", backupJSON); err != nil {
+		backup.Status.Phase = original.Status.Phase
+		backup.Status.CompletionTimestamp = original.Status.CompletionTimestamp
 		return ctrl.Result{}, errors.Wrap(err, "error encoding backup json")
 	}
 	err = backupStore.PutBackupMetadata(backup.Name, backupJSON)
 	if err != nil {
+		backup.Status.Phase = original.Status.Phase
+		backup.Status.CompletionTimestamp = original.Status.CompletionTimestamp
 		return ctrl.Result{}, errors.Wrap(err, "error uploading backup json")
 	}
 	if len(operations) > 0 {
 		err = backupStore.PutBackupContents(backup.Name, outBackupFile)
 		if err != nil {
+			backup.Status.Phase = original.Status.Phase
+			backup.Status.CompletionTimestamp = original.Status.CompletionTimestamp
 			return ctrl.Result{}, errors.Wrap(err, "error uploading backup final contents")
 		}
 	}
+
+	// Record metrics only after all uploads succeed.
+	backupScheduleName := backupRequest.GetLabels()[velerov1api.ScheduleNameLabel]
+	switch original.Status.Phase {
+	case velerov1api.BackupPhaseFinalizing:
+		r.metrics.RegisterBackupSuccess(backupScheduleName)
+		r.metrics.RegisterBackupLastStatus(backupScheduleName, metrics.BackupLastStatusSucc)
+	case velerov1api.BackupPhaseFinalizingPartiallyFailed:
+		r.metrics.RegisterBackupPartialFailure(backupScheduleName)
+		r.metrics.RegisterBackupLastStatus(backupScheduleName, metrics.BackupLastStatusFailure)
+	}
+	recordBackupMetrics(log, backup, outBackupFile, r.metrics, true)
+
 	return ctrl.Result{}, nil
 }
 

--- a/pkg/controller/backup_finalizer_controller_test.go
+++ b/pkg/controller/backup_finalizer_controller_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"fmt"
+
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -42,6 +44,8 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/plugin/clientmgmt"
 	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	persistencemocks "github.com/vmware-tanzu/velero/pkg/persistence/mocks"
+	pluginmocks "github.com/vmware-tanzu/velero/pkg/plugin/mocks"
 	velerotest "github.com/vmware-tanzu/velero/pkg/test"
 )
 
@@ -67,14 +71,17 @@ func TestBackupFinalizerReconcile(t *testing.T) {
 	defaultBackupLocation := builder.ForBackupStorageLocation(velerov1api.DefaultNamespace, "default").Result()
 
 	tests := []struct {
-		name                string
-		backup              *velerov1api.Backup
-		backupOperations    []*itemoperation.BackupOperation
-		backupLocation      *velerov1api.BackupStorageLocation
-		enableCSI           bool
-		expectError         bool
-		expectPhase         velerov1api.BackupPhase
-		expectedCompletedVS int
+		name                     string
+		backup                   *velerov1api.Backup
+		backupOperations         []*itemoperation.BackupOperation
+		backupLocation           *velerov1api.BackupStorageLocation
+		enableCSI                bool
+		expectError              bool
+		expectPhase              velerov1api.BackupPhase
+		expectedCompletedVS      int
+		putBackupMetadataErr     error
+		putBackupContentsErr     error
+		expectCompletionTimestamp bool
 	}{
 		{
 			name: "Finalizing backup is completed",
@@ -161,10 +168,11 @@ func TestBackupFinalizerReconcile(t *testing.T) {
 					Phase:                       velerov1api.BackupPhaseFinalizing,
 				}).
 				Result(),
-			backupLocation:      defaultBackupLocation,
-			enableCSI:           true,
-			expectPhase:         velerov1api.BackupPhaseCompleted,
-			expectedCompletedVS: 1,
+			backupLocation:           defaultBackupLocation,
+			enableCSI:                true,
+			expectPhase:              velerov1api.BackupPhaseCompleted,
+			expectedCompletedVS:      1,
+			expectCompletionTimestamp: true,
 			backupOperations: []*itemoperation.BackupOperation{
 				{
 					Spec: itemoperation.BackupOperationSpec{
@@ -184,6 +192,63 @@ func TestBackupFinalizerReconcile(t *testing.T) {
 							},
 						},
 						OperationID: "operation-3",
+					},
+					Status: itemoperation.OperationStatus{
+						Phase:   itemoperation.OperationPhaseCompleted,
+						Created: &metav1Now,
+					},
+				},
+			},
+		},
+		{
+			name: "PutBackupMetadata failure keeps Finalizing phase",
+			backup: builder.ForBackup(velerov1api.DefaultNamespace, "backup-4").
+				StorageLocation("default").
+				ObjectMeta(builder.WithUID("foo")).
+				StartTimestamp(fakeClock.Now()).
+				Phase(velerov1api.BackupPhaseFinalizing).Result(),
+			backupLocation:       defaultBackupLocation,
+			expectError:          true,
+			expectPhase:          velerov1api.BackupPhaseFinalizing,
+			putBackupMetadataErr: fmt.Errorf("object lock prevented overwrite"),
+			backupOperations:     []*itemoperation.BackupOperation{},
+		},
+		{
+			name: "PutBackupMetadata failure keeps FinalizingPartiallyFailed phase",
+			backup: builder.ForBackup(velerov1api.DefaultNamespace, "backup-5").
+				StorageLocation("default").
+				ObjectMeta(builder.WithUID("foo")).
+				StartTimestamp(fakeClock.Now()).
+				Phase(velerov1api.BackupPhaseFinalizingPartiallyFailed).Result(),
+			backupLocation:       defaultBackupLocation,
+			expectError:          true,
+			expectPhase:          velerov1api.BackupPhaseFinalizingPartiallyFailed,
+			putBackupMetadataErr: fmt.Errorf("object lock prevented overwrite"),
+			backupOperations:     []*itemoperation.BackupOperation{},
+		},
+		{
+			name: "PutBackupContents failure keeps Finalizing phase",
+			backup: builder.ForBackup(velerov1api.DefaultNamespace, "backup-6").
+				StorageLocation("default").
+				ObjectMeta(builder.WithUID("foo")).
+				StartTimestamp(fakeClock.Now()).
+				Phase(velerov1api.BackupPhaseFinalizing).Result(),
+			backupLocation:       defaultBackupLocation,
+			expectError:          true,
+			expectPhase:          velerov1api.BackupPhaseFinalizing,
+			putBackupContentsErr: fmt.Errorf("upload failed"),
+			backupOperations: []*itemoperation.BackupOperation{
+				{
+					Spec: itemoperation.BackupOperationSpec{
+						BackupName:       "backup-6",
+						BackupUID:        "foo",
+						BackupItemAction: "foo",
+						ResourceIdentifier: velero.ResourceIdentifier{
+							GroupResource: kuberesource.Pods,
+							Namespace:     "ns-1",
+							Name:          "pod-1",
+						},
+						OperationID: "operation-6",
 					},
 					Status: itemoperation.OperationStatus{
 						Phase:   itemoperation.OperationPhaseCompleted,
@@ -216,12 +281,17 @@ func TestBackupFinalizerReconcile(t *testing.T) {
 
 			fakeGlobalClient := velerotest.NewFakeControllerRuntimeClient(t, initObjs...)
 
+			// Reinitialize mocks per test to avoid accumulated expectations
+			backupStore = &persistencemocks.BackupStore{}
+			pluginManager = &pluginmocks.Manager{}
+
 			reconciler, backupper := mockBackupFinalizerReconciler(fakeClient, fakeGlobalClient, fakeClock)
 			pluginManager.On("CleanupClients").Return(nil)
 			backupStore.On("GetBackupItemOperations", test.backup.Name).Return(test.backupOperations, nil)
 			backupStore.On("GetBackupContents", mock.Anything).Return(io.NopCloser(bytes.NewReader([]byte("hello world"))), nil)
-			backupStore.On("PutBackupContents", mock.Anything, mock.Anything).Return(nil)
-			backupStore.On("PutBackupMetadata", mock.Anything, mock.Anything).Return(nil)
+			backupStore.On("PutBackupContents", mock.Anything, mock.Anything).Return(test.putBackupContentsErr)
+			backupStore.On("PutBackupMetadata", mock.Anything, mock.Anything).Return(test.putBackupMetadataErr)
+
 			backupStore.On("GetBackupVolumeInfos", mock.Anything).Return(nil, nil)
 			backupStore.On("PutBackupVolumeInfos", mock.Anything, mock.Anything).Return(nil)
 			pluginManager.On("GetBackupItemActionsV2").Return(nil, nil)
@@ -239,6 +309,9 @@ func TestBackupFinalizerReconcile(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, test.expectPhase, backupAfter.Status.Phase)
 			assert.Equal(t, test.expectedCompletedVS, backupAfter.Status.CSIVolumeSnapshotsCompleted)
+			if test.expectError {
+				assert.Nil(t, backupAfter.Status.CompletionTimestamp, "CompletionTimestamp should not be set on upload failure")
+			}
 		})
 	}
 }


### PR DESCRIPTION
# Fix backup-finalizer setting phase to Completed before upload succeeds

When `PutBackupMetadata` or `PutBackupContents` fails in the backup-finalizer controller, the deferred patch was advancing the cluster CR to `Completed`/`PartiallyFailed` because the phase was already set in-memory before the upload attempt. This caused a mismatch where the cluster showed `Completed` but object storage retained `Finalizing`.

**Changes:**
- On upload failure, restore the original phase and `CompletionTimestamp` so the deferred patch keeps the backup in `Finalizing`/`FinalizingPartiallyFailed`, allowing the reconcile requeue to retry
- Move metrics recording to after all uploads succeed, so failed uploads don't count as successful backups

# Does your change fix a particular issue?

Fixes #9645

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.

> [!Note]
> Responses generated with Claude