### PR TITLE
Replace rebase action with GitHub CLI

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -19,6 +19,9 @@ jobs:
       )
     runs-on: ubuntu-latest
     permissions:
+      # contents: write is required because updating the pull request branch
+      # pushes commits to the head branch.
+      contents: write
       pull-requests: write
     steps:
       - name: Rebase pull request

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,18 +1,29 @@
-on: 
+name: Automatic Rebase
+
+on:
   issue_comment:
     types: [created]
-name: Automatic Rebase
+
+permissions: {}
+
 jobs:
   rebase:
     name: Rebase
-    if: github.repository == 'velero-io/velero' && github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
+    if: >-
+      github.repository == 'velero-io/velero' &&
+      github.event.issue.pull_request != null &&
+      github.event.comment.body == '/rebase' &&
+      contains(
+        fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+        github.event.comment.author_association
+      )
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
-    - name: Checkout the latest code
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-    - name: Automatic Rebase
-      uses: cirrus-actions/rebase@1.8
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Rebase pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: gh pr update-branch "$PR_NUMBER" --repo "$GH_REPO" --rebase

--- a/changelogs/unreleased/10093-chlins
+++ b/changelogs/unreleased/10093-chlins
@@ -1,0 +1,1 @@
+Replace rebase action with GitHub CLI


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
This pull request updates the `.github/workflows/rebase.yml` workflow to improve security and reliability when automatically rebasing pull requests. The main changes restrict who can trigger a rebase, update how the rebase is performed, and adjust permissions.

**Security and Access Control:**
* The workflow now only allows users with `OWNER`, `MEMBER`, or `COLLABORATOR` roles to trigger a rebase by commenting `/rebase` on a pull request, preventing unauthorized users from running this workflow.
* The workflow permissions are restricted to only allow write access to pull requests, following GitHub Actions best practices.

**Workflow Implementation:**
* The rebase step now uses the GitHub CLI (`gh pr update-branch --rebase`) instead of the `cirrus-actions/rebase` action, streamlining the process and reducing external dependencies.
* Environment variables are updated to work with the GitHub CLI command.

These changes make the automatic rebase workflow more secure and maintainable.
# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
