### PR TITLE
Use forward slash as the path seperator to make sure it works on both Linux and Windows nodes

### DIFF
--- a/changelogs/unreleased/9968-ywk253100
+++ b/changelogs/unreleased/9968-ywk253100
@@ -1,0 +1,1 @@
+Use forward slash as the path separator to make sure it works on both Linux and Windows nodes

--- a/pkg/install/daemonset.go
+++ b/pkg/install/daemonset.go
@@ -18,7 +18,7 @@ package install
 
 import (
 	"fmt"
-	"path/filepath"
+	"path"
 	"strings"
 
 	appsv1api "k8s.io/api/apps/v1"
@@ -68,8 +68,8 @@ func DaemonSet(namespace string, opts ...podTemplateOption) *appsv1api.DaemonSet
 	if c.forWindows {
 		dsName = "node-agent-windows"
 	}
-	hostPodsVolumePath := filepath.Join(c.kubeletRootDir, "pods")
-	hostPluginsVolumePath := filepath.Join(c.kubeletRootDir, "plugins")
+	hostPodsVolumePath := path.Join(strings.ReplaceAll(c.kubeletRootDir, "\\", "/"), "pods")
+	hostPluginsVolumePath := path.Join(strings.ReplaceAll(c.kubeletRootDir, "\\", "/"), "plugins")
 	volumes := []corev1api.Volume{}
 	volumeMounts := []corev1api.VolumeMount{}
 	if !c.nodeAgentDisableHostPath {

--- a/pkg/install/daemonset_test.go
+++ b/pkg/install/daemonset_test.go
@@ -86,6 +86,10 @@ func TestDaemonSet(t *testing.T) {
 	assert.Equal(t, "/data/test/kubelet/pods", ds.Spec.Template.Spec.Volumes[0].HostPath.Path)
 	assert.Equal(t, "/data/test/kubelet/plugins", ds.Spec.Template.Spec.Volumes[1].HostPath.Path)
 
+	ds = DaemonSet("velero", WithKubeletRootDir(`C:\var\lib\kubelet`))
+	assert.Equal(t, "C:/var/lib/kubelet/pods", ds.Spec.Template.Spec.Volumes[0].HostPath.Path)
+	assert.Equal(t, "C:/var/lib/kubelet/plugins", ds.Spec.Template.Spec.Volumes[1].HostPath.Path)
+
 	ds = DaemonSet("velero", WithNodeAgentDisableHostPath(true))
 	assert.Len(t, ds.Spec.Template.Spec.Volumes, 1)
 	assert.Len(t, ds.Spec.Template.Spec.Containers[0].VolumeMounts, 1)


### PR DESCRIPTION
Use forward slash as the path seperator to make sure it works on both Linux and Windows nodes

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #9961

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
