### PR TITLE
Update the Linux's base image from Ubuntu jammy to noble.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,9 +49,9 @@ RUN mkdir -p /output/usr/bin && \
     go clean -modcache -cache
 
 # Velero image packing section
-FROM paketobuildpacks/run-jammy-tiny:latest
+FROM paketobuildpacks/ubuntu-noble-run-tiny:latest
 
-LABEL maintainer="Xun Jiang <jxun@vmware.com>"
+LABEL maintainer="Xun Jiang <xun.jiang@broadcom.com>"
 
 COPY --from=velero-builder /output /
 


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
This PR updates the Linux Docker image's base image from Ubuntu 22.04 to 24.04.

Because the 22.04's EOL is targeted at 2027, update the base image to 24.04, whose EOL is targeted at 2029.
Ubuntu 26.04 was created weeks ago. `paketo` hasn't released any image for it yet.

# Does your change fix a particular issue?

Fixes #9788

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
