### PR TITLE
Fix the site deployment problem

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   base = "site/"
   command = "hugo --gc --minify"
-  publish = "site/public"
+  publish = "public"
 
 [context.production.environment]
   HUGO_VERSION = "0.73.0"


### PR DESCRIPTION
After updating netlify settings to point to the new repo URL the site failed to deploy.

The netlify error analysis:
```
The problem is that base = "site/" makes the build run from the site subdirectory, and publish = "site/public" is resolved relative to the repo root as site/site/public — but Hugo outputs to site/public. Since the base is already site/, the publish path should just be public (relative to the base directory).
```

This fix passed the deploy preview so I think it should fix the problem.

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
