### PR TITLE
Remove Restic cases and workflow from E2E

### DIFF
--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -95,9 +95,9 @@ jobs:
             \"k8s\":$(wget -q -O - "https://hub.docker.com/v2/namespaces/kindest/repositories/node/tags?page_size=50" | grep -o '"name": *"[^"]*' | grep -o '[^"]*$' | grep -v -E "alpha|beta" | grep -E "v[1-9]\.(2[5-9]|[3-9][0-9])" | awk -F. '{if(!a[$1"."$2]++)print $1"."$2"."$NF}' | sort -r | sed s/v//g | jq -R -c -s 'split("\n")[:-1]'),\
             \"labels\":[\
               \"Basic && (ClusterResource || NodePort || StorageClass)\", \
-              \"ResourceFiltering && !Restic\", \
+              \"ResourceFiltering && !FSBackup\", \
               \"ResourceModifier || (Backups && BackupsSync) || PrivilegesMgmt || OrderedResources\", \
-              \"(NamespaceMapping && Single && Restic) || (NamespaceMapping && Multiple && Restic)\"\
+              \"(NamespaceMapping && Single && FSBackup) || (NamespaceMapping && Multiple && FSBackup)\"\
             ]}" >> $GITHUB_OUTPUT
 
   # Run E2E test against all Kubernetes versions on kind

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -20,4 +20,4 @@ jobs:
           days-before-pr-close: -1
           # Only issues made after Feb 09 2021.
           start-date: "2021-09-02T00:00:00"
-          exempt-issue-labels: "Epic,Area/CLI,Area/Cloud/AWS,Area/Cloud/Azure,Area/Cloud/GCP,Area/Cloud/vSphere,Area/CSI,Area/Design,Area/Documentation,Area/Plugins,Bug,Enhancement/User,kind/requirement,kind/refactor,kind/tech-debt,limitation,Needs investigation,Needs triage,Needs Product,P0 - Hair on fire,P1 - Important,P2 - Long-term important,P3 - Wouldn't it be nice if...,Product Requirements,Restic - GA,Restic,release-blocker,Security,backlog"
+          exempt-issue-labels: "Epic,Area/CLI,Area/Cloud/AWS,Area/Cloud/Azure,Area/Cloud/GCP,Area/Cloud/vSphere,Area/CSI,Area/Design,Area/Documentation,Area/Plugins,Bug,Enhancement/User,kind/requirement,kind/refactor,kind/tech-debt,limitation,Needs investigation,Needs triage,Needs Product,P0 - Hair on fire,P1 - Important,P2 - Long-term important,P3 - Wouldn't it be nice if...,Product Requirements,release-blocker,Security,backlog"

--- a/changelogs/unreleased/9867-Joeavaikath
+++ b/changelogs/unreleased/9867-Joeavaikath
@@ -1,0 +1,1 @@
+Remove Restic cases and workflow from E2E

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -293,18 +293,18 @@ E2E tests can be run with specific cases to be included and/or excluded using th
 
 1. Run Velero tests with specific cases to be included:
 ```bash
-GINKGO_LABELS="Basic && Restic" \
+GINKGO_LABELS="Basic && FSBackup" \
 CLOUD_PROVIDER=aws \
 BSL_BUCKET=example-bucket \
 CREDS_FILE=/path/to/aws-creds \
 make test-e2e \
 ```
 
