### PR TITLE
Issue #10043: Verify owner/permissions of restored entries and warn on mismatches

### DIFF
--- a/pkg/uploader/kopia/restore_verify.go
+++ b/pkg/uploader/kopia/restore_verify.go
@@ -1,0 +1,232 @@
+//go:build !windows
+// +build !windows
+
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kopia
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/kopia/kopia/fs"
+)
+
+const (
+	// maxAttrVerifyEntries caps how many restored entries are verified. Attribute
+	// loss is caused by the nature of the target volume's mount (e.g. root-squashed
+	// NFS, CIFS/FUSE mounts with a fixed identity), which affects all entries in the
+	// volume the same way, so verifying a small sample is enough to detect it without
+	// impacting the restore throughput in the large scale cases.
+	maxAttrVerifyEntries = 50
+
+	// maxAttrMismatchSamples caps how many mismatched entries are listed in the warning log.
+	maxAttrMismatchSamples = 5
+)
+
+type attrMismatch struct {
+	localPath     string
+	uid           uint32
+	gid           uint32
+	mode          os.FileMode
+	ownerMismatch bool
+}
+
+type attrVerifyResult struct {
+	checked       int
+	ownerMismatch int
+	modeMismatch  int
+	samples       []string
+	first         *attrMismatch
+}
+
+// verifyRestoredAttrs samples up to maxAttrVerifyEntries entries restored under
+// targetPath and compares the owner (uid:gid) and permission bits on disk with the
+// metadata recorded in the snapshot. The restore runs with IgnorePermissionErrors,
+// so a chown/chmod rejected by the target volume is silently swallowed; and some
+// mounts even report success for chown/chmod without applying anything. Both end
+// up as a completed restore with wrong attributes. This check makes such restores
+// visible through a warning log; it never fails the restore.
+func verifyRestoredAttrs(ctx context.Context, rootEntry fs.Entry, targetPath string, log logrus.FieldLogger) {
+	rootDir, ok := rootEntry.(fs.Directory)
+	if !ok {
+		return
+	}
+
+	result := attrVerifyResult{}
+
+	type pendingDir struct {
+		dir     fs.Directory
+		relPath string
+	}
+
+	pending := []pendingDir{{dir: rootDir}}
+
+	for len(pending) > 0 && result.checked < maxAttrVerifyEntries {
+		cur := pending[0]
+		pending = pending[1:]
+
+		iter, err := cur.dir.Iterate(ctx)
+		if err != nil {
+			log.WithError(err).Debugf("Failed to iterate snapshot directory %q to verify restored attributes", cur.relPath)
+			continue
+		}
+
+		entry, err := iter.Next(ctx)
+		for entry != nil && result.checked < maxAttrVerifyEntries {
+			relPath := filepath.Join(cur.relPath, entry.Name())
+
+			if subDir, ok := entry.(fs.Directory); ok {
+				pending = append(pending, pendingDir{dir: subDir, relPath: relPath})
+			}
+
+			verifyEntryAttrs(entry, relPath, targetPath, &result)
+
+			entry, err = iter.Next(ctx)
+		}
+
+		iter.Close()
+
+		if err != nil {
+			log.WithError(err).Debugf("Failed to iterate snapshot directory %q to verify restored attributes", cur.relPath)
+		}
+	}
+
+	if result.ownerMismatch == 0 && result.modeMismatch == 0 {
+		log.Debugf("Verified owner/permissions of %d entries restored to %s", result.checked, targetPath)
+		return
+	}
+
+	log.Warnf("Restored data in %s doesn't match the owner/permissions recorded in the snapshot (%d of %d checked entries with unexpected owner, %d with unexpected permissions; %s), samples: [%s]. The volume's mount likely cannot apply these attributes, e.g. root-squashed NFS or CIFS/FUSE mounts with a fixed identity",
+		targetPath, result.ownerMismatch, result.checked, result.modeMismatch, classifyAttrMismatch(result.first), strings.Join(result.samples, "; "))
+}
+
+// verifyEntryAttrs compares the on-disk owner and permission bits of the entry
+// restored to targetPath/relPath with the ones recorded in the snapshot entry and
+// accumulates mismatches into result.
+func verifyEntryAttrs(entry fs.Entry, relPath, targetPath string, result *attrVerifyResult) {
+	// Symlinks and special files need OS specific attribute handling in kopia;
+	// regular files and directories are enough to detect a volume that cannot
+	// apply the attributes recorded in the snapshot.
+	if !entry.Mode().IsRegular() && !entry.Mode().IsDir() {
+		return
+	}
+
+	localPath := filepath.Join(targetPath, relPath)
+
+	st, err := os.Lstat(localPath)
+	if err != nil {
+		return
+	}
+
+	sys, ok := st.Sys().(*syscall.Stat_t)
+	if !ok {
+		return
+	}
+
+	result.checked++
+
+	owner := entry.Owner()
+	expectedMode := entry.Mode() & fs.ModBits
+	actualMode := st.Mode() & fs.ModBits
+
+	ownerMatch := sys.Uid == owner.UserID && sys.Gid == owner.GroupID
+	modeMatch := actualMode == expectedMode
+
+	if ownerMatch && modeMatch {
+		return
+	}
+
+	if !ownerMatch {
+		result.ownerMismatch++
+	}
+
+	if !modeMatch {
+		result.modeMismatch++
+	}
+
+	if result.first == nil {
+		result.first = &attrMismatch{
+			localPath:     localPath,
+			uid:           owner.UserID,
+			gid:           owner.GroupID,
+			mode:          expectedMode,
+			ownerMismatch: !ownerMatch,
+		}
+	}
+
+	if len(result.samples) < maxAttrMismatchSamples {
+		result.samples = append(result.samples, fmt.Sprintf("%s: expected %d:%d %04o, actual %d:%d %04o",
+			relPath, owner.UserID, owner.GroupID, modeOctal(expectedMode), sys.Uid, sys.Gid, modeOctal(actualMode)))
+	}
+}
+
+// classifyAttrMismatch re-applies the expected attribute on one mismatched entry to
+// differentiate the known failure modes: the volume rejecting the change with an
+// error that was swallowed by IgnorePermissionErrors during the restore, or the
+// volume acknowledging the change without applying it.
+func classifyAttrMismatch(m *attrMismatch) string {
+	if m.ownerMismatch {
+		if err := os.Chown(m.localPath, int(m.uid), int(m.gid)); err != nil {
+			return fmt.Sprintf("chown is rejected by the volume: %v", err)
+		}
+
+		if st, err := os.Lstat(m.localPath); err == nil {
+			if sys, ok := st.Sys().(*syscall.Stat_t); ok && (sys.Uid != m.uid || sys.Gid != m.gid) {
+				return "chown reports success but is silently ignored by the volume"
+			}
+		}
+
+		return "chown succeeded when retried"
+	}
+
+	if err := os.Chmod(m.localPath, m.mode); err != nil {
+		return fmt.Sprintf("chmod is rejected by the volume: %v", err)
+	}
+
+	if st, err := os.Lstat(m.localPath); err == nil && st.Mode()&fs.ModBits != m.mode {
+		return "chmod reports success but is silently ignored by the volume"
+	}
+
+	return "chmod succeeded when retried"
+}
+
+// modeOctal converts an os.FileMode to the familiar octal representation,
+// including the setuid/setgid/sticky bits.
+func modeOctal(mode os.FileMode) uint32 {
+	bits := uint32(mode.Perm())
+
+	if mode&os.ModeSetuid != 0 {
+		bits |= 0o4000
+	}
+
+	if mode&os.ModeSetgid != 0 {
+		bits |= 0o2000
+	}
+
+	if mode&os.ModeSticky != 0 {
+		bits |= 0o1000
+	}
+
+	return bits
+}

