### PR TITLE
Fix missing `gcFailureBSLUnavailable` label during garbage collection

### DIFF
--- a/pkg/controller/gc_controller.go
+++ b/pkg/controller/gc_controller.go
@@ -156,6 +156,10 @@ func (c *gcReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 
 	if !veleroutil.BSLIsAvailable(*loc) {
 		log.Infof("BSL %s is unavailable, cannot gc backup", loc.Name)
+		backup.Labels[garbageCollectionFailure] = gcFailureBSLUnavailable
+		if err := c.Update(ctx, backup); err != nil {
+			log.WithError(err).Error("error updating backup labels")
+		}
 		return ctrl.Result{}, fmt.Errorf("bsl %s is unavailable, cannot gc backup", loc.Name)
 	}
 

--- a/pkg/controller/gc_controller_test.go
+++ b/pkg/controller/gc_controller_test.go
@@ -48,11 +48,12 @@ func TestGCReconcile(t *testing.T) {
 	defaultBackupLocation := builder.ForBackupStorageLocation(velerov1api.DefaultNamespace, "default").Phase(velerov1api.BackupStorageLocationPhaseAvailable).Result()
 
 	tests := []struct {
-		name                 string
-		backup               *velerov1api.Backup
-		deleteBackupRequests []*velerov1api.DeleteBackupRequest
-		backupLocation       *velerov1api.BackupStorageLocation
-		expectError          bool
+		name                   string
+		backup                 *velerov1api.Backup
+		deleteBackupRequests   []*velerov1api.DeleteBackupRequest
+		backupLocation         *velerov1api.BackupStorageLocation
+		expectError            bool
+		expectedGCFailureLabel string
 	}{
 		{
 			name: "can't find backup - no error",
@@ -118,10 +119,11 @@ func TestGCReconcile(t *testing.T) {
 			},
 		},
 		{
-			name:           "BSL is unavailable",
-			backup:         defaultBackup().Expiration(fakeClock.Now().Add(-time.Second)).StorageLocation("default").Result(),
-			backupLocation: builder.ForBackupStorageLocation(velerov1api.DefaultNamespace, "default").Phase(velerov1api.BackupStorageLocationPhaseUnavailable).Result(),
-			expectError:    true,
+			name:                   "BSL is unavailable",
+			backup:                 defaultBackup().Expiration(fakeClock.Now().Add(-time.Second)).StorageLocation("default").Result(),
+			backupLocation:         builder.ForBackupStorageLocation(velerov1api.DefaultNamespace, "default").Phase(velerov1api.BackupStorageLocationPhaseUnavailable).Result(),
+			expectError:            true,
+			expectedGCFailureLabel: gcFailureBSLUnavailable,
 		},
 	}
 
@@ -147,6 +149,12 @@ func TestGCReconcile(t *testing.T) {
 			_, err := reconciler.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: test.backup.Namespace, Name: test.backup.Name}})
 			gotErr := err != nil
 			assert.Equal(t, test.expectError, gotErr)
+
+			if test.expectedGCFailureLabel != "" {
+				updatedBackup := &velerov1api.Backup{}
+				assert.NoError(t, fakeClient.Get(t.Context(), types.NamespacedName{Namespace: test.backup.Namespace, Name: test.backup.Name}, updatedBackup))
+				assert.Equal(t, test.expectedGCFailureLabel, updatedBackup.Labels[garbageCollectionFailure])
+			}
 		})
 	}
 }

--- a/pkg/controller/gc_controller_test.go
+++ b/pkg/controller/gc_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -152,7 +153,7 @@ func TestGCReconcile(t *testing.T) {
 
 			if test.expectedGCFailureLabel != "" {
 				updatedBackup := &velerov1api.Backup{}
-				assert.NoError(t, fakeClient.Get(t.Context(), types.NamespacedName{Namespace: test.backup.Namespace, Name: test.backup.Name}, updatedBackup))
+				require.NoError(t, fakeClient.Get(t.Context(), types.NamespacedName{Namespace: test.backup.Namespace, Name: test.backup.Name}, updatedBackup))
 				assert.Equal(t, test.expectedGCFailureLabel, updatedBackup.Labels[garbageCollectionFailure])
 			}
 		})


### PR DESCRIPTION
Fixes #10153 

## What this PR does / why we need it:
This PR fixes an oversight in the GC controller where the `gcFailureBSLUnavailable` constant was defined but never actually applied to a backup when its `BackupStorageLocation` is unavailable. 

Before this change, if a BSL was unavailable, the controller would log an error and return without applying the `velero.io/gc-failure` label. This made it impossible to query or alert on backups that were orphaned/stuck due to this specific issue. 

I've updated the BSL availability check to apply the label right before it returns the error. This brings the behavior in line with how the other failure modes (`BSLNotFound`, `BSLCannotGet`, and `BSLReadOnly`) are handled. I also extended the existing test cases in `gc_controller_test.go` to explicitly verify that the label is applied during this failure mode.

## How to test it:
- Create a backup and let its expiration pass.
- Set its associated `BackupStorageLocation` to an `Unavailable` phase.
- Wait for the GC controller to run (or trigger it).
- Verify that `kubectl get backup <name> -n velero -o yaml` now correctly shows the `velero.io/gc-failure: BSLUnavailable` label.

## Checklist:
- [x] Code follows the existing patterns in the controller
- [x] Unit tests updated to cover the new label assignment
- [x] All `go test ./pkg/controller` tests pass locally
