### PR TITLE
feat(resourcepolicies): add pvcVolumeMode condition for volume policies

### DIFF
--- a/changelogs/unreleased/9877-chlins
+++ b/changelogs/unreleased/9877-chlins
@@ -1,0 +1,1 @@
+feat(resourcepolicies): add pvcVolumeMode condition for volume policies

--- a/internal/resourcepolicies/resource_policies.go
+++ b/internal/resourcepolicies/resource_policies.go
@@ -155,6 +155,19 @@ func unmarshalResourcePolicies(yamlData *string) (*ResourcePolicies, error) {
 				return nil, fmt.Errorf("pvcLabels must be a map of string to string, got %T", raw)
 			}
 		}
+		if raw, ok := vp.Conditions["pvcVolumeMode"]; ok {
+			switch values := raw.(type) {
+			case []any:
+				for _, value := range values {
+					if _, ok := value.(string); !ok {
+						return nil, fmt.Errorf("pvcVolumeMode must be a list of strings, got element %T", value)
+					}
+				}
+			case []string:
+			default:
+				return nil, fmt.Errorf("pvcVolumeMode must be a list of strings, got %T", raw)
+			}
+		}
 	}
 	return resPolicies, nil
 }
@@ -181,6 +194,9 @@ func (p *Policies) BuildPolicy(resPolicies *ResourcePolicies) error {
 		}
 		if len(con.PVCPhase) > 0 {
 			volP.conditions = append(volP.conditions, &pvcPhaseCondition{phases: con.PVCPhase})
+		}
+		if len(con.PVCVolumeMode) > 0 {
+			volP.conditions = append(volP.conditions, &pvcVolumeModeCondition{volumeModes: con.PVCVolumeMode})
 		}
 		p.volumePolicies = append(p.volumePolicies, volP)
 	}

