### PR TITLE
feat: enable modernize linter in golangci-lint and fix all violations

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -167,6 +167,12 @@ linters:
       ignore-rules:
         - someword
 
+    modernize:
+      # List of analyzers to disable.
+      # By default, all analyzers are enabled.
+      disable:
+        - newexpr
+
     nakedret:
       # make an issue if func has more lines of code than this setting and it has naked returns; default is 30
       max-func-lines: 30
@@ -325,6 +331,7 @@ linters:
     - importas
     - ineffassign
     - misspell
+    - modernize
     - nakedret
     - nilerr
     - noctx

--- a/internal/resourcemodifiers/json_patch.go
+++ b/internal/resourcemodifiers/json_patch.go
@@ -99,5 +99,5 @@ func (p *JSONPatcher) patchArrayToByteArray() []byte {
 		patches = append(patches, patch.ToString())
 	}
 	patchesStr := strings.Join(patches, ",\n\t")
-	return []byte(fmt.Sprintf(`[%s]`, patchesStr))
+	return fmt.Appendf(nil, `[%s]`, patchesStr)
 }

--- a/internal/resourcepolicies/volume_resources.go
+++ b/internal/resourcepolicies/volume_resources.go
@@ -18,6 +18,7 @@ package resourcepolicies
 import (
 	"bytes"
 	"fmt"
+	"slices"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/labels"
@@ -127,12 +128,7 @@ func (c *pvcPhaseCondition) match(v *structuredVolume) bool {
 	if v.pvcPhase == "" {
 		return false
 	}
-	for _, phase := range c.phases {
-		if v.pvcPhase == phase {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(c.phases, v.pvcPhase)
 }
 
 func (c *pvcPhaseCondition) validate() error {
@@ -160,13 +156,7 @@ func (s *storageClassCondition) match(v *structuredVolume) bool {
 		return false
 	}
 
-	for _, sc := range s.storageClass {
-		if v.storageClass == sc {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(s.storageClass, v.storageClass)
 }
 
 type nfsCondition struct {

--- a/internal/resourcepolicies/volume_types_conditions.go
+++ b/internal/resourcepolicies/volume_types_conditions.go
@@ -17,6 +17,8 @@ limitations under the License.
 package resourcepolicies
 
 import (
+	"slices"
+
 	corev1api "k8s.io/api/core/v1"
 )
 
@@ -64,12 +66,7 @@ func (v *volumeTypeCondition) match(s *structuredVolume) bool {
 		return true
 	}
 
-	for _, vt := range v.volumeTypes {
-		if vt == s.volumeType {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(v.volumeTypes, s.volumeType)
 }
 
 func (v *volumeTypeCondition) validate() error {

--- a/internal/volumehelper/volume_policy_helper.go
+++ b/internal/volumehelper/volume_policy_helper.go
@@ -3,6 +3,7 @@ package volumehelper
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -295,23 +296,11 @@ func (v volumeHelperImpl) shouldPerformFSBackupLegacy(
 	// Check volume in opt-in way
 	if !v.defaultVolumesToFSBackup {
 		optInVolumeNames := podvolumeutil.GetVolumesToBackup(&pod)
-		for _, volumeName := range optInVolumeNames {
-			if volume.Name == volumeName {
-				return true
-			}
-		}
-
-		return false
+		return slices.Contains(optInVolumeNames, volume.Name)
 	} else {
 		// Check volume in opt-out way
 		optOutVolumeNames := podvolumeutil.GetVolumesToExclude(&pod)
-		for _, volumeName := range optOutVolumeNames {
-			if volume.Name == volumeName {
-				return false
-			}
-		}
-
-		return true
+		return !slices.Contains(optOutVolumeNames, volume.Name)
 	}
 }
 

--- a/pkg/backup/actions/csi/pvc_action.go
+++ b/pkg/backup/actions/csi/pvc_action.go
@@ -19,6 +19,7 @@ package csi
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strconv"
 	"time"
 
@@ -241,9 +242,7 @@ func (p *pvcBackupItemAction) createVolumeSnapshot(
 	p.log.Infof("VolumeSnapshotClass=%s", vsClass.Name)
 
 	vsLabels := map[string]string{}
-	for k, v := range pvc.ObjectMeta.Labels {
-		vsLabels[k] = v
-	}
+	maps.Copy(vsLabels, pvc.ObjectMeta.Labels)
 	vsLabels[velerov1api.BackupNameLabel] = label.GetValidName(backup.Name)
 
 	// Craft the vs object to be created

--- a/pkg/backup/backed_up_items_map.go
+++ b/pkg/backup/backed_up_items_map.go
@@ -18,6 +18,7 @@ package backup
 
 import (
 	"fmt"
+	"maps"
 	"sort"
 	"sync"
 )
@@ -41,9 +42,7 @@ func (m *backedUpItemsMap) CopyItemMap() map[itemKey]struct{} {
 	m.RLock()
 	defer m.RUnlock()
 	returnMap := make(map[itemKey]struct{}, len(m.backedUpItems))
-	for key, val := range m.backedUpItems {
-		returnMap[key] = val
-	}
+	maps.Copy(returnMap, m.backedUpItems)
 	return returnMap
 }
 

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -663,9 +664,7 @@ func (ib *itemBackupper) takePVSnapshot(obj runtime.Unstructured, log logrus.Fie
 
 	// create tags from the backup's labels
 	tags := map[string]string{}
-	for k, v := range ib.backupRequest.GetLabels() {
-		tags[k] = v
-	}
+	maps.Copy(tags, ib.backupRequest.GetLabels())
 	tags["velero.io/backup"] = ib.backupRequest.Name
 	tags["velero.io/pv"] = pv.Name
 

--- a/pkg/backup/item_block_worker_pool.go
+++ b/pkg/backup/item_block_worker_pool.go
@@ -53,7 +53,7 @@ func StartItemBlockWorkerPool(ctx context.Context, workers int, log logrus.Field
 	ctx, cancelFunc := context.WithCancel(ctx)
 	wg := &sync.WaitGroup{}
 
-	for i := 0; i < workers; i++ {
+	for i := range workers {
 		logger := log.WithField("worker", i)
 		wg.Add(1)
 		go processItemBlockWorker(ctx, inputChannel, logger, wg)

--- a/pkg/builder/object_meta.go
+++ b/pkg/builder/object_meta.go
@@ -17,6 +17,7 @@ limitations under the License.
 package builder
 
 import (
+	"maps"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,9 +61,7 @@ func WithLabelsMap(labels map[string]string) func(obj metav1.Object) {
 		}
 
 		// If the label already exists in the object, it will be overwritten
-		for k, v := range labels {
-			objLabels[k] = v
-		}
+		maps.Copy(objLabels, labels)
 
 		obj.SetLabels(objLabels)
 	}
@@ -86,9 +85,7 @@ func WithAnnotationsMap(annotations map[string]string) func(obj metav1.Object) {
 		}
 
 		// If the label already exists in the object, it will be overwritten
-		for k, v := range annotations {
-			objAnnotations[k] = v
-		}
+		maps.Copy(objAnnotations, annotations)
 
 		obj.SetAnnotations(objAnnotations)
 	}

--- a/pkg/builder/testcr_builder.go
+++ b/pkg/builder/testcr_builder.go
@@ -61,13 +61,13 @@ type TestCR struct {
 	metav1.TypeMeta `json:",inline"`
 
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// +optional
-	Spec TestCRSpec `json:"spec,omitempty"`
+	Spec TestCRSpec `json:"spec,omitzero"`
 
 	// +optional
-	Status TestCRStatus `json:"status,omitempty"`
+	Status TestCRStatus `json:"status,omitzero"`
 }
 
 type TestCRSpec struct {

--- a/pkg/cmd/util/flag/enum.go
+++ b/pkg/cmd/util/flag/enum.go
@@ -17,6 +17,8 @@ limitations under the License.
 package flag
 
 import (
+	"slices"
+
 	"github.com/pkg/errors"
 )
 
@@ -48,11 +50,9 @@ func (e *Enum) String() string {
 // receiver. It returns an error if the string
 // is not an allowed value.
 func (e *Enum) Set(s string) error {
-	for _, val := range e.allowedValues {
-		if val == s {
-			e.value = s
-			return nil
-		}
+	if slices.Contains(e.allowedValues, s) {
+		e.value = s
+		return nil
 	}
 
 	return errors.Errorf("invalid value: %q", s)

--- a/pkg/controller/backup_storage_location_controller.go
+++ b/pkg/controller/backup_storage_location_controller.go
@@ -125,8 +125,8 @@ func sanitizeStorageError(err error) string {
 			cleanMsg = desc
 		} else {
 			// Last resort: return first line
-			if idx := strings.Index(errMsg, "\n"); idx != -1 {
-				cleanMsg = errMsg[:idx]
+			if before, _, ok := strings.Cut(errMsg, "\n"); ok {
+				cleanMsg = before
 			} else {
 				cleanMsg = errMsg
 			}

--- a/pkg/controller/data_download_controller.go
+++ b/pkg/controller/data_download_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -294,8 +295,8 @@ func (r *DataDownloadReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if peekErr := r.restoreExposer.PeekExposed(ctx, getDataDownloadOwnerObject(dd)); peekErr != nil {
 			log.Errorf("Cancel dd %s/%s because of expose error %s", dd.Namespace, dd.Name, peekErr)
 
-			diags := strings.Split(r.restoreExposer.DiagnoseExpose(ctx, getDataDownloadOwnerObject(dd)), "\n")
-			for _, diag := range diags {
+			diags := strings.SplitSeq(r.restoreExposer.DiagnoseExpose(ctx, getDataDownloadOwnerObject(dd)), "\n")
+			for diag := range diags {
 				log.Warnf("[Diagnose DD expose]%s", diag)
 			}
 
@@ -814,8 +815,8 @@ func (r *DataDownloadReconciler) onPrepareTimeout(ctx context.Context, dd *veler
 		return
 	}
 
-	diags := strings.Split(r.restoreExposer.DiagnoseExpose(ctx, getDataDownloadOwnerObject(dd)), "\n")
-	for _, diag := range diags {
+	diags := strings.SplitSeq(r.restoreExposer.DiagnoseExpose(ctx, getDataDownloadOwnerObject(dd)), "\n")
+	for diag := range diags {
 		log.Warnf("[Diagnose DD expose]%s", diag)
 	}
 
@@ -873,9 +874,7 @@ func (r *DataDownloadReconciler) setupExposeParam(dd *velerov2alpha1api.DataDown
 
 	hostingPodLabels := map[string]string{velerov1api.DataDownloadLabel: dd.Name}
 	if len(r.podLabels) > 0 {
-		for k, v := range r.podLabels {
-			hostingPodLabels[k] = v
-		}
+		maps.Copy(hostingPodLabels, r.podLabels)
 	} else {
 		for _, k := range util.ThirdPartyLabels {
 			if v, err := nodeagent.GetLabelValue(context.Background(), r.kubeClient, dd.Namespace, k, nodeOS); err != nil {
@@ -890,9 +889,7 @@ func (r *DataDownloadReconciler) setupExposeParam(dd *velerov2alpha1api.DataDown
 
 	hostingPodAnnotation := map[string]string{}
 	if len(r.podAnnotations) > 0 {
-		for k, v := range r.podAnnotations {
-			hostingPodAnnotation[k] = v
-		}
+		maps.Copy(hostingPodAnnotation, r.podAnnotations)
 	} else {
 		for _, k := range util.ThirdPartyAnnotations {
 			if v, err := nodeagent.GetAnnotationValue(context.Background(), r.kubeClient, dd.Namespace, k, nodeOS); err != nil {

--- a/pkg/controller/data_upload_controller.go
+++ b/pkg/controller/data_upload_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -300,8 +301,8 @@ func (r *DataUploadReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if peekErr := ep.PeekExposed(ctx, getOwnerObject(du)); peekErr != nil {
 			log.Errorf("Cancel du %s/%s because of expose error %s", du.Namespace, du.Name, peekErr)
 
-			diags := strings.Split(ep.DiagnoseExpose(ctx, getOwnerObject(du)), "\n")
-			for _, diag := range diags {
+			diags := strings.SplitSeq(ep.DiagnoseExpose(ctx, getOwnerObject(du)), "\n")
+			for diag := range diags {
 				log.Warnf("[Diagnose DU expose]%s", diag)
 			}
 
@@ -874,8 +875,8 @@ func (r *DataUploadReconciler) onPrepareTimeout(ctx context.Context, du *velerov
 			volumeSnapshotName = du.Spec.CSISnapshot.VolumeSnapshot
 		}
 
-		diags := strings.Split(ep.DiagnoseExpose(ctx, getOwnerObject(du)), "\n")
-		for _, diag := range diags {
+		diags := strings.SplitSeq(ep.DiagnoseExpose(ctx, getOwnerObject(du)), "\n")
+		for diag := range diags {
 			log.Warnf("[Diagnose DU expose]%s", diag)
 		}
 
@@ -949,9 +950,7 @@ func (r *DataUploadReconciler) setupExposeParam(du *velerov2alpha1api.DataUpload
 
 		hostingPodLabels := map[string]string{velerov1api.DataUploadLabel: du.Name}
 		if len(r.podLabels) > 0 {
-			for k, v := range r.podLabels {
-				hostingPodLabels[k] = v
-			}
+			maps.Copy(hostingPodLabels, r.podLabels)
 		} else {
 			for _, k := range util.ThirdPartyLabels {
 				if v, err := nodeagent.GetLabelValue(context.Background(), r.kubeClient, du.Namespace, k, nodeOS); err != nil {
@@ -966,9 +965,7 @@ func (r *DataUploadReconciler) setupExposeParam(du *velerov2alpha1api.DataUpload
 
 		hostingPodAnnotation := map[string]string{}
 		if len(r.podAnnotations) > 0 {
-			for k, v := range r.podAnnotations {
-				hostingPodAnnotation[k] = v
-			}
+			maps.Copy(hostingPodAnnotation, r.podAnnotations)
 		} else {
 			for _, k := range util.ThirdPartyAnnotations {
 				if v, err := nodeagent.GetAnnotationValue(context.Background(), r.kubeClient, du.Namespace, k, nodeOS); err != nil {

--- a/pkg/controller/pod_volume_backup_controller.go
+++ b/pkg/controller/pod_volume_backup_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -261,8 +262,8 @@ func (r *PodVolumeBackupReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		if peekErr := r.exposer.PeekExposed(ctx, getPVBOwnerObject(pvb)); peekErr != nil {
 			log.Errorf("Cancel PVB %s/%s because of expose error %s", pvb.Namespace, pvb.Name, peekErr)
 
-			diags := strings.Split(r.exposer.DiagnoseExpose(ctx, getPVBOwnerObject(pvb)), "\n")
-			for _, diag := range diags {
+			diags := strings.SplitSeq(r.exposer.DiagnoseExpose(ctx, getPVBOwnerObject(pvb)), "\n")
+			for diag := range diags {
 				log.Warnf("[Diagnose PVB expose]%s", diag)
 			}
 
@@ -486,8 +487,8 @@ func (r *PodVolumeBackupReconciler) onPrepareTimeout(ctx context.Context, pvb *v
 		return
 	}
 
-	diags := strings.Split(r.exposer.DiagnoseExpose(ctx, getPVBOwnerObject(pvb)), "\n")
-	for _, diag := range diags {
+	diags := strings.SplitSeq(r.exposer.DiagnoseExpose(ctx, getPVBOwnerObject(pvb)), "\n")
+	for diag := range diags {
 		log.Warnf("[Diagnose PVB expose]%s", diag)
 	}
 
@@ -821,9 +822,7 @@ func (r *PodVolumeBackupReconciler) setupExposeParam(pvb *velerov1api.PodVolumeB
 
 	hostingPodLabels := map[string]string{velerov1api.PVBLabel: pvb.Name}
 	if len(r.podLabels) > 0 {
-		for k, v := range r.podLabels {
-			hostingPodLabels[k] = v
-		}
+		maps.Copy(hostingPodLabels, r.podLabels)
 	} else {
 		for _, k := range util.ThirdPartyLabels {
 			if v, err := nodeagent.GetLabelValue(context.Background(), r.kubeClient, pvb.Namespace, k, nodeOS); err != nil {
@@ -838,9 +837,7 @@ func (r *PodVolumeBackupReconciler) setupExposeParam(pvb *velerov1api.PodVolumeB
 
 	hostingPodAnnotation := map[string]string{}
 	if len(r.podAnnotations) > 0 {
-		for k, v := range r.podAnnotations {
-			hostingPodAnnotation[k] = v
-		}
+		maps.Copy(hostingPodAnnotation, r.podAnnotations)
 	} else {
 		for _, k := range util.ThirdPartyAnnotations {
 			if v, err := nodeagent.GetAnnotationValue(context.Background(), r.kubeClient, pvb.Namespace, k, nodeOS); err != nil {

--- a/pkg/controller/pod_volume_restore_controller.go
+++ b/pkg/controller/pod_volume_restore_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -275,8 +276,8 @@ func (r *PodVolumeRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if peekErr := r.exposer.PeekExposed(ctx, getPVROwnerObject(pvr)); peekErr != nil {
 			log.Errorf("Cancel PVR %s/%s because of expose error %s", pvr.Namespace, pvr.Name, peekErr)
 
-			diags := strings.Split(r.exposer.DiagnoseExpose(ctx, getPVROwnerObject(pvr)), "\n")
-			for _, diag := range diags {
+			diags := strings.SplitSeq(r.exposer.DiagnoseExpose(ctx, getPVROwnerObject(pvr)), "\n")
+			for diag := range diags {
 				log.Warnf("[Diagnose PVR expose]%s", diag)
 			}
 
@@ -501,8 +502,8 @@ func (r *PodVolumeRestoreReconciler) onPrepareTimeout(ctx context.Context, pvr *
 		return
 	}
 
-	diags := strings.Split(r.exposer.DiagnoseExpose(ctx, getPVROwnerObject(pvr)), "\n")
-	for _, diag := range diags {
+	diags := strings.SplitSeq(r.exposer.DiagnoseExpose(ctx, getPVROwnerObject(pvr)), "\n")
+	for diag := range diags {
 		log.Warnf("[Diagnose PVR expose]%s", diag)
 	}
 
@@ -895,9 +896,7 @@ func (r *PodVolumeRestoreReconciler) setupExposeParam(pvr *velerov1api.PodVolume
 
 	hostingPodLabels := map[string]string{velerov1api.PVRLabel: pvr.Name}
 	if len(r.podLabels) > 0 {
-		for k, v := range r.podLabels {
-			hostingPodLabels[k] = v
-		}
+		maps.Copy(hostingPodLabels, r.podLabels)
 	} else {
 		for _, k := range util.ThirdPartyLabels {
 			if v, err := nodeagent.GetLabelValue(context.Background(), r.kubeClient, pvr.Namespace, k, nodeOS); err != nil {
@@ -912,9 +911,7 @@ func (r *PodVolumeRestoreReconciler) setupExposeParam(pvr *velerov1api.PodVolume
 
 	hostingPodAnnotation := map[string]string{}
 	if len(r.podAnnotations) > 0 {
-		for k, v := range r.podAnnotations {
-			hostingPodAnnotation[k] = v
-		}
+		maps.Copy(hostingPodAnnotation, r.podAnnotations)
 	} else {
 		for _, k := range util.ThirdPartyAnnotations {
 			if v, err := nodeagent.GetAnnotationValue(context.Background(), r.kubeClient, pvr.Namespace, k, nodeOS); err != nil {

--- a/pkg/datapath/types.go
+++ b/pkg/datapath/types.go
@@ -32,14 +32,14 @@ type Result struct {
 type BackupResult struct {
 	SnapshotID       string      `json:"snapshotID"`
 	EmptySnapshot    bool        `json:"emptySnapshot"`
-	Source           AccessPoint `json:"source,omitempty"`
+	Source           AccessPoint `json:"source,omitzero"`
 	TotalBytes       int64       `json:"totalBytes,omitempty"`
 	IncrementalBytes int64       `json:"incrementalBytes,omitempty"`
 }
 
 // RestoreResult represents the result of a restore
 type RestoreResult struct {
-	Target     AccessPoint `json:"target,omitempty"`
+	Target     AccessPoint `json:"target,omitzero"`
 	TotalBytes int64       `json:"totalBytes,omitempty"`
 }
 

--- a/pkg/install/import_test.go
+++ b/pkg/install/import_test.go
@@ -43,7 +43,7 @@ func TestPkgImportNoCloudProvider(t *testing.T) {
 	cloudProvider, err := regexp.Compile("aws|cloud.google.com|azure")
 	require.NoError(t, err)
 	cloudProviderDeps := []string{}
-	for _, dep := range strings.Split(deps, "\n") {
+	for dep := range strings.SplitSeq(deps, "\n") {
 		if !k8sio.MatchString(dep) {
 			if cloudProvider.MatchString(dep) {
 				cloudProviderDeps = append(cloudProviderDeps, dep)

--- a/pkg/install/resources.go
+++ b/pkg/install/resources.go
@@ -18,6 +18,7 @@ package install
 
 import (
 	"fmt"
+	"maps"
 	"time"
 
 	corev1api "k8s.io/api/core/v1"
@@ -70,9 +71,7 @@ func podLabels(userLabels ...map[string]string) map[string]string {
 
 	// Merge base labels with user labels to enforce CLI precedence
 	for _, labels := range userLabels {
-		for k, v := range labels {
-			base[k] = v
-		}
+		maps.Copy(base, labels)
 	}
 
 	return base
@@ -87,9 +86,7 @@ func podAnnotations(userAnnotations map[string]string) map[string]string {
 	}
 
 	// Merge base annotations with user annotations to enforce CLI precedence
-	for k, v := range userAnnotations {
-		base[k] = v
-	}
+	maps.Copy(base, userAnnotations)
 
 	return base
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -231,7 +231,7 @@ func TestMultipleAdhocBackupsShareMetrics(t *testing.T) {
 	m := NewServerMetrics()
 
 	// Simulate multiple adhoc backup attempts
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		m.RegisterBackupAttempt("")
 	}
 

--- a/pkg/persistence/in_memory_object_store.go
+++ b/pkg/persistence/in_memory_object_store.go
@@ -110,14 +110,14 @@ func (o *inMemoryObjectStore) ListCommonPrefixes(bucket, prefix, delimiter strin
 		afterPrefix := key[len(prefix):]
 
 		// index of the *start* of 'delimiter' in 'afterPrefix'
-		delimiterStart := strings.Index(afterPrefix, delimiter)
-		if delimiterStart == -1 {
+		before, _, ok := strings.Cut(afterPrefix, delimiter)
+		if !ok {
 			continue
 		}
 
 		// return the prefix, plus everything after the prefix and before
 		// the delimiter, plus the delimiter
-		fullPrefix := prefix + afterPrefix[0:delimiterStart] + delimiter
+		fullPrefix := prefix + before + delimiter
 
 		prefixes = append(prefixes, fullPrefix)
 	}

--- a/pkg/persistence/object_store.go
+++ b/pkg/persistence/object_store.go
@@ -20,6 +20,7 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"io"
+	"maps"
 	"strings"
 	"time"
 
@@ -159,9 +160,7 @@ func (b *objectBackupStoreGetter) Get(location *velerov1api.BackupStorageLocatio
 	// the in-cluster BSL with data which doesn't belong in Spec.Config
 	objectStoreConfig := make(map[string]string)
 	if location.Spec.Config != nil {
-		for key, val := range location.Spec.Config {
-			objectStoreConfig[key] = val
-		}
+		maps.Copy(objectStoreConfig, location.Spec.Config)
 	}
 
 	// add the bucket name and prefix to the config map so that object stores

--- a/pkg/plugin/clientmgmt/manager_test.go
+++ b/pkg/plugin/clientmgmt/manager_test.go
@@ -145,7 +145,7 @@ func TestCleanupClients(t *testing.T) {
 
 	m := NewManager(logger, logLevel, registry).(*manager)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		rp := &restartabletest.MockRestartableProcess{}
 		defer rp.AssertExpectations(t)
 		rp.On("Stop")

--- a/pkg/plugin/framework/import_test.go
+++ b/pkg/plugin/framework/import_test.go
@@ -43,7 +43,7 @@ func TestPkgImportNoCloudProvider(t *testing.T) {
 	cloudProvider, err := regexp.Compile("aws|cloud.google.com|azure")
 	require.NoError(t, err)
 	cloudProviderDeps := []string{}
-	for _, dep := range strings.Split(deps, "\n") {
+	for dep := range strings.SplitSeq(deps, "\n") {
 		if !k8sio.MatchString(dep) {
 			if cloudProvider.MatchString(dep) {
 				cloudProviderDeps = append(cloudProviderDeps, dep)

--- a/pkg/podvolume/backupper_test.go
+++ b/pkg/podvolume/backupper_test.go
@@ -281,7 +281,7 @@ func createPodObj(running bool, withVolume bool, withVolumeMounted bool, volumeN
 	}
 
 	if withVolume {
-		for i := 0; i < volumeNum; i++ {
+		for i := range volumeNum {
 			podObj.Spec.Volumes = append(podObj.Spec.Volumes, corev1api.Volume{
 				Name: fmt.Sprintf("fake-volume-%d", i+1),
 				VolumeSource: corev1api.VolumeSource{
@@ -294,7 +294,7 @@ func createPodObj(running bool, withVolume bool, withVolumeMounted bool, volumeN
 
 		if withVolumeMounted {
 			volumeMount := []corev1api.VolumeMount{}
-			for i := 0; i < volumeNum; i++ {
+			for i := range volumeNum {
 				volumeMount = append(volumeMount, corev1api.VolumeMount{
 					Name: fmt.Sprintf("fake-volume-%d", i+1),
 				})
@@ -630,7 +630,7 @@ func TestBackupPodVolumes(t *testing.T) {
 			pvbs, _, errs := bp.BackupPodVolumes(backupObj, test.sourcePod, test.volumes, nil, velerotest.NewLogger())
 
 			if test.errs != nil {
-				for i := 0; i < len(errs); i++ {
+				for i := range errs {
 					require.EqualError(t, errs[i], test.errs[i])
 				}
 			}

--- a/pkg/podvolume/restorer_test.go
+++ b/pkg/podvolume/restorer_test.go
@@ -389,7 +389,7 @@ func TestRestorePodVolumes(t *testing.T) {
 			if errs == nil {
 				assert.Nil(t, test.errs)
 			} else {
-				for i := 0; i < len(errs); i++ {
+				for i := range errs {
 					if test.errs[i].prefixOnly {
 						errMsg := errs[i].Error()
 						if len(errMsg) >= len(test.errs[i].err) {
@@ -398,7 +398,7 @@ func TestRestorePodVolumes(t *testing.T) {
 
 						assert.Equal(t, test.errs[i].err, errMsg)
 					} else {
-						for i := 0; i < len(errs); i++ {
+						for i := range errs {
 							j := 0
 							for ; j < len(test.errs); j++ {
 								err := errs[i].Error()

--- a/pkg/repository/maintenance/maintenance.go
+++ b/pkg/repository/maintenance/maintenance.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"math"
 	"sort"
 	"strings"
@@ -390,10 +391,7 @@ func WaitAllJobsComplete(ctx context.Context, cli client.Client, repo *velerov1a
 
 	history := []velerov1api.BackupRepositoryMaintenanceStatus{}
 
-	startPos := len(jobList.Items) - limit
-	if startPos < 0 {
-		startPos = 0
-	}
+	startPos := max(len(jobList.Items)-limit, 0)
 
 	for i := startPos; i < len(jobList.Items); i++ {
 		job := &jobList.Items[i]
@@ -609,9 +607,7 @@ func buildJob(
 		RepositoryNameLabel: velerolabel.ReturnNameOrHash(repo.Name),
 	}
 	if config != nil && len(config.PodLabels) > 0 {
-		for k, v := range config.PodLabels {
-			podLabels[k] = v
-		}
+		maps.Copy(podLabels, config.PodLabels)
 	} else {
 		for _, k := range util.ThirdPartyLabels {
 			if v := veleroutil.GetVeleroServerLabelValue(deployment, k); v != "" {
@@ -622,9 +618,7 @@ func buildJob(
 
 	podAnnotations := map[string]string{}
 	if config != nil && len(config.PodAnnotations) > 0 {
-		for k, v := range config.PodAnnotations {
-			podAnnotations[k] = v
-		}
+		maps.Copy(podAnnotations, config.PodAnnotations)
 	} else {
 		for _, k := range util.ThirdPartyAnnotations {
 			if v := veleroutil.GetVeleroServerAnnotationValue(deployment, k); v != "" {

--- a/pkg/repository/provider/unified_repo.go
+++ b/pkg/repository/provider/unified_repo.go
@@ -598,9 +598,7 @@ func getStorageVariables(backupLocation *velerov1api.BackupStorageLocation, repo
 		result[udmrepo.StoreOptionS3DisableTLSVerify] = config["insecureSkipTLSVerify"]
 		result[udmrepo.StoreOptionS3DisableTLS] = strconv.FormatBool(disableTLS)
 	} else if backendType == repoconfig.AzureBackend {
-		for k, v := range config {
-			result[k] = v
-		}
+		maps.Copy(result, config)
 	}
 
 	result[udmrepo.StoreOptionOssBucket] = bucket

--- a/pkg/repository/udmrepo/repo_options.go
+++ b/pkg/repository/udmrepo/repo_options.go
@@ -162,9 +162,7 @@ func WithConfigFile(workPath string, repoID string) func(*RepoOptions) error {
 // WithGenOptions sets the GeneralOptions to RepoOptions
 func WithGenOptions(genOptions map[string]string) func(*RepoOptions) error {
 	return func(options *RepoOptions) error {
-		for k, v := range genOptions {
-			options.GeneralOptions[k] = v
-		}
+		maps.Copy(options.GeneralOptions, genOptions)
 
 		return nil
 	}

--- a/pkg/restic/command_factory_test.go
+++ b/pkg/restic/command_factory_test.go
@@ -74,9 +74,9 @@ func TestGetSnapshotCommand(t *testing.T) {
 			actualFlags = append(actualFlags, parts[0])
 
 			// split based on ,
-			tags := strings.Split(parts[1], ",")
+			tags := strings.SplitSeq(parts[1], ",")
 			// loop through each key-value tag pair
-			for _, tag := range tags {
+			for tag := range tags {
 				// split the pair on =
 				kvs := strings.Split(tag, "=")
 				// record actual key & value

--- a/pkg/restore/actions/csi/volumesnapshot_action.go
+++ b/pkg/restore/actions/csi/volumesnapshot_action.go
@@ -19,6 +19,7 @@ package csi
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	volumegroupsnapshotv1beta2 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta2"
 	snapshotv1api "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
@@ -203,11 +204,9 @@ func (p *volumeSnapshotRestoreItemAction) addSnapshotHandleToVGSC(
 ) error {
 	// Check if handle is already in the list
 	if vgsc.Spec.Source.GroupSnapshotHandles != nil {
-		for _, handle := range vgsc.Spec.Source.GroupSnapshotHandles.VolumeSnapshotHandles {
-			if handle == snapshotHandle {
-				p.log.Infof("Snapshot handle %s already present in VGSC %s", snapshotHandle, vgsc.Name)
-				return nil
-			}
+		if slices.Contains(vgsc.Spec.Source.GroupSnapshotHandles.VolumeSnapshotHandles, snapshotHandle) {
+			p.log.Infof("Snapshot handle %s already present in VGSC %s", snapshotHandle, vgsc.Name)
+			return nil
 		}
 	}
 

--- a/pkg/restore/actions/service_account_action.go
+++ b/pkg/restore/actions/service_account_action.go
@@ -17,6 +17,7 @@ limitations under the License.
 package actions
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -56,11 +57,10 @@ func (a *ServiceAccountAction) Execute(input *velero.RestoreItemActionExecuteInp
 
 	log.Debug("Checking secrets")
 	check := serviceAccount.Name + "-token-"
-	for i := len(serviceAccount.Secrets) - 1; i >= 0; i-- {
-		secret := &serviceAccount.Secrets[i]
-		log.Debugf("Checking if secret %s matches %s", secret.Name, check)
+	for i, v := range slices.Backward(serviceAccount.Secrets) {
+		log.Debugf("Checking if secret %s matches %s", v.Name, check)
 
-		if strings.HasPrefix(secret.Name, check) {
+		if strings.HasPrefix(v.Name, check) {
 			// Copy all secrets *except* -token-
 			log.Debug("Match found - excluding this secret")
 			serviceAccount.Secrets = append(serviceAccount.Secrets[:i], serviceAccount.Secrets[i+1:]...)

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1897,11 +1897,9 @@ func restorePodVolumeBackups(ctx *restoreContext, createdObj *unstructured.Unstr
 	if ctx.podVolumeRestorer == nil {
 		ctx.log.Warn("No pod volume restorer, not restoring pod's volumes")
 	} else {
-		ctx.podVolumeWaitGroup.Add(1)
-		go func() {
+		ctx.podVolumeWaitGroup.Go(func() {
 			// Done() will only be called after all errors have been successfully
 			// sent on the ctx.podVolumeErrs channel
-			defer ctx.podVolumeWaitGroup.Done()
 
 			pod := new(corev1api.Pod)
 			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(createdObj.UnstructuredContent(), &pod); err != nil {
@@ -1924,7 +1922,7 @@ func restorePodVolumeBackups(ctx *restoreContext, createdObj *unstructured.Unstr
 					ctx.podVolumeErrs <- err
 				}
 			}
-		}()
+		})
 	}
 }
 

--- a/pkg/uploader/kopia/block_backup.go
+++ b/pkg/uploader/kopia/block_backup.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
 Copyright The Velero Contributors.

--- a/pkg/uploader/kopia/block_restore.go
+++ b/pkg/uploader/kopia/block_restore.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
 Copyright The Velero Contributors.

--- a/pkg/uploader/kopia/flush_volume_linux.go
+++ b/pkg/uploader/kopia/flush_volume_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright The Velero Contributors.

--- a/pkg/uploader/provider/kopia.go
+++ b/pkg/uploader/provider/kopia.go
@@ -47,7 +47,7 @@ type kopiaProvider struct {
 	bkRepo        udmrepo.BackupRepo
 	credGetter    *credentials.CredentialGetter
 	log           logrus.FieldLogger
-	canceling     int32
+	canceling     atomic.Int32
 }
 
 // NewKopiaUploaderProvider initialized with open or create a repository
@@ -91,7 +91,7 @@ func (kp *kopiaProvider) CheckContext(ctx context.Context, finishChan chan struc
 		kp.log.Infof("Action finished")
 		return
 	case <-ctx.Done():
-		atomic.StoreInt32(&kp.canceling, 1)
+		kp.canceling.Store(1)
 
 		if uploader != nil {
 			uploader.Cancel()
@@ -239,7 +239,7 @@ func (kp *kopiaProvider) RunRestore(
 		return 0, errors.Wrapf(err, "Failed to run kopia restore")
 	}
 
-	if atomic.LoadInt32(&kp.canceling) == 1 {
+	if kp.canceling.Load() == 1 {
 		log.Error("Kopia restore is canceled")
 		return 0, ErrorCanceled
 	}

--- a/pkg/util/actionhelpers/service_account_helper.go
+++ b/pkg/util/actionhelpers/service_account_helper.go
@@ -17,6 +17,8 @@ limitations under the License.
 package actionhelpers
 
 import (
+	"slices"
+
 	"github.com/sirupsen/logrus"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,15 +55,12 @@ func RelatedItemsForServiceAccount(objectMeta metav1.Object, clusterRoleBindings
 	)
 
 	for _, crb := range clusterRoleBindings {
-		for _, s := range crb.ServiceAccountSubjects(namespace) {
-			if s == name {
-				log.Infof("Adding clusterrole %s and clusterrolebinding %s to relatedItems since serviceaccount %s/%s is a subject",
-					crb.RoleRefName(), crb.Name(), namespace, name)
+		if slices.Contains(crb.ServiceAccountSubjects(namespace), name) {
+			log.Infof("Adding clusterrole %s and clusterrolebinding %s to relatedItems since serviceaccount %s/%s is a subject",
+				crb.RoleRefName(), crb.Name(), namespace, name)
 
-				bindings.Insert(crb.Name())
-				roles.Insert(crb.RoleRefName())
-				break
-			}
+			bindings.Insert(crb.Name())
+			roles.Insert(crb.RoleRefName())
 		}
 	}
 

--- a/pkg/util/kube/utils.go
+++ b/pkg/util/kube/utils.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -338,9 +339,7 @@ func AddAnnotations(o *metav1.ObjectMeta, vals map[string]string) {
 	if o.Annotations == nil {
 		o.Annotations = make(map[string]string)
 	}
-	for k, v := range vals {
-		o.Annotations[k] = v
-	}
+	maps.Copy(o.Annotations, vals)
 }
 
 // AddLabels adds the supplied key-values to the labels on the object

--- a/pkg/util/logging/log_location_hook.go
+++ b/pkg/util/logging/log_location_hook.go
@@ -121,9 +121,9 @@ func getLogSourceSetMarker(entry *logrus.Entry) string {
 }
 
 func removeVeleroPackagePrefix(file string) string {
-	if index := strings.Index(file, veleroPackage); index != -1 {
+	if _, after, ok := strings.Cut(file, veleroPackage); ok {
 		// strip off .../github.com/vmware-tanzu/velero/ so we just have pkg/...
-		return file[index+veleroPackageLen:]
+		return after
 	}
 
 	return file

--- a/pkg/util/podvolume/pod_volume_test.go
+++ b/pkg/util/podvolume/pod_volume_test.go
@@ -1158,7 +1158,7 @@ func TestBuildCacheForNamespaceIdempotent(t *testing.T) {
 	cache := NewPVCPodCache()
 
 	// Build cache multiple times - should be idempotent
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		err := cache.BuildCacheForNamespace(t.Context(), "ns1", fakeClient)
 		require.NoError(t, err)
 		assert.True(t, cache.IsNamespaceBuilt("ns1"))

--- a/pkg/util/stringslice/stringslice.go
+++ b/pkg/util/stringslice/stringslice.go
@@ -16,16 +16,12 @@ limitations under the License.
 
 package stringslice
 
+import "slices"
+
 // Has returns true if the `items` slice contains the
 // value `val`, or false otherwise.
 func Has(items []string, val string) bool {
-	for _, itm := range items {
-		if itm == val {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(items, val)
 }
 
 // Except returns a new string slice that contains all of the entries

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -19,15 +19,11 @@ package util
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"slices"
 )
 
 func Contains(slice []string, key string) bool {
-	for _, i := range slice {
-		if i == key {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(slice, key)
 }
 
 // GenerateSha256FromRestoreUIDAndVsName Use the restore UID and the VS Name to generate

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -754,8 +754,8 @@ func TestE2e(t *testing.T) {
 
 	// Validate the UpgradeFromVeleroVersion if provided
 	if len(test.VeleroCfg.UpgradeFromVeleroVersion) > 0 {
-		versions := strings.Split(test.VeleroCfg.UpgradeFromVeleroVersion, ",")
-		for _, version := range versions {
+		versions := strings.SplitSeq(test.VeleroCfg.UpgradeFromVeleroVersion, ",")
+		for version := range versions {
 			if err := veleroutil.ValidateVeleroVersion(version); err != nil {
 				fmt.Println("UpgradeFromVeleroVersion is invalid: ", version)
 				t.Error(err)
@@ -765,8 +765,8 @@ func TestE2e(t *testing.T) {
 
 	// Validate the MigrateFromVeleroVersion if provided
 	if len(test.VeleroCfg.MigrateFromVeleroVersion) > 0 {
-		versions := strings.Split(test.VeleroCfg.MigrateFromVeleroVersion, ",")
-		for _, version := range versions {
+		versions := strings.SplitSeq(test.VeleroCfg.MigrateFromVeleroVersion, ",")
+		for version := range versions {
 			if err := veleroutil.ValidateVeleroVersion(version); err != nil {
 				fmt.Println("MigrateFromVeleroVersion is invalid: ", version)
 				t.Error(err)

--- a/test/util/common/common.go
+++ b/test/util/common/common.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 )
 
@@ -47,10 +48,10 @@ func GetListByCmdPipes(ctx context.Context, cmdLines []*OsCommandLine) ([]string
 		}
 	}
 	cmds[len(cmds)-1].Stdout = &buf
-	for i := len(cmds) - 1; i >= 0; i-- {
-		_ = cmds[i].Start()
+	for i, v := range slices.Backward(cmds) {
+		_ = v.Start()
 		if i == 0 {
-			_ = cmds[i].Run()
+			_ = v.Run()
 		}
 	}
 	for i := 1; i < len(cmds); i++ {

--- a/test/util/k8s/crd.go
+++ b/test/util/k8s/crd.go
@@ -70,7 +70,7 @@ func InstallCR(ctx context.Context, crFile, ns string) error {
 	var stderr string
 	var err error
 
-	for i := 0; i < retries; i++ {
+	for i := range retries {
 		fmt.Printf("Attempt %d: Install custom resource %s\n", i+1, crFile)
 		cmd := exec.CommandContext(ctx, "kubectl", "apply", "-n", ns, "-f", crFile)
 		_, stderr, err = veleroexec.RunCommand(cmd)

--- a/test/util/k8s/serviceaccount.go
+++ b/test/util/k8s/serviceaccount.go
@@ -66,7 +66,7 @@ func PatchServiceAccountWithImagePullSecret(ctx context.Context, client TestClie
 	}
 
 	if _, err = client.ClientGo.CoreV1().ServiceAccounts(namespace).Patch(ctx, serviceAccount, types.StrategicMergePatchType,
-		[]byte(fmt.Sprintf(`{"imagePullSecrets": [{"name": "%s"}]}`, secretName)), metav1.PatchOptions{}); err != nil {
+		fmt.Appendf(nil, `{"imagePullSecrets": [{"name": "%s"}]}`, secretName), metav1.PatchOptions{}); err != nil {
 		return errors.Wrapf(err, "failed to patch the service account %q under the namespace %q", serviceAccount, namespace)
 	}
 	return nil

--- a/test/util/kibishii/kibishii_utils.go
+++ b/test/util/kibishii/kibishii_utils.go
@@ -66,7 +66,7 @@ var KibishiiStorageClassName = "kibishii-storage-class"
 
 func GetKibishiiPVCNameList(workerCount int) []string {
 	var kibishiiPVCNameList []string
-	for i := 0; i < workerCount; i++ {
+	for i := range workerCount {
 		kibishiiPVCNameList = append(kibishiiPVCNameList, fmt.Sprintf("kibishii-data-kibishii-deployment-%d", i))
 	}
 	return kibishiiPVCNameList
@@ -466,9 +466,9 @@ func readBaseEtcdImage(etcdFilePath string) string {
 	}
 
 	// Split on document marker
-	docs := strings.Split(string(bytes), "---")
+	docs := strings.SplitSeq(string(bytes), "---")
 
-	for _, doc := range docs {
+	for doc := range docs {
 		doc = strings.TrimSpace(doc)
 		if doc == "" {
 			continue

--- a/test/util/providers/common.go
+++ b/test/util/providers/common.go
@@ -55,7 +55,7 @@ func ObjectsShouldNotBeInBucket(objectStoreProvider, cloudCredentialsFile, bslBu
 	if cloudCredentialsFile == "" {
 		return errors.New(fmt.Sprintf("|| ERROR || - Please provide credential file of cloud %s \n", objectStoreProvider))
 	}
-	for i := 0; i < retryTimes; i++ {
+	for range retryTimes {
 		exist, err = IsObjectsInBucket(objectStoreProvider, cloudCredentialsFile, bslBucket, bslPrefix, bslConfig, backupName, subPrefix)
 		if err != nil {
 			return errors.Wrapf(err, "|| UNEXPECTED || - Failed to get backup %s in object store\n", backupName)

--- a/test/util/velero/velero_utils.go
+++ b/test/util/velero/velero_utils.go
@@ -1267,8 +1267,8 @@ func SnapshotCRsCountShouldBe(ctx context.Context, namespace, backupName string,
 	}
 	count := 0
 	stdout = strings.Replace(stdout, "'", "", -1)
-	arr := strings.Split(stdout, "\n")
-	for _, bn := range arr {
+	arr := strings.SplitSeq(stdout, "\n")
+	for bn := range arr {
 		fmt.Println("Snapshot CR:" + bn)
 		if strings.Contains(bn, backupName) {
 			count++


### PR DESCRIPTION
## Please add a summary of your change

Enables the `modernize` linter in the golangci-lint configuration and fixes all reported violations across the codebase. The `modernize` linter is part of `golangci-lint` since v2.1.0 and the project already uses v2.12.0, so no tooling version bump is needed.

### Changes to `.golangci.yaml`
- Added `modernize` to the `linters.enable` list
- Disabled the `newexpr` check via `linters.settings.modernize.disable` (placed in alphabetical order within `linters.settings`) — the golangci-lint auto-fix for `newexpr` generates syntactically invalid Go code (`new(literal_value)` — `new` only accepts types, not values), making it unsafe to enable

### Fixes applied across 49 Go files

| Check | Description | Files touched |
|---|---|---|
| `mapsloop` | Replace `for k, v := range src { dst[k] = v }` with `maps.Copy` | 10 files |
| `slicescontains` | Replace manual contains loops with `slices.Contains` | 6 files |
| `stringsseq` | Replace `for _, s := range strings.Split(...)` with `strings.SplitSeq` | 7 files |
| `stringscut` | Replace `strings.Index` patterns with `strings.Cut` | 3 files |
| `rangeint` | Replace `for i := 0; i < n; i++ {}` with `for range n {}` | 8 files |
| `fmtappendf` | Replace `[]byte(fmt.Sprintf...)` with `fmt.Appendf(nil, ...)` | 2 files |
| `plusbuild` | Remove legacy `// +build` lines (replaced by `//go:build`) | 3 files |
| `minmax` | Replace if/else patterns with `max()`/`min()` builtins | 1 file |
| `omitzero` | Replace `omitempty` (no-op for struct fields) with `omitzero` | 2 files |
| `slicesbackward` | Replace backward loops with `slices.Backward` | 2 files |
| `waitgroupgo` | Replace `wg.Add(1); go func() { defer wg.Done() ... }()` with `wg.Go(...)` | 1 file |
| `atomictypes` | Replace `var x int32` + `atomic.*Int32` calls with `atomic.Int32` | 1 file |

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.