-In this example, only case have both `Basic` and `Restic` labels are included.
+In this example, only case have both `Basic` and `FSBackup` labels are included.
 
 1. Run Velero tests with specific cases to be excluded:
 ```bash
-GINKGO_LABELS="!(Scale || Schedule || TTL || (Upgrade && Restic) || (Migration && Restic))" \
+GINKGO_LABELS="!(Scale || Schedule || TTL || (Upgrade && FSBackup) || (Migration && FSBackup))" \
 CLOUD_PROVIDER=aws \
 BSL_BUCKET=example-bucket \
 CREDS_FILE=/path/to/aws-creds \
@@ -315,8 +315,8 @@ In this example, cases are labelled as
 * `Scale`
 * `Schedule`
 * `TTL`
-* `Upgrade` and `Restic`
-* `Migration` and `Restic` 
+* `Upgrade` and `FSBackup`
+* `Migration` and `FSBackup` 
 will be skipped.
 
 #### VKS environment test
@@ -370,9 +370,7 @@ Following pipelines should cover all E2E tests along with proper filters:
 
 1. **CSI pipeline:** As we can see lots of labels in E2E test code, there're many snapshot-labeled test scripts. To cover CSI scenario, a pipeline with CSI enabled should be a good choice, otherwise, we will double all the snapshot cases for CSI scenario, it's very time-wasting. By providing `FEATURES=EnableCSI` and  `PLUGINS=<provider-plugin-images>`, a CSI pipeline is ready for testing.
 1. **Data mover pipeline:** Data mover scenario is the same scenario with migaration test except the restriction of migaration between different providers, so it better to separated it out from other pipelines. Please refer the example in previous.
-1. **Restic/Kopia backup path pipelines:**
-    1. **Restic pipeline:** For the same reason of saving time, set `UPLOADER_TYPE` to `restic` for all file system backup test cases;
-    1. **Kopia pipeline:** Set `UPLOADER_TYPE` to `kopia` for all file system backup test cases;
+1. **File system backup pipeline:** Set `UPLOADER_TYPE` to `kopia` for all file system backup test cases;
 1. **Long time pipeline:** Long time cases should be group into one pipeline, currently these test cases with labels `Scale`, `Schedule` or `TTL` can be group into a pipeline, and make sure to skip them off in any other pipelines.
     
 **Note:** please organize filters among proper pipelines for other test cases.

--- a/test/e2e/backup/backup.go
+++ b/test/e2e/backup/backup.go
@@ -43,7 +43,7 @@ func BackupRestoreWithSnapshots() {
 	BackupRestoreTest(config)
 }
 
-func BackupRestoreWithRestic() {
+func BackupRestoreWithFSBackup() {
 	config := BackupRestoreTestConfig{false, "", false}
 	BackupRestoreTest(config)
 }
@@ -53,7 +53,7 @@ func BackupRestoreRetainedPVWithSnapshots() {
 	BackupRestoreTest(config)
 }
 
-func BackupRestoreRetainedPVWithRestic() {
+func BackupRestoreRetainedPVWithFSBackup() {
 	config := BackupRestoreTestConfig{false, "overlays/sc-reclaim-policy/", true}
 	BackupRestoreTest(config)
 }

--- a/test/e2e/backups/deletion.go
+++ b/test/e2e/backups/deletion.go
@@ -34,13 +34,11 @@ import (
 	. "github.com/vmware-tanzu/velero/test/util/velero"
 )
 
-// Test backup and restore of Kibishii using restic
-
 func BackupDeletionWithSnapshots() {
 	backup_deletion_test(true)
 }
 
-func BackupDeletionWithRestic() {
+func BackupDeletionWithFSBackup() {
 	backup_deletion_test(false)
 }
 func backup_deletion_test(useVolumeSnapshots bool) {

--- a/test/e2e/basic/namespace-mapping.go
+++ b/test/e2e/basic/namespace-mapping.go
@@ -21,8 +21,8 @@ type NamespaceMapping struct {
 
 const NamespaceBaseName string = "ns-mp-"
 
-var OneNamespaceMappingResticTest func() = TestFunc(&NamespaceMapping{TestCase: TestCase{NamespacesTotal: 1, UseVolumeSnapshots: false}})
-var MultiNamespacesMappingResticTest func() = TestFunc(&NamespaceMapping{TestCase: TestCase{NamespacesTotal: 2, UseVolumeSnapshots: false}})
+var OneNamespaceMappingFSBackupTest func() = TestFunc(&NamespaceMapping{TestCase: TestCase{NamespacesTotal: 1, UseVolumeSnapshots: false}})
+var MultiNamespacesMappingFSBackupTest func() = TestFunc(&NamespaceMapping{TestCase: TestCase{NamespacesTotal: 2, UseVolumeSnapshots: false}})
 var OneNamespaceMappingSnapshotTest func() = TestFunc(&NamespaceMapping{TestCase: TestCase{NamespacesTotal: 1, UseVolumeSnapshots: true}})
 var MultiNamespacesMappingSnapshotTest func() = TestFunc(&NamespaceMapping{TestCase: TestCase{NamespacesTotal: 2, UseVolumeSnapshots: true}})
 
@@ -37,7 +37,7 @@ func (n *NamespaceMapping) Init() error {
 	if n.VeleroCfg.CloudProvider == "kind" {
 		n.kibishiiData = &KibishiiData{Levels: 0, DirsPerLevel: 0, FilesPerLevel: 0, FileLength: 0, BlockSize: 0, PassNum: 0, ExpectedNodes: 2}
 	}
-	backupType := "restic"
+	backupType := "fs-backup"
 	if n.UseVolumeSnapshots {
 		backupType = "snapshot"
 	}

--- a/test/e2e/bsl-mgmt/deletion.go
+++ b/test/e2e/bsl-mgmt/deletion.go
@@ -41,13 +41,11 @@ const (
 	bslDeletionTestNs = "bsl-deletion"
 )
 
-// Test backup and restore of Kibishii using restic
-
 func BslDeletionWithSnapshots() {
 	BslDeletionTest(true)
 }
 
-func BslDeletionWithRestic() {
+func BslDeletionWithFSBackup() {
 	BslDeletionTest(false)
 }
 func BslDeletionTest(useVolumeSnapshots bool) {
@@ -89,7 +87,7 @@ func BslDeletionTest(useVolumeSnapshots bool) {
 	})
 
 	When("kibishii is the sample workload", func() {
-		It("Local backups and restic repos (if Velero was installed with Restic) will be deleted once the corresponding backup storage location is deleted", func() {
+		It("Local backups and backup repos will be deleted once the corresponding backup storage location is deleted", func() {
 			oneHourTimeout, ctxCancel := context.WithTimeout(context.Background(), time.Minute*60)
 			defer ctxCancel()
 			if veleroCfg.AdditionalBSLProvider == "" {
@@ -165,7 +163,7 @@ func BslDeletionTest(useVolumeSnapshots bool) {
 				)).To(Succeed())
 			})
 
-			// Restic can not backup PV only, so pod need to be labeled also
+			// FS backup can not backup PV only, so pod need to be labeled also
 			By("Label all 2 worker-pods of Kibishii", func() {
 				Expect(AddLabelToPod(context.Background(), podName1, bslDeletionTestNs, label1)).To(Succeed())
 				Expect(AddLabelToPod(context.Background(), "kibishii-deployment-1", bslDeletionTestNs, label2)).To(Succeed())

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -397,11 +397,10 @@ var _ = Describe(
 	APIExtensionsVersionsTest,
 )
 
-// Test backup and restore of Kibishii using restic
 var _ = Describe(
-	"Velero tests on cluster using the plugin provider for object storage and Restic for volume backups",
-	Label("Basic", "Restic", "AdditionalBSL"),
-	BackupRestoreWithRestic,
+	"Velero tests on cluster using the plugin provider for object storage and file system backup for volumes",
+	Label("Basic", "FSBackup", "AdditionalBSL"),
+	BackupRestoreWithFSBackup,
 )
 
 var _ = Describe(
@@ -417,9 +416,9 @@ var _ = Describe(
 )
 
 var _ = Describe(
-	"Velero tests on cluster using the plugin provider for object storage and snapshots for volume backups",
-	Label("Basic", "Restic", "RetainPV", "AdditionalBSL"),
-	BackupRestoreRetainedPVWithRestic,
+	"Velero tests on cluster using the plugin provider for object storage and file system backup for volumes",
+	Label("Basic", "FSBackup", "RetainPV", "AdditionalBSL"),
+	BackupRestoreRetainedPVWithFSBackup,
 )
 
 var _ = Describe(
@@ -452,11 +451,10 @@ var _ = Describe(
 	MultiNSBackupRestore,
 )
 
-// Upgrade test by Kibishii using Restic
 var _ = Describe(
-	"Velero upgrade tests on cluster using the plugin provider for object storage and Restic for volume backups",
-	Label("Upgrade", "Restic"),
-	BackupUpgradeRestoreWithRestic,
+	"Velero upgrade tests on cluster using the plugin provider for object storage and file system backup for volumes",
+	Label("Upgrade", "FSBackup"),
+	BackupUpgradeRestoreWithFSBackup,
 )
 var _ = Describe(
 	"Velero upgrade tests on cluster using the plugin provider for object storage and snapshots for volume backups",
@@ -522,7 +520,7 @@ var _ = Describe(
 )
 var _ = Describe(
 	"Velero test on skip backup of volume by resource policies",
-	Label("ResourceFiltering", "ResourcePolicies", "Restic"),
+	Label("ResourceFiltering", "ResourcePolicies", "FSBackup"),
 	ResourcePoliciesTest,
 )
 
@@ -560,9 +558,9 @@ var _ = Describe(
 )
 
 var _ = Describe(
-	"Velero tests of Restic backup deletion",
-	Label("Backups", "Deletion", "Restic"),
-	BackupDeletionWithRestic,
+	"Velero tests of file system backup deletion",
+	Label("Backups", "Deletion", "FSBackup"),
+	BackupDeletionWithFSBackup,
 )
 var _ = Describe(
 	"Velero tests of snapshot backup deletion",
@@ -570,7 +568,7 @@ var _ = Describe(
 	BackupDeletionWithSnapshots,
 )
 var _ = Describe(
-	"Local backups and Restic repos will be deleted once the corresponding backup storage location is deleted",
+	"Local backups and backup repos will be deleted once the corresponding backup storage location is deleted",
 	Label("Backups", "TTL", "LongTime", "Snapshot", "SkipVanillaZfs"),
 	TTLTest,
 )
@@ -608,9 +606,9 @@ var _ = Describe(
 	BslDeletionWithSnapshots,
 )
 var _ = Describe(
-	"Local backups and Restic repos will be deleted once the corresponding backup storage location is deleted",
-	Label("BSL", "Deletion", "Restic", "AdditionalBSL"),
-	BslDeletionWithRestic,
+	"Local backups and backup repos will be deleted once the corresponding backup storage location is deleted",
+	Label("BSL", "Deletion", "FSBackup", "AdditionalBSL"),
+	BslDeletionWithFSBackup,
 )
 
 var _ = Describe(
@@ -626,13 +624,13 @@ var _ = Describe(
 
 var _ = Describe(
 	"Backup resources should follow the specific order in schedule",
-	Label("NamespaceMapping", "Single", "Restic"),
-	OneNamespaceMappingResticTest,
+	Label("NamespaceMapping", "Single", "FSBackup"),
+	OneNamespaceMappingFSBackupTest,
 )
 var _ = Describe(
 	"Backup resources should follow the specific order in schedule",
-	Label("NamespaceMapping", "Multiple", "Restic"),
-	MultiNamespacesMappingResticTest,
+	Label("NamespaceMapping", "Multiple", "FSBackup"),
+	MultiNamespacesMappingFSBackupTest,
 )
 var _ = Describe(
 	"Backup resources should follow the specific order in schedule",

--- a/test/e2e/test/test.go
+++ b/test/e2e/test/test.go
@@ -179,10 +179,6 @@ func (t *TestCase) Start() error {
 		Skip("Skip due to issue https://github.com/kubernetes/kubernetes/issues/114384 on AKS")
 	}
 
-	if veleroCfg.UploaderType == UploaderTypeRestic &&
-		strings.Contains(t.GetTestCase().CaseBaseName, "ParallelFiles") {
-		Skip("Skip Parallel Files upload and download test cases for environments using Restic as uploader.")
-	}
 	return nil
 }
 

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -43,7 +43,7 @@ func BackupUpgradeRestoreWithSnapshots() {
 	}
 }
 
-func BackupUpgradeRestoreWithRestic() {
+func BackupUpgradeRestoreWithFSBackup() {
 	veleroCfg = VeleroCfg
 	for _, upgradeFromVelero := range GetVersionList(veleroCfg.UpgradeFromVeleroCLI, veleroCfg.UpgradeFromVeleroVersion) {
 		BackupUpgradeRestoreTest(false, upgradeFromVelero)
@@ -108,8 +108,6 @@ func BackupUpgradeRestoreTest(useVolumeSnapshots bool, veleroCLI2Version VeleroC
 			Expect(err).To(Succeed())
 			oneHourTimeout, ctxCancel := context.WithTimeout(context.Background(), time.Minute*60)
 			defer ctxCancel()
-			supportUploaderType, err := IsSupportUploaderType(veleroCLI2Version.VeleroVersion)
-			Expect(err).To(Succeed())
 			if veleroCLI2Version.VeleroCLI == "" {
 				//Assume tag of velero server image is identical to velero CLI version
 				//Download velero CLI if it's empty according to velero CLI version
@@ -182,8 +180,6 @@ func BackupUpgradeRestoreTest(useVolumeSnapshots bool, veleroCLI2Version VeleroC
 				BackupCfg.UseVolumeSnapshots = useVolumeSnapshots
 				BackupCfg.DefaultVolumesToFsBackup = !useVolumeSnapshots
 				BackupCfg.Selector = ""
-				//TODO: pay attention to this param, remove it when restic is not the default backup tool any more.
-				BackupCfg.UseResticIfFSBackup = !supportUploaderType
 				Expect(VeleroBackupNamespace(oneHourTimeout, tmpCfg.UpgradeFromVeleroCLI,
 					tmpCfg.VeleroNamespace, BackupCfg)).To(Succeed(), func() string {
 					RunDebug(context.Background(), tmpCfg.UpgradeFromVeleroCLI, tmpCfg.VeleroNamespace,
@@ -247,17 +243,9 @@ func BackupUpgradeRestoreTest(useVolumeSnapshots bool, veleroCLI2Version VeleroC
 				tmpCfg.GCFrequency = ""
 				tmpCfg.UseNodeAgent = !useVolumeSnapshots
 				Expect(err).To(Succeed())
-				if supportUploaderType {
-					Expect(VeleroInstall(context.Background(), &tmpCfg, false)).To(Succeed())
-					Expect(CheckVeleroVersion(context.Background(), tmpCfg.VeleroCLI,
-						tmpCfg.VeleroVersion)).To(Succeed())
-				} else {
-					// For upgrade from v1.9 or other version below v1.9
-					tmpCfg.UploaderType = "restic"
-					Expect(VeleroUpgrade(context.Background(), tmpCfg)).To(Succeed())
-					Expect(CheckVeleroVersion(context.Background(), tmpCfg.VeleroCLI,
-						tmpCfg.VeleroVersion)).To(Succeed())
-				}
+				Expect(VeleroInstall(context.Background(), &tmpCfg, false)).To(Succeed())
+				Expect(CheckVeleroVersion(context.Background(), tmpCfg.VeleroCLI,
+					tmpCfg.VeleroVersion)).To(Succeed())
 			})
 
 			// Wait for 70s to make sure the backups are synced after Velero reinstall

--- a/test/types.go
+++ b/test/types.go
@@ -44,10 +44,7 @@ const CSI = "csi"
 const Velero = "velero"
 const VeleroRestoreHelper = "velero-restore-helper"
 
-const (
-	UploaderTypeRestic = "restic"
-	UploaderTypeKopia  = "kopia"
-)
+const UploaderTypeKopia = "kopia"
 
 const (
 	KubeSystemNamespace           = "kube-system"
@@ -168,7 +165,6 @@ type BackupConfig struct {
 	ExcludeResources            string
 	IncludeClusterResources     bool
 	OrderedResources            string
-	UseResticIfFSBackup         bool
 	DefaultVolumesToFsBackup    bool
 	SnapshotMoveData            bool
 }

--- a/test/util/velero/install.go
+++ b/test/util/velero/install.go
@@ -616,10 +616,8 @@ func createVeleroResources(ctx context.Context, cli, namespace string, args []st
 		return errors.Wrapf(err, "failed to run velero install dry run command, stdout=%s, stderr=%s", stdout, stderr)
 	}
 
-	// From v1.15, the Restic uploader is deprecated,
-	// and a warning message is printed for the install CLI.
-	// Need to skip the deprecation of Restic message before the generated JSON.
-	// Redirect to the stdout to the first curly bracket to skip the warning.
+	// The install CLI may print warning messages before the generated JSON.
+	// Skip any text before the first curly bracket.
 	if stdout[0] != '{' {
 		newIndex := strings.Index(stdout, "{")
 		stdout = stdout[newIndex:]
@@ -730,7 +728,7 @@ func patchResources(resources *unstructured.UnstructuredList, namespace string, 
 		}
 	}
 
-	// customize the restic restore helper image
+	// customize the restore helper image
 	if len(options.RestoreHelperImage) > 0 {
 		restoreActionConfig := corev1api.ConfigMap{
 			TypeMeta: metav1.TypeMeta{
@@ -755,7 +753,7 @@ func patchResources(resources *unstructured.UnstructuredList, namespace string, 
 			return errors.Wrapf(err, "failed to convert restore action config to unstructure")
 		}
 		resources.Items = append(resources.Items, un)
-		fmt.Printf("the restic restore helper image is set by the configmap %q \n", "fs-restore-action-config")
+		fmt.Printf("the restore helper image is set by the configmap %q \n", "fs-restore-action-config")
 	}
 
 	return nil

--- a/test/util/velero/velero_utils.go
+++ b/test/util/velero/velero_utils.go
@@ -41,7 +41,6 @@ import (
 	schedulingv1api "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	ver "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -240,7 +239,7 @@ func getProviderVeleroInstallOptions(veleroCfg *VeleroConfig,
 	}
 
 	io := cliinstall.NewInstallOptions()
-	// always wait for velero and restic pods to be running.
+	// always wait for velero and node-agent pods to be running.
 	io.Wait = true
 	io.ProviderName = veleroCfg.ObjectStoreProvider
 
@@ -471,11 +470,7 @@ func VeleroBackupNamespace(ctx context.Context, veleroCLI, veleroNamespace strin
 		}
 	}
 	if backupCfg.DefaultVolumesToFsBackup {
-		if backupCfg.UseResticIfFSBackup {
-			args = append(args, "--default-volumes-to-restic")
-		} else {
-			args = append(args, "--default-volumes-to-fs-backup")
-		}
+		args = append(args, "--default-volumes-to-fs-backup")
 
 		// To workaround https://github.com/vmware-tanzu/velero-plugin-for-vsphere/issues/347 for vsphere plugin v1.1.1
 		// if the "--snapshot-volumes=false" isn't specified explicitly, the vSphere plugin will always take snapshots
@@ -484,20 +479,11 @@ func VeleroBackupNamespace(ctx context.Context, veleroCLI, veleroNamespace strin
 		if backupCfg.ProvideSnapshotsVolumeParam && !backupCfg.UseVolumeSnapshots {
 			args = append(args, "--snapshot-volumes=false")
 		} // if "--snapshot-volumes" is not provide, snapshot should be taken as default behavior.
-	} else { // DefaultVolumesToFsBackup is false
+	} else if backupCfg.UseVolumeSnapshots {
 		// Although DefaultVolumesToFsBackup is false, but probably DefaultVolumesToFsBackup
 		// was set to true in installation CLI in snapshot volume test, so set DefaultVolumesToFsBackup
 		// to false specifically to make sure volume snapshot was taken
-		if backupCfg.UseVolumeSnapshots {
-			if backupCfg.UseResticIfFSBackup {
-				args = append(args, "--default-volumes-to-restic=false")
-			} else {
-				args = append(args, "--default-volumes-to-fs-backup=false")
-			}
-		}
-		// Although DefaultVolumesToFsBackup is false, but probably DefaultVolumesToFsBackup
-		// was set to true in installation CLI in FS volume backup test, so do nothing here, no DefaultVolumesToFsBackup
-		// appear in backup CLI
+		args = append(args, "--default-volumes-to-fs-backup=false")
 	}
 	if backupCfg.BackupLocation != "" {
 		args = append(args, "--storage-location", backupCfg.BackupLocation)
@@ -1282,14 +1268,14 @@ func SnapshotCRsCountShouldBe(ctx context.Context, namespace, backupName string,
 }
 
 func BackupRepositoriesCountShouldBe(ctx context.Context, veleroNamespace, targetNamespace string, expectedCount int) error {
-	resticArr, err := GetRepositories(ctx, veleroNamespace, targetNamespace)
+	repos, err := GetRepositories(ctx, veleroNamespace, targetNamespace)
 	if err != nil {
 		return errors.Wrapf(err, "Fail to get BackupRepositories")
 	}
-	if len(resticArr) == expectedCount {
+	if len(repos) == expectedCount {
 		return nil
 	} else {
-		return errors.New(fmt.Sprintf("BackupRepositories count %d in namespace %s is not as expected %d", len(resticArr), targetNamespace, expectedCount))
+		return errors.New(fmt.Sprintf("BackupRepositories count %d in namespace %s is not as expected %d", len(repos), targetNamespace, expectedCount))
 	}
 }
 
@@ -1429,36 +1415,6 @@ func GetSchedule(ctx context.Context, veleroNamespace, scheduleName string) (str
 	return stdout, err
 }
 
-func VeleroUpgrade(ctx context.Context, veleroCfg VeleroConfig) error {
-	crd, err := ApplyCRDs(ctx, veleroCfg.VeleroCLI)
-	if err != nil {
-		return errors.Wrap(err, "Fail to Apply CRDs")
-	}
-	fmt.Println(crd)
-	deploy, err := UpdateVeleroDeployment(ctx, veleroCfg)
-	if err != nil {
-		return errors.Wrap(err, "Fail to update Velero deployment")
-	}
-	fmt.Println(deploy)
-	if veleroCfg.UseNodeAgent {
-		dsjson, err := KubectlGetDsJson(veleroCfg.VeleroNamespace)
-		if err != nil {
-			return errors.Wrap(err, "Fail to update Velero deployment")
-		}
-
-		err = DeleteVeleroDs(ctx)
-		if err != nil {
-			return errors.Wrap(err, "Fail to delete Velero ds")
-		}
-		update, err := UpdateNodeAgent(ctx, veleroCfg, dsjson)
-		fmt.Println(update)
-		if err != nil {
-			return errors.Wrap(err, "Fail to update node agent")
-		}
-	}
-	return waitVeleroReady(ctx, veleroCfg.VeleroNamespace, veleroCfg.UseNodeAgent, veleroCfg.UseNodeAgentWindows)
-}
-
 func ApplyCRDs(ctx context.Context, veleroCLI string) ([]string, error) {
 	cmds := []*common.OsCommandLine{}
 
@@ -1473,78 +1429,6 @@ func ApplyCRDs(ctx context.Context, veleroCLI string) ([]string, error) {
 		Args: []string{"apply", "-f", "-"},
 	}
 	cmds = append(cmds, cmd)
-	return common.GetListByCmdPipes(ctx, cmds)
-}
-
-func UpdateVeleroDeployment(ctx context.Context, veleroCfg VeleroConfig) ([]string, error) {
-	cmds := []*common.OsCommandLine{}
-
-	cmd := &common.OsCommandLine{
-		Cmd:  "kubectl",
-		Args: []string{"get", "deploy", "-n", veleroCfg.VeleroNamespace, "-ojson"},
-	}
-	cmds = append(cmds, cmd)
-
-	cmd = &common.OsCommandLine{
-		Cmd:  "sed",
-		Args: []string{fmt.Sprintf("s#\\\"server\\\",#\\\"server\\\",\\\"--uploader-type=%s\\\",#g", veleroCfg.UploaderType)},
-	}
-	cmds = append(cmds, cmd)
-
-	cmd = &common.OsCommandLine{
-		Cmd:  "sed",
-		Args: []string{"s#default-volumes-to-restic#default-volumes-to-fs-backup#g"},
-	}
-	cmds = append(cmds, cmd)
-
-	cmd = &common.OsCommandLine{
-		Cmd:  "sed",
-		Args: []string{"s#default-restic-prune-frequency#default-repo-maintain-frequency#g"},
-	}
-	cmds = append(cmds, cmd)
-
-	cmd = &common.OsCommandLine{
-		Cmd:  "sed",
-		Args: []string{"s#restic-timeout#fs-backup-timeout#g"},
-	}
-	cmds = append(cmds, cmd)
-
-	cmd = &common.OsCommandLine{
-		Cmd:  "kubectl",
-		Args: []string{"apply", "-f", "-"},
-	}
-	cmds = append(cmds, cmd)
-
-	return common.GetListByCmdPipes(ctx, cmds)
-}
-
-func UpdateNodeAgent(ctx context.Context, veleroCfg VeleroConfig, dsjson string) ([]string, error) {
-	cmds := []*common.OsCommandLine{}
-
-	cmd := &common.OsCommandLine{
-		Cmd:  "echo",
-		Args: []string{dsjson},
-	}
-	cmds = append(cmds, cmd)
-
-	cmd = &common.OsCommandLine{
-		Cmd:  "sed",
-		Args: []string{"s#\\\"name\\\"\\: \\\"restic\\\"#\\\"name\\\"\\: \\\"node-agent\\\"#g"},
-	}
-	cmds = append(cmds, cmd)
-
-	cmd = &common.OsCommandLine{
-		Cmd:  "sed",
-		Args: []string{"s#\\\"restic\\\",#\\\"node-agent\\\",#g"},
-	}
-	cmds = append(cmds, cmd)
-
-	cmd = &common.OsCommandLine{
-		Cmd:  "kubectl",
-		Args: []string{"create", "-f", "-"},
-	}
-	cmds = append(cmds, cmd)
-
 	return common.GetListByCmdPipes(ctx, cmds)
 }
 
@@ -1589,22 +1473,6 @@ func RestorePVRNum(ctx context.Context, veleroNamespace, restoreName string) (in
 	)
 
 	return len(outputList), err
-}
-
-func IsSupportUploaderType(version string) (bool, error) {
-	verSupportUploaderType, err := ver.ParseSemantic("v1.10.0")
-	if err != nil {
-		return false, err
-	}
-	v, err := ver.ParseSemantic(version)
-	if err != nil {
-		return false, err
-	}
-	if v.AtLeast(verSupportUploaderType) {
-		return true, nil
-	} else {
-		return false, nil
-	}
 }
 
 func GetVeleroPodName(ctx context.Context) ([]string, error) {


### PR DESCRIPTION
# Summary

Remove all Restic references from E2E tests and CI workflows.

The "Restic"-labeled E2E tests don't actually test the Restic uploader — they test the
file system backup path, which now defaults to Kopia. The "Restic" naming is historical
from when Restic was the only FS backup uploader. Additionally, the server now rejects
Restic as an unsupported uploader type (`pkg/uploader/provider`), making the pre-v1.10
upgrade code path dead code.

**Changes:**
- Rename all "Restic" Ginkgo labels to "FSBackup" (preserves FS backup test coverage)
- Rename test functions: `*WithRestic` → `*WithFSBackup`
- Remove dead code: `VeleroUpgrade`, `UpdateVeleroDeployment`, `UpdateNodeAgent`,
  `IsSupportUploaderType`, `UseResticIfFSBackup`, `UploaderTypeRestic`
- Simplify `VeleroBackupNamespace` to always use `--default-volumes-to-fs-backup`
- Remove pre-v1.10 upgrade path from upgrade test
- Update CI workflow label filters and stale issue exemptions
- Update README examples and documentation

# Does your change fix a particular issue?

Fixes #9482

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.