--- a/internal/resourcepolicies/resource_policies_test.go
+++ b/internal/resourcepolicies/resource_policies_test.go
@@ -25,6 +25,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func pvcVolumeMode(mode corev1api.PersistentVolumeMode) *corev1api.PersistentVolumeMode {
+	return &mode
+}
+
 func TestLoadResourcePolicies(t *testing.T) {
 	testCases := []struct {
 		name     string
@@ -157,6 +161,29 @@ volumePolicies:
       type: skip
 `,
 			wantErr: false,
+		},
+		{
+			name: "supported format pvcVolumeMode",
+			yamlData: `version: v1
+volumePolicies:
+  - conditions:
+      pvcVolumeMode:
+        - Block
+    action:
+      type: skip
+`,
+			wantErr: false,
+		},
+		{
+			name: "error format of pvcVolumeMode (not a list)",
+			yamlData: `version: v1
+volumePolicies:
+  - conditions:
+      pvcVolumeMode: Block
+    action:
+      type: skip
+`,
+			wantErr: true,
 		},
 	}
 	for _, tc := range testCases {
@@ -1046,6 +1073,87 @@ volumePolicies:
 			},
 			skip: true,
 		},
+		{
+			name: "PVC volume mode matching - Block volume mode should skip",
+			yamlData: `version: v1
+volumePolicies:
+- conditions:
+   pvcVolumeMode: ["Block"]
+  action:
+    type: skip`,
+			vol:    nil,
+			podVol: nil,
+			pvc: &corev1api.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "pvc-block",
+				},
+				Spec: corev1api.PersistentVolumeClaimSpec{
+					VolumeMode: pvcVolumeMode(corev1api.PersistentVolumeBlock),
+				},
+			},
+			skip: true,
+		},
+		{
+			name: "PVC volume mode matching - Filesystem volume mode should not skip",
+			yamlData: `version: v1
+volumePolicies:
+- conditions:
+   pvcVolumeMode: ["Block"]
+  action:
+    type: skip`,
+			vol:    nil,
+			podVol: nil,
+			pvc: &corev1api.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "pvc-filesystem",
+				},
+				Spec: corev1api.PersistentVolumeClaimSpec{
+					VolumeMode: pvcVolumeMode(corev1api.PersistentVolumeFilesystem),
+				},
+			},
+			skip: false,
+		},
+		{
+			name: "PVC volume mode matching - nil volume mode defaults to Filesystem",
+			yamlData: `version: v1
+volumePolicies:
+- conditions:
+   pvcVolumeMode: ["Filesystem"]
+  action:
+    type: skip`,
+			vol:    nil,
+			podVol: nil,
+			pvc: &corev1api.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "pvc-default-filesystem",
+				},
+			},
+			skip: true,
+		},
+		{
+			name: "PVC volume mode matching - Multiple volume modes",
+			yamlData: `version: v1
+volumePolicies:
+- conditions:
+   pvcVolumeMode: ["Filesystem", "Block"]
+  action:
+    type: skip`,
+			vol:    nil,
+			podVol: nil,
+			pvc: &corev1api.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "pvc-block",
+				},
+				Spec: corev1api.PersistentVolumeClaimSpec{
+					VolumeMode: pvcVolumeMode(corev1api.PersistentVolumeBlock),
+				},
+			},
+			skip: true,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1119,28 +1227,33 @@ func TestGetMatchAction_Errors(t *testing.T) {
 
 func TestParsePVC(t *testing.T) {
 	tests := []struct {
-		name           string
-		pvc            *corev1api.PersistentVolumeClaim
-		expectedLabels map[string]string
-		expectedPhase  string
-		expectErr      bool
+		name               string
+		pvc                *corev1api.PersistentVolumeClaim
+		expectedLabels     map[string]string
+		expectedPhase      string
+		expectedVolumeMode string
+		expectErr          bool
 	}{
 		{
-			name: "valid PVC with labels and Pending phase",
+			name: "valid PVC with labels, Pending phase, and Block volume mode",
 			pvc: &corev1api.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{"env": "prod"},
+				},
+				Spec: corev1api.PersistentVolumeClaimSpec{
+					VolumeMode: pvcVolumeMode(corev1api.PersistentVolumeBlock),
 				},
 				Status: corev1api.PersistentVolumeClaimStatus{
 					Phase: corev1api.ClaimPending,
 				},
 			},
-			expectedLabels: map[string]string{"env": "prod"},
-			expectedPhase:  "Pending",
-			expectErr:      false,
+			expectedLabels:     map[string]string{"env": "prod"},
+			expectedPhase:      "Pending",
+			expectedVolumeMode: "Block",
+			expectErr:          false,
 		},
 		{
-			name: "valid PVC with Bound phase",
+			name: "valid PVC with Bound phase and nil volume mode",
 			pvc: &corev1api.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{},
@@ -1149,27 +1262,33 @@ func TestParsePVC(t *testing.T) {
 					Phase: corev1api.ClaimBound,
 				},
 			},
-			expectedLabels: nil,
-			expectedPhase:  "Bound",
-			expectErr:      false,
+			expectedLabels:     nil,
+			expectedPhase:      "Bound",
+			expectedVolumeMode: "Filesystem",
+			expectErr:          false,
 		},
 		{
-			name: "valid PVC with Lost phase",
+			name: "valid PVC with Lost phase and Filesystem volume mode",
 			pvc: &corev1api.PersistentVolumeClaim{
+				Spec: corev1api.PersistentVolumeClaimSpec{
+					VolumeMode: pvcVolumeMode(corev1api.PersistentVolumeFilesystem),
+				},
 				Status: corev1api.PersistentVolumeClaimStatus{
 					Phase: corev1api.ClaimLost,
 				},
 			},
-			expectedLabels: nil,
-			expectedPhase:  "Lost",
-			expectErr:      false,
+			expectedLabels:     nil,
+			expectedPhase:      "Lost",
+			expectedVolumeMode: "Filesystem",
+			expectErr:          false,
 		},
 		{
-			name:           "nil PVC pointer",
-			pvc:            (*corev1api.PersistentVolumeClaim)(nil),
-			expectedLabels: nil,
-			expectedPhase:  "",
-			expectErr:      false,
+			name:               "nil PVC pointer",
+			pvc:                (*corev1api.PersistentVolumeClaim)(nil),
+			expectedLabels:     nil,
+			expectedPhase:      "",
+			expectedVolumeMode: "",
+			expectErr:          false,
 		},
 	}
 
@@ -1180,6 +1299,7 @@ func TestParsePVC(t *testing.T) {
 
 			assert.Equal(t, tc.expectedLabels, s.pvcLabels)
 			assert.Equal(t, tc.expectedPhase, s.pvcPhase)
+			assert.Equal(t, tc.expectedVolumeMode, s.pvcVolumeMode)
 		})
 	}
 }
@@ -1509,7 +1629,7 @@ namespacedFilterPolicies:
 - namespaces: ["team-frontend-*", "specific-ns"]
   resourceFilters:
   - kinds: ["Pod", "ConfigMap", "Secret"]
-- namespaces: ["team-*", "another-pattern"] 
+- namespaces: ["team-*", "another-pattern"]
   resourceFilters:
   - kinds: ["Deployment", "Service"]`
 
@@ -1535,4 +1655,63 @@ namespacedFilterPolicies:
 	policy2 := nfPolicies[1]
 	assert.Equal(t, []string{"team-*", "another-pattern"}, policy2.Namespaces)
 	assert.Equal(t, []string{"Deployment", "Service"}, policy2.ResourceFilters[0].Kinds)
+}
+
+func TestPVCVolumeModeMatch(t *testing.T) {
+	tests := []struct {
+		name          string
+		condition     *pvcVolumeModeCondition
+		volume        *structuredVolume
+		expectedMatch bool
+	}{
+		{
+			name:          "match Block volume mode",
+			condition:     &pvcVolumeModeCondition{volumeModes: []string{"Block"}},
+			volume:        &structuredVolume{pvcVolumeMode: "Block"},
+			expectedMatch: true,
+		},
+		{
+			name:          "match multiple volume modes - Filesystem matches",
+			condition:     &pvcVolumeModeCondition{volumeModes: []string{"Filesystem", "Block"}},
+			volume:        &structuredVolume{pvcVolumeMode: "Filesystem"},
+			expectedMatch: true,
+		},
+		{
+			name:          "match multiple volume modes - Block matches",
+			condition:     &pvcVolumeModeCondition{volumeModes: []string{"Filesystem", "Block"}},
+			volume:        &structuredVolume{pvcVolumeMode: "Block"},
+			expectedMatch: true,
+		},
+		{
+			name:          "no match for different volume mode",
+			condition:     &pvcVolumeModeCondition{volumeModes: []string{"Block"}},
+			volume:        &structuredVolume{pvcVolumeMode: "Filesystem"},
+			expectedMatch: false,
+		},
+		{
+			name:          "no match for empty volume mode",
+			condition:     &pvcVolumeModeCondition{volumeModes: []string{"Block"}},
+			volume:        &structuredVolume{pvcVolumeMode: ""},
+			expectedMatch: false,
+		},
+		{
+			name:          "match with empty volume modes list (always match)",
+			condition:     &pvcVolumeModeCondition{volumeModes: []string{}},
+			volume:        &structuredVolume{pvcVolumeMode: "Block"},
+			expectedMatch: true,
+		},
+		{
+			name:          "match with nil volume modes list (always match)",
+			condition:     &pvcVolumeModeCondition{volumeModes: nil},
+			volume:        &structuredVolume{pvcVolumeMode: "Block"},
+			expectedMatch: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.condition.match(tc.volume)
+			assert.Equal(t, tc.expectedMatch, result)
+		})
+	}
 }

