### PR TITLE
Derive dev-tool CLI versions from go.mod (ginkgo, protoc-gen-go, goimports)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,11 @@ GOARCH = $(word 2, $(platform_temp))
 GOPROXY ?= https://proxy.golang.org
 GOBIN=$$(pwd)/.go/bin
 
+# Keep these build-image tool versions in sync with go.mod so the CLI/library
+# pair doesn't drift (see https://github.com/velero-io/velero/issues/10023).
+PROTOC_GEN_GO_VERSION := $(shell go list -m -f '{{.Version}}' google.golang.org/protobuf)
+GOIMPORTS_VERSION := $(shell go list -m -f '{{.Version}}' golang.org/x/tools)
+
 # If you want to build all binaries, see the 'all-build' rule.
 # If you want to build all containers, see the 'all-containers' rule.
 all:
@@ -395,9 +400,9 @@ ifeq ($(BUILDX_ENABLED), true)
 ifneq ($(CONTAINER_TOOL),docker)
 	$(error $(DOCKER_ONLY_ERROR))
 endif
-	@cd hack/build-image && $(CONTAINER_TOOL) buildx build --build-arg=GOPROXY=$(GOPROXY) --output=type=docker --pull -t $(BUILDER_IMAGE) -f $(BUILDER_IMAGE_DOCKERFILE_REALPATH) .
+	@cd hack/build-image && $(CONTAINER_TOOL) buildx build --build-arg=GOPROXY=$(GOPROXY) --build-arg=PROTOC_GEN_GO_VERSION=$(PROTOC_GEN_GO_VERSION) --build-arg=GOIMPORTS_VERSION=$(GOIMPORTS_VERSION) --output=type=docker --pull -t $(BUILDER_IMAGE) -f $(BUILDER_IMAGE_DOCKERFILE_REALPATH) .
 else
-	@cd hack/build-image && $(CONTAINER_TOOL) build --build-arg=GOPROXY=$(GOPROXY) --pull -t $(BUILDER_IMAGE) -f $(BUILDER_IMAGE_DOCKERFILE_REALPATH) .
+	@cd hack/build-image && $(CONTAINER_TOOL) build --build-arg=GOPROXY=$(GOPROXY) --build-arg=PROTOC_GEN_GO_VERSION=$(PROTOC_GEN_GO_VERSION) --build-arg=GOIMPORTS_VERSION=$(GOIMPORTS_VERSION) --pull -t $(BUILDER_IMAGE) -f $(BUILDER_IMAGE_DOCKERFILE_REALPATH) .
 endif
 	$(eval new_id=$(shell $(CONTAINER_TOOL) image inspect  --format '{{ .ID }}' ${BUILDER_IMAGE} 2>/dev/null))
 	@if [ "$(old_id)" != "" ] && [ "$(old_id)" != "$(new_id)" ]; then \

--- a/hack/build-image/Dockerfile
+++ b/hack/build-image/Dockerfile
@@ -15,6 +15,8 @@
 FROM --platform=$TARGETPLATFORM golang:1.26-trixie
 
 ARG GOPROXY
+ARG PROTOC_GEN_GO_VERSION
+ARG GOIMPORTS_VERSION
 
 ENV GO111MODULE=on
 # Use a proxy for go modules to reduce the likelihood of various hosts being down and breaking the build
@@ -34,9 +36,9 @@ RUN wget --quiet https://github.com/kubernetes-sigs/kubebuilder/releases/downloa
 # get controller-tools
 RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.5
 
-# get goimports (the revision is pinned so we don't indiscriminately update, but the particular commit
-# is not important)
-RUN go install golang.org/x/tools/cmd/goimports@v0.33.0
+# get goimports, version derived from go.mod's golang.org/x/tools requirement
+# (see https://github.com/velero-io/velero/issues/10023)
+RUN go install golang.org/x/tools/cmd/goimports@${GOIMPORTS_VERSION}
 
 # get protoc compiler and golang plugin
 WORKDIR /root
@@ -71,7 +73,7 @@ RUN ARCH=$(go env GOARCH) && \
     chmod a+x /usr/include/google/protobuf && \
     chmod a+r -R /usr/include/google && \
     chmod +x /usr/bin/protoc
-RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.33.0 \
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION} \
     && go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0
 
 # get goreleaser

--- a/test/Makefile
+++ b/test/Makefile
@@ -48,6 +48,7 @@ GOBIN := $(REPO_ROOT)/.go/bin
 TOOLS_BIN_DIR := $(TOOLS_DIR)/$(BIN_DIR)
 
 GINKGO := $(GOBIN)/ginkgo
+GINKGO_VERSION := $(shell go list -m -f '{{.Version}}' github.com/onsi/ginkgo/v2 2>/dev/null)
 
 KUSTOMIZE := $(TOOLS_BIN_DIR)/kustomize
 
@@ -186,7 +187,7 @@ ginkgo: ${GOBIN}/ginkgo
 
 # This target does not run if ginkgo is already in $GOBIN
 ${GOBIN}/ginkgo:
-	GOBIN=${GOBIN} go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.0
+	GOBIN=${GOBIN} go install github.com/onsi/ginkgo/v2/ginkgo@${GINKGO_VERSION}
 
 .PHONY: run-e2e
 run-e2e: ginkgo


### PR DESCRIPTION
Fixes tool/library version drift where a `go install ...@vX` pin in build tooling falls out of sync with the version actually required by `go.mod`.

- `test/Makefile`: Ginkgo CLI was pinned to `v2.22.0` while go.mod required `v2.28.3`, causing a Ginkgo CLI/package version mismatch warning. Now derived via `go list -m`.
- `hack/build-image/Dockerfile`: same issue for `protoc-gen-go` (`v1.33.0` vs go.mod's `v1.36.12...`) and `goimports` (`v0.33.0` vs go.mod's `v0.44.0`). The Dockerfile's build context (`hack/build-image`) doesn't include `go.mod`, so versions are computed in the root `Makefile` (which does have `go.mod`) and passed through as `--build-arg`, same pattern already used for `GOPROXY`.

Left as hardcoded: `protoc-gen-go-grpc`, `controller-gen`, `setup-envtest`, `golangci-lint` — no matching go.mod entry, or versioned independently from the module they live alongside.

Fixes #10023