--- a/pkg/uploader/kopia/restore_verify.go
+++ b/pkg/uploader/kopia/restore_verify.go
@@ -176,7 +176,7 @@ func verifyEntryAttrs(entry fs.Entry, relPath, targetPath string, result *attrVe
 	}
 
 	if len(result.samples) < maxAttrMismatchSamples {
-		result.samples = append(result.samples, fmt.Sprintf("%s: expected %d:%d %04o, actual %d:%d %04o",
+		result.samples = append(result.samples, fmt.Sprintf("%s: expected %d:%d %04o, observed %d:%d %04o",
 			relPath, owner.UserID, owner.GroupID, modeOctal(expectedMode), sys.Uid, sys.Gid, modeOctal(actualMode)))
 	}
 }
@@ -187,6 +187,10 @@ func verifyEntryAttrs(entry fs.Entry, relPath, targetPath string, result *attrVe
 // volume acknowledging the change without applying it.
 func classifyAttrMismatch(m *attrMismatch) string {
 	if m.ownerMismatch {
+		maxInt := uint64(^uint(0) >> 1)
+		if uint64(m.uid) > maxInt || uint64(m.gid) > maxInt {
+			return fmt.Sprintf("chown cannot be retried on this platform (uid/gid out of int range): %d:%d", m.uid, m.gid)
+		}
 		if err := os.Chown(m.localPath, int(m.uid), int(m.gid)); err != nil {
 			return fmt.Sprintf("chown is rejected by the volume: %v", err)
 		}

--- a/pkg/uploader/kopia/restore_verify_test.go
+++ b/pkg/uploader/kopia/restore_verify_test.go
@@ -131,7 +131,7 @@ func TestVerifyRestoredAttrs(t *testing.T) {
 			expectedWarns: []string{
 				"doesn't match the owner/permissions recorded in the snapshot",
 				"1 of 1 checked entries with unexpected owner",
-				fmt.Sprintf("file1: expected %d:%d 0640, actual %d:%d 0640", otherOwner.UserID, otherOwner.GroupID, owner.UserID, owner.GroupID),
+				fmt.Sprintf("file1: expected %d:%d 0640, observed %d:%d 0640", otherOwner.UserID, otherOwner.GroupID, owner.UserID, owner.GroupID),
 				"chown",
 			},
 		},
@@ -150,7 +150,7 @@ func TestVerifyRestoredAttrs(t *testing.T) {
 			},
 			expectedWarns: []string{
 				"1 with unexpected permissions",
-				fmt.Sprintf("file1: expected %d:%d 0600, actual %d:%d 0644", owner.UserID, owner.GroupID, owner.UserID, owner.GroupID),
+				fmt.Sprintf("file1: expected %d:%d 0600, observed %d:%d 0644", owner.UserID, owner.GroupID, owner.UserID, owner.GroupID),
 				"chmod succeeded when retried",
 			},
 		},

--- a/pkg/uploader/kopia/restore_verify_test.go
+++ b/pkg/uploader/kopia/restore_verify_test.go
@@ -1,0 +1,258 @@
+//go:build !windows
+// +build !windows
+
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kopia
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kopia/kopia/fs"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeEntry struct {
+	name  string
+	mode  os.FileMode
+	owner fs.OwnerInfo
+}
+
+func (e *fakeEntry) Name() string                { return e.name }
+func (e *fakeEntry) Size() int64                 { return 0 }
+func (e *fakeEntry) Mode() os.FileMode           { return e.mode }
+func (e *fakeEntry) ModTime() time.Time          { return time.Time{} }
+func (e *fakeEntry) IsDir() bool                 { return e.mode.IsDir() }
+func (e *fakeEntry) Sys() any                    { return nil }
+func (e *fakeEntry) Owner() fs.OwnerInfo         { return e.owner }
+func (e *fakeEntry) Device() fs.DeviceInfo       { return fs.DeviceInfo{} }
+func (e *fakeEntry) LocalFilesystemPath() string { return "" }
+func (e *fakeEntry) Close()                      {}
+
+type fakeDirectory struct {
+	fakeEntry
+	entries []fs.Entry
+}
+
+func (d *fakeDirectory) Child(ctx context.Context, name string) (fs.Entry, error) {
+	return fs.IterateEntriesAndFindChild(ctx, d, name)
+}
+
+func (d *fakeDirectory) Iterate(ctx context.Context) (fs.DirectoryIterator, error) {
+	return fs.StaticIterator(d.entries, nil), nil
+}
+
+func (d *fakeDirectory) SupportsMultipleIterations() bool { return true }
+
+func TestVerifyRestoredAttrs(t *testing.T) {
+	owner := fs.OwnerInfo{UserID: uint32(os.Getuid()), GroupID: uint32(os.Getgid())}
+	otherOwner := fs.OwnerInfo{UserID: owner.UserID + 1, GroupID: owner.GroupID}
+
+	writeFile := func(t *testing.T, path string, mode os.FileMode) {
+		t.Helper()
+		require.NoError(t, os.WriteFile(path, []byte("data"), mode))
+		require.NoError(t, os.Chmod(path, mode))
+	}
+
+	type testCase struct {
+		name          string
+		setup         func(t *testing.T, dir string) fs.Entry
+		expectedWarns []string
+		expectedDebug string
+	}
+
+	testCases := []testCase{
+		{
+			name: "root entry is not a directory",
+			setup: func(t *testing.T, dir string) fs.Entry {
+				t.Helper()
+				return &fakeEntry{name: "root", mode: 0o640, owner: owner}
+			},
+		},
+		{
+			name: "all attributes match",
+			setup: func(t *testing.T, dir string) fs.Entry {
+				t.Helper()
+				writeFile(t, filepath.Join(dir, "file1"), 0o640)
+				require.NoError(t, os.Mkdir(filepath.Join(dir, "sub"), 0o750))
+				require.NoError(t, os.Chmod(filepath.Join(dir, "sub"), 0o750))
+				writeFile(t, filepath.Join(dir, "sub", "file2"), 0o600)
+
+				return &fakeDirectory{
+					fakeEntry: fakeEntry{name: "root", mode: os.ModeDir | 0o755, owner: owner},
+					entries: []fs.Entry{
+						&fakeEntry{name: "file1", mode: 0o640, owner: owner},
+						&fakeDirectory{
+							fakeEntry: fakeEntry{name: "sub", mode: os.ModeDir | 0o750, owner: owner},
+							entries: []fs.Entry{
+								&fakeEntry{name: "file2", mode: 0o600, owner: owner},
+							},
+						},
+					},
+				}
+			},
+			expectedDebug: "Verified owner/permissions of 3 entries",
+		},
+		{
+			name: "owner mismatch is detected and classified",
+			setup: func(t *testing.T, dir string) fs.Entry {
+				t.Helper()
+				writeFile(t, filepath.Join(dir, "file1"), 0o640)
+
+				return &fakeDirectory{
+					fakeEntry: fakeEntry{name: "root", mode: os.ModeDir | 0o755, owner: owner},
+					entries: []fs.Entry{
+						&fakeEntry{name: "file1", mode: 0o640, owner: otherOwner},
+					},
+				}
+			},
+			expectedWarns: []string{
+				"doesn't match the owner/permissions recorded in the snapshot",
+				"1 of 1 checked entries with unexpected owner",
+				fmt.Sprintf("file1: expected %d:%d 0640, actual %d:%d 0640", otherOwner.UserID, otherOwner.GroupID, owner.UserID, owner.GroupID),
+				"chown",
+			},
+		},
+		{
+			name: "permission mismatch is detected and classified",
+			setup: func(t *testing.T, dir string) fs.Entry {
+				t.Helper()
+				writeFile(t, filepath.Join(dir, "file1"), 0o644)
+
+				return &fakeDirectory{
+					fakeEntry: fakeEntry{name: "root", mode: os.ModeDir | 0o755, owner: owner},
+					entries: []fs.Entry{
+						&fakeEntry{name: "file1", mode: 0o600, owner: owner},
+					},
+				}
+			},
+			expectedWarns: []string{
+				"1 with unexpected permissions",
+				fmt.Sprintf("file1: expected %d:%d 0600, actual %d:%d 0644", owner.UserID, owner.GroupID, owner.UserID, owner.GroupID),
+				"chmod succeeded when retried",
+			},
+		},
+		{
+			name: "missing and non-regular entries are skipped",
+			setup: func(t *testing.T, dir string) fs.Entry {
+				t.Helper()
+				writeFile(t, filepath.Join(dir, "file1"), 0o640)
+
+				return &fakeDirectory{
+					fakeEntry: fakeEntry{name: "root", mode: os.ModeDir | 0o755, owner: owner},
+					entries: []fs.Entry{
+						&fakeEntry{name: "file1", mode: 0o640, owner: owner},
+						&fakeEntry{name: "ghost", mode: 0o640, owner: otherOwner},
+						&fakeEntry{name: "link", mode: os.ModeSymlink | 0o777, owner: otherOwner},
+					},
+				}
+			},
+			expectedDebug: "Verified owner/permissions of 1 entries",
+		},
+		{
+			name: "verified entries are capped",
+			setup: func(t *testing.T, dir string) fs.Entry {
+				t.Helper()
+				entries := []fs.Entry{}
+				for i := range maxAttrVerifyEntries + 5 {
+					name := fmt.Sprintf("file%d", i)
+					writeFile(t, filepath.Join(dir, name), 0o640)
+					entries = append(entries, &fakeEntry{name: name, mode: 0o640, owner: owner})
+				}
+
+				return &fakeDirectory{
+					fakeEntry: fakeEntry{name: "root", mode: os.ModeDir | 0o755, owner: owner},
+					entries:   entries,
+				}
+			},
+			expectedDebug: fmt.Sprintf("Verified owner/permissions of %d entries", maxAttrVerifyEntries),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			rootEntry := tc.setup(t, dir)
+
+			logger, hook := test.NewNullLogger()
+			logger.SetLevel(logrus.DebugLevel)
+
+			verifyRestoredAttrs(t.Context(), rootEntry, dir, logger)
+
+			warns := []string{}
+			debugs := []string{}
+			for _, entry := range hook.AllEntries() {
+				switch entry.Level {
+				case logrus.WarnLevel:
+					warns = append(warns, entry.Message)
+				case logrus.DebugLevel:
+					debugs = append(debugs, entry.Message)
+				}
+			}
+
+			if len(tc.expectedWarns) == 0 {
+				assert.Empty(t, warns)
+			} else {
+				require.Len(t, warns, 1)
+				for _, expected := range tc.expectedWarns {
+					assert.Contains(t, warns[0], expected)
+				}
+			}
+
+			if tc.expectedDebug != "" {
+				require.Len(t, debugs, 1)
+				assert.Contains(t, debugs[0], tc.expectedDebug)
+			}
+		})
+	}
+}
+
+func TestClassifyAttrMismatch(t *testing.T) {
+	t.Run("chmod succeeds when retried", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "file1")
+		require.NoError(t, os.WriteFile(path, []byte("data"), 0o644))
+
+		verdict := classifyAttrMismatch(&attrMismatch{localPath: path, mode: 0o600})
+
+		assert.Equal(t, "chmod succeeded when retried", verdict)
+
+		st, err := os.Lstat(path)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o600), st.Mode()&fs.ModBits)
+	})
+
+	t.Run("chmod is rejected on a missing file", func(t *testing.T) {
+		verdict := classifyAttrMismatch(&attrMismatch{localPath: filepath.Join(t.TempDir(), "missing"), mode: 0o600})
+
+		assert.Contains(t, verdict, "chmod is rejected by the volume")
+	})
+}
+
+func TestModeOctal(t *testing.T) {
+	assert.Equal(t, uint32(0o640), modeOctal(0o640))
+	assert.Equal(t, uint32(0o4755), modeOctal(os.ModeSetuid|0o755))
+	assert.Equal(t, uint32(0o2750), modeOctal(os.ModeSetgid|0o750))
+	assert.Equal(t, uint32(0o1777), modeOctal(os.ModeSticky|0o777))
+}

