### PR TITLE
Fix By() called outside running spec

### DIFF
--- a/test/perf/e2e_suite_test.go
+++ b/test/perf/e2e_suite_test.go
@@ -107,7 +107,6 @@ var testSuitePassed bool
 
 func TestE2e(t *testing.T) {
 	flag.Parse()
-	By("Install test resources before testing TestE2e")
 	// Skip running E2E tests when running only "short" tests because:
 	// 1. E2E tests are long running tests involving installation of Velero and performing backup and restore operations.
 	// 2. E2E tests require a Kubernetes cluster to install and run velero which further requires more configuration. See above referenced command line flags.

--- a/test/perf/test/test.go
+++ b/test/perf/test/test.go
@@ -81,7 +81,7 @@ type TestCase struct {
 func TestFunc(test VeleroBackupRestoreTest) func() {
 	return func() {
 		Expect(test.Init()).To(Succeed(), "Failed to instantiate test cases")
-		By(fmt.Sprintf("Run test %s ...... \n", test.GetTestCase().CaseBaseName))
+		
 		BeforeEach(func() {
 			// Using the global velero config which covered the installation for most common cases
 			if InstallVelero {
@@ -89,6 +89,7 @@ func TestFunc(test VeleroBackupRestoreTest) func() {
 			}
 		})
 		It(test.GetTestMsg().Text, func() {
+			By(fmt.Sprintf("Run test %s ...... \n", test.GetTestCase().CaseBaseName))
 			Expect(RunTestCase(test)).To(Succeed(), test.GetTestMsg().FailedMSG)
 		})
 	}


### PR DESCRIPTION
Removes an invalid By() call in e2e_suite_test.go and relocates one in test.go into the It() block where Ginkgo allows it to run. Both were causing a panic: 'you are calling By outside of a running spec.'

Thank you for contributing to Velero!

# Please add a summary of your change
Removes an invalid By() call in e2e_suite_test.go and relocates one in test.go into the It() block where Ginkgo allows it to run. Both were causing a panic: 'you are calling By outside of a running spec.'



# Does your change fix a particular issue?
yes the panic cause by improper placement of by call() 
<img width="1601" height="1033" alt="Screenshot From 2026-08-03 12-19-18" src="https://github.com/user-attachments/assets/524aa55d-7360-4707-9c6e-7cab05d1e870" />



# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
