### PR TITLE
Fix CI: make Bitnami MinIO Dockerfile SHA lookup resilient to API/rate-limit failures

### DIFF
--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -62,8 +62,28 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          DOCKERFILE_SHA=$(curl -s -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/bitnami/containers/commits?path=bitnami/minio/2026/debian-12/Dockerfile\&per_page=1 | jq -r '.[0].sha')
-          echo "dockerfile_sha=${DOCKERFILE_SHA}" >> $GITHUB_OUTPUT
+          set -euo pipefail
+
+          url="https://api.github.com/repos/bitnami/containers/commits?path=bitnami/minio/2026/debian-12/Dockerfile&per_page=1"
+
+          response="$(curl --fail-with-body -sS \
+            --retry 5 \
+            --retry-delay 2 \
+            --retry-all-errors \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "$url")"
+
+          DOCKERFILE_SHA="$(echo "$response" | jq -r '.[0].sha // empty')"
+
+          if [ -z "$DOCKERFILE_SHA" ]; then
+            echo "Failed to resolve Bitnami MinIO Dockerfile SHA from GitHub API response"
+            echo "$response"
+            exit 1
+          fi
+
+          echo "dockerfile_sha=${DOCKERFILE_SHA}" >> "$GITHUB_OUTPUT"
       - name: Cache MinIO Image
         uses: actions/cache@v4
         id: minio-cache


### PR DESCRIPTION
## Summary
- `Check Bitnami MinIO Dockerfile version` step piped `curl` output straight into `jq` with no error handling — a non-JSON or failed HTTP response (rate limit, transient API error) caused an opaque `jq: parse error`
- Add `--fail-with-body`, retries (`--retry 5 --retry-delay 2 --retry-all-errors`), proper GitHub API headers, and validate the parsed SHA before continuing; fail with an actionable message + response body if resolution fails

Fixes #10048

## Test plan
- [ ] `yq e '.' .github/workflows/e2e-test-kind.yaml` parses clean
- [ ] CI run on this PR exercises the updated step successfully
