### PR TITLE
Fix Tiltfile Developer Experience and Plugin Build Issues

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -99,7 +99,7 @@ local_resource(
 
 local_resource(
     "velero_local_binary",
-    cmd = 'cd ' + '.' + ';mkdir -p _tiltbuild/local;PKG=. BIN=velero GOOS=' + local_goos + ' GOARCH=amd64 GIT_SHA=' + git_sha + ' VERSION=main GIT_TREE_STATE=dirty OUTPUT_DIR=_tiltbuild/local ' + get_debug_flag() + ' REGISTRY=' + settings.get("default_registry") + ' ./hack/build.sh',
+    cmd = 'cd ' + '.' + ';mkdir -p _tiltbuild/local;PKG=. BIN=velero GOBIN=$(pwd)/.go/bin GOOS=' + local_goos  + ' GOARCH=amd64 GIT_SHA=' + git_sha + ' VERSION=main GIT_TREE_STATE=dirty OUTPUT_DIR=_tiltbuild/local ' + get_debug_flag() + ' REGISTRY=' + settings.get("default_registry") + ' ./hack/build.sh',
     deps = ["internal", "pkg/cmd"],
 )
 
@@ -236,7 +236,7 @@ def enable_provider(provider):
     # Set up a local_resource build of the plugin binary. The main.go path must be provided via go_main option. The binary is written to _tiltbuild/<NAME>.
     local_resource(
         name + "_plugin",
-        cmd = 'cd ' + context + ';mkdir -p _tiltbuild;PKG=' + context + ' BIN=' + go_main + ' GOOS=linux GOARCH=amd64 OUTPUT_DIR=_tiltbuild ./hack/build.sh',
+        cmd = 'cd ' + context + ';mkdir -p _tiltbuild;if [ -f "./cmd/' + go_main + '" ]; then GOBIN=$(pwd)/.go/bin GOOS=linux GOARCH=amd64 go build -o _tiltbuild/' + plugin_name + ' ./cmd; else GOBIN=$(pwd)/.go/bin GOOS=linux GOARCH=amd64 go build -o _tiltbuild/' + plugin_name + ' .; fi',
         deps = live_reload_deps,
     )
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -92,7 +92,7 @@ def get_debug_flag():
 # Set up a local_resource build of the Velero binary. The binary is written to _tiltbuild/velero.
 local_resource(
     "velero_server_binary",
-    cmd = 'cd ' + '.' + ';mkdir -p _tiltbuild;PKG=. BIN=velero GOOS=linux GOARCH=amd64 GIT_SHA=' + git_sha + ' VERSION=main GIT_TREE_STATE=dirty OUTPUT_DIR=_tiltbuild ' + get_debug_flag() + ' REGISTRY=' + settings.get("default_registry") + ' ./hack/build.sh',
+    cmd = 'cd ' + '.' + ';mkdir -p _tiltbuild;PKG=. BIN=velero GOOS=linux GOARCH=amd64 GOBIN=$(pwd)/.go/bin GIT_SHA=' + git_sha + ' VERSION=main GIT_TREE_STATE=dirty OUTPUT_DIR=_tiltbuild ' + get_debug_flag() + ' REGISTRY=' + settings.get("default_registry") + ' ./hack/build.sh',
     deps = ["cmd", "internal", "pkg"],
     ignore = ["pkg/cmd"],
 )

--- a/Tiltfile
+++ b/Tiltfile
@@ -94,7 +94,7 @@ local_resource(
     "velero_server_binary",
     cmd = 'cd ' + '.' + ';mkdir -p _tiltbuild;PKG=. BIN=velero GOOS=linux GOARCH=amd64 GOBIN=$(pwd)/.go/bin GIT_SHA=' + git_sha + ' VERSION=main GIT_TREE_STATE=dirty OUTPUT_DIR=_tiltbuild ' + get_debug_flag() + ' REGISTRY=' + settings.get("default_registry") + ' ./hack/build.sh',
     deps = ["cmd", "internal", "pkg"],
-    ignore = ["pkg/cmd"],
+    ignore = ["pkg/cmd/cli", "pkg/cmd/test"],
 )
 
 local_resource(


### PR DESCRIPTION
This PR addresses three local development experience issues in the `Tiltfile` and its plugin-building helper:

1. **Fixes `tilt up` startup failure:** Added `GOBIN=$(pwd)/.go/bin` to the local resource build commands (`velero_server_binary` and `velero_local_binary`) to avoid `./hack/build.sh: GOBIN: unbound variable` crashes on environments where GOBIN is not exported.
2. **Fixes server live-reload:** Replaced `ignore = ["pkg/cmd"]` with `ignore = ["pkg/cmd/cli", "pkg/cmd/test"]`. This ensures edits to server command logic (`pkg/cmd/server`) cleanly trigger a build and container restart while ignoring client CLI changes.
3. **Fixes plugin compilation and deployment:** Replaced the plugin `hack/build.sh` build step with a direct `go build` command that uses relative paths to target `./cmd` or `.` directories. This solves path mismatches for non-Velero plugin repos, resolves Go module dependency resolution issues, and names the output binary correctly to align with Docker image builds and live update sync expectations.

# Does your change fix a particular issue?

Fixes #10130 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.

`/kind changelog-not-required`