### PR TITLE
build(image): remove kubectl installation from build image

### DIFF
--- a/hack/build-image/Dockerfile
+++ b/hack/build-image/Dockerfile
@@ -100,10 +100,5 @@ RUN ARCH=$(go env GOARCH) && \
 # release API/CDN, which has been returning intermittent/persistent HTTP 504s.
 RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
 
-# install kubectl
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/$(go env GOARCH)/kubectl
-RUN chmod +x ./kubectl
-RUN mv ./kubectl /usr/local/bin
-
 # Fix the "dubious ownership" issue from git when running goreleaser.sh
 RUN echo "[safe] \n\t directory = *" > /.gitconfig


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
This pull request makes a small change to the Docker build process by removing the installation of `kubectl` from the `hack/build-image/Dockerfile`. This simplifies the image and may reduce its size and build time.

* Removed the steps that download, add execute permissions to, and move `kubectl` into `/usr/local/bin` in `hack/build-image/Dockerfile`
# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
