### PR TITLE
fix(kopia): fix block restore write loop slice bounds

### DIFF
--- a/changelogs/unreleased/10090-Jay2006sawant
+++ b/changelogs/unreleased/10090-Jay2006sawant
@@ -1,0 +1,1 @@
+Fix Kopia block restore write loop slice bounds bug during partial writes

--- a/pkg/uploader/kopia/block_restore.go
+++ b/pkg/uploader/kopia/block_restore.go
@@ -49,7 +49,7 @@ func (o *BlockOutput) WriteFile(ctx context.Context, relativePath string, remote
 	}
 	defer remoteReader.Close()
 
-	targetFile, err := os.Create(o.targetFileName)
+	targetFile, err := os.OpenFile(o.targetFileName, os.O_RDWR, 0)
 	if err != nil {
 		return errors.Wrapf(err, "failed to open file %s", o.targetFileName)
 	}
@@ -68,19 +68,29 @@ func (o *BlockOutput) WriteFile(ctx context.Context, relativePath string, remote
 		}
 
 		if bytesToWrite > 0 {
-			offset := 0
-			for bytesToWrite > 0 {
-				if bytesWritten, err := targetFile.Write(buffer[offset:bytesToWrite]); err == nil {
-					progressCb(int64(bytesWritten))
-					bytesToWrite -= bytesWritten
-					offset += bytesWritten
-				} else {
-					return errors.Wrapf(err, "failed to write data to file %s", o.targetFileName)
-				}
+			if err := writeBufferContents(targetFile, buffer, bytesToWrite, progressCb); err != nil {
+				return errors.Wrapf(err, "failed to write data to file %s", o.targetFileName)
 			}
 		}
 	}
 
+	return nil
+}
+
+func writeBufferContents(w io.Writer, buffer []byte, bytesToWrite int, progressCb restore.FileWriteProgress) error {
+	offset := 0
+	for bytesToWrite > 0 {
+		bytesWritten, err := w.Write(buffer[offset : offset+bytesToWrite])
+		if err != nil {
+			return err
+		}
+		if bytesWritten == 0 {
+			return io.ErrShortWrite
+		}
+		progressCb(int64(bytesWritten))
+		bytesToWrite -= bytesWritten
+		offset += bytesWritten
+	}
 	return nil
 }
 

