### PR TITLE
Release wait for canceled PodVolumeBackups

### DIFF
--- a/changelogs/unreleased/10037-lifeofgurpreet
+++ b/changelogs/unreleased/10037-lifeofgurpreet
@@ -1,0 +1,1 @@
+Fix canceled PodVolumeBackups blocking file-system backup completion until timeout

--- a/pkg/podvolume/backupper.go
+++ b/pkg/podvolume/backupper.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 the Velero contributors.
+Copyright the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -181,7 +181,7 @@ func newBackupper(
 					// the PVB in the indexer is already in final status, no need to call WaitGroup.Done()
 					if ok && (existPVB.Status.Phase == velerov1api.PodVolumeBackupPhaseCompleted ||
 						existPVB.Status.Phase == velerov1api.PodVolumeBackupPhaseFailed ||
-						pvb.Status.Phase == velerov1api.PodVolumeBackupPhaseCanceled) {
+						existPVB.Status.Phase == velerov1api.PodVolumeBackupPhaseCanceled) {
 						statusChangedToFinal = false
 					}
 				}

--- a/pkg/podvolume/backupper_test.go
+++ b/pkg/podvolume/backupper_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 the Velero contributors.
+Copyright the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -845,6 +845,60 @@ func TestWaitAllPodVolumesProcessed(t *testing.T) {
 			assert.Equal(t, c.expectedPVBPhase, pvbs[0].Status.Phase)
 		}
 	}
+}
+
+func TestCanceledPodVolumeBackupCompletesWaitOnlyOnce(t *testing.T) {
+	const backupUID = "backup-uid"
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	informer := &fakeInformer{}
+	backup := builder.ForBackup(velerov1api.DefaultNamespace, "backup").
+		ObjectMeta(builder.WithUID(backupUID)).
+		Result()
+	backupper := newBackupper(ctx, logrus.New(), nil, nil, informer, nil, "", backup)
+	pvb := builder.ForPodVolumeBackup(velerov1api.DefaultNamespace, "pvb").
+		PodNamespace("pod-namespace").
+		PodName("pod-name").
+		Volume("volume").
+		Labels(map[string]string{velerov1api.BackupUIDLabel: backupUID}).
+		Phase(velerov1api.PodVolumeBackupPhaseInProgress).
+		Result()
+	require.NoError(t, backupper.pvbIndexer.Add(pvb))
+	backupper.wg.Add(1)
+
+	waitResult := make(chan []*velerov1api.PodVolumeBackup, 1)
+	go func() {
+		waitResult <- backupper.WaitAllPodVolumesProcessed(logrus.New())
+	}()
+
+	canceledPVB := pvb.DeepCopy()
+	canceledPVB.Status.Phase = velerov1api.PodVolumeBackupPhaseCanceled
+	require.NotNil(t, informer.handler)
+	require.NotPanics(t, func() {
+		informer.handler.OnUpdate(pvb, canceledPVB)
+	})
+
+	select {
+	case pvbs := <-waitResult:
+		require.NoError(t, ctx.Err(), "wait returned because its context timed out")
+		require.Len(t, pvbs, 1)
+		assert.Equal(t, velerov1api.PodVolumeBackupPhaseCanceled, pvbs[0].Status.Phase)
+	case <-time.After(time.Second):
+		t.Fatal("wait did not complete after the PodVolumeBackup was canceled")
+	}
+
+	duplicateCanceledPVB := canceledPVB.DeepCopy()
+	require.NotPanics(t, func() {
+		informer.handler.OnUpdate(canceledPVB, duplicateCanceledPVB)
+	}, "duplicate Canceled updates must not decrement the wait group")
+
+	completedPVB := canceledPVB.DeepCopy()
+	completedPVB.Status.Phase = velerov1api.PodVolumeBackupPhaseCompleted
+	require.NotPanics(t, func() {
+		informer.handler.OnUpdate(canceledPVB, completedPVB)
+	}, "cross-final updates must not decrement the wait group")
 }
 
 func TestPVCBackupSummary(t *testing.T) {


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

- Detect an already-final PodVolumeBackup from the indexed object, not the incoming update.
- Allow the first transition to Canceled to release the backup waiter.
- Cover duplicate cancellation and cross-final updates so the wait group is decremented exactly once.

# Does your change fix a particular issue?

Addresses Biji-Biji-Initiative/bbi-infrastructure#8526.

The current operand treats the first incoming Canceled update as if the indexed object were already final. The parent backup can then remain blocked until itemOperationTimeout even though every PodVolumeBackup is terminal.

# Testing

- hack/test.sh ./pkg/podvolume
- focused cancellation regression with the race detector, repeated 10 times
- git diff --check

# Backport

Please backport this fix to release-1.18 after the main PR merges. The same faulty operand is present on that branch at 99a8590b17ceff6e5005fceb237b400656d76f7b.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (make new-changelog)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment /kind changelog-not-required on this PR.
- [x] Updated documentation is not applicable; this corrects event handling and adds regression coverage.
