### PR TITLE
Pin prow GitHub action to commit SHA

### DIFF
--- a/.github/workflows/prow-action.yml
+++ b/.github/workflows/prow-action.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository == 'velero-io/velero'
     runs-on: ubuntu-latest
     steps:
-      - uses: jpmcb/prow-github-actions@v1.1.3
+      - uses: jpmcb/prow-github-actions@f4d01dd4b13f289014c23fe5a19878a2479cb35b # v1.1.3
         with:
           # TODO: before allowing the /lgtm command, see if we can block merging if changelog labels are missing.
           prow-commands: |


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
This pull request updates the GitHub Actions workflow to use a specific commit hash for the `jpmcb/prow-github-actions` action instead of referencing it by tag. This change locks the action to an exact version, improving build reproducibility and security.

Dependency management:

* Updated the `jpmcb/prow-github-actions` action in `.github/workflows/prow-action.yml` to use the commit hash `f4d01dd4b13f289014c23fe5a19878a2479cb35b` instead of the `v1.1.3` tag, ensuring consistent and predictable workflow runs.
# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
