### PR TITLE
Fix stale backupLastSuccessfulTimestamp metric after schedule deletion

### DIFF
--- a/changelogs/unreleased/10000-shubham-pampattiwar
+++ b/changelogs/unreleased/10000-shubham-pampattiwar
@@ -1,0 +1,1 @@
+Fix stale backupLastSuccessfulTimestamp metric after schedule deletion

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -107,10 +107,11 @@ type backupReconciler struct {
 	credentialFileStore           credentials.FileStore
 	maxConcurrentK8SConnections   int
 	defaultSnapshotMoveData       bool
-	globalCRClient                kbclient.Client
-	itemBlockWorkerCount          int
-	concurrentBackups             int
-	globalVolumePoliciesConfigMap string
+	globalCRClient                        kbclient.Client
+	itemBlockWorkerCount                  int
+	concurrentBackups                     int
+	globalVolumePoliciesConfigMap         string
+	knownSchedulesWithSuccessfulBackup    sets.Set[string]
 }
 
 func NewBackupReconciler(
@@ -204,28 +205,41 @@ func (b *backupReconciler) updateTotalBackupMetric() {
 		time.Sleep(5 * time.Second)
 
 		wait.Until(
-			func() {
-				// recompute backup_total metric
-				backups := &velerov1api.BackupList{}
-				err := b.kbClient.List(context.Background(), backups, &kbclient.ListOptions{LabelSelector: labels.Everything()})
-				if err != nil {
-					b.logger.Error(err, "Error computing backup_total metric")
-				} else {
-					b.metrics.SetBackupTotal(int64(len(backups.Items)))
-
-					// recompute backup_last_successful_timestamp metric for each
-					// schedule (including the empty schedule, i.e. ad-hoc backups).
-					// Reset first to prune stale entries for deleted schedules.
-					b.metrics.ResetBackupLastSuccessfulTimestamp()
-					for schedule, timestamp := range getLastSuccessBySchedule(backups.Items) {
-						b.metrics.SetBackupLastSuccessfulTimestamp(schedule, timestamp)
-					}
-				}
-			},
+			b.resyncBackupMetrics,
 			backupResyncPeriod,
 			b.ctx.Done(),
 		)
 	}()
+}
+
+func (b *backupReconciler) resyncBackupMetrics() {
+	backups := &velerov1api.BackupList{}
+	err := b.kbClient.List(context.Background(), backups, &kbclient.ListOptions{LabelSelector: labels.Everything()})
+	if err != nil {
+		b.logger.Error(err, "Error computing backup_total metric")
+		return
+	}
+
+	b.metrics.SetBackupTotal(int64(len(backups.Items)))
+
+	currentSchedules := getLastSuccessBySchedule(backups.Items)
+	for schedule, timestamp := range currentSchedules {
+		b.metrics.SetBackupLastSuccessfulTimestamp(schedule, timestamp)
+	}
+
+	// Remove metrics for schedules that no longer have successful backups
+	if b.knownSchedulesWithSuccessfulBackup != nil {
+		for schedule := range b.knownSchedulesWithSuccessfulBackup {
+			if _, exists := currentSchedules[schedule]; !exists {
+				b.metrics.DeleteBackupLastSuccessfulTimestamp(schedule)
+			}
+		}
+	}
+
+	b.knownSchedulesWithSuccessfulBackup = sets.New[string]()
+	for schedule := range currentSchedules {
+		b.knownSchedulesWithSuccessfulBackup.Insert(schedule)
+	}
 }
 
 // getLastSuccessBySchedule finds the most recent completed backup for each schedule

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -84,34 +84,34 @@ var autoExcludeClusterScopedResources = []string{
 }
 
 type backupReconciler struct {
-	ctx                           context.Context
-	logger                        logrus.FieldLogger
-	discoveryHelper               discovery.Helper
-	backupper                     pkgbackup.Backupper
-	kbClient                      kbclient.Client
-	clock                         clock.WithTickerAndDelayedExecution
-	backupLogLevel                logrus.Level
-	newPluginManager              func(logrus.FieldLogger) clientmgmt.Manager
-	backupTracker                 BackupTracker
-	defaultBackupLocation         string
-	defaultVolumesToFsBackup      bool
-	defaultBackupTTL              time.Duration
-	defaultVGSLabelKey            string
-	defaultCSISnapshotTimeout     time.Duration
-	resourceTimeout               time.Duration
-	defaultItemOperationTimeout   time.Duration
-	defaultSnapshotLocations      map[string]string
-	metrics                       *metrics.ServerMetrics
-	backupStoreGetter             persistence.ObjectBackupStoreGetter
-	formatFlag                    logging.Format
-	credentialFileStore           credentials.FileStore
-	maxConcurrentK8SConnections   int
-	defaultSnapshotMoveData       bool
-	globalCRClient                        kbclient.Client
-	itemBlockWorkerCount                  int
-	concurrentBackups                     int
-	globalVolumePoliciesConfigMap         string
-	knownSchedulesWithSuccessfulBackup    sets.Set[string]
+	ctx                                context.Context
+	logger                             logrus.FieldLogger
+	discoveryHelper                    discovery.Helper
+	backupper                          pkgbackup.Backupper
+	kbClient                           kbclient.Client
+	clock                              clock.WithTickerAndDelayedExecution
+	backupLogLevel                     logrus.Level
+	newPluginManager                   func(logrus.FieldLogger) clientmgmt.Manager
+	backupTracker                      BackupTracker
+	defaultBackupLocation              string
+	defaultVolumesToFsBackup           bool
+	defaultBackupTTL                   time.Duration
+	defaultVGSLabelKey                 string
+	defaultCSISnapshotTimeout          time.Duration
+	resourceTimeout                    time.Duration
+	defaultItemOperationTimeout        time.Duration
+	defaultSnapshotLocations           map[string]string
+	metrics                            *metrics.ServerMetrics
+	backupStoreGetter                  persistence.ObjectBackupStoreGetter
+	formatFlag                         logging.Format
+	credentialFileStore                credentials.FileStore
+	maxConcurrentK8SConnections        int
+	defaultSnapshotMoveData            bool
+	globalCRClient                     kbclient.Client
+	itemBlockWorkerCount               int
+	concurrentBackups                  int
+	globalVolumePoliciesConfigMap      string
+	knownSchedulesWithSuccessfulBackup sets.Set[string]
 }
 
 func NewBackupReconciler(

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -212,14 +212,14 @@ func (b *backupReconciler) updateTotalBackupMetric() {
 					b.logger.Error(err, "Error computing backup_total metric")
 				} else {
 					b.metrics.SetBackupTotal(int64(len(backups.Items)))
-				}
 
-				// recompute backup_last_successful_timestamp metric for each
-				// schedule (including the empty schedule, i.e. ad-hoc backups).
-				// Reset first to prune stale entries for deleted schedules.
-				b.metrics.ResetBackupLastSuccessfulTimestamp()
-				for schedule, timestamp := range getLastSuccessBySchedule(backups.Items) {
-					b.metrics.SetBackupLastSuccessfulTimestamp(schedule, timestamp)
+					// recompute backup_last_successful_timestamp metric for each
+					// schedule (including the empty schedule, i.e. ad-hoc backups).
+					// Reset first to prune stale entries for deleted schedules.
+					b.metrics.ResetBackupLastSuccessfulTimestamp()
+					for schedule, timestamp := range getLastSuccessBySchedule(backups.Items) {
+						b.metrics.SetBackupLastSuccessfulTimestamp(schedule, timestamp)
+					}
 				}
 			},
 			backupResyncPeriod,

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -215,7 +215,9 @@ func (b *backupReconciler) updateTotalBackupMetric() {
 				}
 
 				// recompute backup_last_successful_timestamp metric for each
