### PR TITLE
Fix flaky block uploader backup test

### DIFF
--- a/pkg/uploader/block/uploader.go
+++ b/pkg/uploader/block/uploader.go
@@ -172,53 +172,68 @@ func (blkup *blockUploader) backupData(reader io.ReaderAt, writer udmrepo.Object
 	totalCount := bitmap.Count()
 	aligned := (totalLength + int64(blockSize) - 1) / int64(blockSize) * int64(blockSize)
 
-	quit := make(chan struct{})
-	defer close(quit)
+	var quit chan struct{}
+	var readerDone chan struct{}
+	if totalCount > 0 {
+		quit = make(chan struct{})
+		readerDone = make(chan struct{})
 
-	go func() {
-		defer close(resultChan)
+		go func() {
+			defer func() {
+				close(resultChan)
+				close(readerDone)
+			}()
 
-		offset, valid := bitmap.Next()
-		var buffer []byte
-		for valid {
-			select {
-			case <-blkup.ctx.Done():
-				return
-			case <-quit:
-				return
-			case buffer = <-list.Chunks():
+			offset, valid := bitmap.Next()
+			var buffer []byte
+			for valid {
+				select {
+				case <-blkup.ctx.Done():
+					return
+				case <-quit:
+					return
+				case buffer = <-list.Chunks():
+				}
+
+				length := blockSize
+				if offset+uint64(length) > uint64(totalLength) {
+					length = uint(uint64(totalLength) - offset)
+					clear(buffer)
+				}
+
+				readBytes, err := reader.ReadAt(buffer[:length], int64(offset))
+				if err == nil && readBytes <= 0 {
+					err = io.ErrUnexpectedEOF
+				}
+
+				r := readResult{
+					buffer: buffer,
+					offset: int64(offset),
+					err:    err,
+				}
+
+				if r.err != nil {
+					r.resetBuffer(list)
+				}
+
+				select {
+				case resultChan <- r:
+				case <-blkup.ctx.Done():
+					r.resetBuffer(list)
+					return
+				case <-quit:
+					r.resetBuffer(list)
+					return
+				}
+
+				if r.err != nil {
+					return
+				}
+
+				offset, valid = bitmap.Next()
 			}
-
-			length := blockSize
-			if offset+uint64(length) > uint64(totalLength) {
-				length = uint(uint64(totalLength) - offset)
-				clear(buffer)
-			}
-
-			readBytes, err := reader.ReadAt(buffer[:length], int64(offset))
-			if err == nil && readBytes <= 0 {
-				err = io.ErrUnexpectedEOF
-			}
-
-			r := readResult{
-				buffer: buffer,
-				offset: int64(offset),
-				err:    err,
-			}
-
-			if r.err != nil {
-				r.resetBuffer(list)
-			}
-
-			resultChan <- r
-
-			if r.err != nil {
-				return
-			}
-
-			offset, valid = bitmap.Next()
-		}
-	}()
+		}()
+	}
 
 	var lastPos int64
 	var result readResult
@@ -267,6 +282,11 @@ func (blkup *blockUploader) backupData(reader io.ReaderAt, writer udmrepo.Object
 		curCount++
 
 		blkup.progress.UpdateProgress(&uploader.Progress{BytesDone: lastPos, TotalBytes: aligned})
+	}
+
+	if readerDone != nil {
+		close(quit)
+		<-readerDone
 	}
 
 	result.resetBuffer(list)

--- a/pkg/uploader/block/uploader_test.go
+++ b/pkg/uploader/block/uploader_test.go
@@ -340,10 +340,9 @@ func TestBlockUploaderBackup(t *testing.T) {
 
 						objWriter.On("Result").Return(udmrepo.ID(""), errors.New("write failed")).Maybe()
 					} else {
-						// Setup backupData sequence: next returns false immediately
+						// No allocated or changed blocks; backupData should not advance the iterator.
 						iterMock.On("BlockSize").Return(uint(1048576))
 						iterMock.On("Count").Return(uint64(0))
-						iterMock.On("Next").Return(uint64(0), false)
 
 						if tc.writeObjErr != nil {
 							objWriter.On("WriteAt", mock.Anything, mock.Anything).Return(0, tc.writeObjErr)


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
This pull request improves the concurrency handling and resource management in the `blockUploader.backupData` method. The changes ensure that goroutines are only started when necessary, channels are properly closed to avoid leaks, and the backup process is more robust in handling cancellation and completion signals.

**Concurrency and resource management improvements:**

* Only create and start the goroutine for reading blocks if there are blocks to process (`totalCount > 0`), preventing unnecessary goroutine launches and channel allocations. [[1]](diffhunk://#diff-19b278465c5511c35f057e3970383d266fbdef7bea07a1957d2ffdf9166645e6L175-R185) [[2]](diffhunk://#diff-19b278465c5511c35f057e3970383d266fbdef7bea07a1957d2ffdf9166645e6R236)
* Introduced a `readerDone` channel to signal when the reading goroutine has finished, and ensured the main function waits for its completion before proceeding, improving synchronization and preventing premature resource cleanup. [[1]](diffhunk://#diff-19b278465c5511c35f057e3970383d266fbdef7bea07a1957d2ffdf9166645e6L175-R185) [[2]](diffhunk://#diff-19b278465c5511c35f057e3970383d266fbdef7bea07a1957d2ffdf9166645e6R287-R291)
* Enhanced the select statement when sending results to handle context cancellation (`blkup.ctx.Done()`) and the `quit` signal, ensuring proper cleanup and early exit in error scenarios.
* Updated the test to clarify that when there are no allocated or changed blocks, the backup process should not advance the iterator, aligning the test comments with the new logic.
# Does your change fix a particular issue?

Fixes https://github.com/velero-io/velero/issues/10022

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
