### PR TITLE
Fix delete wait helpers to poll requested objects

### DIFF
--- a/changelogs/unreleased/9800-immanuwell
+++ b/changelogs/unreleased/9800-immanuwell
@@ -1,0 +1,1 @@
+Fix test delete wait helpers to poll the requested object name.

--- a/test/util/k8s/configmap.go
+++ b/test/util/k8s/configmap.go
@@ -86,7 +86,7 @@ func WaitForConfigmapDelete(c clientset.Interface, ns, name string) error {
 
 	return waitutil.PollImmediateInfinite(5*time.Second,
 		func() (bool, error) {
-			if _, err := c.CoreV1().ConfigMaps(ns).Get(context.TODO(), ns, metav1.GetOptions{}); err != nil {
+			if _, err := c.CoreV1().ConfigMaps(ns).Get(context.TODO(), name, metav1.GetOptions{}); err != nil {
 				if apierrors.IsNotFound(err) {
 					return true, nil
 				}

--- a/test/util/k8s/delete_wait_test.go
+++ b/test/util/k8s/delete_wait_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8s
+
+import (
+	"testing"
+
+	corev1api "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	kubetesting "k8s.io/client-go/testing"
+)
+
+func TestWaitForServiceDeletePollsRequestedService(t *testing.T) {
+	const namespace = "test-ns"
+	const name = "test-service"
+
+	client := fake.NewSimpleClientset(&corev1api.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	})
+
+	if err := WaitForServiceDelete(TestClient{ClientGo: client}, namespace, name, true); err != nil {
+		t.Fatalf("WaitForServiceDelete returned error: %v", err)
+	}
+
+	assertGetActionName(t, client.Actions(), "services", name)
+}
+
+func TestWaitForSecretDeletePollsRequestedSecret(t *testing.T) {
+	const namespace = "test-ns"
+	const name = "test-secret"
+
+	client := fake.NewSimpleClientset(&corev1api.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	})
+
+	if err := WaitForSecretDelete(client, namespace, name); err != nil {
+		t.Fatalf("WaitForSecretDelete returned error: %v", err)
+	}
+
+	assertGetActionName(t, client.Actions(), "secrets", name)
+}
+
+func TestWaitForConfigmapDeletePollsRequestedConfigMap(t *testing.T) {
+	const namespace = "test-ns"
+	const name = "test-configmap"
+
+	client := fake.NewSimpleClientset(&corev1api.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	})
+
+	if err := WaitForConfigmapDelete(client, namespace, name); err != nil {
+		t.Fatalf("WaitForConfigmapDelete returned error: %v", err)
+	}
+
+	assertGetActionName(t, client.Actions(), "configmaps", name)
+}
+
+func assertGetActionName(t *testing.T, actions []kubetesting.Action, resource, expectedName string) {
+	t.Helper()
+
+	for _, action := range actions {
+		getAction, ok := action.(kubetesting.GetAction)
+		if !ok || getAction.GetVerb() != "get" || getAction.GetResource().Resource != resource {
+			continue
+		}
+
+		if getAction.GetName() != expectedName {
+			t.Fatalf("expected get action for %q, got %q", expectedName, getAction.GetName())
+		}
+		return
+	}
+
+	t.Fatalf("expected get action for resource %q", resource)
+}

--- a/test/util/k8s/secret.go
+++ b/test/util/k8s/secret.go
@@ -48,7 +48,7 @@ func WaitForSecretDelete(c clientset.Interface, ns, name string) error {
 	}
 	return waitutil.PollImmediateInfinite(5*time.Second,
 		func() (bool, error) {
-			if _, err := c.CoreV1().Secrets(ns).Get(context.TODO(), ns, metav1.GetOptions{}); err != nil {
+			if _, err := c.CoreV1().Secrets(ns).Get(context.TODO(), name, metav1.GetOptions{}); err != nil {
 				if apierrors.IsNotFound(err) {
 					return true, nil
 				}

--- a/test/util/k8s/service.go
+++ b/test/util/k8s/service.go
@@ -63,7 +63,7 @@ func WaitForServiceDelete(client TestClient, ns, name string, deleteFirst bool) 
 	}
 	return waitutil.PollImmediateInfinite(5*time.Second,
 		func() (bool, error) {
-			if _, err := client.ClientGo.CoreV1().Services(ns).Get(context.TODO(), ns, metav1.GetOptions{}); err != nil {
+			if _, err := client.ClientGo.CoreV1().Services(ns).Get(context.TODO(), name, metav1.GetOptions{}); err != nil {
 				if apierrors.IsNotFound(err) {
 					return true, nil
 				}


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

Fixes three delete-wait helpers that deleted the requested object, then polled the namespace name instead of the object name. Tiny cleanup footgun, but it can make E2E cleanup lie or wait on the wrong thing when `ns != name`.

# Does your change fix a particular issue?

No related issue found.

Repro:
- change the helper poll calls back from `name` to `ns`
- run `go test ./test/util/k8s -run 'TestWaitFor.*DeletePolls' -count=1`
- tests fail with `expected get action for "test-service", got "test-ns"` and same deal for Secret/ConfigMap

Checked:
- `go test ./test/util/k8s ./test/util/velero -count=1`

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main` (not needed; no docs behavior changed).