--- a/pkg/uploader/kopia/block_restore_test.go
+++ b/pkg/uploader/kopia/block_restore_test.go
@@ -1,0 +1,200 @@
+//go:build !windows
+// +build !windows
+
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kopia
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kopia/kopia/fs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type partialWriter struct {
+	limit int
+}
+
+func (p *partialWriter) Write(b []byte) (int, error) {
+	n := len(b)
+	if n > p.limit {
+		n = p.limit
+	}
+	return n, nil
+}
+
+type zeroWriter struct{}
+
+func (zeroWriter) Write([]byte) (int, error) {
+	return 0, nil
+}
+
+type errorWriter struct {
+	err error
+}
+
+func (e errorWriter) Write([]byte) (int, error) {
+	return 0, e.err
+}
+
+func TestWriteBufferContentsPartialWrites(t *testing.T) {
+	data := make([]byte, 256)
+	for i := range data {
+		data[i] = byte(i)
+	}
+
+	var progress int64
+	err := writeBufferContents(&partialWriter{limit: 50}, data, len(data), func(n int64) {
+		progress += n
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(data)), progress)
+}
+
+func TestWriteBufferContentsZeroWriteReturnsError(t *testing.T) {
+	data := []byte("test")
+	err := writeBufferContents(zeroWriter{}, data, len(data), func(int64) {})
+	require.ErrorIs(t, err, io.ErrShortWrite)
+}
+
+func TestWriteBufferContentsWriteError(t *testing.T) {
+	writeErr := errors.New("write failed")
+	data := []byte("test")
+	err := writeBufferContents(errorWriter{err: writeErr}, data, len(data), func(int64) {})
+	require.ErrorIs(t, err, writeErr)
+}
+
+func TestWriteBufferContentsIncorrectSliceEndPanics(t *testing.T) {
+	data := make([]byte, 256)
+
+	panicked := false
+	func() {
+		defer func() {
+			if recover() != nil {
+				panicked = true
+			}
+		}()
+
+		pw := &partialWriter{limit: 50}
+		buffer := data
+		bytesToWrite := len(buffer)
+		offset := 0
+		for bytesToWrite > 0 {
+			n, _ := pw.Write(buffer[offset:bytesToWrite])
+			bytesToWrite -= n
+			offset += n
+		}
+	}()
+
+	assert.True(t, panicked, "incorrect slice end should panic on partial writes")
+}
+
+type mockFile struct {
+	name    string
+	size    int64
+	reader  io.ReadCloser
+	openErr error
+}
+
+func (m *mockFile) Name() string                { return m.name }
+func (m *mockFile) Size() int64                 { return m.size }
+func (m *mockFile) Mode() os.FileMode           { return 0o644 }
+func (m *mockFile) ModTime() time.Time          { return time.Time{} }
+func (m *mockFile) IsDir() bool                 { return false }
+func (m *mockFile) Sys() any                    { return nil }
+func (m *mockFile) Owner() fs.OwnerInfo         { return fs.OwnerInfo{} }
+func (m *mockFile) Device() fs.DeviceInfo       { return fs.DeviceInfo{} }
+func (m *mockFile) LocalFilesystemPath() string { return "" }
+func (m *mockFile) Close()                      {}
+func (m *mockFile) Open(context.Context) (fs.Reader, error) {
+	if m.openErr != nil {
+		return nil, m.openErr
+	}
+	return &mockReader{reader: m.reader, entry: m}, nil
+}
+
+type mockReader struct {
+	reader io.ReadCloser
+	entry  fs.Entry
+}
+
+func (r *mockReader) Read(p []byte) (int, error)     { return r.reader.Read(p) }
+func (r *mockReader) Close() error                   { return r.reader.Close() }
+func (r *mockReader) Seek(int64, int) (int64, error) { return 0, nil }
+func (r *mockReader) Entry() (fs.Entry, error)       { return r.entry, nil }
+
+func TestBlockOutputWriteFile(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "block-data")
+	require.NoError(t, os.WriteFile(tmpFile, make([]byte, 512), 0o644))
+
+	data := make([]byte, 512)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+
+	output := &BlockOutput{
+		targetFileName: tmpFile,
+	}
+
+	remoteFile := &mockFile{
+		name:   "bdev",
+		size:   int64(len(data)),
+		reader: io.NopCloser(bytes.NewReader(data)),
+	}
+
+	err := output.WriteFile(context.Background(), "bdev", remoteFile, func(int64) {})
+	require.NoError(t, err)
+
+	written, err := os.ReadFile(tmpFile)
+	require.NoError(t, err)
+	assert.Equal(t, data, written)
+}
+
+func TestBlockOutputWriteFileOpenError(t *testing.T) {
+	openErr := errors.New("open failed")
+	output := &BlockOutput{targetFileName: filepath.Join(t.TempDir(), "missing")}
+
+	remoteFile := &mockFile{
+		name:    "bdev",
+		openErr: openErr,
+	}
+
+	err := output.WriteFile(context.Background(), "bdev", remoteFile, func(int64) {})
+	require.ErrorIs(t, err, openErr)
+}
+
+func TestBlockOutputWriteFileTargetOpenError(t *testing.T) {
+	output := &BlockOutput{targetFileName: filepath.Join(t.TempDir(), "missing", "bdev")}
+
+	remoteFile := &mockFile{
+		name:   "bdev",
+		reader: io.NopCloser(bytes.NewReader([]byte("data"))),
+	}
+
+	err := output.WriteFile(context.Background(), "bdev", remoteFile, func(int64) {})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to open file")
+}


### PR DESCRIPTION

## Summary

Fixes a bug in Kopia block-volume restore (`BlockOutput.WriteFile`) where the partial-write loop used the wrong slice end index (`buffer[offset:bytesToWrite]` instead of `buffer[offset:offset+bytesToWrite]`). On partial writes this could panic with `slice bounds out of range` or corrupt restored block device data.

Also opens block devices with `os.OpenFile(..., os.O_RDWR, 0)` instead of `os.Create`, avoiding `O_TRUNC` on block devices.

Changes:
- Extract `writeBufferContents()` with correct partial-write handling
- Add unit tests covering partial writes and the old buggy behavior

## Does your change fix a particular issue?

Fixes #10089 

## Checklist

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.

Documentation update not required - internal bug fix with no user-facing doc changes.