--- a/internal/resourcepolicies/volume_resources.go
+++ b/internal/resourcepolicies/volume_resources.go
@@ -18,6 +18,7 @@ package resourcepolicies
 import (
 	"bytes"
 	"fmt"
+	"slices"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/labels"
@@ -45,13 +46,14 @@ type capacity struct {
 }
 
 type structuredVolume struct {
-	capacity     resource.Quantity
-	storageClass string
-	nfs          *nFSVolumeSource
-	csi          *csiVolumeSource
-	volumeType   SupportedVolume
-	pvcLabels    map[string]string
-	pvcPhase     string
+	capacity      resource.Quantity
+	storageClass  string
+	nfs           *nFSVolumeSource
+	csi           *csiVolumeSource
+	volumeType    SupportedVolume
+	pvcLabels     map[string]string
+	pvcPhase      string
+	pvcVolumeMode string
 }
 
 func (s *structuredVolume) parsePV(pv *corev1api.PersistentVolume) {
@@ -76,6 +78,11 @@ func (s *structuredVolume) parsePVC(pvc *corev1api.PersistentVolumeClaim) {
 			s.pvcLabels = pvc.Labels
 		}
 		s.pvcPhase = string(pvc.Status.Phase)
+		if pvc.Spec.VolumeMode != nil {
+			s.pvcVolumeMode = string(*pvc.Spec.VolumeMode)
+		} else {
+			s.pvcVolumeMode = string(corev1api.PersistentVolumeFilesystem)
+		}
 	}
 }
 
