### PR TITLE
feat(resourcepolicies): support dataMover parameter in snapshot volum…

### DIFF
--- a/changelogs/unreleased/9829-chlins
+++ b/changelogs/unreleased/9829-chlins
@@ -1,0 +1,1 @@
+Support selecting the data mover type (velero-fs or velero-block) through the volume policy snapshot action's dataMover parameter

--- a/internal/resourcepolicies/resource_policies.go
+++ b/internal/resourcepolicies/resource_policies.go
@@ -46,12 +46,53 @@ const (
 	Custom VolumeActionType = "custom"
 )
 
+const (
+	// DataMoverParameter is the key of the action parameter that selects the data
+	// mover to be used for the matched volumes when the action type is snapshot.
+	DataMoverParameter = "dataMover"
+
+	// DataMoverVelero refers to the default built-in data mover. The default data
+	// mover may change among releases; currently it is the file system data mover.
+	DataMoverVelero = "velero"
+	// DataMoverVeleroFS refers to the Velero file system data mover.
+	DataMoverVeleroFS = "velero-fs"
+	// DataMoverVeleroBlock refers to the Velero block data mover.
+	DataMoverVeleroBlock = "velero-block"
+)
+
+// validDataMovers is the set of data mover values accepted in the snapshot
+// action's dataMover parameter.
+var validDataMovers = map[string]struct{}{
+	DataMoverVelero:      {},
+	DataMoverVeleroFS:    {},
+	DataMoverVeleroBlock: {},
+}
+
 // Action defined as one action for a specific way of backup
 type Action struct {
 	// Type defined specific type of action, currently only support 'skip'
 	Type VolumeActionType `yaml:"type"`
 	// Parameters defined map of parameters when executing a specific action
 	Parameters map[string]any `yaml:"parameters,omitempty"`
+}
+
+// GetDataMover returns the data mover configured in the snapshot action's
+// parameters. The second return value is false when the dataMover parameter is
+// not set, in which case callers should fall back to the per-backup DataMover
+// value. It only applies to the snapshot action type.
+func (a *Action) GetDataMover() (string, bool) {
+	if a == nil || a.Type != Snapshot || len(a.Parameters) == 0 {
+		return "", false
+	}
+	raw, ok := a.Parameters[DataMoverParameter]
+	if !ok {
+		return "", false
+	}
+	dataMover, ok := raw.(string)
+	if !ok {
+		return "", false
+	}
+	return dataMover, true
 }
 
 // ResourceFilter defines a filter for specific resource kinds.

--- a/internal/resourcepolicies/resource_policies_test.go
+++ b/internal/resourcepolicies/resource_policies_test.go
@@ -1242,3 +1242,53 @@ func TestPVCPhaseMatch(t *testing.T) {
 		})
 	}
 }
+
+func TestActionGetDataMover(t *testing.T) {
+	testCases := []struct {
+		name         string
+		action       *Action
+		expectedMove string
+		expectedOK   bool
+	}{
+		{
+			name:       "nil action",
+			action:     nil,
+			expectedOK: false,
+		},
+		{
+			name:       "snapshot action without parameters",
+			action:     &Action{Type: Snapshot},
+			expectedOK: false,
+		},
+		{
+			name:         "snapshot action with velero-fs dataMover",
+			action:       &Action{Type: Snapshot, Parameters: map[string]any{"dataMover": "velero-fs"}},
+			expectedMove: "velero-fs",
+			expectedOK:   true,
+		},
+		{
+			name:         "snapshot action with velero-block dataMover",
+			action:       &Action{Type: Snapshot, Parameters: map[string]any{"dataMover": "velero-block"}},
+			expectedMove: "velero-block",
+			expectedOK:   true,
+		},
+		{
+			name:       "non-snapshot action ignores dataMover",
+			action:     &Action{Type: FSBackup, Parameters: map[string]any{"dataMover": "velero-fs"}},
+			expectedOK: false,
+		},
+		{
+			name:       "snapshot action with non-string dataMover",
+			action:     &Action{Type: Snapshot, Parameters: map[string]any{"dataMover": 123}},
+			expectedOK: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dataMover, ok := tc.action.GetDataMover()
+			assert.Equal(t, tc.expectedOK, ok)
+			assert.Equal(t, tc.expectedMove, dataMover)
+		})
+	}
+}

--- a/internal/resourcepolicies/volume_resources_validator.go
+++ b/internal/resourcepolicies/volume_resources_validator.go
@@ -97,6 +97,22 @@ func (a *Action) validate() error {
 		return fmt.Errorf("invalid action type %s", a.Type)
 	}
 
