### PR TITLE
[1.18] Bump golang.org/x/crypto to v0.52.0 for Restic.

### DIFF
--- a/hack/fix_restic_cve.txt
+++ b/hack/fix_restic_cve.txt
@@ -1,5 +1,5 @@
 diff --git a/go.mod b/go.mod
-index 5f939c481..312a5dd64 100644
+index 5f939c481..891dbd4e7 100644
 --- a/go.mod
 +++ b/go.mod
 @@ -1,15 +1,15 @@
@@ -33,7 +33,7 @@ index 5f939c481..312a5dd64 100644
 -	golang.org/x/term v0.4.0
 -	golang.org/x/text v0.6.0
 -	google.golang.org/api v0.106.0
-+	golang.org/x/crypto v0.51.0
++	golang.org/x/crypto v0.52.0
 +	golang.org/x/net v0.55.0
 +	golang.org/x/oauth2 v0.36.0
 +	golang.org/x/sync v0.20.0
@@ -120,7 +120,7 @@ index 5f939c481..312a5dd64 100644
 -go 1.18
 +go 1.25.8
 diff --git a/go.sum b/go.sum
-index 026e1d2fa..9a2f8b0e5 100644
+index 026e1d2fa..94d984253 100644
 --- a/go.sum
 +++ b/go.sum
 @@ -1,42 +1,61 @@
@@ -386,8 +386,8 @@ index 026e1d2fa..9a2f8b0e5 100644
 -golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 -golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 -golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
-+golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
-+golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
++golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
++golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
  golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 -golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 -golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