-				// schedule (including the empty schedule, i.e. ad-hoc backups)
+				// schedule (including the empty schedule, i.e. ad-hoc backups).
+				// Reset first to prune stale entries for deleted schedules.
+				b.metrics.ResetBackupLastSuccessfulTimestamp()
 				for schedule, timestamp := range getLastSuccessBySchedule(backups.Items) {
 					b.metrics.SetBackupLastSuccessfulTimestamp(schedule, timestamp)
 				}

--- a/pkg/controller/backup_controller_test.go
+++ b/pkg/controller/backup_controller_test.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"reflect"
@@ -32,7 +31,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	snapshotv1api "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
-	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -2043,60 +2042,15 @@ func Test_getLastSuccessBySchedule(t *testing.T) {
 	}
 }
 
-// Test_updateTotalBackupMetric_prunesStaleTimestamps verifies that the periodic
-// resync removes backupLastSuccessfulTimestamp entries for schedules that no longer
-// have any completed backups (e.g. after the schedule and its backups are deleted).
-func Test_updateTotalBackupMetric_prunesStaleTimestamps(t *testing.T) {
+// Test_resyncBackupMetrics_prunesStaleTimestamps verifies that resyncBackupMetrics
+// removes backupLastSuccessfulTimestamp entries for schedules that no longer have
+// any completed backups (e.g. after the schedule and its backups are deleted).
+func Test_resyncBackupMetrics_prunesStaleTimestamps(t *testing.T) {
 	baseTime, err := time.Parse(time.RFC1123, time.RFC1123)
 	require.NoError(t, err)
 
 	m := metrics.NewServerMetrics()
-	gauge := m.Metrics()["backup_last_successful_timestamp"].(*prometheus.GaugeVec)
-
-	// Simulate a previous resync that set the metric for "deleted-schedule"
-	m.SetBackupLastSuccessfulTimestamp("deleted-schedule", baseTime)
-	require.Equal(t, 1, collectGaugeCount(t, gauge))
-
-	// Current backups only contain entries for "active-schedule"
-	backups := []velerov1api.Backup{
-		*builder.ForBackup("velero", "b1").
-			ObjectMeta(builder.WithLabels(velerov1api.ScheduleNameLabel, "active-schedule")).
-			Phase(velerov1api.BackupPhaseCompleted).
-			CompletionTimestamp(baseTime).
-			Result(),
-	}
-
-	// Replicate the resync logic: reset then set
-	m.ResetBackupLastSuccessfulTimestamp()
-	for schedule, timestamp := range getLastSuccessBySchedule(backups) {
-		m.SetBackupLastSuccessfulTimestamp(schedule, timestamp)
-	}
-
-	// Only "active-schedule" should remain; "deleted-schedule" should be pruned
-	assert.Equal(t, 1, collectGaugeCount(t, gauge))
-}
-
-func collectGaugeCount(t *testing.T, g *prometheus.GaugeVec) int {
-	t.Helper()
-	ch := make(chan prometheus.Metric, 10)
-	g.Collect(ch)
-	close(ch)
-	count := 0
-	for range ch {
-		count++
-	}
-	return count
-}
-
-// Test_updateTotalBackupMetric_prunesStaleTimestamps_integration tests the actual
-// updateTotalBackupMetric goroutine with a fake client to verify stale metrics are
-// pruned during a real resync cycle.
-func Test_updateTotalBackupMetric_prunesStaleTimestamps_integration(t *testing.T) {
-	baseTime, err := time.Parse(time.RFC1123, time.RFC1123)
-	require.NoError(t, err)
-
-	m := metrics.NewServerMetrics()
-	gauge := m.Metrics()["backup_last_successful_timestamp"].(*prometheus.GaugeVec)
+	gauge := m.Metrics()["backup_last_successful_timestamp"]
 
 	activeBackup := builder.ForBackup("velero", "b1").
 		ObjectMeta(builder.WithLabels(velerov1api.ScheduleNameLabel, "active-schedule")).
@@ -2104,26 +2058,30 @@ func Test_updateTotalBackupMetric_prunesStaleTimestamps_integration(t *testing.T
 		CompletionTimestamp(baseTime).
 		Result()
 
-	fakeClient := velerotest.NewFakeControllerRuntimeClient(t, activeBackup)
+	deletedBackup := builder.ForBackup("velero", "b2").
+		ObjectMeta(builder.WithLabels(velerov1api.ScheduleNameLabel, "deleted-schedule")).
+		Phase(velerov1api.BackupPhaseCompleted).
+		CompletionTimestamp(baseTime).
+		Result()
 
-	m.SetBackupLastSuccessfulTimestamp("deleted-schedule", baseTime)
-	require.Equal(t, 1, collectGaugeCount(t, gauge))
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	fakeClient := velerotest.NewFakeControllerRuntimeClient(t, activeBackup, deletedBackup)
 
 	c := &backupReconciler{
-		ctx:      ctx,
 		kbClient: fakeClient,
 		logger:   logrus.StandardLogger(),
 		metrics:  m,
 	}
 
-	c.updateTotalBackupMetric()
-	time.Sleep(7 * time.Second)
-	cancel()
+	// First resync: sets metrics for both schedules
+	c.resyncBackupMetrics()
+	assert.Equal(t, 2, testutil.CollectAndCount(gauge))
 
-	assert.Equal(t, 1, collectGaugeCount(t, gauge))
+	// Simulate schedule deletion: remove the backup for "deleted-schedule"
+	require.NoError(t, fakeClient.Delete(t.Context(), deletedBackup))
+
+	// Second resync: prunes "deleted-schedule" metric, keeps "active-schedule"
+	c.resyncBackupMetrics()
+	assert.Equal(t, 1, testutil.CollectAndCount(gauge))
 }
 
 // Unit tests to make sure that the backup's status is updated correctly during reconcile.

--- a/pkg/controller/backup_controller_test.go
+++ b/pkg/controller/backup_controller_test.go
@@ -2041,6 +2041,38 @@ func Test_getLastSuccessBySchedule(t *testing.T) {
 	}
 }
 
+// Test_updateTotalBackupMetric_prunesStaleTimestamps verifies that the periodic
+// resync removes backupLastSuccessfulTimestamp entries for schedules that no longer
+// have any completed backups (e.g. after the schedule and its backups are deleted).
+func Test_updateTotalBackupMetric_prunesStaleTimestamps(t *testing.T) {
+	baseTime, err := time.Parse(time.RFC1123, time.RFC1123)
+	require.NoError(t, err)
+
+	m := metrics.NewServerMetrics()
+
+	// Simulate a previous resync that set the metric for "deleted-schedule"
+	m.SetBackupLastSuccessfulTimestamp("deleted-schedule", baseTime)
+	require.Equal(t, 1, m.BackupLastSuccessfulTimestampCount())
+
+	// Current backups only contain entries for "active-schedule"
+	backups := []velerov1api.Backup{
+		*builder.ForBackup("velero", "b1").
+			ObjectMeta(builder.WithLabels(velerov1api.ScheduleNameLabel, "active-schedule")).
+			Phase(velerov1api.BackupPhaseCompleted).
+			CompletionTimestamp(baseTime).
+			Result(),
+	}
+
+	// Replicate the resync logic: reset then set
+	m.ResetBackupLastSuccessfulTimestamp()
+	for schedule, timestamp := range getLastSuccessBySchedule(backups) {
+		m.SetBackupLastSuccessfulTimestamp(schedule, timestamp)
+	}
+
+	// Only "active-schedule" should remain; "deleted-schedule" should be pruned
+	assert.Equal(t, 1, m.BackupLastSuccessfulTimestampCount())
+}
+
 // Unit tests to make sure that the backup's status is updated correctly during reconcile.
 // To clear up confusion whether status can be updated with Patch alone without status writer and not kbClient.Status().Patch()
 func TestPatchResourceWorksWithStatus(t *testing.T) {

--- a/pkg/controller/backup_controller_test.go
+++ b/pkg/controller/backup_controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"reflect"
@@ -2085,6 +2086,44 @@ func collectGaugeCount(t *testing.T, g *prometheus.GaugeVec) int {
 		count++
 	}
 	return count
+}
+
+// Test_updateTotalBackupMetric_prunesStaleTimestamps_integration tests the actual
+// updateTotalBackupMetric goroutine with a fake client to verify stale metrics are
+// pruned during a real resync cycle.
+func Test_updateTotalBackupMetric_prunesStaleTimestamps_integration(t *testing.T) {
+	baseTime, err := time.Parse(time.RFC1123, time.RFC1123)
+	require.NoError(t, err)
+
+	m := metrics.NewServerMetrics()
+	gauge := m.Metrics()["backup_last_successful_timestamp"].(*prometheus.GaugeVec)
+
+	activeBackup := builder.ForBackup("velero", "b1").
+		ObjectMeta(builder.WithLabels(velerov1api.ScheduleNameLabel, "active-schedule")).
+		Phase(velerov1api.BackupPhaseCompleted).
+		CompletionTimestamp(baseTime).
+		Result()
+
+	fakeClient := velerotest.NewFakeControllerRuntimeClient(t, activeBackup)
+
+	m.SetBackupLastSuccessfulTimestamp("deleted-schedule", baseTime)
+	require.Equal(t, 1, collectGaugeCount(t, gauge))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := &backupReconciler{
+		ctx:      ctx,
+		kbClient: fakeClient,
+		logger:   logrus.StandardLogger(),
+		metrics:  m,
+	}
+
+	c.updateTotalBackupMetric()
+	time.Sleep(7 * time.Second)
+	cancel()
+
+	assert.Equal(t, 1, collectGaugeCount(t, gauge))
 }
 
 // Unit tests to make sure that the backup's status is updated correctly during reconcile.

--- a/pkg/controller/backup_controller_test.go
+++ b/pkg/controller/backup_controller_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	snapshotv1api "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -2049,10 +2050,11 @@ func Test_updateTotalBackupMetric_prunesStaleTimestamps(t *testing.T) {
 	require.NoError(t, err)
 
 	m := metrics.NewServerMetrics()
+	gauge := m.Metrics()["backup_last_successful_timestamp"].(*prometheus.GaugeVec)
 
 	// Simulate a previous resync that set the metric for "deleted-schedule"
 	m.SetBackupLastSuccessfulTimestamp("deleted-schedule", baseTime)
-	require.Equal(t, 1, m.BackupLastSuccessfulTimestampCount())
+	require.Equal(t, 1, collectGaugeCount(t, gauge))
 
 	// Current backups only contain entries for "active-schedule"
 	backups := []velerov1api.Backup{
@@ -2070,7 +2072,19 @@ func Test_updateTotalBackupMetric_prunesStaleTimestamps(t *testing.T) {
 	}
 
 	// Only "active-schedule" should remain; "deleted-schedule" should be pruned
-	assert.Equal(t, 1, m.BackupLastSuccessfulTimestampCount())
+	assert.Equal(t, 1, collectGaugeCount(t, gauge))
+}
+
+func collectGaugeCount(t *testing.T, g *prometheus.GaugeVec) int {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 10)
+	g.Collect(ch)
+	close(ch)
+	count := 0
+	for range ch {
+		count++
+	}
+	return count
 }
 
 // Unit tests to make sure that the backup's status is updated correctly during reconcile.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -765,23 +765,6 @@ func (m *ServerMetrics) ResetBackupLastSuccessfulTimestamp() {
 	}
 }
 
