### PR TITLE
Install golangci-lint by go install instead of curl

### DIFF
--- a/hack/build-image/Dockerfile
+++ b/hack/build-image/Dockerfile
@@ -96,7 +96,9 @@ RUN ARCH=$(go env GOARCH) && \
     chmod +x /usr/bin/goreleaser
 
 # get golangci-lint
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.5.0
+# Use "go install" so the download goes through GOPROXY instead of the GitHub
+# release API/CDN, which has been returning intermittent/persistent HTTP 504s.
+RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
 
 # install kubectl
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/$(go env GOARCH)/kubectl


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Use "go install" so the download goes through GOPROXY instead of the GitHub release API/CDN, which has been returning intermittent/persistent HTTP 504s.

https://github.com/velero-io/velero/actions/runs/27123392266/job/80049372594?pr=9890

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
