### PR TITLE
fix(delete): surface DeleteItemAction plugin errors from InvokeDelete…

### DIFF
--- a/changelogs/unreleased/9993-chlins
+++ b/changelogs/unreleased/9993-chlins
@@ -1,0 +1,1 @@
+Surface DeleteItemAction plugin errors from InvokeDeleteActions so backup deletion fails and retries instead of silently orphaning data mover snapshots and other private artifacts

--- a/internal/delete/delete_item_action_handler.go
+++ b/internal/delete/delete_item_action_handler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubeerrs "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -80,6 +81,15 @@ func InvokeDeleteActions(ctx *Context) error {
 	}
 	processdResources := sets.NewString()
 
+	// deleteErrs collects errors returned by DeleteItemAction plugins. We keep
+	// looping over the remaining items even when a plugin fails, but we must not
+	// swallow these errors: a DIA failure means the private artifacts it manages
+	// (e.g. data mover repository snapshots) may not have been deleted. If we
+	// returned nil here, the caller would proceed to delete the backup and its
+	// metadata, orphaning those artifacts forever. Returning the aggregated error
+	// makes the caller fail the deletion so it can be retried.
+	var deleteErrs []error
+
 	for resource := range backupResources {
 		groupResource := schema.ParseGroupResource(resource)
 
@@ -124,15 +134,19 @@ func InvokeDeleteActions(ctx *Context) error {
 						Item:   obj,
 						Backup: ctx.Backup,
 					})
-					// Since we want to keep looping even on errors, log them instead of just returning.
+					// Keep looping even on errors so a single failing plugin
+					// doesn't prevent the remaining items from being cleaned up,
+					// but record the error so it can be surfaced to the caller.
 					if err != nil {
 						itemLog.WithError(err).Error("plugin error")
+						deleteErrs = append(deleteErrs, errors.Wrapf(err,
+							"error executing DeleteItemAction for %s %s", groupResource.String(), obj.GetName()))
 					}
 				}
 			}
 		}
 	}
-	return nil
+	return kubeerrs.NewAggregate(deleteErrs)
 }
 
 // getApplicableActions takes resolved DeleteItemActions and filters them for a given group/resource and namespace.

--- a/internal/delete/delete_item_action_handler_test.go
+++ b/internal/delete/delete_item_action_handler_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package delete
 
 import (
+	"errors"
 	"io"
 	"sort"
 	"testing"
@@ -275,4 +276,55 @@ func TestInvokeDeleteItemActionsWithNoPlugins(t *testing.T) {
 	}
 	err := InvokeDeleteActions(c)
 	require.NoError(t, err)
+}
+
+// failingAction is a DeleteItemAction that always returns an error from Execute.
+// It is used to verify that InvokeDeleteActions surfaces plugin errors instead
+// of swallowing them.
+type failingAction struct {
+	selector velero.ResourceSelector
+	err      error
+	executed int
+}
+
+func (a *failingAction) AppliesTo() (velero.ResourceSelector, error) {
+	return a.selector, nil
+}
+
+func (a *failingAction) Execute(input *velero.DeleteItemActionExecuteInput) error {
+	a.executed++
+	return a.err
+}
+
+func TestInvokeDeleteActionsReturnsPluginErrors(t *testing.T) {
+	fs := test.NewFakeFileSystem()
+	log := logrus.StandardLogger()
+
+	tarball := test.NewTarWriter(t).
+		AddItems("pods", builder.ForPod("ns-1", "pod-1").Result(), builder.ForPod("ns-2", "pod-2").Result()).
+		Done()
+
+	action := &failingAction{err: errors.New("could not delete artifact")}
+
+	h := newHarness(t)
+	h.addResource(t, test.Pods())
+
+	c := &Context{
+		Backup:          builder.ForBackup("velero", "velero").Result(),
+		BackupReader:    tarball,
+		Filesystem:      fs,
+		DiscoveryHelper: h.discoveryHelper,
+		Actions:         []velero.DeleteItemAction{action},
+		Log:             log,
+	}
+
+	err := InvokeDeleteActions(c)
+
+	// The plugin error must be surfaced so the caller can fail the deletion
+	// rather than orphaning the artifacts the plugin failed to delete.
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not delete artifact")
+	// The loop must keep going: the action should run for every matching item,
+	// not stop at the first failure.
+	assert.Equal(t, 2, action.executed)
 }

--- a/pkg/controller/backup_deletion_controller.go
+++ b/pkg/controller/backup_deletion_controller.go
@@ -295,7 +295,7 @@ func (r *backupDeletionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			err = delete.InvokeDeleteActions(deleteCtx)
 			if err != nil {
 				log.WithError(err).Error("Error invoking delete item actions")
-				err2 := r.patchDeleteBackupRequestWithError(ctx, dbr, errors.New("error invoking delete item actions"))
+				err2 := r.patchDeleteBackupRequestWithError(ctx, dbr, errors.Wrap(err, "error invoking delete item actions"))
 				return ctrl.Result{}, err2
 			}
 		}


### PR DESCRIPTION
This pull request improves the reliability of backup deletion by ensuring that errors from `DeleteItemAction` plugins are properly surfaced and handled, rather than being silently ignored. This prevents scenarios where artifacts (like data mover snapshots) are orphaned if a plugin fails. The changes also add new tests to verify this behavior.

**Error handling improvements:**

* [`internal/delete/delete_item_action_handler.go`](diffhunk://#diff-033515a28abdd659555f8daa40a67d0c243b466eb46172e7331e2b5a66b0bec1R84-R92): Aggregates and returns all errors from `DeleteItemAction` plugins in `InvokeDeleteActions` instead of returning `nil`, ensuring that backup deletion fails and can be retried if any plugin fails. [[1]](diffhunk://#diff-033515a28abdd659555f8daa40a67d0c243b466eb46172e7331e2b5a66b0bec1R84-R92) [[2]](diffhunk://#diff-033515a28abdd659555f8daa40a67d0c243b466eb46172e7331e2b5a66b0bec1L127-R149)
* [`pkg/controller/backup_deletion_controller.go`](diffhunk://#diff-a80acd1bc4b343e9b39fd3946bbe36a89a61a5279912bb742190e5ed7f10bdcdL298-R298): Wraps and surfaces plugin errors when patching the `DeleteBackupRequest`, providing more context in error reporting.

**Testing enhancements:**

* [`internal/delete/delete_item_action_handler_test.go`](diffhunk://#diff-ffd8997cd69c2d8be60bf0373e749be8dc072b0c5766ecaf28f3d76a0f0a8674R280-R330): Adds a test (`TestInvokeDeleteActionsReturnsPluginErrors`) with a failing action plugin to ensure that errors are surfaced and that all matching items are processed, not just the first.

**Dependency updates:**

* [`internal/delete/delete_item_action_handler.go`](diffhunk://#diff-033515a28abdd659555f8daa40a67d0c243b466eb46172e7331e2b5a66b0bec1R28): Imports `k8s.io/apimachinery/pkg/util/errors` to enable error aggregation.

**Documentation:**

* [`changelogs/unreleased/9803-chlins`](diffhunk://#diff-dc27a841e0a3ebdb41310d2b5c92810c3f5b7273a7e8cddb558b55535d23189aR1): Adds a changelog entry describing the improved error surfacing for `DeleteItemAction` plugins.

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes https://github.com/velero-io/velero/issues/9803

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
