### PR TITLE
Bump actions/labeler from v5 to v6

### DIFF
--- a/.github/workflows/auto_label_prs.yml
+++ b/.github/workflows/auto_label_prs.yml
@@ -18,6 +18,6 @@ jobs:
     if: github.repository == 'velero-io/velero'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6
         with:
           configuration-path: .github/labeler.yml


### PR DESCRIPTION
# Please add a summary of your change

Bumps `actions/labeler` from v5 to v6 in `.github/workflows/auto_label_prs.yml`.

v5 runs on the Node.js 20 runtime, which is being retired on GitHub Actions runners. v6 ([release notes](https://github.com/actions/labeler/releases/tag/v6.0.0)) moves to Node.js 24. The only breaking change in v6 is the runtime bump — the labeler configuration format is unchanged from v5, so `.github/labeler.yml` needs no changes. v6 requires runner v2.327.1+, which GitHub-hosted `ubuntu-latest` already satisfies.

CI/workflow-only change, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Does your change fix a particular issue?

No.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.