@@ -127,15 +134,30 @@ func (c *pvcPhaseCondition) match(v *structuredVolume) bool {
 	if v.pvcPhase == "" {
 		return false
 	}
-	for _, phase := range c.phases {
-		if v.pvcPhase == phase {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(c.phases, v.pvcPhase)
 }
 
 func (c *pvcPhaseCondition) validate() error {
+	return nil
+}
+
+// pvcVolumeModeCondition defines a condition that matches if the PVC's volume mode matches any of the provided volume modes.
+type pvcVolumeModeCondition struct {
+	volumeModes []string
+}
+
+func (c *pvcVolumeModeCondition) match(v *structuredVolume) bool {
+	// No volume modes specified: always match.
+	if len(c.volumeModes) == 0 {
+		return true
+	}
+	if v.pvcVolumeMode == "" {
+		return false
+	}
+	return slices.Contains(c.volumeModes, v.pvcVolumeMode)
+}
+
+func (c *pvcVolumeModeCondition) validate() error {
 	return nil
 }
 

--- a/internal/resourcepolicies/volume_resources_test.go
+++ b/internal/resourcepolicies/volume_resources_test.go
@@ -430,6 +430,22 @@ func TestUnmarshalVolumeConditions(t *testing.T) {
 			},
 			expectedError: "!!str `production` into map[string]string",
 		},
+		{
+			name: "Valid pvcVolumeMode input",
+			input: map[string]any{
+				"capacity":      "1Gi,10Gi",
+				"pvcVolumeMode": []string{"Filesystem", "Block"},
+			},
+			expectedError: "",
+		},
+		{
+			name: "Invalid pvcVolumeMode input: not a list",
+			input: map[string]any{
+				"capacity":      "1Gi,10Gi",
+				"pvcVolumeMode": "Block",
+			},
+			expectedError: "str `Block` into []string",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/resourcepolicies/volume_resources_validator.go
+++ b/internal/resourcepolicies/volume_resources_validator.go
@@ -40,13 +40,14 @@ type nFSVolumeSource struct {
 
 // volumeConditions defined the current format of conditions we parsed
 type volumeConditions struct {
-	Capacity     string            `yaml:"capacity,omitempty"`
-	StorageClass []string          `yaml:"storageClass,omitempty"`
-	NFS          *nFSVolumeSource  `yaml:"nfs,omitempty"`
-	CSI          *csiVolumeSource  `yaml:"csi,omitempty"`
-	VolumeTypes  []SupportedVolume `yaml:"volumeTypes,omitempty"`
-	PVCLabels    map[string]string `yaml:"pvcLabels,omitempty"`
-	PVCPhase     []string          `yaml:"pvcPhase,omitempty"`
+	Capacity      string            `yaml:"capacity,omitempty"`
+	StorageClass  []string          `yaml:"storageClass,omitempty"`
+	NFS           *nFSVolumeSource  `yaml:"nfs,omitempty"`
+	CSI           *csiVolumeSource  `yaml:"csi,omitempty"`
+	VolumeTypes   []SupportedVolume `yaml:"volumeTypes,omitempty"`
+	PVCLabels     map[string]string `yaml:"pvcLabels,omitempty"`
+	PVCPhase      []string          `yaml:"pvcPhase,omitempty"`
+	PVCVolumeMode []string          `yaml:"pvcVolumeMode,omitempty"`
 }
 
 func (c *capacityCondition) validate() error {

--- a/site/content/docs/main/resource-filtering.md
+++ b/site/content/docs/main/resource-filtering.md
@@ -287,6 +287,9 @@ The policies YAML config file would look like this:
         # pvc matches specific phase(s)
         pvcPhase:
           - Pending
+        # pvc matches specific volume mode(s)
+        pvcVolumeMode:
+          - Block
       action:
         type: skip
     - conditions:
@@ -380,6 +383,7 @@ Currently, Velero supports the volume attributes listed below:
 - storageClass: matching volumes those with specified `storageClass`, such as `gp2`, `ebs-sc` in eks
 - volume sources: matching volumes that used specified volume sources. Currently we support nfs or csi backend volume source
 - pvcPhase: matching volumes based on the phase of their associated PVCs (Pending, Bound, Lost)
+- pvcVolumeMode: matching volumes based on the volume mode of their associated PVCs (Filesystem, Block)
 
 Velero supported conditions and format listed below:
 - capacity
@@ -519,6 +523,46 @@ Velero supported conditions and format listed below:
             - gp2
         action:
           type: skip
+      ```
+
+- pvc VolumeMode
+
+  This condition filters volumes based on the volume mode of their associated PVCs. The condition is specified as a list of volume modes to match. The volume matches this condition if the PVC's volume mode matches any of the volume modes in the list. Supported volume modes are: `Filesystem` and `Block`. PVCs without an explicit volume mode are treated as `Filesystem`, matching the Kubernetes default.
+    ```yaml
+    pvcVolumeMode:
+      - Block
+    ```
+
+    Some examples:
+  - Skip Block PVCs: Skip backup of volumes whose associated PVC uses `Block` volume mode.
+      ```yaml
+      volumePolicies:
+      - conditions:
+          pvcVolumeMode:
+            - Block
+        action:
+          type: skip
+      ```
+  - Match multiple volume modes: Apply an action to volumes whose associated PVC uses either `Filesystem` or `Block` volume mode.
+      ```yaml
+      volumePolicies:
+      - conditions:
+          pvcVolumeMode:
+            - Filesystem
+            - Block
+        action:
+          type: snapshot
+      ```
+  - Combine with other conditions: You can combine PVC volume mode conditions with other conditions like PVC phase, storage class, or labels.
+      ```yaml
+      volumePolicies:
+      - conditions:
+          pvcVolumeMode:
+            - Block
+          pvcPhase:
+            - Bound
+        action:
+          type: snapshot
       ```
 
 


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
This pull request adds support for filtering Kubernetes PersistentVolumeClaims (PVCs) by their `volumeMode` (either `Filesystem` or `Block`) in Velero's resource policies. The change includes parsing, validation, matching logic, and comprehensive test coverage, as well as updated documentation to describe the new feature and its usage.

**Resource policy enhancements:**

* Added support for a new `pvcVolumeMode` condition in resource policy YAML, allowing users to filter volumes based on the volume mode of associated PVCs. PVCs without an explicit volume mode are treated as `Filesystem` by default. [[1]](diffhunk://#diff-ec2c1bb35711f0fbca0e0bcc1338614c25a9bfd5727b9f0833c75f26ec425813R156-R168) [[2]](diffhunk://#diff-6a04a4c5038a8c06c065551dbe1d95ba606dad4edebbe5fe905aa776221d7d43R50) [[3]](diffhunk://#diff-674670974ea7a0bc6b0c1c420cfdfb30d7b49ee36b7365be3ad64ddf9b141e3eR56) [[4]](diffhunk://#diff-674670974ea7a0bc6b0c1c420cfdfb30d7b49ee36b7365be3ad64ddf9b141e3eR81-R85) [[5]](diffhunk://#diff-674670974ea7a0bc6b0c1c420cfdfb30d7b49ee36b7365be3ad64ddf9b141e3eL130-R160)

* Integrated the new `pvcVolumeMode` condition into the policy-building logic so that it is evaluated alongside existing conditions.

**Testing improvements:**

* Added and expanded unit tests to cover parsing, validation, and matching of the new `pvcVolumeMode` condition, including edge cases and error scenarios. [[1]](diffhunk://#diff-8eb4a45072de04bbb414fe0c6be48b863a010752db49ea4a42dbcf59d873a374R28-R31) [[2]](diffhunk://#diff-8eb4a45072de04bbb414fe0c6be48b863a010752db49ea4a42dbcf59d873a374R165-R187) [[3]](diffhunk://#diff-8eb4a45072de04bbb414fe0c6be48b863a010752db49ea4a42dbcf59d873a374R1076-R1156) [[4]](diffhunk://#diff-8eb4a45072de04bbb414fe0c6be48b863a010752db49ea4a42dbcf59d873a374R1234-R1256) [[5]](diffhunk://#diff-8eb4a45072de04bbb414fe0c6be48b863a010752db49ea4a42dbcf59d873a374R1267-R1290) [[6]](diffhunk://#diff-8eb4a45072de04bbb414fe0c6be48b863a010752db49ea4a42dbcf59d873a374R1302) [[7]](diffhunk://#diff-8eb4a45072de04bbb414fe0c6be48b863a010752db49ea4a42dbcf59d873a374R1365-R1423) [[8]](diffhunk://#diff-ab3cb40d6a71a33a21ab0cea38cdd9f71ee04159433f3a5b4fbb61f57fc20677R433-R448)

**Documentation updates:**

* Updated the documentation to describe the new `pvcVolumeMode` condition, provide YAML configuration examples, and explain its interaction with other conditions. [[1]](diffhunk://#diff-6294b7c20c8c127b2da9c7f46491c371b095ff67fa944007e89ec77c11e4b8b3R290-R292) [[2]](diffhunk://#diff-6294b7c20c8c127b2da9c7f46491c371b095ff67fa944007e89ec77c11e4b8b3R386) [[3]](diffhunk://#diff-6294b7c20c8c127b2da9c7f46491c371b095ff67fa944007e89ec77c11e4b8b3R528-R567)

# Does your change fix a particular issue?

Fixes partial of https://github.com/velero-io/velero/issues/9859

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
