### PR TITLE
Add design doc for dynamic CLI resource autocompletion

### DIFF
--- a/design/cli-dynamic-resource-completion_design.md
+++ b/design/cli-dynamic-resource-completion_design.md
@@ -1,0 +1,157 @@
+# Dynamic Resource Autocompletion for Velero CLI
+
+## Abstract
+
+Velero CLI currently has no dynamic shell completion for resource names.
+Tab-completing `velero backup describe <TAB>` produces no suggestions, even when backups exist on the cluster.
+This proposal adds dynamic completion for all commands that take Velero resource names as positional arguments or flag values, using cobra's `ValidArgsFunction` and `RegisterFlagCompletionFunc` mechanisms.
+
+## Background
+
+Shell completion is a standard UX feature in Kubernetes CLI tooling.
+Tools like `kubectl`, `oc`, and `helm` all provide dynamic completions that query the cluster to suggest resource names.
+Velero's `velero completion` command generates static completion scripts using cobra's v1 API (`GenBashCompletion`), which only completes command and flag names.
+Cobra v1.8.1 (Velero's current version) supports dynamic completion via `ValidArgsFunction` on `cobra.Command` and `RegisterFlagCompletionFunc` for flag values, but Velero does not use either.
+
+The bash v1 completion generator (`GenBashCompletion`) does not invoke `ValidArgsFunction` callbacks.
+Cobra provides a v2 generator (`GenBashCompletionV2`) that does.
+The zsh and fish generators already support `ValidArgsFunction` natively.
+
+## Goals
+
+- Add dynamic shell completion for all 20 commands that accept existing Velero resource names as positional arguments.
+- Add dynamic flag completion for 5 flags that reference existing Velero resources (`--from-backup`, `--from-schedule`, `--storage-location`, `--volume-snapshot-locations`).
+- Fail silently when the cluster is unreachable, matching the behavior of `oc` and `kubectl`.
+
+## Non Goals
+
+- Completing positional arguments for commands that take new resource names (e.g., `velero backup create <new-name>`).
+- Completing flags that take non-resource values (e.g., `--include-namespaces`, `--labels`).
+- Adding completion for hidden internal commands (`data-mover`, `pod-volume`, `repo-maintenance`).
+- Caching cluster state across tab presses.
+
+## High-Level Design
+
+A centralized set of completion functions is added to `pkg/cmd/cli/completion_functions.go`.
+Each function takes a `client.Factory`, returns a closure matching cobra's `ValidArgsFunction` signature, and lists resources of a specific type from the cluster.
+Each command constructor wires the appropriate completion function onto its `cobra.Command` via `ValidArgsFunction` or `RegisterFlagCompletionFunc`.
+The bash completion generator is switched from v1 to v2 to enable dynamic completion support.
+
+## Detailed Design
+
+### Completion functions
+
+A new file `pkg/cmd/cli/completion_functions.go` in the `cli` package provides six public functions:
+
+| Function | Resource listed |
+|---|---|
+| `CompleteBackupNames(f client.Factory)` | `velerov1api.BackupList` |
+| `CompleteRestoreNames(f client.Factory)` | `velerov1api.RestoreList` |
+| `CompleteScheduleNames(f client.Factory)` | `velerov1api.ScheduleList` |
+| `CompleteBackupStorageLocationNames(f client.Factory)` | `velerov1api.BackupStorageLocationList` |
+| `CompleteVolumeSnapshotLocationNames(f client.Factory)` | `velerov1api.VolumeSnapshotLocationList` |
+| `CompleteBackupRepositoryNames(f client.Factory)` | `velerov1api.BackupRepositoryList` |
+
+Each function returns a `func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)` closure.
+The closure:
+
+1. Calls `f.KubebuilderClient()` to get a controller-runtime client.
+2. Lists resources in `f.Namespace()`.
+3. Filters names by `strings.HasPrefix(name, toComplete)`.
+4. Returns the matching names with `cobra.ShellCompDirectiveNoFileComp`.
+
+If either the client construction or the list call fails, the function returns `nil, cobra.ShellCompDirectiveNoFileComp` (silent failure, no file completion fallback).
+
+A package-level type alias keeps the function signatures readable:
+
+```go
+type completionFunc = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
+```
+
+Note: `cobra.ValidArgsFunction` is not an exported type in cobra v1.8.1.
+It is only the inline type of the `ValidArgsFunction` field on `cobra.Command`.
+The type alias is used for return types of the completion helper functions and is directly assignable to the field.
+
+### Commands wired with `ValidArgsFunction`
+
+Each `New*Command` constructor sets `c.ValidArgsFunction` after creating the command and before returning it.
+Because Velero exposes both `velero backup get` and `velero get backups` via the same constructor function (`backup.NewGetCommand`), both command trees get completion automatically.
+
+| Package | Commands | Completion function |
+|---|---|---|
+| `backup` | get, describe, delete, logs, download | `CompleteBackupNames` |
+| `restore` | get, describe, delete, logs | `CompleteRestoreNames` |
+| `schedule` | get, describe, delete, pause, unpause | `CompleteScheduleNames` |
+| `backuplocation` | get, set, delete | `CompleteBackupStorageLocationNames` |
+| `snapshotlocation` | get, set | `CompleteVolumeSnapshotLocationNames` |
+| `repo` | get | `CompleteBackupRepositoryNames` |
+
+### Flags wired with `RegisterFlagCompletionFunc`
+
+| Command | Flag | Completion function |
+|---|---|---|
+| `backup create` | `--from-schedule` | `CompleteScheduleNames` |
+| `backup create` | `--storage-location` | `CompleteBackupStorageLocationNames` |
+| `backup create` | `--volume-snapshot-locations` | `CompleteVolumeSnapshotLocationNames` |
+| `restore create` | `--from-backup` | `CompleteBackupNames` |
+| `restore create` | `--from-schedule` | `CompleteScheduleNames` |
+
+The return value of `RegisterFlagCompletionFunc` is discarded (`_ =`) because it only fails if the named flag does not exist, which would be a compile-time coding error.
+
+### Bash completion v1 to v2 migration
+
+In `pkg/cmd/cli/completion/completion.go`, the bash case is changed from:
+
+```go
+cmd.Root().GenBashCompletion(os.Stdout)
+```
+
+to:
+
+```go
+cmd.Root().GenBashCompletionV2(os.Stdout, true)
+```
+
+The `true` parameter includes completion descriptions.
+Zsh and fish generators are unchanged as they already support `ValidArgsFunction`.
+
+### Client construction
+
+Completion functions use `f.KubebuilderClient()`, which constructs a REST config and a controller-runtime client with the Velero scheme on each invocation.
+This is the same client used by the commands themselves.
+The factory is captured by closure from the command constructor, so no changes to `completion.NewCommand()` or the root command wiring are needed.
+
+## Alternatives Considered
+
+### Generic completion function using Go generics
+
+A single generic function parameterized by list type and item type was considered to avoid the six similar functions.
+This was rejected because the list types do not share a common interface for extracting item names (no `GetItems()` method), so the generic version would need function parameters for constructing the list and extracting names, making it no simpler than individual functions.
+
+### Passing the factory to the completion command
+
+It was considered whether `completion.NewCommand()` should receive `client.Factory` to register completion callbacks centrally.
+This is unnecessary because `ValidArgsFunction` is set per-command-instance in each constructor, and cobra's hidden `__complete` command handles runtime dispatch.
+The completion command only generates the shell script.
+
+## Security Considerations
+
+Completion functions issue read-only list requests to the Kubernetes API server using the user's existing kubeconfig credentials.
+No new permissions are required beyond what the user already has for the commands themselves.
+No data is written, cached, or transmitted to external services.
+
+## Compatibility
+
+The bash completion output format changes from v1 to v2.
+Users who have previously generated and sourced bash completion scripts will need to regenerate them with `velero completion bash`.
+This is the expected workflow when upgrading any CLI tool.
+Zsh and fish completion scripts are unchanged in format.
+
+Existing command behavior is unaffected.
+The `ValidArgsFunction` field is only invoked during shell completion; it has no effect on normal command execution.
+
+## Implementation
+
+The implementation is contained in a single commit on the `feature/dynamic-cli-completion` branch.
+It touches 24 files (1 new, 23 modified) with 201 insertions and 1 deletion.
+All existing tests pass without modification.

--- a/design/cli-dynamic-resource-completion_design.md
+++ b/design/cli-dynamic-resource-completion_design.md
@@ -53,14 +53,33 @@ A new file `pkg/cmd/cli/completion_functions.go` in the `cli` package provides s
 | `CompleteBackupRepositoryNames(f client.Factory)` | `velerov1api.BackupRepositoryList` |
 
 Each function returns a `func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)` closure.
-The closure:
+
+Internally, all six functions delegate to a single private helper:
+
+```go
+func completeNames(f client.Factory, list kbclient.ObjectList) completionFunc
+```
+
+This helper uses `k8s.io/apimachinery/pkg/api/meta.ExtractList()` and `meta.Accessor()` from the Kubernetes apimachinery library to extract object names from any `ObjectList` type without Go generics.
+Each public function is a one-liner that passes the appropriate list type:
+
+```go
+func CompleteBackupNames(f client.Factory) completionFunc {
+    return completeNames(f, &velerov1api.BackupList{})
+}
+```
+
+The `completeNames` closure:
 
 1. Calls `f.KubebuilderClient()` to get a controller-runtime client.
-2. Lists resources in `f.Namespace()`.
-3. Filters names by `strings.HasPrefix(name, toComplete)`.
-4. Returns the matching names with `cobra.ShellCompDirectiveNoFileComp`.
+2. Deep-copies the list object to prevent state accumulation across repeated tab presses.
+3. Lists resources in `f.Namespace()` with a **3-second context timeout** to avoid blocking the user's shell if the API server is slow or unreachable.
+4. Extracts individual objects from the list using `meta.ExtractList()`.
+5. For each object, uses `meta.Accessor()` to read its name and filters by `strings.HasPrefix(name, toComplete)`.
+6. Returns the matching names with `cobra.ShellCompDirectiveNoFileComp`.
 
-If either the client construction or the list call fails, the function returns `nil, cobra.ShellCompDirectiveNoFileComp` (silent failure, no file completion fallback).
+If any step fails — client construction, the list call, or `meta.ExtractList` — the function returns `nil, cobra.ShellCompDirectiveNoFileComp` (silent failure, no file completion fallback).
+If `meta.Accessor` fails on an individual item, that item is skipped and completion continues with the remaining items.
 
 A package-level type alias keeps the function signatures readable:
 
@@ -126,7 +145,8 @@ The factory is captured by closure from the command constructor, so no changes t
 ### Generic completion function using Go generics
 
 A single generic function parameterized by list type and item type was considered to avoid the six similar functions.
-This was rejected because the list types do not share a common interface for extracting item names (no `GetItems()` method), so the generic version would need function parameters for constructing the list and extracting names, making it no simpler than individual functions.
+Go generics were unnecessary because the Kubernetes apimachinery library already provides a type-agnostic way to extract names from any `ObjectList` via `meta.ExtractList()` and `meta.Accessor()`.
+The implementation uses these runtime interfaces in a single `completeNames` helper, achieving the same DRY goal without generics while keeping the six public wrapper functions as a stable API surface.
 
 ### Passing the factory to the completion command
 
@@ -149,6 +169,16 @@ Zsh and fish completion scripts are unchanged in format.
 
 Existing command behavior is unaffected.
 The `ValidArgsFunction` field is only invoked during shell completion; it has no effect on normal command execution.
+
+## Testing
+
+Unit tests in `pkg/cmd/cli/completion_functions_test.go` cover:
+
+- **Core logic (`TestCompleteNames`):** Table-driven tests exercising all six resource types across scenarios: empty cluster, full match, prefix filtering, and no match.
+- **Error resilience (`TestCompleteNames_KubebuilderClientError`):** Verifies that a factory error (e.g., missing kubeconfig) returns nil completions without panicking.
+- **Wrapper isolation (`TestCompleteWrappers`):** Creates one object of every resource type on a single fake client, then verifies each `Complete*Names` wrapper returns only its own resource type.
+
+Tests use `factorymocks.Factory` and `velerotest.NewFakeControllerRuntimeClient` from the existing test infrastructure.
 
 ## Implementation
 

--- a/design/cli-dynamic-resource-completion_design.md
+++ b/design/cli-dynamic-resource-completion_design.md
@@ -20,7 +20,7 @@ The zsh and fish generators already support `ValidArgsFunction` natively.
 ## Goals
 
 - Add dynamic shell completion for all 20 commands that accept existing Velero resource names as positional arguments.
-- Add dynamic flag completion for 5 flags that reference existing Velero resources (`--from-backup`, `--from-schedule`, `--storage-location`, `--volume-snapshot-locations`).
+- Add dynamic flag completion for 7 flags that reference existing Velero resources (`--from-backup`, `--from-schedule`, `--storage-location`, `--volume-snapshot-locations`, `--backup`, `--restore`).
 - Fail silently when the cluster is unreachable, matching the behavior of `oc` and `kubectl`.
 
 ## Non Goals
@@ -76,7 +76,8 @@ The `completeNames` closure:
 3. Lists resources in `f.Namespace()` with a **3-second context timeout** to avoid blocking the user's shell if the API server is slow or unreachable.
 4. Extracts individual objects from the list using `meta.ExtractList()`.
 5. For each object, uses `meta.Accessor()` to read its name and filters by `strings.HasPrefix(name, toComplete)`.
-6. Returns the matching names with `cobra.ShellCompDirectiveNoFileComp`.
+6. Removes names already present in `args` so that commands accepting multiple names (e.g., `velero backup delete b1 b2`) do not re-suggest previously typed arguments. This follows the same pattern used by kubectl.
+7. Returns the matching names with `cobra.ShellCompDirectiveNoFileComp`.
 
 If any step fails — client construction, the list call, or `meta.ExtractList` — the function returns `nil, cobra.ShellCompDirectiveNoFileComp` (silent failure, no file completion fallback).
 If `meta.Accessor` fails on an individual item, that item is skipped and completion continues with the remaining items.
@@ -114,6 +115,8 @@ Because Velero exposes both `velero backup get` and `velero get backups` via the
 | `backup create` | `--volume-snapshot-locations` | `CompleteVolumeSnapshotLocationNames` |
 | `restore create` | `--from-backup` | `CompleteBackupNames` |
 | `restore create` | `--from-schedule` | `CompleteScheduleNames` |
+| `debug` | `--backup` | `CompleteBackupNames` |
+| `debug` | `--restore` | `CompleteRestoreNames` |
 
 The return value of `RegisterFlagCompletionFunc` is discarded (`_ =`) because it only fails if the named flag does not exist, which would be a compile-time coding error.
 

--- a/design/cli-dynamic-resource-completion_design.md
+++ b/design/cli-dynamic-resource-completion_design.md
@@ -2,26 +2,22 @@
 
 ## Abstract
 
-Velero CLI currently has no dynamic shell completion for resource names ([#9782](https://github.com/vmware-tanzu/velero/issues/9782)).
+Velero CLI has no dynamic shell completion for resource names ([#9782](https://github.com/vmware-tanzu/velero/issues/9782)).
 Tab-completing `velero backup describe <TAB>` produces no suggestions, even when backups exist on the cluster.
-This proposal adds dynamic completion for all commands that take Velero resource names as positional arguments or flag values, using cobra's `ValidArgsFunction` and `RegisterFlagCompletionFunc` mechanisms.
+This proposal adds dynamic completion for all commands that take Velero resource names as positional arguments or flag values (using cobra's built-in completion callbacks).
 
 ## Background
 
 Shell completion is a standard UX feature in Kubernetes CLI tooling.
 Tools like `kubectl`, `oc`, and `helm` all provide dynamic completions that query the cluster to suggest resource names.
-Velero's `velero completion` command generates static completion scripts using cobra's v1 API (`GenBashCompletion`), which only completes command and flag names.
-Cobra v1.8.1 (Velero's current version) supports dynamic completion via `ValidArgsFunction` on `cobra.Command` and `RegisterFlagCompletionFunc` for flag values, but Velero does not use either.
-
-The bash v1 completion generator (`GenBashCompletion`) does not invoke `ValidArgsFunction` callbacks.
-Cobra provides a v2 generator (`GenBashCompletionV2`) that does.
-The zsh and fish generators already support `ValidArgsFunction` natively.
+Velero's `velero completion` command generates completion scripts, but the CLI does not register any completion callbacks, so tab-completing resource names produces no suggestions.
+Cobra's completion infrastructure already supports dynamic completion across all shell types (bash, zsh, fish); Velero just needs to register the callbacks.
 
 ## Goals
 
 - Add dynamic shell completion for all 20 commands that accept existing Velero resource names as positional arguments.
-- Add dynamic flag completion for 7 flags that reference existing Velero resources (`--from-backup`, `--from-schedule`, `--storage-location`, `--volume-snapshot-locations`, `--backup`, `--restore`).
-- Fail silently when the cluster is unreachable, matching the behavior of `oc` and `kubectl`.
+- Add dynamic flag completion for 9 flags that reference existing Velero resources.
+- Fail silently when the cluster is unreachable, matching the behavior of `kubectl`.
 
 ## Non Goals
 
@@ -33,69 +29,35 @@ The zsh and fish generators already support `ValidArgsFunction` natively.
 ## High-Level Design
 
 A centralized set of completion functions is added to `pkg/cmd/cli/completion_functions.go`.
-Each function takes a `client.Factory`, returns a closure matching cobra's `ValidArgsFunction` signature, and lists resources of a specific type from the cluster.
+Each function takes a `client.Factory`, returns a closure matching cobra's completion function signature, and lists resources of a specific type from the cluster.
 Each command constructor wires the appropriate completion function onto its `cobra.Command` via `ValidArgsFunction` or `RegisterFlagCompletionFunc`.
-The bash completion generator is switched from v1 to v2 to enable dynamic completion support.
 
 ## Detailed Design
 
 ### Completion functions
 
-A new file `pkg/cmd/cli/completion_functions.go` in the `cli` package provides six public functions:
+A new file `pkg/cmd/cli/completion_functions.go` provides six public functions:
 
 | Function | Resource listed |
 |---|---|
-| `CompleteBackupNames(f client.Factory)` | `velerov1api.BackupList` |
-| `CompleteRestoreNames(f client.Factory)` | `velerov1api.RestoreList` |
-| `CompleteScheduleNames(f client.Factory)` | `velerov1api.ScheduleList` |
-| `CompleteBackupStorageLocationNames(f client.Factory)` | `velerov1api.BackupStorageLocationList` |
-| `CompleteVolumeSnapshotLocationNames(f client.Factory)` | `velerov1api.VolumeSnapshotLocationList` |
-| `CompleteBackupRepositoryNames(f client.Factory)` | `velerov1api.BackupRepositoryList` |
+| `CompleteBackupNames(f client.Factory)` | `BackupList` |
+| `CompleteRestoreNames(f client.Factory)` | `RestoreList` |
+| `CompleteScheduleNames(f client.Factory)` | `ScheduleList` |
+| `CompleteBackupStorageLocationNames(f client.Factory)` | `BackupStorageLocationList` |
+| `CompleteVolumeSnapshotLocationNames(f client.Factory)` | `VolumeSnapshotLocationList` |
+| `CompleteBackupRepositoryNames(f client.Factory)` | `BackupRepositoryList` |
 
-Each function returns a `func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)` closure.
+All six delegate to a single private `completeNames` helper that uses `meta.ExtractList()` and `meta.Accessor()` to extract names from any `ObjectList` type.
 
-Internally, all six functions delegate to a single private helper:
+The completion closure:
 
-```go
-func completeNames(f client.Factory, list kbclient.ObjectList) completionFunc
-```
-
-This helper uses `k8s.io/apimachinery/pkg/api/meta.ExtractList()` and `meta.Accessor()` from the Kubernetes apimachinery library to extract object names from any `ObjectList` type without Go generics.
-Each public function is a one-liner that passes the appropriate list type:
-
-```go
-func CompleteBackupNames(f client.Factory) completionFunc {
-    return completeNames(f, &velerov1api.BackupList{})
-}
-```
-
-The `completeNames` closure:
-
-1. Calls `f.KubebuilderClient()` to get a controller-runtime client.
-2. Deep-copies the list object to prevent state accumulation across repeated tab presses.
-3. Lists resources in `f.Namespace()` with a **3-second context timeout** to avoid blocking the user's shell if the API server is slow or unreachable.
-4. Extracts individual objects from the list using `meta.ExtractList()`.
-5. For each object, uses `meta.Accessor()` to read its name and filters by `strings.HasPrefix(name, toComplete)`.
-6. Removes names already present in `args` so that commands accepting multiple names (e.g., `velero backup delete b1 b2`) do not re-suggest previously typed arguments. This follows the same pattern used by kubectl.
-7. Returns the matching names with `cobra.ShellCompDirectiveNoFileComp`.
-
-If any step fails — client construction, the list call, or `meta.ExtractList` — the function returns `nil, cobra.ShellCompDirectiveNoFileComp` (silent failure, no file completion fallback).
-If `meta.Accessor` fails on an individual item, that item is skipped and completion continues with the remaining items.
-
-A package-level type alias keeps the function signatures readable:
-
-```go
-type completionFunc = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
-```
-
-Note: `cobra.ValidArgsFunction` is not an exported type in cobra v1.8.1.
-It is only the inline type of the `ValidArgsFunction` field on `cobra.Command`.
-The type alias is used for return types of the completion helper functions and is directly assignable to the field.
+- Lists resources in the configured namespace with a **3-second context timeout**.
+- Filters by `strings.HasPrefix(name, toComplete)`.
+- Removes names already present in `args` to avoid re-suggesting previously typed arguments.
+- Returns `cobra.ShellCompDirectiveNoFileComp` in all cases (success or failure).
+- Fails silently on any error (client construction, API call, extraction), returning no suggestions.
 
 ### Commands wired with `ValidArgsFunction`
-
-Each `New*Command` constructor sets `c.ValidArgsFunction` after creating the command and before returning it.
-Because Velero exposes both `velero backup get` and `velero get backups` via the same constructor function (`backup.NewGetCommand`), both command trees get completion automatically.
 
 | Package | Commands | Completion function |
 |---|---|---|
@@ -112,84 +74,49 @@ Because Velero exposes both `velero backup get` and `velero get backups` via the
 |---|---|---|
 | `backup create` | `--from-schedule` | `CompleteScheduleNames` |
 | `backup create` | `--storage-location` | `CompleteBackupStorageLocationNames` |
-| `backup create` | `--volume-snapshot-locations` | `CompleteVolumeSnapshotLocationNames` |
+| `backup create` | `--volume-snapshot-locations` * | `CompleteVolumeSnapshotLocationNames` |
+| `schedule create` | `--storage-location` | `CompleteBackupStorageLocationNames` |
+| `schedule create` | `--volume-snapshot-locations` * | `CompleteVolumeSnapshotLocationNames` |
 | `restore create` | `--from-backup` | `CompleteBackupNames` |
 | `restore create` | `--from-schedule` | `CompleteScheduleNames` |
 | `debug` | `--backup` | `CompleteBackupNames` |
 | `debug` | `--restore` | `CompleteRestoreNames` |
 
-The return value of `RegisterFlagCompletionFunc` is discarded (`_ =`) because it only fails if the named flag does not exist, which would be a compile-time coding error.
-
-### Bash completion v1 to v2 migration
-
-In `pkg/cmd/cli/completion/completion.go`, the bash case is changed from:
-
-```go
-cmd.Root().GenBashCompletion(os.Stdout)
-```
-
-to:
-
-```go
-cmd.Root().GenBashCompletionV2(os.Stdout, true)
-```
-
-The `true` parameter includes completion descriptions.
-Zsh and fish generators are unchanged as they already support `ValidArgsFunction`.
-
-### Client construction
-
-Completion functions use `f.KubebuilderClient()`, which constructs a REST config and a controller-runtime client with the Velero scheme on each invocation.
-This is the same client used by the commands themselves.
-The factory is captured by closure from the command constructor, so no changes to `completion.NewCommand()` or the root command wiring are needed.
+\* See Open Issues — comma-separated values.
 
 ## Alternatives Considered
 
-### Generic completion function using Go generics
-
-A single generic function parameterized by list type and item type was considered to avoid the six similar functions.
-Go generics were unnecessary because the Kubernetes apimachinery library already provides a type-agnostic way to extract names from any `ObjectList` via `meta.ExtractList()` and `meta.Accessor()`.
-The implementation uses these runtime interfaces in a single `completeNames` helper, achieving the same DRY goal without generics while keeping the six public wrapper functions as a stable API surface.
-
-### Passing the factory to the completion command
-
-It was considered whether `completion.NewCommand()` should receive `client.Factory` to register completion callbacks centrally.
-This is unnecessary because `ValidArgsFunction` is set per-command-instance in each constructor, and cobra's hidden `__complete` command handles runtime dispatch.
-The completion command only generates the shell script.
+The approach follows the standard cobra pattern for dynamic completion. No alternative designs were considered.
 
 ## Security Considerations
 
-Completion functions issue read-only list requests to the Kubernetes API server using the user's existing kubeconfig credentials.
-No new permissions are required beyond what the user already has for the commands themselves.
-No data is written, cached, or transmitted to external services.
-Users without list permission for a resource type will receive empty completions, consistent with kubectl's behavior.
+Completion functions issue read-only list requests using the user's existing kubeconfig credentials.
+No new permissions are required beyond what the user already has.
+Users without list permission receive empty completions, consistent with kubectl's behavior.
 
 ## Compatibility
 
-The bash completion output format changes from v1 to v2.
-Users who have previously generated and sourced bash completion scripts will need to regenerate them with `velero completion bash`.
-This is the expected workflow when upgrading any CLI tool.
-Zsh and fish completion scripts are unchanged in format.
-
-`GenBashCompletionV2` requires bash 4.0+ for associative array support.
-macOS ships with bash 3.2 by default, but zsh has been the default shell since macOS Catalina (10.15).
-Users on bash 3.2 can either upgrade bash via Homebrew or use `velero completion zsh`.
-
 Existing command behavior is unaffected.
-The `ValidArgsFunction` field is only invoked during shell completion; it has no effect on normal command execution.
+`ValidArgsFunction` is only invoked during shell completion; it has no effect on normal command execution.
+Completion respects the `--namespace` flag and `VELERO_NAMESPACE` environment variable.
 
 ## Testing
 
 Unit tests in `pkg/cmd/cli/completion_functions_test.go` cover:
 
-- **Core logic (`TestCompleteNames`):** Table-driven tests exercising all six resource types across scenarios: empty cluster, full match, prefix filtering, and no match.
-- **Error resilience (`TestCompleteNames_KubebuilderClientError`):** Verifies that a factory error (e.g., missing kubeconfig) returns nil completions without panicking.
-- **Wrapper isolation (`TestCompleteWrappers`):** Creates one object of every resource type on a single fake client, then verifies each `Complete*Names` wrapper returns only its own resource type.
+- **Core logic:** Table-driven tests across all six resource types: empty cluster, full match, prefix filtering, no match.
+- **Error resilience:** Factory errors return nil completions without panicking.
+- **Wrapper isolation:** Each `Complete*Names` wrapper returns only its own resource type.
 
-Tests use `factorymocks.Factory` and `velerotest.NewFakeControllerRuntimeClient` from the existing test infrastructure.
+## Open Issues
 
-## Implementation
+- **Single-argument commands:** Commands like `backup download` and `backup logs` accept exactly one positional argument, but cobra still calls the completion function after one arg is provided.
+The completion function should check `len(args)` and return no suggestions when the maximum arg count is reached.
+The approach (parameter on the helper vs. per-command wrapper) is TBD.
 
-The implementation is contained in a single commit on the `feature/dynamic-cli-completion` branch.
-It touches 24 files (1 new, 23 modified) with 201 insertions and 1 deletion.
-All existing tests pass without modification.
+- **Comma-separated flag values:** `--volume-snapshot-locations` accepts comma-separated values.
+Completion only works for the first value because `toComplete` contains the full string including commas.
+Completing subsequent values would require comma-aware splitting, similar to how kubectl handles this.
+
+- **Bash v1 to v2 migration:** The current bash completion generator already supports dynamic completion through cobra's `__complete` mechanism, so migration to v2 is not required for this feature.
+A separate migration could be considered for other benefits (cleaner generated scripts, ActiveHelp support) but would require users to regenerate their completion scripts.

--- a/design/cli-dynamic-resource-completion_design.md
+++ b/design/cli-dynamic-resource-completion_design.md
@@ -159,6 +159,7 @@ The completion command only generates the shell script.
 Completion functions issue read-only list requests to the Kubernetes API server using the user's existing kubeconfig credentials.
 No new permissions are required beyond what the user already has for the commands themselves.
 No data is written, cached, or transmitted to external services.
+Users without list permission for a resource type will receive empty completions, consistent with kubectl's behavior.
 
 ## Compatibility
 
@@ -166,6 +167,10 @@ The bash completion output format changes from v1 to v2.
 Users who have previously generated and sourced bash completion scripts will need to regenerate them with `velero completion bash`.
 This is the expected workflow when upgrading any CLI tool.
 Zsh and fish completion scripts are unchanged in format.
+
+`GenBashCompletionV2` requires bash 4.0+ for associative array support.
+macOS ships with bash 3.2 by default, but zsh has been the default shell since macOS Catalina (10.15).
+Users on bash 3.2 can either upgrade bash via Homebrew or use `velero completion zsh`.
 
 Existing command behavior is unaffected.
 The `ValidArgsFunction` field is only invoked during shell completion; it has no effect on normal command execution.

--- a/design/cli-dynamic-resource-completion_design.md
+++ b/design/cli-dynamic-resource-completion_design.md
@@ -2,7 +2,7 @@
 
 ## Abstract
 
-Velero CLI currently has no dynamic shell completion for resource names.
+Velero CLI currently has no dynamic shell completion for resource names ([#9782](https://github.com/vmware-tanzu/velero/issues/9782)).
 Tab-completing `velero backup describe <TAB>` produces no suggestions, even when backups exist on the cluster.
 This proposal adds dynamic completion for all commands that take Velero resource names as positional arguments or flag values, using cobra's `ValidArgsFunction` and `RegisterFlagCompletionFunc` mechanisms.
 


### PR DESCRIPTION
## Summary

Adds a design document proposing dynamic shell completion for all Velero CLI commands that accept existing resource names as positional arguments or flag values.

Fixes #9782

## Details

The design proposes:
- Six completion functions (one per Velero resource type) in a new `pkg/cmd/cli/completion_functions.go` file, backed by a shared `completeNames` helper
- Wiring `ValidArgsFunction` on 20 commands across backup, restore, schedule, backup-location, snapshot-location, and repo
- `RegisterFlagCompletionFunc` for 9 flags (`--from-backup`, `--from-schedule`, `--storage-location`, `--volume-snapshot-locations`, `--backup`, `--restore`)
- Silent failure on unreachable clusters, matching kubectl behavior

## Checklist

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.