### PR TITLE
Fix stale 'Latest Release Information' link on velero.io

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -10,7 +10,7 @@ hero:
   content: Velero is an open source tool to safely backup and restore, perform disaster recovery, and migrate Kubernetes cluster resources and persistent volumes.
   cta_link1:
     text: Latest Release Information
-    url: /blog/Velero-1.11/
+    url: https://github.com/velero-io/velero/releases/latest
   cta_link2:
     text:  Download Velero
     url: https://github.com/velero-io/velero/releases/latest


### PR DESCRIPTION
# Summary

Update the "Latest Release Information" CTA link on the velero.io landing page from the outdated `/blog/Velero-1.11/` blog post to `https://github.com/velero-io/velero/releases/latest`, which always resolves to the most recent release and will not go stale.

# Does your change fix a particular issue?

Fixes #10080

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.