### PR TITLE
Fix spurious snapshot errors when defaultVolumesToFsBackup is true

### DIFF
--- a/internal/volumehelper/volume_policy_helper.go
+++ b/internal/volumehelper/volume_policy_helper.go
@@ -69,7 +69,7 @@ func (v *volumeHelperImpl) ShouldPerformSnapshot(obj runtime.Unstructured, group
 		pv, err = kubeutil.GetPVForPVC(pvc, v.client)
 		if err != nil {
 			if v.defaultVolumesToFSBackup {
-				v.logger.Infof("PV not found for PVC %s, skipping snapshot because defaultVolumesToFsBackup is true",
+				v.logger.Infof("PV not found for PVC %s, skipping snapshot",
 					pvc.Namespace+"/"+pvc.Name)
 				return false, nil
 			}
@@ -163,7 +163,7 @@ func (v volumeHelperImpl) ShouldPerformFSBackup(volume corev1api.Volume, pod cor
 			resource, err = kubeutil.GetPVForPVC(pvc, v.client)
 			if err != nil {
 				if v.defaultVolumesToFSBackup {
-					v.logger.Infof("PV not found for PVC %s, falling through to fs-backup because defaultVolumesToFsBackup is true",
+					v.logger.Infof("PV not found for PVC %s, skipping volume policy check",
 						pvc.Namespace+"/"+pvc.Name)
 					pvFound = false
 				} else {

--- a/internal/volumehelper/volume_policy_helper.go
+++ b/internal/volumehelper/volume_policy_helper.go
@@ -68,6 +68,11 @@ func (v *volumeHelperImpl) ShouldPerformSnapshot(obj runtime.Unstructured, group
 
 		pv, err = kubeutil.GetPVForPVC(pvc, v.client)
 		if err != nil {
+			if v.defaultVolumesToFSBackup {
+				v.logger.Infof("PV not found for PVC %s, skipping snapshot because defaultVolumesToFsBackup is true",
+					pvc.Namespace+"/"+pvc.Name)
+				return false, nil
+			}
 			v.logger.WithError(err).Errorf("fail to get PV for PVC %s", pvc.Namespace+"/"+pvc.Name)
 			return false, err
 		}
@@ -148,6 +153,7 @@ func (v volumeHelperImpl) ShouldPerformFSBackup(volume corev1api.Volume, pod cor
 		var err error
 		resource = &volume
 		var pvc = &corev1api.PersistentVolumeClaim{}
+		pvFound := true
 		if volume.VolumeSource.PersistentVolumeClaim != nil {
 			pvc, err = kubeutil.GetPVCForPodVolume(&volume, &pod, v.client)
 			if err != nil {
@@ -156,32 +162,40 @@ func (v volumeHelperImpl) ShouldPerformFSBackup(volume corev1api.Volume, pod cor
 			}
 			resource, err = kubeutil.GetPVForPVC(pvc, v.client)
 			if err != nil {
-				v.logger.WithError(err).Errorf("fail to get PV for PVC %s", pvc.Namespace+"/"+pvc.Name)
-				return false, err
+				if v.defaultVolumesToFSBackup {
+					v.logger.Infof("PV not found for PVC %s, falling through to fs-backup because defaultVolumesToFsBackup is true",
+						pvc.Namespace+"/"+pvc.Name)
+					pvFound = false
+				} else {
+					v.logger.WithError(err).Errorf("fail to get PV for PVC %s", pvc.Namespace+"/"+pvc.Name)
+					return false, err
+				}
 			}
 		}
 
-		pv, podVolume, err := v.getVolumeFromResource(resource)
-		if err != nil {
-			return false, err
-		}
+		if pvFound {
+			pv, podVolume, err := v.getVolumeFromResource(resource)
+			if err != nil {
+				return false, err
+			}
 
-		vfd := resourcepolicies.NewVolumeFilterData(pv, podVolume, pvc)
-		action, err := v.volumePolicy.GetMatchAction(vfd)
-		if err != nil {
-			v.logger.WithError(err).Error("fail to get VolumePolicy match action for volume")
-			return false, err
-		}
+			vfd := resourcepolicies.NewVolumeFilterData(pv, podVolume, pvc)
+			action, err := v.volumePolicy.GetMatchAction(vfd)
+			if err != nil {
+				v.logger.WithError(err).Error("fail to get VolumePolicy match action for volume")
+				return false, err
+			}
 
-		if action != nil {
-			if action.Type == resourcepolicies.FSBackup {
-				v.logger.Infof("Perform fs-backup action for volume %s of pod %s due to volume policy match",
-					volume.Name, pod.Namespace+"/"+pod.Name)
-				return true, nil
-			} else {
-				v.logger.Infof("Skip fs-backup action for volume %s for pod %s because the action type is %s",
-					volume.Name, pod.Namespace+"/"+pod.Name, action.Type)
-				return false, nil
+			if action != nil {
+				if action.Type == resourcepolicies.FSBackup {
+					v.logger.Infof("Perform fs-backup action for volume %s of pod %s due to volume policy match",
+						volume.Name, pod.Namespace+"/"+pod.Name)
+					return true, nil
+				} else {
+					v.logger.Infof("Skip fs-backup action for volume %s for pod %s because the action type is %s",
+						volume.Name, pod.Namespace+"/"+pod.Name, action.Type)
+					return false, nil
+				}
 			}
 		}
 	}

--- a/internal/volumehelper/volume_policy_helper.go
+++ b/internal/volumehelper/volume_policy_helper.go
@@ -69,7 +69,9 @@ func (v *volumeHelperImpl) ShouldPerformSnapshot(obj runtime.Unstructured, group
 		pv, err = kubeutil.GetPVForPVC(pvc, v.client)
 		if err != nil {
 			if v.defaultVolumesToFSBackup {
-				v.logger.Infof("PV not found for PVC %s, skipping snapshot",
+				v.logger.Warnf("PV not found for PVC %s: cannot evaluate volume policy to determine if snapshot was intended. "+
+					"Defaulting to fs-backup, but note that volume policies may override defaultVolumesToFsBackup. "+
+					"Ensure the PVC is bound to a PV if a snapshot policy should apply.",
 					pvc.Namespace+"/"+pvc.Name)
 				return false, nil
 			}
@@ -163,7 +165,9 @@ func (v volumeHelperImpl) ShouldPerformFSBackup(volume corev1api.Volume, pod cor
 			resource, err = kubeutil.GetPVForPVC(pvc, v.client)
 			if err != nil {
 				if v.defaultVolumesToFSBackup {
-					v.logger.Infof("PV not found for PVC %s, skipping volume policy check",
+					v.logger.Warnf("PV not found for PVC %s: cannot evaluate volume policy. "+
+						"Falling back to fs-backup, but volume policies may override defaultVolumesToFsBackup. "+
+						"Ensure the PVC is bound to a PV if a specific volume policy should apply.",
 						pvc.Namespace+"/"+pvc.Name)
 					pvFound = false
 				} else {

--- a/internal/volumehelper/volume_policy_helper_test.go
+++ b/internal/volumehelper/volume_policy_helper_test.go
@@ -295,6 +295,18 @@ func TestVolumeHelperImpl_ShouldPerformSnapshot(t *testing.T) {
 			shouldSnapshot:      false,
 			expectedErr:         true,
 		},
+		{
+			name:          "PVC not having PV with defaultVolumesToFSBackup=true, return false and no error",
+			inputObj:      builder.ForPersistentVolumeClaim("default", "example-pvc").StorageClass("gp2-csi").Result(),
+			groupResource: kuberesource.PersistentVolumeClaims,
+			resourcePolicies: &resourcepolicies.ResourcePolicies{
+				Version: "v1",
+			},
+			snapshotVolumesFlag:      ptr.To(true),
+			defaultVolumesToFSBackup: true,
+			shouldSnapshot:           false,
+			expectedErr:              false,
+		},
 	}
 
 	objs := []runtime.Object{
@@ -668,6 +680,72 @@ func TestVolumeHelperImpl_ShouldPerformFSBackup(t *testing.T) {
 			defaultVolumesToFSBackup: true,
 			shouldFSBackup:           false,
 			expectedErr:              false,
+		},
+		{
+			name: "VolumePolicy no match, PV not found, defaultVolumesToFSBackup=true, falls through to legacy and returns true",
+			pod: builder.ForPod("ns", "pod-1").
+				Volumes(
+					&corev1api.Volume{
+						Name: "vol-1",
+						VolumeSource: corev1api.VolumeSource{
+							PersistentVolumeClaim: &corev1api.PersistentVolumeClaimVolumeSource{
+								ClaimName: "pvc-no-pv",
+							},
+						},
+					}).Result(),
+			resources: []runtime.Object{
+				builder.ForPersistentVolumeClaim("ns", "pvc-no-pv").
+					StorageClass("gp2-csi").Phase(corev1api.ClaimPending).Result(),
+			},
+			resourcePolicies: &resourcepolicies.ResourcePolicies{
+				Version: "v1",
+				VolumePolicies: []resourcepolicies.VolumePolicy{
+					{
+						Conditions: map[string]any{
+							"storageClass": []string{"gp3-csi"},
+						},
+						Action: resourcepolicies.Action{
+							Type: resourcepolicies.FSBackup,
+						},
+					},
+				},
+			},
+			defaultVolumesToFSBackup: true,
+			shouldFSBackup:           true,
+			expectedErr:              false,
+		},
+		{
+			name: "VolumePolicy no match, PV not found, defaultVolumesToFSBackup=false, returns error",
+			pod: builder.ForPod("ns", "pod-1").
+				Volumes(
+					&corev1api.Volume{
+						Name: "vol-1",
+						VolumeSource: corev1api.VolumeSource{
+							PersistentVolumeClaim: &corev1api.PersistentVolumeClaimVolumeSource{
+								ClaimName: "pvc-no-pv",
+							},
+						},
+					}).Result(),
+			resources: []runtime.Object{
+				builder.ForPersistentVolumeClaim("ns", "pvc-no-pv").
+					StorageClass("gp2-csi").Phase(corev1api.ClaimPending).Result(),
+			},
+			resourcePolicies: &resourcepolicies.ResourcePolicies{
+				Version: "v1",
+				VolumePolicies: []resourcepolicies.VolumePolicy{
+					{
+						Conditions: map[string]any{
+							"storageClass": []string{"gp3-csi"},
+						},
+						Action: resourcepolicies.Action{
+							Type: resourcepolicies.FSBackup,
+						},
+					},
+				},
+			},
+			defaultVolumesToFSBackup: false,
+			shouldFSBackup:           false,
+			expectedErr:              true,
 		},
 	}
 

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -380,11 +380,15 @@ func (ib *itemBackupper) executeActions(
 			}
 
 			if !snapshotVolume {
+				skipReason := "not satisfy the criteria for VolumePolicy or the legacy snapshot way"
+				if boolptr.IsSetToTrue(ib.backupRequest.Spec.DefaultVolumesToFsBackup) {
+					skipReason = "snapshot skipped, volume will use filesystem backup (defaultVolumesToFsBackup=true)"
+				}
 				ib.trackSkippedPV(
 					obj,
 					kuberesource.PersistentVolumeClaims,
 					volumeSnapshotApproach,
-					"not satisfy the criteria for VolumePolicy or the legacy snapshot way",
+					skipReason,
 					log,
 				)
 				continue
@@ -538,11 +542,15 @@ func (ib *itemBackupper) takePVSnapshot(obj runtime.Unstructured, log logrus.Fie
 	}
 
 	if !snapshotVolume {
+		skipReason := "not satisfy the criteria for VolumePolicy or the legacy snapshot way"
+		if boolptr.IsSetToTrue(ib.backupRequest.Spec.DefaultVolumesToFsBackup) {
+			skipReason = "snapshot skipped, volume will use filesystem backup (defaultVolumesToFsBackup=true)"
+		}
 		ib.trackSkippedPV(
 			obj,
 			kuberesource.PersistentVolumes,
 			volumeSnapshotApproach,
-			"not satisfy the criteria for VolumePolicy or the legacy snapshot way",
+			skipReason,
 			log,
 		)
 		return nil

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -380,15 +380,11 @@ func (ib *itemBackupper) executeActions(
 			}
 
 			if !snapshotVolume {
-				skipReason := "not satisfy the criteria for VolumePolicy or the legacy snapshot way"
-				if boolptr.IsSetToTrue(ib.backupRequest.Spec.DefaultVolumesToFsBackup) {
-					skipReason = "snapshot skipped, volume will use filesystem backup (defaultVolumesToFsBackup=true)"
-				}
 				ib.trackSkippedPV(
 					obj,
 					kuberesource.PersistentVolumeClaims,
 					volumeSnapshotApproach,
-					skipReason,
+					"volume not selected for snapshot",
 					log,
 				)
 				continue
@@ -542,15 +538,11 @@ func (ib *itemBackupper) takePVSnapshot(obj runtime.Unstructured, log logrus.Fie
 	}
 
 	if !snapshotVolume {
-		skipReason := "not satisfy the criteria for VolumePolicy or the legacy snapshot way"
-		if boolptr.IsSetToTrue(ib.backupRequest.Spec.DefaultVolumesToFsBackup) {
-			skipReason = "snapshot skipped, volume will use filesystem backup (defaultVolumesToFsBackup=true)"
-		}
 		ib.trackSkippedPV(
 			obj,
 			kuberesource.PersistentVolumes,
 			volumeSnapshotApproach,
-			skipReason,
+			"volume not selected for snapshot",
 			log,
 		)
 		return nil


### PR DESCRIPTION
## Summary

- When `defaultVolumesToFsBackup: true`, Velero logged error-level messages about PVs not being found for PVCs during snapshot eligibility checks. These errors are spurious when the user has opted for filesystem backup as the default, since the PV not being found doesn't prevent fs-backup.
- **`ShouldPerformSnapshot`**: When PV lookup fails for a PVC and `defaultVolumesToFsBackup` is true, downgrade from `Error` to `Info` and return `(false, nil)` instead of propagating the error. The message states the actual reason ("PV not found") without misattributing it to `defaultVolumesToFsBackup`, since that flag only sets the default — volume policies and opt-in/opt-out annotations can still override individual volumes to use snapshots.
- **`ShouldPerformFSBackup`**: When PV lookup fails and `defaultVolumesToFsBackup` is true, skip volume policy matching and fall through to the legacy fs-backup check instead of returning an error that blocks the backup entirely.
- **Tracking messages**: Changed from the confusing "not satisfy the criteria for VolumePolicy or the legacy snapshot way" to a neutral "volume not selected for snapshot". The detailed reason is already logged at Info level inside `ShouldPerformSnapshot`.

Fixes: OADP-7574

## Test plan

- [x] Existing `TestVolumeHelperImpl_ShouldPerformSnapshot` tests pass (including `defaultVolumesToFSBackup=false` error case — existing behavior preserved)
- [x] New test: PVC without PV + `defaultVolumesToFSBackup=true` returns `(false, nil)` — no error
- [x] New test: `ShouldPerformFSBackup` with PV not found + `defaultVolumesToFSBackup=true` falls through to legacy check and returns `true`
- [x] New test: `ShouldPerformFSBackup` with PV not found + `defaultVolumesToFSBackup=false` still returns error (existing behavior preserved)
- [x] All `pkg/backup/...` tests pass
- [ ] Manual: run backup with `defaultVolumesToFsBackup: true` and verify no error-level PV/snapshot messages in logs
- [ ] Manual: run backup with `defaultVolumesToFsBackup: false` (or unset) and verify error-level messages still appear for genuine PV-not-found issues
- [ ] Manual: verify VolumePolicy `action: snapshot` still works correctly when `defaultVolumesToFsBackup: true` and PV exists

*Posted via [Claude Code](https://claude.ai/code)*