### PR TITLE
Sync restore resource priorities docs with code defaults

### DIFF
--- a/changelogs/unreleased/9895-shubham-pampattiwar
+++ b/changelogs/unreleased/9895-shubham-pampattiwar
@@ -1,0 +1,1 @@
+Sync restore resource priorities docs with code defaults

--- a/site/content/docs/main/restore-reference.md
+++ b/site/content/docs/main/restore-reference.md
@@ -72,32 +72,55 @@ The following is an overview of Velero's restore process that starts after you r
 
 By default, Velero will restore resources in the following order:
 
+**High priorities** (restored first):
+
 * Custom Resource Definitions
 * Namespaces
 * StorageClasses
 * VolumeSnapshotClass
 * VolumeSnapshotContents
 * VolumeSnapshots
+* DataUploads
 * PersistentVolumes
 * PersistentVolumeClaims
+* ClusterRoles
+* Roles
+* ServiceAccounts
+* ClusterRoleBindings
+* RoleBindings
 * Secrets
 * ConfigMaps
-* ServiceAccounts
 * LimitRanges
+* PriorityClasses
 * Pods
 * ReplicaSets
+* ClusterClasses
+* Endpoints
+* Services
+
+**Low priorities** (restored last):
+
+* ClusterBootstraps
 * Clusters
 * ClusterResourceSets
+* Apps (kappctrl)
+* PackageInstalls (carvel)
 
-It's recommended that you use the default order for your restores. You are able to customize this order if you need to by setting the `--restore-resource-priorities` flag on the Velero server and specifying a different resource order. This customized order will apply to all future restores. You don't have to specify all resources in the `--restore-resource-priorities` flag. Velero will append resources not listed to the end of your customized list in alphabetical order.
+Any resource not listed is restored alphabetically between the high and low priorities.
+
+It's recommended that you use the default order for your restores. You are able to customize this order if you need to by setting the `--restore-resource-priorities` flag on the Velero server and specifying a different resource order. This customized order will apply to all future restores. You don't have to specify all resources in the `--restore-resource-priorities` flag. The priority list contains two parts which are split by the `-` element. Resources before `-` are restored first as high priorities, resources after `-` are restored last as low priorities, and any resource not in the list will be restored alphabetically between the high and low priorities.
 
 ```shell
 velero server \
 --restore-resource-priorities=customresourcedefinitions,namespaces,storageclasses,\
 volumesnapshotclass.snapshot.storage.k8s.io,volumesnapshotcontents.snapshot.storage.k8s.io,\
-volumesnapshots.snapshot.storage.k8s.io,persistentvolumes,persistentvolumeclaims,secrets,\
-configmaps,serviceaccounts,limitranges,pods,replicasets.apps,clusters.cluster.x-k8s.io,\
-clusterresourcesets.addons.cluster.x-k8s.io
+volumesnapshots.snapshot.storage.k8s.io,datauploads.velero.io,persistentvolumes,\
+persistentvolumeclaims,clusterroles,roles,serviceaccounts,clusterrolebindings,rolebindings,\
+secrets,configmaps,limitranges,priorityclasses,pods,replicasets.apps,\
+clusterclasses.cluster.x-k8s.io,endpoints,services,-,\
+clusterbootstraps.run.tanzu.vmware.com,clusters.cluster.x-k8s.io,\
+clusterresourcesets.addons.cluster.x-k8s.io,apps.kappctrl.k14s.io,\
+packageinstalls.packaging.carvel.dev
 ```
 
 

--- a/site/content/docs/v1.18/restore-reference.md
+++ b/site/content/docs/v1.18/restore-reference.md
@@ -72,32 +72,55 @@ The following is an overview of Velero's restore process that starts after you r
 
 By default, Velero will restore resources in the following order:
 
+**High priorities** (restored first):
+
 * Custom Resource Definitions
 * Namespaces
 * StorageClasses
 * VolumeSnapshotClass
 * VolumeSnapshotContents
 * VolumeSnapshots
+* DataUploads
 * PersistentVolumes
 * PersistentVolumeClaims
+* ClusterRoles
+* Roles
+* ServiceAccounts
+* ClusterRoleBindings
+* RoleBindings
 * Secrets
 * ConfigMaps
-* ServiceAccounts
 * LimitRanges
+* PriorityClasses
 * Pods
 * ReplicaSets
+* ClusterClasses
+* Endpoints
+* Services
+
+**Low priorities** (restored last):
+
+* ClusterBootstraps
 * Clusters
 * ClusterResourceSets
+* Apps (kappctrl)
+* PackageInstalls (carvel)
 
-It's recommended that you use the default order for your restores. You are able to customize this order if you need to by setting the `--restore-resource-priorities` flag on the Velero server and specifying a different resource order. This customized order will apply to all future restores. You don't have to specify all resources in the `--restore-resource-priorities` flag. Velero will append resources not listed to the end of your customized list in alphabetical order.
+Any resource not listed is restored alphabetically between the high and low priorities.
+
+It's recommended that you use the default order for your restores. You are able to customize this order if you need to by setting the `--restore-resource-priorities` flag on the Velero server and specifying a different resource order. This customized order will apply to all future restores. You don't have to specify all resources in the `--restore-resource-priorities` flag. The priority list contains two parts which are split by the `-` element. Resources before `-` are restored first as high priorities, resources after `-` are restored last as low priorities, and any resource not in the list will be restored alphabetically between the high and low priorities.
 
 ```shell
 velero server \
 --restore-resource-priorities=customresourcedefinitions,namespaces,storageclasses,\
 volumesnapshotclass.snapshot.storage.k8s.io,volumesnapshotcontents.snapshot.storage.k8s.io,\
-volumesnapshots.snapshot.storage.k8s.io,persistentvolumes,persistentvolumeclaims,secrets,\
-configmaps,serviceaccounts,limitranges,pods,replicasets.apps,clusters.cluster.x-k8s.io,\
-clusterresourcesets.addons.cluster.x-k8s.io
+volumesnapshots.snapshot.storage.k8s.io,datauploads.velero.io,persistentvolumes,\
+persistentvolumeclaims,clusterroles,roles,serviceaccounts,clusterrolebindings,rolebindings,\
+secrets,configmaps,limitranges,priorityclasses,pods,replicasets.apps,\
+clusterclasses.cluster.x-k8s.io,endpoints,services,-,\
+clusterbootstraps.run.tanzu.vmware.com,clusters.cluster.x-k8s.io,\
+clusterresourcesets.addons.cluster.x-k8s.io,apps.kappctrl.k14s.io,\
+packageinstalls.packaging.carvel.dev
 ```
 
 


### PR DESCRIPTION
# Summary

The documented default restore resource priorities in `restore-reference.md` were outdated and missing several resources added to the code defaults over multiple releases. Most critically, `datauploads.velero.io` was missing, which causes PVC restore failures with data mover when users copy the documented list to customize their restore priorities.

Changes:
- Added missing resources: `datauploads.velero.io`, `clusterroles`, `roles`, `clusterrolebindings`, `rolebindings`, `priorityclasses`, `clusterclasses`, `endpoints`, `services`
- Documented the high/low priority split (the `-` separator), which was not documented at all
- Added the low priority resources: `clusterbootstraps`, `apps.kappctrl`, `packageinstalls.packaging.carvel`
- Fixed `clusters` and `clusterresourcesets` placement (they are low priorities, not high)
- Updated the example `--restore-resource-priorities` CLI flag to match
- Applied the same fix to both `main` and `v1.18` docs

# Does your change fix a particular issue?

Fixes #9885

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.