### PR TITLE
Pin e2e third-party clones to reviewed commits

### DIFF
--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -1,6 +1,14 @@
 name: "Run the E2E test on kind"
+permissions:
+  contents: read
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  # Reviewed commit pins for third-party sources this workflow clones and executes.
+  # Bump them deliberately after reviewing the upstream changes.
+  # bitnami/containers: [bitnami/minio] Release 2026.7.17-debian-12-r0
+  BITNAMI_CONTAINERS_COMMIT: 19fb570e551f15ab0c8264aafa93774266761b8d
+  # vmware-tanzu-experiments/distributed-data-generator: main as of 2025-07-15
+  KIBISHII_COMMIT: bce0469e5f9dd33f31432fab22ff90ad6f2b45ca
 on:
   push:
   pull_request:
@@ -19,8 +27,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: get-go-version
-    outputs:
-      minio-dockerfile-sha: ${{ steps.minio-version.outputs.dockerfile_sha }}
     steps:
       - name: Check out the code
         uses: actions/checkout@v6
@@ -56,45 +62,22 @@ jobs:
         run: |
           IMAGE=velero VERSION=pr-test BUILD_OUTPUT_TYPE=docker make container
           docker save velero:pr-test-linux-amd64 -o ./velero.tar
-      # Check and build MinIO image once for all e2e tests
-      - name: Check Bitnami MinIO Dockerfile version
-        id: minio-version
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          url="https://api.github.com/repos/bitnami/containers/commits?path=bitnami/minio/2026/debian-12/Dockerfile&per_page=1"
-
-          response="$(curl --fail-with-body -sS \
-            --retry 5 \
-            --retry-delay 2 \
-            --retry-all-errors \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${GH_TOKEN}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "$url")"
-
-          DOCKERFILE_SHA="$(echo "$response" | jq -r '.[0].sha // empty')"
-
-          if [ -z "$DOCKERFILE_SHA" ]; then
-            echo "Failed to resolve Bitnami MinIO Dockerfile SHA from GitHub API response"
-            echo "$response"
-            exit 1
-          fi
-
-          echo "dockerfile_sha=${DOCKERFILE_SHA}" >> "$GITHUB_OUTPUT"
+      # Build the MinIO image once for all e2e tests, from the reviewed bitnami/containers commit.
       - name: Cache MinIO Image
         uses: actions/cache@v4
         id: minio-cache
         with:
           path: ./minio-image.tar
-          key: minio-bitnami-${{ steps.minio-version.outputs.dockerfile_sha }}
+          key: minio-bitnami-${{ env.BITNAMI_CONTAINERS_COMMIT }}
       - name: Build MinIO Image from Bitnami Dockerfile
         if: steps.minio-cache.outputs.cache-hit != 'true'
         run: |
-          echo "Building MinIO image from Bitnami Dockerfile..."
-          git clone --depth 1 https://github.com/bitnami/containers.git /tmp/bitnami-containers
+          set -euo pipefail
+          echo "Building MinIO image from Bitnami Dockerfile at ${BITNAMI_CONTAINERS_COMMIT}..."
+          git init -q /tmp/bitnami-containers
+          git -C /tmp/bitnami-containers remote add origin https://github.com/bitnami/containers.git
+          git -C /tmp/bitnami-containers fetch --depth 1 origin "${BITNAMI_CONTAINERS_COMMIT}"
+          git -C /tmp/bitnami-containers checkout -q "${BITNAMI_CONTAINERS_COMMIT}"
           cd /tmp/bitnami-containers/bitnami/minio/2026/debian-12
           docker build -t bitnami/minio:local .
           docker save bitnami/minio:local > ${{ github.workspace }}/minio-image.tar
@@ -149,7 +132,7 @@ jobs:
         id: minio-cache
         with:
           path: ./minio-image.tar
-          key: minio-bitnami-${{ needs.build.outputs.minio-dockerfile-sha }}
+          key: minio-bitnami-${{ env.BITNAMI_CONTAINERS_COMMIT }}
       - name: Load MinIO Image
         run: |
           echo "Loading MinIO image..."
@@ -189,7 +172,10 @@ jobs:
           curl -LO https://dl.k8s.io/release/v${{ matrix.k8s }}/bin/linux/amd64/kubectl
           sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
-          git clone https://github.com/vmware-tanzu-experiments/distributed-data-generator.git -b main /tmp/kibishii
+          git init -q /tmp/kibishii
+          git -C /tmp/kibishii remote add origin https://github.com/vmware-tanzu-experiments/distributed-data-generator.git
+          git -C /tmp/kibishii fetch --depth 1 origin "${KIBISHII_COMMIT}"
+          git -C /tmp/kibishii checkout -q "${KIBISHII_COMMIT}"
 
           GOPATH=~/go \
               CLOUD_PROVIDER=kind \


### PR DESCRIPTION
Pin bitnami/containers and distributed-data-generator to fixed SHAs instead of building default-branch HEAD, and add a minimal permissions block.

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
