### PR TITLE
Add log when resources are filtered out due to verbs or sub-resources.

### DIFF
--- a/pkg/discovery/helper.go
+++ b/pkg/discovery/helper.go
@@ -171,7 +171,7 @@ func (h *helper) Refresh() error {
 	}
 
 	h.resources = discovery.FilteredBy(
-		And(filterByVerbs, skipSubresource),
+		And(h.filterByVerbsWithLogging, h.skipSubresourceWithLogging),
 		serverResources,
 	)
 
@@ -266,9 +266,36 @@ func filterByVerbs(groupVersion string, r *metav1.APIResource) bool {
 	return discovery.SupportsAllVerbs{Verbs: []string{"list", "create", "get", "delete"}}.Match(groupVersion, r)
 }
 
+func (h *helper) filterByVerbsWithLogging(groupVersion string, r *metav1.APIResource) bool {
+	if filterByVerbs(groupVersion, r) {
+		return true
+	}
+
+	h.logger.WithFields(logrus.Fields{
+		"groupVersion": groupVersion,
+		"resource":     r.Name,
+		"verbs":        r.Verbs,
+	}).Info("Skipping resource because it does not support required verbs")
+
+	return false
+}
+
 func skipSubresource(_ string, r *metav1.APIResource) bool {
 	// if we have a slash, then this is a subresource and we shouldn't include it.
 	return !strings.Contains(r.Name, "/")
+}
+
+func (h *helper) skipSubresourceWithLogging(groupVersion string, r *metav1.APIResource) bool {
+	if skipSubresource(groupVersion, r) {
+		return true
+	}
+
+	h.logger.WithFields(logrus.Fields{
+		"groupVersion": groupVersion,
+		"resource":     r.Name,
+	}).Info("Skipping subresource")
+
+	return false
 }
 
 // sortResources sources resources by moving extensions to the end of the slice. The order of all


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