--- a/pkg/uploader/kopia/restore_verify_windows.go
+++ b/pkg/uploader/kopia/restore_verify_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+// +build windows
+
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kopia
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/kopia/kopia/fs"
+)
+
+// verifyRestoredAttrs is a no-op on Windows: kopia doesn't restore POSIX
+// owners there, so there is nothing to verify.
+func verifyRestoredAttrs(_ context.Context, _ fs.Entry, _ string, _ logrus.FieldLogger) {
+}

--- a/pkg/uploader/kopia/snapshot.go
+++ b/pkg/uploader/kopia/snapshot.go
@@ -487,5 +487,9 @@ func Restore(ctx context.Context, rep repo.RepositoryWriter, progress *Progress,
 		log.Infof("Flush done for volume dir %v", path)
 	}
 
+	if volMode == uploader.PersistentVolumeFilesystem {
+		verifyRestoredAttrs(kopiaCtx, rootEntry, path, log)
+	}
+
 	return stat.RestoredTotalFileSize, stat.RestoredFileCount, nil
 }

--- a/pkg/uploader/kopia/snapshot_test.go
+++ b/pkg/uploader/kopia/snapshot_test.go
@@ -719,6 +719,17 @@ func TestRestore(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name: "Expect successful with attributes verification for directory root entry",
+			filesystemEntryFunc: func(ctx context.Context, rep repo.Repository, rootID string, consistentAttributes bool) (fs.Entry, error) {
+				return virtualfs.NewStaticDirectory("fake-dir", nil), nil
+			},
+			restoreEntryFunc: func(ctx context.Context, rep repo.Repository, output restore.Output, rootEntry fs.Entry, options restore.Options) (restore.Stats, error) {
+				return restore.Stats{}, nil
+			},
+			snapshotID:    "snapshot-123",
+			expectedError: nil,
+		},
+		{
 			name: "Expect block volume successful",
 			filesystemEntryFunc: func(ctx context.Context, rep repo.Repository, rootID string, consistentAttributes bool) (fs.Entry, error) {
 				return snapshotfs.EntryFromDirEntry(rep, &snapshot.DirEntry{Type: snapshot.EntryTypeFile}), nil


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

Phase 1 (detect & log) of #10043: after a successful filesystem-mode kopia restore, verify that the restored data actually carries the owner (uid:gid) and permission bits recorded in the snapshot, and emit a warning in the node-agent log when it doesn't.

Today two empirically proven failure modes end in a `Completed` restore with wrong owners/permissions and no signal anywhere:

1. **Swallowed EPERM** — `pkg/uploader/kopia/snapshot.go` hardcodes `IgnorePermissionErrors: true`, so a chown/chmod rejected by the volume (root-squashed NFS, NFSv4 idmap SETATTR failure, #10040) is silently eaten by kopia's `maybeIgnorePermissionError`.
2. **Fake-success chown/chmod** — CIFS (Azure Files) and blobfuse mounts return success for chown/chmod without applying anything (#10044), so there is no error for any error-path fix to catch.

Following the maintainer feedback on the issue (https://github.com/vmware-tanzu/velero/issues/10043#issuecomment-5030815916), this implementation deliberately:

- **Lives entirely in Velero** — no change to the `project-velero/kopia` fork; generic kopia changes belong upstream.
- **Does not lstat every restored file** — attribute loss is caused by the nature of the target volume's mount, which affects all entries in the volume the same way, so the check samples up to 50 restored entries (breadth-first over the snapshot tree, regular files and directories) and compares their on-disk uid:gid and permission bits with the snapshot metadata. Cost is at most 50 `lstat` calls per restore, independent of volume size.
- **Differentiates the setAttr failure modes** (the open question in the issue thread): when a mismatch is found, the expected attribute change is re-applied on a single mismatched entry — an error means the volume *rejects* the change (the error was swallowed during restore because of `IgnorePermissionErrors`); success followed by an unchanged `lstat` means the volume *acknowledges the change without applying it* (CIFS/blobfuse fake-success). The classification is included in the warning.

Example warning (node-agent / data-mover pod log):

```
Restored data in /host_pods/.../volumes/... doesn't match the owner/permissions recorded in the snapshot (12 of 50 checked entries with unexpected owner, 0 with unexpected permissions; chown is rejected by the volume: chown /host_pods/.../data/app.conf: operation not permitted), samples: [data/app.conf: expected 1001:1001 0640, actual 65534:65534 0640; ...]. The volume's mount likely cannot apply these attributes, e.g. root-squashed NFS or CIFS/FUSE mounts with a fixed identity
```

The check never fails the restore (behavior-preserving, per the issue's scope notes), runs only for filesystem-mode restores, and is a no-op on Windows where kopia does not restore POSIX owners.

Phase 2 (propagating the result into `datapath.RestoreResult` → PodVolumeRestore / DataDownload status → restore warnings so `velero restore describe` shows it) is left for a follow-up PR, as staged in the issue.

# Does your change fix a particular issue?

Part of #10043 (phase 1 — detect & log; phase 2, surfacing to `velero restore describe`, will follow). Detection consolidated from #10044; complements #10040.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`. (Log-only change; the user-facing limitation docs are scoped to #10044.)