-	// TODO validate parameters
+	// validate parameters
+	if raw, ok := a.Parameters[DataMoverParameter]; ok {
+		// the dataMover parameter is only meaningful for the snapshot action
+		if a.Type != Snapshot {
+			return fmt.Errorf("parameter %q is only supported for the %q action, but the action type is %q",
+				DataMoverParameter, Snapshot, a.Type)
+		}
+		dataMover, ok := raw.(string)
+		if !ok {
+			return fmt.Errorf("parameter %q must be a string, got %T", DataMoverParameter, raw)
+		}
+		if _, ok := validDataMovers[dataMover]; !ok {
+			return fmt.Errorf("invalid %q value %q, valid values are %q, %q, %q",
+				DataMoverParameter, dataMover, DataMoverVelero, DataMoverVeleroFS, DataMoverVeleroBlock)
+		}
+	}
+
 	return nil
 }

--- a/internal/resourcepolicies/volume_resources_validator_test.go
+++ b/internal/resourcepolicies/volume_resources_validator_test.go
@@ -549,6 +549,115 @@ func TestValidate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "snapshot action with valid dataMover velero-fs",
+			res: &ResourcePolicies{
+				Version: "v1",
+				VolumePolicies: []VolumePolicy{
+					{
+						Action: Action{
+							Type:       Snapshot,
+							Parameters: map[string]any{"dataMover": "velero-fs"},
+						},
+						Conditions: map[string]any{"storageClass": []string{"gp2"}},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "snapshot action with valid dataMover velero-block",
+			res: &ResourcePolicies{
+				Version: "v1",
+				VolumePolicies: []VolumePolicy{
+					{
+						Action: Action{
+							Type:       Snapshot,
+							Parameters: map[string]any{"dataMover": "velero-block"},
+						},
+						Conditions: map[string]any{"storageClass": []string{"gp2"}},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "snapshot action with valid dataMover velero",
+			res: &ResourcePolicies{
+				Version: "v1",
+				VolumePolicies: []VolumePolicy{
+					{
+						Action: Action{
+							Type:       Snapshot,
+							Parameters: map[string]any{"dataMover": "velero"},
+						},
+						Conditions: map[string]any{"storageClass": []string{"gp2"}},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "snapshot action with invalid dataMover value",
+			res: &ResourcePolicies{
+				Version: "v1",
+				VolumePolicies: []VolumePolicy{
+					{
+						Action: Action{
+							Type:       Snapshot,
+							Parameters: map[string]any{"dataMover": "unknown-mover"},
+						},
+						Conditions: map[string]any{"storageClass": []string{"gp2"}},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "snapshot action with non-string dataMover value",
+			res: &ResourcePolicies{
+				Version: "v1",
+				VolumePolicies: []VolumePolicy{
+					{
+						Action: Action{
+							Type:       Snapshot,
+							Parameters: map[string]any{"dataMover": 123},
+						},
+						Conditions: map[string]any{"storageClass": []string{"gp2"}},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "dataMover parameter on non-snapshot action is rejected",
+			res: &ResourcePolicies{
+				Version: "v1",
+				VolumePolicies: []VolumePolicy{
+					{
+						Action: Action{
+							Type:       FSBackup,
+							Parameters: map[string]any{"dataMover": "velero-fs"},
+						},
+						Conditions: map[string]any{"storageClass": []string{"gp2"}},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "snapshot action without parameters still valid",
+			res: &ResourcePolicies{
+				Version: "v1",
+				VolumePolicies: []VolumePolicy{
+					{
+						Action:     Action{Type: Snapshot},
+						Conditions: map[string]any{"storageClass": []string{"gp2"}},
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
This pull request adds support for selecting the data mover type (`velero-fs`, `velero-block`, or `velero`) through the `dataMover` parameter in the volume policy snapshot action. It introduces validation logic to ensure only valid values are accepted and updates tests to cover these scenarios.

**Data mover selection and validation:**

* Added the `dataMover` parameter to snapshot actions, allowing users to specify which data mover to use (`velero`, `velero-fs`, or `velero-block`). [[1]](diffhunk://#diff-ec2c1bb35711f0fbca0e0bcc1338614c25a9bfd5727b9f0833c75f26ec425813R49-R70) [[2]](diffhunk://#diff-b4a211bb0da7003e8ded25ae4e54e84bfbce60c8d5772d3ac7d494a7dea34461R1)
* Implemented the `GetDataMover` method on the `Action` struct to retrieve the configured data mover from action parameters.
* Enhanced validation logic to ensure that the `dataMover` parameter is only used with snapshot actions, is a string, and is one of the allowed values.

**Testing improvements:**

* Added unit tests for the new `GetDataMover` method to cover various valid and invalid configurations.
* Expanded validation tests to cover all scenarios for the `dataMover` parameter, including valid values, invalid values, type checks, and usage with non-snapshot actions.
# Does your change fix a particular issue?

Fixes https://github.com/velero-io/velero/issues/9829

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
