### PR TITLE
Enable forbidigo linter to forbid new context.TODO() usages

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -77,6 +77,13 @@ linters:
       # switch
       default-signifies-exhaustive: false
 
+    forbidigo:
+      forbid:
+        # context.TODO() defeats cancellation and timeout propagation. Use the
+        # context from the caller, reconcile request, or cobra command instead.
+        - pattern: ^context\.TODO$
+          msg: "do not use context.TODO; propagate a real context so cancellation and timeouts work"
+
     funlen:
       lines: 60
       statements: 40
@@ -316,6 +323,7 @@ linters:
     - errcheck
     - errchkjson
     - exptostd
+    - forbidigo
     - ginkgolinter
     #- goconst # Disable goconst for now, as it reports a lot of false positives. We can enable it later after refactoring the codebase to reduce the number of string literals.
     - goheader
@@ -360,6 +368,7 @@ linters:
       - path: ".*_test.go$"
         linters:
           - errcheck
+          - forbidigo
           - goconst
           - gosec
           - govet
@@ -369,12 +378,58 @@ linters:
       - path: test/
         linters:
           - errcheck
+          - forbidigo
           - goconst
           - gosec
           - nilerr
           - staticcheck
           - unparam
           - unused
+      # These files still call context.TODO(); remove a file from this list
+      # once a caller context is threaded through it.
+      - { path: ^internal/delete/actions/csi/volumesnapshotcontent_action\.go$, linters: [forbidigo] }
+      - { path: ^internal/volume/volumes_information\.go$, linters: [forbidigo] }
+      - { path: ^pkg/backup/actions/csi/pvc_action\.go$, linters: [forbidigo] }
+      - { path: ^pkg/backup/actions/csi/volumesnapshot_action\.go$, linters: [forbidigo] }
+      - { path: ^pkg/backup/actions/remap_crd_version_action\.go$, linters: [forbidigo] }
+      - { path: ^pkg/backup/snapshots\.go$, linters: [forbidigo] }
+      - { path: ^pkg/client/dynamic\.go$, linters: [forbidigo] }
+      - { path: ^pkg/cmd/cli/backup/create\.go$, linters: [forbidigo] }
+      - { path: ^pkg/cmd/cli/backup/delete\.go$, linters: [forbidigo] }
+      - { path: ^pkg/cmd/cli/backup/get\.go$, linters: [forbidigo] }
+      - { path: ^pkg/cmd/cli/debug/debug\.go$, linters: [forbidigo] }
+      - { path: ^pkg/cmd/cli/plugin/add\.go$, linters: [forbidigo] }
+      - { path: ^pkg/cmd/cli/plugin/remove\.go$, linters: [forbidigo] }
+      - { path: ^pkg/cmd/cli/repo/get\.go$, linters: [forbidigo] }
+      - { path: ^pkg/cmd/cli/restore/create\.go$, linters: [forbidigo] }
+      - { path: ^pkg/cmd/cli/restore/delete\.go$, linters: [forbidigo] }
+      - { path: ^pkg/cmd/cli/restore/describe\.go$, linters: [forbidigo] }
+      - { path: ^pkg/cmd/cli/restore/get\.go$, linters: [forbidigo] }
+      - { path: ^pkg/cmd/cli/schedule/create\.go$, linters: [forbidigo] }
+      - { path: ^pkg/cmd/cli/schedule/delete\.go$, linters: [forbidigo] }
+      - { path: ^pkg/cmd/cli/schedule/describe\.go$, linters: [forbidigo] }
+      - { path: ^pkg/cmd/cli/schedule/get\.go$, linters: [forbidigo] }
+      - { path: ^pkg/cmd/cli/schedule/pause\.go$, linters: [forbidigo] }
+      - { path: ^pkg/cmd/cli/snapshotlocation/create\.go$, linters: [forbidigo] }
+      - { path: ^pkg/cmd/cli/snapshotlocation/get\.go$, linters: [forbidigo] }
+      - { path: ^pkg/controller/backup_repository_controller\.go$, linters: [forbidigo] }
+      - { path: ^pkg/controller/pod_volume_restore_controller\.go$, linters: [forbidigo] }
+      - { path: ^pkg/controller/restore_controller\.go$, linters: [forbidigo] }
+      - { path: ^pkg/podvolume/backupper\.go$, linters: [forbidigo] }
+      - { path: ^pkg/podvolume/restorer\.go$, linters: [forbidigo] }
+      - { path: ^pkg/repository/keys/keys\.go$, linters: [forbidigo] }
+      - { path: ^pkg/repository/maintenance/maintenance\.go$, linters: [forbidigo] }
+      - { path: ^pkg/restore/actions/change_image_name_action\.go$, linters: [forbidigo] }
+      - { path: ^pkg/restore/actions/change_storageclass_action\.go$, linters: [forbidigo] }
+      - { path: ^pkg/restore/actions/csi/pvc_action\.go$, linters: [forbidigo] }
+      - { path: ^pkg/restore/actions/pod_volume_restore_action\.go$, linters: [forbidigo] }
+      - { path: ^pkg/restore/restore\.go$, linters: [forbidigo] }
+      - { path: ^pkg/util/actionhelpers/rbac\.go$, linters: [forbidigo] }
+      - { path: ^pkg/util/csi/volume_snapshot\.go$, linters: [forbidigo] }
+      - { path: ^pkg/util/kube/pvc_pv\.go$, linters: [forbidigo] }
+      - { path: ^pkg/util/kube/secrets\.go$, linters: [forbidigo] }
+      - { path: ^pkg/util/kube/utils\.go$, linters: [forbidigo] }
+      - { path: ^pkg/util/podvolume/pod_volume\.go$, linters: [forbidigo] }
       - path: ".*data_upload_controller_test.go$"
         linters:
           - dupword


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

Enable the `forbidigo` linter with a pattern that forbids `context.TODO()`, so new code must propagate a real context and cancellation/timeouts work end to end.

New violations now fail lint with:
use of context.TODO forbidden because "do not use context.TODO; propagate a real context so cancellation and timeouts work" (forbidigo)


Scope of this PR:

- Add `forbidigo` to the enabled linters in `.golangci.yaml` with a `^context\.TODO$` pattern.
- Exclude test code (`*_test.go` and `test/`), where `context.TODO()` is acceptable.
- Exclude files with pre-existing `context.TODO()` calls via a per-file list in `.golangci.yaml`. This list acts as a burn-down list: each follow-up PR that threads a caller context through a file removes that file from the list, and the linter prevents any new `context.TODO()` from being introduced anywhere else.

This is a lint-config-only change — no Go code or behavior changes. Verified locally with golangci-lint v2.12.0 (the version used in CI): the config validates, the full repo lints clean, and a deliberately introduced `context.TODO()` in a non-excluded file is correctly reported.

# Does your change fix a particular issue?

Fixes #10086

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.

