### PR TITLE
Add image volume type support to volume policies

### DIFF
--- a/changelogs/unreleased/9978-shubham-pampattiwar
+++ b/changelogs/unreleased/9978-shubham-pampattiwar
@@ -1,0 +1,1 @@
+Add image volume type support to volume policies

--- a/internal/resourcepolicies/volume_types_conditions.go
+++ b/internal/resourcepolicies/volume_types_conditions.go
@@ -45,6 +45,7 @@ const (
 	Glusterfs            SupportedVolume = "glusterfs"
 	GCEPersistentDisk    SupportedVolume = "gcePersistentDisk"
 	HostPath             SupportedVolume = "hostPath"
+	Image                SupportedVolume = "image"
 	ISCSI                SupportedVolume = "iscsi"
 	Local                SupportedVolume = "local"
 	NFS                  SupportedVolume = "nfs"
@@ -242,6 +243,9 @@ func getVolumeTypeFromVolume(vol *corev1api.Volume) SupportedVolume {
 	}
 	if vol.EmptyDir != nil {
 		return EmptyDir
+	}
+	if vol.Image != nil {
+		return Image
 	}
 	return ""
 }

--- a/internal/resourcepolicies/volume_types_conditions_test.go
+++ b/internal/resourcepolicies/volume_types_conditions_test.go
@@ -563,6 +563,15 @@ func TestGetVolumeTypeFromVolume(t *testing.T) {
 			},
 			expected: Ephemeral,
 		},
+		{
+			name: "Test Image",
+			inputVol: &corev1api.Volume{
+				VolumeSource: corev1api.VolumeSource{
+					Image: &corev1api.ImageVolumeSource{},
+				},
+			},
+			expected: Image,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
# Summary

Adds support for the Kubernetes `image` volume type (GA in k8s 1.31) in Velero's volume policy system.

The `image` volume type ([KEP-4639](https://github.com/kubernetes/enhancements/issues/4639)) allows mounting OCI container images as read-only volumes in pods. Velero's volume type detection did not recognize this type, so volume policies with `volumeTypes: [image]` were silently ignored. This caused failed file-system backups when `defaultVolumesToFsBackup` was enabled, since image volumes have no host path for the node agent to back up.

**Changes:**
- Add `Image` constant to `SupportedVolume`
- Add `vol.Image != nil` detection in `getVolumeTypeFromVolume()`
- Add corresponding unit test

# Does your change fix a particular issue?

Fixes velero-io/velero#9977

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.