### PR TITLE
fix globalExcludes lookup

### DIFF
--- a/changelogs/unreleased/9989-adam-jian-zhang
+++ b/changelogs/unreleased/9989-adam-jian-zhang
@@ -1,0 +1,1 @@
+Fix globalExcludes lookup, it should be lookup against lower case

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -552,7 +552,9 @@ func resolveRestoreNamespacedFilterPolicies(
 	// Build a quick lookup map for globally excluded resources
 	globalExcludes := make(map[string]bool)
 	for _, ex := range excludedResources {
-		globalExcludes[ex] = true
+		// We lowercase the excluded resources here because the kinds in the resource filters
+		// are lowercased during resolution, and we want to ensure case-insensitive matching.
+		globalExcludes[strings.ToLower(ex)] = true
 	}
 
 	for _, policy := range policies {

--- a/pkg/restore/restore_policies_test.go
+++ b/pkg/restore/restore_policies_test.go
@@ -2,9 +2,11 @@ package restore
 
 import (
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 	corev1api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -282,4 +284,49 @@ func TestResolveRestoreClusterScopedFilterPolicy_Validation(t *testing.T) {
 	_, err := resolveRestoreClusterScopedFilterPolicy(policy, helper, log)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "ambiguous policy: duplicate kind")
+}
+
+func TestResolveRestoreNamespacedFilterPolicies_GlobalExcludesWarning(t *testing.T) {
+	log, hook := logrustest.NewNullLogger()
+	helper := test.NewFakeDiscoveryHelper(true, nil)
+
+	policies := []resourcepolicies.NamespacedFilterPolicy{
+		{
+			Namespaces: []string{"ns-1"},
+			ResourceFilters: []resourcepolicies.ResourceFilter{
+				{
+					Kinds: []string{"ConfigMaps"},
+				},
+			},
+		},
+	}
+
+	excludedResources := []string{"ConfigMaps"} // Same case
+	_, _, err := resolveRestoreNamespacedFilterPolicies(policies, excludedResources, helper, log)
+	require.NoError(t, err)
+
+	// Check if a warning was emitted
+	found := false
+	for _, entry := range hook.Entries {
+		if entry.Level == logrus.WarnLevel && strings.Contains(entry.Message, "namespacedFilterPolicies entry lists a kind that is globally excluded") {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "expected warning about globally excluded resource")
+
+	hook.Reset()
+
+	excludedResourcesDiffCase := []string{"configmaps"} // Different case
+	_, _, err = resolveRestoreNamespacedFilterPolicies(policies, excludedResourcesDiffCase, helper, log)
+	require.NoError(t, err)
+
+	found = false
+	for _, entry := range hook.Entries {
+		if entry.Level == logrus.WarnLevel && strings.Contains(entry.Message, "namespacedFilterPolicies entry lists a kind that is globally excluded") {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "expected warning about globally excluded resource even if case differs")
 }


### PR DESCRIPTION
The kind is normalized to lower case, so should the lookup.

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)
https://github.com/velero-io/velero/issues/9936

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
