### PR TITLE
Disable fips140 enforcement because Kopia doesn't support it.

### DIFF
--- a/changelogs/unreleased/9974-blackpiglet
+++ b/changelogs/unreleased/9974-blackpiglet
@@ -1,0 +1,1 @@
+Disable fips140 enforcement because Kopia doesn't support it.

--- a/pkg/cmd/cli/datamover/backup.go
+++ b/pkg/cmd/cli/datamover/backup.go
@@ -15,6 +15,7 @@ package datamover
 
 import (
 	"context"
+	"crypto/fips140"
 	"fmt"
 	"os"
 	"strings"
@@ -87,7 +88,10 @@ func NewBackupCommand(f client.Factory) *cobra.Command {
 				kube.ExitPodWithMessage(logger, false, "Failed to create data mover backup, %v", err)
 			}
 
-			s.run()
+			// Disable FIPS-140 compliance check, because Kopia doesn't support FIPS-140 yet.
+			fips140.WithoutEnforcement(func() {
+				s.run()
+			})
 		},
 	}
 

--- a/pkg/cmd/cli/datamover/restore.go
+++ b/pkg/cmd/cli/datamover/restore.go
@@ -15,6 +15,7 @@ package datamover
 
 import (
 	"context"
+	"crypto/fips140"
 	"fmt"
 	"os"
 	"strings"
@@ -81,7 +82,10 @@ func NewRestoreCommand(f client.Factory) *cobra.Command {
 				kube.ExitPodWithMessage(logger, false, "Failed to create data mover restore, %v", err)
 			}
 
-			s.run()
+			// Disable FIPS-140 compliance check, because Kopia doesn't support FIPS-140 yet.
+			fips140.WithoutEnforcement(func() {
+				s.run()
+			})
 		},
 	}
 

--- a/pkg/cmd/cli/podvolume/backup.go
+++ b/pkg/cmd/cli/podvolume/backup.go
@@ -15,6 +15,7 @@ package podvolume
 
 import (
 	"context"
+	"crypto/fips140"
 	"fmt"
 	"os"
 	"strings"
@@ -80,7 +81,10 @@ func NewBackupCommand(f client.Factory) *cobra.Command {
 				kube.ExitPodWithMessage(logger, false, "Failed to create pod volume backup, %v", err)
 			}
 
-			s.run()
+			// Disable FIPS-140 compliance check, because Kopia doesn't support FIPS-140 yet.
+			fips140.WithoutEnforcement(func() {
+				s.run()
+			})
 		},
 	}
 

--- a/pkg/cmd/cli/podvolume/restore.go
+++ b/pkg/cmd/cli/podvolume/restore.go
@@ -15,6 +15,7 @@ package podvolume
 
 import (
 	"context"
+	"crypto/fips140"
 	"fmt"
 	"os"
 	"strings"
@@ -79,7 +80,10 @@ func NewRestoreCommand(f client.Factory) *cobra.Command {
 				kube.ExitPodWithMessage(logger, false, "Failed to create pod volume restore, %v", err)
 			}
 
-			s.run()
+			// Disable FIPS-140 compliance check, because Kopia doesn't support FIPS-140 yet.
+			fips140.WithoutEnforcement(func() {
+				s.run()
+			})
 		},
 	}
 

--- a/pkg/cmd/cli/repomantenance/maintenance.go
+++ b/pkg/cmd/cli/repomantenance/maintenance.go
@@ -2,6 +2,7 @@ package repomantenance
 
 import (
 	"context"
+	"crypto/fips140"
 	"fmt"
 	"os"
 	"strings"
@@ -57,7 +58,10 @@ func NewCommand(f velerocli.Factory) *cobra.Command {
 		Hidden: true,
 		Short:  "VELERO INTERNAL COMMAND ONLY - not intended to be run directly by users",
 		Run: func(c *cobra.Command, args []string) {
-			o.Run(f)
+			// Disable FIPS-140 compliance check, because Kopia doesn't support FIPS-140 yet.
+			fips140.WithoutEnforcement(func() {
+				o.Run(f)
+			})
 		},
 	}
 

--- a/pkg/repository/manager/manager.go
+++ b/pkg/repository/manager/manager.go
@@ -18,6 +18,7 @@ package repository
 
 import (
 	"context"
+	"crypto/fips140"
 	"fmt"
 	"time"
 
@@ -173,7 +174,13 @@ func (m *manager) PrepareRepo(repo *velerov1api.BackupRepository) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	return prd.PrepareRepo(context.Background(), param)
+
+	// Disable FIPS-140 compliance check, because Kopia doesn't support FIPS-140 yet.
+	var prepareErr error
+	fips140.WithoutEnforcement(func() {
+		prepareErr = prd.PrepareRepo(context.Background(), param)
+	})
+	return prepareErr
 }
 
 func (m *manager) PruneRepo(repo *velerov1api.BackupRepository) error {
@@ -244,11 +251,20 @@ func (m *manager) BatchForget(ctx context.Context, repo *velerov1api.BackupRepos
 		return []error{errors.WithStack(err)}
 	}
 
-	if err := prd.BoostRepoConnect(context.Background(), param); err != nil {
+	// Disable FIPS-140 compliance check, because Kopia doesn't support FIPS-140 yet.
+	var connectErr error
+	fips140.WithoutEnforcement(func() {
+		connectErr = prd.BoostRepoConnect(context.Background(), param)
+	})
+	if connectErr != nil {
 		return []error{errors.WithStack(err)}
 	}
 
-	return prd.BatchForget(context.Background(), snapshots, param)
+	forgetErr := make([]error, 0)
+	fips140.WithoutEnforcement(func() {
+		forgetErr = prd.BatchForget(context.Background(), snapshots, param)
+	})
+	return forgetErr
 }
 
 func (m *manager) DefaultMaintenanceFrequency(repo *velerov1api.BackupRepository) (time.Duration, error) {


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #9975

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
