### PR TITLE
Skip VGS cleanup when backup did not use VolumeGroupSnapshots

### DIFF
--- a/changelogs/unreleased/9896-shubham-pampattiwar
+++ b/changelogs/unreleased/9896-shubham-pampattiwar
@@ -1,0 +1,1 @@
+Skip VGS cleanup when backup did not use VolumeGroupSnapshots

--- a/pkg/controller/restore_finalizer_controller.go
+++ b/pkg/controller/restore_finalizer_controller.go
@@ -301,8 +301,10 @@ func (ctx *finalizerContext) execute() (results.Result, results.Result) {
 	pdpErrs := ctx.patchDynamicPVWithVolumeInfo()
 	errs.Merge(&pdpErrs)
 
-	vgscWarnings := ctx.cleanupStubVGSC()
-	warnings.Merge(&vgscWarnings)
+	if ctx.hasVolumeGroupSnapshotHandles() {
+		vgscWarnings := ctx.cleanupStubVGSC()
+		warnings.Merge(&vgscWarnings)
+	}
 
 	rehErrs := ctx.WaitRestoreExecHook()
 	errs.Merge(&rehErrs)
@@ -447,6 +449,15 @@ func (ctx *finalizerContext) patchDynamicPVWithVolumeInfo() (errs results.Result
 	ctx.logger.Info("patching newly dynamically provisioned PV ends")
 
 	return errs
+}
+
+func (ctx *finalizerContext) hasVolumeGroupSnapshotHandles() bool {
+	for _, vi := range ctx.volumeInfo {
+		if vi.CSISnapshotInfo != nil && vi.CSISnapshotInfo.VolumeGroupSnapshotHandle != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // cleanupStubVGSC deletes stub VolumeGroupSnapshotContent objects that were

--- a/pkg/controller/restore_finalizer_controller_test.go
+++ b/pkg/controller/restore_finalizer_controller_test.go
@@ -743,6 +743,83 @@ func TestRestoreOperationList(t *testing.T) {
 	}
 }
 
+func TestHasVolumeGroupSnapshotHandles(t *testing.T) {
+	tests := []struct {
+		name       string
+		volumeInfo []*volume.BackupVolumeInfo
+		expected   bool
+	}{
+		{
+			name:       "nil volumeInfo",
+			volumeInfo: nil,
+			expected:   false,
+		},
+		{
+			name:       "empty volumeInfo",
+			volumeInfo: []*volume.BackupVolumeInfo{},
+			expected:   false,
+		},
+		{
+			name: "no CSISnapshotInfo",
+			volumeInfo: []*volume.BackupVolumeInfo{
+				{PVCName: "pvc-1", BackupMethod: volume.NativeSnapshot},
+			},
+			expected: false,
+		},
+		{
+			name: "CSISnapshotInfo with empty VolumeGroupSnapshotHandle",
+			volumeInfo: []*volume.BackupVolumeInfo{
+				{
+					PVCName:      "pvc-1",
+					BackupMethod: volume.CSISnapshot,
+					CSISnapshotInfo: &volume.CSISnapshotInfo{
+						SnapshotHandle: "snap-1",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "one volume with VolumeGroupSnapshotHandle",
+			volumeInfo: []*volume.BackupVolumeInfo{
+				{
+					PVCName:      "pvc-1",
+					BackupMethod: volume.CSISnapshot,
+					CSISnapshotInfo: &volume.CSISnapshotInfo{
+						SnapshotHandle:            "snap-1",
+						VolumeGroupSnapshotHandle: "vgs-handle-1",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "mixed volumes only one with VolumeGroupSnapshotHandle",
+			volumeInfo: []*volume.BackupVolumeInfo{
+				{PVCName: "pvc-1", BackupMethod: volume.NativeSnapshot},
+				{
+					PVCName:      "pvc-2",
+					BackupMethod: volume.CSISnapshot,
+					CSISnapshotInfo: &volume.CSISnapshotInfo{
+						SnapshotHandle:            "snap-2",
+						VolumeGroupSnapshotHandle: "vgs-handle-2",
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := &finalizerContext{
+				volumeInfo: tc.volumeInfo,
+			}
+			assert.Equal(t, tc.expected, ctx.hasVolumeGroupSnapshotHandles())
+		})
+	}
+}
+
 func TestCleanupStubVGSC(t *testing.T) {
 	snapshotHandle1 := "snap-handle-1"
 	snapshotHandle2 := "snap-handle-2"


### PR DESCRIPTION
# Please add a summary of your change

Guards the `cleanupStubVGSC()` call in restore finalization with a check for `VolumeGroupSnapshotHandle` in `volumeInfo`. This avoids a spurious warning on clusters where the v1beta2 `VolumeGroupSnapshotContent` CRD is not installed, since the `List` call would fail even though no stubs exist to clean up.

The stub VGSCs are only created conditionally via the CSI restore plugin actions, but `cleanupStubVGSC()` previously ran unconditionally on every restore finalization. On clusters with older external-snapshotter versions (v1beta1 only), the API call fails and emits a warning that is confusing and unnecessary.

The new `hasVolumeGroupSnapshotHandles()` helper checks whether any volume in the backup has a non-empty `VolumeGroupSnapshotHandle` in its `CSISnapshotInfo`. If none do, the cleanup is skipped entirely.

# Does your change fix a particular issue?

Fixes #9882

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.