### PR TITLE
ci(push): pin action versions to commit SHAs and restrict permissions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,6 +8,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   get-go-version:
     uses: ./.github/workflows/get-go-version.yaml
@@ -20,21 +23,21 @@ jobs:
     needs: get-go-version
     steps:
       - name: Check out the code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up Go version
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ needs.get-go-version.outputs.version }}
 
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
         with:
           platforms: all
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           version: latest
       - name: Build
@@ -45,7 +48,7 @@ jobs:
       - name: Test
         run: make test
       - name: Upload test coverage
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
This pull request updates the GitHub Actions workflow configuration to improve security and reliability by pinning action dependencies to specific commit SHAs and explicitly setting permissions. The most important changes are:

Security and permissions:

* Added a `permissions` block with `contents: read` to the workflow, restricting the default token's access and following GitHub's best practices.

Dependency pinning:

* Updated all workflow action dependencies (such as `actions/checkout`, `actions/setup-go`, `docker/setup-qemu-action`, `docker/setup-buildx-action`, and `codecov/codecov-action`) to use specific commit SHAs instead of version tags, reducing the risk of supply chain attacks and ensuring consistent builds. [[1]](diffhunk://#diff-f3fc934cf0d89bdf07de358896ff90f1202585df812cf606206d1830a9949811L23-R40) [[2]](diffhunk://#diff-f3fc934cf0d89bdf07de358896ff90f1202585df812cf606206d1830a9949811L48-R51)
# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
