### PR TITLE
Use "" as parentSnapshot for DU when BackupType is incremental.

### DIFF
--- a/changelogs/unreleased/10126-blackpiglet
+++ b/changelogs/unreleased/10126-blackpiglet
@@ -1,0 +1,1 @@
+Use "" as parentSnapshot for DU when BackupType is incremental.

--- a/pkg/backup/actions/csi/pvc_action.go
+++ b/pkg/backup/actions/csi/pvc_action.go
@@ -536,14 +536,10 @@ func newDataUpload(
 	vsc *snapshotv1api.VolumeSnapshotContent,
 	fsType string,
 ) *velerov2alpha1.DataUpload {
-	var parentSnapshot string
-	switch backup.Spec.BackupType {
-	case velerov1api.BackupTypeFull:
+	parentSnapshot := ""
+
+	if backup.Spec.BackupType == velerov1api.BackupTypeFull {
 		parentSnapshot = veleroshared.DataUploadParentSnapshotNone
-	case velerov1api.BackupTypeIncremental:
-		parentSnapshot = veleroshared.DataUploadParentSnapshotAuto
-	default:
-		parentSnapshot = veleroshared.DataUploadParentSnapshotAuto
 	}
 
 	dataUpload := &velerov2alpha1.DataUpload{

--- a/pkg/backup/actions/csi/pvc_action_test.go
+++ b/pkg/backup/actions/csi/pvc_action_test.go
@@ -45,7 +45,6 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/velero/pkg/apis/velero/shared"
-	veleroshared "github.com/vmware-tanzu/velero/pkg/apis/velero/shared"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	velerov2alpha1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v2alpha1"
 	"github.com/vmware-tanzu/velero/pkg/builder"
@@ -162,7 +161,7 @@ func TestExecute(t *testing.T) {
 					SourcePVC:        "testPVC",
 					SourceNamespace:  "velero",
 					OperationTimeout: metav1.Duration{Duration: 1 * time.Minute},
-					ParentSnapshot:   veleroshared.DataUploadParentSnapshotAuto,
+					ParentSnapshot:   "",
 				},
 			},
 		},
@@ -2199,7 +2198,7 @@ func TestNewDataUpload(t *testing.T) {
 			backupType:         velerov1api.BackupTypeIncremental,
 			vsClassName:        ptr.To("test-vs-class"),
 			uploaderConfig:     &velerov1api.UploaderConfigForBackup{ParallelFilesUpload: 10},
-			expectedParentSnap: "auto",
+			expectedParentSnap: "",
 			expectedDataMoverCfg: map[string]string{
 				uploaderUtil.ParallelFilesUpload: "10",
 			},
@@ -2209,7 +2208,7 @@ func TestNewDataUpload(t *testing.T) {
 			backupType:           "",
 			vsClassName:          ptr.To("test-vs-class"),
 			uploaderConfig:       &velerov1api.UploaderConfigForBackup{ParallelFilesUpload: 0},
-			expectedParentSnap:   "auto",
+			expectedParentSnap:   "",
 			expectedDataMoverCfg: nil,
 		},
 	}


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

Modify function `newDataUpload()` in the backup's pvc_action.go file. 
Before modification, the parentSnapshot is set as `auto` when the backup's spec.backupType is set as `incremental`.
However, the Kopia uploader can only handle parentSnapshot's value as ``.

As a result, use "" as parentSnapshot for DU when BackupType is `incremental`.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
