### PR TITLE
Fix unknown containerd config version error in run-e2e-test action

### DIFF
--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -136,7 +136,7 @@ jobs:
       - uses: engineerd/setup-kind@v0.6.2
         with:
           skipClusterLogsExport: true
-          version: "v0.27.0"
+          version: "v0.32.0"
           image: "kindest/node:v${{ matrix.k8s }}"
       - name: Fetch built CLI
         id: cli-cache


### PR DESCRIPTION
Use kind load docker-image to replace kind load image-archive. This error happens due to the kind load image-archive CLI is incompatible with the runner's containerd.

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