-// BackupLastSuccessfulTimestampCount returns the number of active time series
-// in the backupLastSuccessfulTimestamp gauge.
-func (m *ServerMetrics) BackupLastSuccessfulTimestampCount() int {
-	g, ok := m.metrics[backupLastSuccessfulTimestamp].(*prometheus.GaugeVec)
-	if !ok {
-		return 0
-	}
-	ch := make(chan prometheus.Metric, 100)
-	g.Collect(ch)
-	close(ch)
-	count := 0
-	for range ch {
-		count++
-	}
-	return count
-}
-
 // SetBackupTarballSizeBytesGauge records the size, in bytes, of a backup tarball.
 func (m *ServerMetrics) SetBackupTarballSizeBytesGauge(backupSchedule string, size int64) {
 	if g, ok := m.metrics[backupTarballSizeBytesGauge].(*prometheus.GaugeVec); ok {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -758,6 +758,13 @@ func (m *ServerMetrics) RegisterPodVolumeOpLatencyGauge(node, pvbName, opName, b
 	}
 }
 
+// ResetBackupLastSuccessfulTimestamp removes all schedule-level backupLastSuccessfulTimestamp values.
+func (m *ServerMetrics) ResetBackupLastSuccessfulTimestamp() {
+	if g, ok := m.metrics[backupLastSuccessfulTimestamp].(*prometheus.GaugeVec); ok {
+		g.Reset()
+	}
+}
+
 // SetBackupTarballSizeBytesGauge records the size, in bytes, of a backup tarball.
 func (m *ServerMetrics) SetBackupTarballSizeBytesGauge(backupSchedule string, size int64) {
 	if g, ok := m.metrics[backupTarballSizeBytesGauge].(*prometheus.GaugeVec); ok {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -758,10 +758,11 @@ func (m *ServerMetrics) RegisterPodVolumeOpLatencyGauge(node, pvbName, opName, b
 	}
 }
 
-// ResetBackupLastSuccessfulTimestamp removes all schedule-level backupLastSuccessfulTimestamp values.
-func (m *ServerMetrics) ResetBackupLastSuccessfulTimestamp() {
+// DeleteBackupLastSuccessfulTimestamp removes the backupLastSuccessfulTimestamp
+// metric for a single schedule.
+func (m *ServerMetrics) DeleteBackupLastSuccessfulTimestamp(scheduleName string) {
 	if g, ok := m.metrics[backupLastSuccessfulTimestamp].(*prometheus.GaugeVec); ok {
-		g.Reset()
+		g.DeleteLabelValues(scheduleName)
 	}
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -765,6 +765,23 @@ func (m *ServerMetrics) ResetBackupLastSuccessfulTimestamp() {
 	}
 }
 
+// BackupLastSuccessfulTimestampCount returns the number of active time series
+// in the backupLastSuccessfulTimestamp gauge.
+func (m *ServerMetrics) BackupLastSuccessfulTimestampCount() int {
+	g, ok := m.metrics[backupLastSuccessfulTimestamp].(*prometheus.GaugeVec)
+	if !ok {
+		return 0
+	}
+	ch := make(chan prometheus.Metric, 100)
+	g.Collect(ch)
+	close(ch)
+	count := 0
+	for range ch {
+		count++
+	}
+	return count
+}
+
 // SetBackupTarballSizeBytesGauge records the size, in bytes, of a backup tarball.
 func (m *ServerMetrics) SetBackupTarballSizeBytesGauge(backupSchedule string, size int64) {
 	if g, ok := m.metrics[backupTarballSizeBytesGauge].(*prometheus.GaugeVec); ok {

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -457,6 +457,38 @@ func getHistogramCount(t *testing.T, vec *prometheus.HistogramVec, scheduleLabel
 	return 0
 }
 
+// TestResetBackupLastSuccessfulTimestamp verifies that ResetBackupLastSuccessfulTimestamp
+// removes all schedule-level values from the backupLastSuccessfulTimestamp gauge.
+func TestResetBackupLastSuccessfulTimestamp(t *testing.T) {
+	m := NewServerMetrics()
+
+	now := time.Now()
+	m.SetBackupLastSuccessfulTimestamp("schedule-1", now)
+	m.SetBackupLastSuccessfulTimestamp("schedule-2", now.Add(-time.Hour))
+	m.SetBackupLastSuccessfulTimestamp("", now.Add(-2*time.Hour))
+
+	// Verify all three entries exist
+	g := m.metrics[backupLastSuccessfulTimestamp].(*prometheus.GaugeVec)
+	assert.Equal(t, 3, collectGaugeCount(t, g))
+
+	// Reset should remove all entries
+	m.ResetBackupLastSuccessfulTimestamp()
+	assert.Equal(t, 0, collectGaugeCount(t, g))
+}
+
+// collectGaugeCount returns the number of time series in a GaugeVec.
+func collectGaugeCount(t *testing.T, g *prometheus.GaugeVec) int {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 10)
+	g.Collect(ch)
+	close(ch)
+	count := 0
+	for range ch {
+		count++
+	}
+	return count
+}
+
 // TestRepoMaintenanceMetrics verifies that repo maintenance metrics are properly recorded.
 func TestRepoMaintenanceMetrics(t *testing.T) {
 	tests := []struct {

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -457,9 +458,9 @@ func getHistogramCount(t *testing.T, vec *prometheus.HistogramVec, scheduleLabel
 	return 0
 }
 
-// TestResetBackupLastSuccessfulTimestamp verifies that ResetBackupLastSuccessfulTimestamp
-// removes all schedule-level values from the backupLastSuccessfulTimestamp gauge.
-func TestResetBackupLastSuccessfulTimestamp(t *testing.T) {
+// TestDeleteBackupLastSuccessfulTimestamp verifies that DeleteBackupLastSuccessfulTimestamp
+// removes only the specified schedule's metric.
+func TestDeleteBackupLastSuccessfulTimestamp(t *testing.T) {
 	m := NewServerMetrics()
 
 	now := time.Now()
@@ -467,13 +468,17 @@ func TestResetBackupLastSuccessfulTimestamp(t *testing.T) {
 	m.SetBackupLastSuccessfulTimestamp("schedule-2", now.Add(-time.Hour))
 	m.SetBackupLastSuccessfulTimestamp("", now.Add(-2*time.Hour))
 
-	// Verify all three entries exist
 	g := m.metrics[backupLastSuccessfulTimestamp].(*prometheus.GaugeVec)
-	assert.Equal(t, 3, collectGaugeCount(t, g))
+	assert.Equal(t, 3, testutil.CollectAndCount(g))
 
-	// Reset should remove all entries
-	m.ResetBackupLastSuccessfulTimestamp()
-	assert.Equal(t, 0, collectGaugeCount(t, g))
+	m.DeleteBackupLastSuccessfulTimestamp("schedule-1")
+	assert.Equal(t, 2, testutil.CollectAndCount(g))
+
+	m.DeleteBackupLastSuccessfulTimestamp("schedule-2")
+	assert.Equal(t, 1, testutil.CollectAndCount(g))
+
+	m.DeleteBackupLastSuccessfulTimestamp("")
+	assert.Equal(t, 0, testutil.CollectAndCount(g))
 }
 
 // collectGaugeCount returns the number of time series in a GaugeVec.

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -473,25 +473,15 @@ func TestDeleteBackupLastSuccessfulTimestamp(t *testing.T) {
 
 	m.DeleteBackupLastSuccessfulTimestamp("schedule-1")
 	assert.Equal(t, 2, testutil.CollectAndCount(g))
+	assert.Equal(t, float64(now.Add(-time.Hour).Unix()), testutil.ToFloat64(g.WithLabelValues("schedule-2")))
+	assert.Equal(t, float64(now.Add(-2*time.Hour).Unix()), testutil.ToFloat64(g.WithLabelValues("")))
 
 	m.DeleteBackupLastSuccessfulTimestamp("schedule-2")
 	assert.Equal(t, 1, testutil.CollectAndCount(g))
+	assert.Equal(t, float64(now.Add(-2*time.Hour).Unix()), testutil.ToFloat64(g.WithLabelValues("")))
 
 	m.DeleteBackupLastSuccessfulTimestamp("")
 	assert.Equal(t, 0, testutil.CollectAndCount(g))
-}
-
-// collectGaugeCount returns the number of time series in a GaugeVec.
-func collectGaugeCount(t *testing.T, g *prometheus.GaugeVec) int {
-	t.Helper()
-	ch := make(chan prometheus.Metric, 10)
-	g.Collect(ch)
-	close(ch)
-	count := 0
-	for range ch {
-		count++
-	}
-	return count
 }
 
 // TestRepoMaintenanceMetrics verifies that repo maintenance metrics are properly recorded.


### PR DESCRIPTION
# Summary

When a schedule is deleted and its backups are removed, the `velero_backup_last_successful_timestamp` gauge metric persists until the Velero pod is restarted. The periodic resync in `updateTotalBackupMetric` (runs every 1 minute) only sets the metric for schedules with completed backups but never removes stale entries.

The fix resets the `backupLastSuccessfulTimestamp` GaugeVec before re-setting values each resync cycle so that deleted or empty schedules naturally drop off within ~1 minute.

# Does your change fix a particular issue?

Fixes #9239

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.